### PR TITLE
configs: Allow to use Xiangshan system without gcpt

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -670,7 +670,6 @@ def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None):
     self.clint.pio_size = 0xC000
     self.clint.num_threads = 1
 
-    self.workload.xiangshan_cpt = True
     self.workload.reset_vect = 0x80000000
     return self
 

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -131,8 +131,10 @@ def build_test_system(np):
     if buildEnv['TARGET_ISA'] == 'riscv':
         if args.generic_rv_cpt is not None :
             test_sys.workload.bootloader = ''
+            test_sys.workload.xiangshan_cpt = True
         else :
             test_sys.workload.bootloader = args.kernel
+            test_sys.workload.xiangshan_cpt = False
     elif args.kernel is not None:
         test_sys.workload.object_file = binary(args.kernel)
 

--- a/src/arch/riscv/bare_metal/fs_workload.cc
+++ b/src/arch/riscv/bare_metal/fs_workload.cc
@@ -49,6 +49,8 @@ BareMetal::BareMetal(const Params &p) : Workload(p),
                  p.bootloader);
         _resetVect = bootloader->entryPoint();
         bootloaderSymtab = bootloader->symtab();
+        inform("Using bootloader or BareMetal workload, reset to %#lx\n",
+               _resetVect);
     } else {
         bootloader = nullptr;
         assert(p.bootloader.empty());


### PR DESCRIPTION
- TODO: Difftest now depend on gcpt, we should move it independent
from gcpt.
- TODO: provide ready-to-run binary and test it

Change-Id: I3da712891d8c412d902f4a431f075b28e9f5ba3b