### PR TITLE
misc: Add more verbose debug logs for difftest

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -327,6 +327,7 @@ def template CSRExecute {{
             return std::make_shared<IllegalInstFault>(
                     csprintf("Illegal CSR index %#x\n", csr), machInst);
         }
+        DPRINTF(RiscvMisc, "Executing inst: %s\n", mnemonic);
 
         %(op_decl)s;
         %(op_rd)s;


### PR DESCRIPTION
- When difftest fails, print src regs
- Print disassemble and reg values on ValueCommit
- Print CSR instruction type when executing it

Change-Id: Ib56ad8902851e22283bd80d3574c4e72f4f78e2d