### PR TITLE
arch-riscv: Allow to load raw binary image for riscv

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -546,8 +546,11 @@ def addFSOptions(parser):
 
     # Xiangshan related options
     parser.add_argument("--xiangshan-system", action= "store_true",
-                        help = "Use memory layout of Xiangshan system")
+                        help="Use memory layout of Xiangshan system")
 
     parser.add_argument("--generic-rv-cpt", action= "store", type = str,
-                        default = None,
+                        default=None,
                         help="The path of Xiangshan risc-v checkpoint")
+
+    parser.add_argument("--raw-bbl", action= "store_true",
+                        help = "The kernel/bbl/app is not elf but binary")

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -82,7 +82,6 @@ def build_test_system(np):
         test_sys = makeSparcSystem(test_mem_mode, bm[0], cmdline=cmdline)
     elif buildEnv['TARGET_ISA'] == "riscv":
         if args.xiangshan_system:
-            assert args.generic_rv_cpt is not None
             test_sys = makeBareMetalXiangshanSystem(test_mem_mode, bm[0],
                                                     cmdline=cmdline)
         else:
@@ -135,6 +134,9 @@ def build_test_system(np):
         else :
             test_sys.workload.bootloader = args.kernel
             test_sys.workload.xiangshan_cpt = False
+            if args.xiangshan_system and args.raw_bbl:
+                test_sys.workload.raw_bootloader = True
+
     elif args.kernel is not None:
         test_sys.workload.object_file = binary(args.kernel)
 

--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -41,6 +41,8 @@ class RiscvBareMetal(Workload):
     bare_metal = Param.Bool(True, "Using Bare Metal Application?")
     reset_vect = Param.Addr(0x0, 'Reset vector')
     xiangshan_cpt = Param.Bool(False, "Using Xiangshan checkpoint")
+    raw_bootloader = Param.Bool(
+        False, "kernel or bbl provided is binary not elf")
 
 class RiscvLinux(KernelWorkload):
     type = 'RiscvLinux'

--- a/src/arch/riscv/bare_metal/fs_workload.hh
+++ b/src/arch/riscv/bare_metal/fs_workload.hh
@@ -48,6 +48,7 @@ class BareMetal : public Workload
     Addr _resetVect;
     loader::ObjectFile *bootloader;
     loader::SymbolTable bootloaderSymtab;
+    bool raw_binary;
 
   public:
     PARAMS(RiscvBareMetal);

--- a/src/base/loader/memory_image.hh
+++ b/src/base/loader/memory_image.hh
@@ -161,6 +161,12 @@ class MemoryImage
         }
         return false;
     }
+
+    void
+    setSegAddr(size_t i, Addr addr)
+    {
+        _segments.at(i).base = addr;
+    }
 };
 
 static inline std::ostream &

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -261,6 +261,10 @@ PhysicalMemory::createBackingStore(
                               conf_table_reported, in_addr_map, kvm_map,
                               shm_fd, map_offset);
 
+    // For Difftest copy memory
+    pmemStart = pmem;
+    pmemSize = range.size();
+
     // point the memories to their backing store
     for (const auto& m : _memories) {
         DPRINTF(AddrRanges, "Mapping memory %s to backing store\n",
@@ -512,9 +516,6 @@ PhysicalMemory::unserializeStoreFrom(std::string filepath,
         fatal("Close failed on physical memory checkpoint file '%s'\n",
               filepath.c_str());
 
-    // For Difftest copy memory
-    pmemStart = pmem;
-    pmemSize = range.size();
 }
 
 bool PhysicalMemory::tryRestoreFromXSCpt() {


### PR DESCRIPTION
- When loading raw binary image:
```--raw-bbl --kernel hello.bin```
- When loading elf image:
```--kernel hello.elf```
- The implementation is a little bit hacky: the addr of the _resetVect
is manually injected into the RawImage object
- Decouple difftest from cpt mode by move pmem pointer update from
`PhysicalMemory::unserializeStoreFrom` to
`PhysicalMemory::createBackingStore`

Change-Id: I684d6eb1a11fd7ac332f4dc6f1d62e180d552d17