### PR TITLE
cpu: reset stats after N insts without switching CPU

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -387,6 +387,10 @@ def addCommonOptions(parser):
     parser.add_argument("-p", "--prog-interval", type=str,
                         help="CPU Progress Interval")
 
+    # for warmup without switching cpu
+    parser.add_argument("--warmup-insts-no-switch", action="store", type=int,
+        default=None,
+        help="Warmup period in total instructions, reset stats without switch")
     # Fastforwarding and simpoint related materials
     parser.add_argument(
         "-W", "--warmup-insts", action="store", type=int, default=None,

--- a/configs/common/Simulation.py
+++ b/configs/common/Simulation.py
@@ -498,6 +498,10 @@ def run(options, root, testsys, cpu_class):
         testsys.switch_cpus = switch_cpus
         switch_cpu_list = [(testsys.cpu[i], switch_cpus[i]) for i in range(np)]
 
+    for i in range(np):
+        if options.warmup_insts_no_switch != None:
+            testsys.cpu[i].warmupInstCount = options.warmup_insts_no_switch
+
     if options.repeat_switch:
         switch_class = getCPUClass(options.cpu_type)[0]
         if switch_class.require_caches() and \

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -147,6 +147,9 @@ class BaseCPU(ClockedObject):
     _uncached_interrupt_response_ports = []
     _uncached_interrupt_request_ports = []
 
+    warmupInstCount = Param.Counter(0,
+        "reset stats when any thread has reached this inst count")
+
     enable_difftest = Param.Bool(False,"use NEMU as ref to difftest")
     difftest_ref_so = Param.String("", "The reference so for online difftest")
 

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -139,7 +139,8 @@ BaseCPU::BaseCPU(const Params &p, bool is_checker)
       syscallRetryLatency(p.syscallRetryLatency),
       pwrGatingLatency(p.pwr_gating_latency),
       powerGatingOnIdle(p.power_gating_on_idle),
-      enterPwrGatingEvent([this]{ enterPwrGating(); }, name())
+      enterPwrGatingEvent([this]{ enterPwrGating(); }, name()),
+      warmupInstCount(p.warmupInstCount)
 {
     // if Python did not provide a valid ID, do it here
     if (_cpuId == -1 ) {

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -647,6 +647,8 @@ class BaseCPU : public ClockedObject
     const bool powerGatingOnIdle;
     EventFunctionWrapper enterPwrGatingEvent;
 
+    const uint64_t warmupInstCount;
+
     //const uint64_t repeatDumpInstCount;
 
     uint64_t nextDumpInstCount{0};

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -56,6 +56,7 @@
 #include "debug/Quiesce.hh"
 #include "debug/ValueCommit.hh"
 #include "enums/MemoryMode.hh"
+#include "sim/async.hh"
 #include "sim/cur_tick.hh"
 #include "sim/full_system.hh"
 #include "sim/process.hh"
@@ -1265,6 +1266,11 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
 
         // Check for instruction-count-based events.
         thread[tid]->comInstEventQueue.serviceEvents(thread[tid]->numInst);
+
+        if (this->warmupInstCount && totalInsts() == this->warmupInstCount) {
+            fprintf(stderr, "Will trigger stat dump and reset\n");
+            Stats::schedStatEvent(true, true, curTick(), 0);
+        }
 
         if (!hasCommit && inst->pcState().instAddr() == 0x80000000u) {
             hasCommit = true;


### PR DESCRIPTION
usage: to use 50 insts for warmup and another 50 for
collecting data, specify 100 total instructions:
`-I 100 --warmup-insts-no-switch 50`

Change-Id: I49391fe61e158618f25bc3d14c9d5e1f46265052