### PR TITLE
cpu-o3: separate difftest from instDone

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1057,6 +1057,8 @@ Commit::commitInsts()
                 // Updates misc. registers.
                 head_inst->updateMiscRegs();
 
+                cpu->difftestStep(head_inst);
+
                 // Check instruction execution if it successfully commits and
                 // is not carrying a fault.
                 if (cpu->checker) {

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -627,6 +627,7 @@ class CPU : public BaseCPU
     void htmSendAbortSignal(ThreadID tid, uint64_t htm_uid,
                             HtmFailureFaultCause cause) override;
 
+    // online difftest
   private:
     uint32_t diffWDst[DIFFTEST_WIDTH];
     uint64_t diffWData[DIFFTEST_WIDTH];
@@ -644,6 +645,8 @@ class CPU : public BaseCPU
 
     std::pair<int, bool> diffWithNEMU(const DynInstPtr &inst);
 
+  public:
+    void difftestStep(const DynInstPtr &inst);
 };
 
 } // namespace o3


### PR DESCRIPTION
- Because updateMiscReg is done after cpu.instDone,
we cannot get updated Misc regs in cpu.instDone
- Always check misc regs like mstatus

Change-Id: I7a88144f48ba4368e44d5932f3f71ec1fb715b5a