### PR TITLE
arch-riscv: fix the behavior of mstatus.sd

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -490,7 +490,9 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 auto cur = readMiscRegNoEffect(misc_reg);
                 val &= ~(STATUS_SXL_MASK | STATUS_UXL_MASK);
                 val |= cur & (STATUS_SXL_MASK | STATUS_UXL_MASK);
-                setMiscRegNoEffect(misc_reg, val);
+                STATUS mstatus = val;
+                mstatus.sd = mstatus.fs == 0x3;
+                setMiscRegNoEffect(misc_reg, mstatus);
             }
             break;
           default:


### PR DESCRIPTION
mstatus.sd should be cleared when fs is not dirty

Change-Id: Ie90d6cea37efb53e1400cb9cc687a8bf1d4e3ba3