### PR TITLE
cpu, arch-riscv: enforce TLB flush after write satp

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -392,6 +392,9 @@ def template CSRExecute {{
               case CSR_MSTATUS: case CSR_SSTATUS: case CSR_USTATUS:
                 if (newdata_all != olddata_all) {
                     xc->setMiscReg(midx, newdata_all);
+                    auto new_val = xc->readMiscReg(MISCREG_STATUS);
+                    DPRINTF(RiscvMisc, "After writing mstatus: %#lx.\n",
+                            new_val);
                 } else {
                     return std::make_shared<IllegalInstFault>(
                             "Only bits in mask are allowed to be set\n",

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -353,7 +353,7 @@ class BaseCPU : public ClockedObject
      * it easier to compare traces when debugging
      * handover/checkpointing.
      */
-    void flushTLBs();
+    virtual void flushTLBs();
 
     /**
      * Determine if the CPU is switched out.

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1448,6 +1448,13 @@ CPU::squashInstIt(const ListIt &instIt, ThreadID tid)
 }
 
 void
+CPU::flushTLBs()
+{
+    BaseCPU::flushTLBs();
+    fetch.flushFetchBuffer();
+}
+
+void
 CPU::cleanUpRemovedInsts()
 {
     while (!removeList.empty()) {

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -367,6 +367,9 @@ class CPU : public BaseCPU
     /** Removes the instruction pointed to by the iterator. */
     void squashInstIt(const ListIt &instIt, ThreadID tid);
 
+    // flush fetch buffer while flushing tlb
+    void flushTLBs() override;
+
     /** Cleans up all instructions on the remove list. */
     void cleanUpRemovedInsts();
 

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -64,6 +64,7 @@
 #include "cpu/static_inst.hh"
 #include "cpu/translation.hh"
 #include "debug/HtmCpu.hh"
+#include "debug/RiscvMisc.hh"
 
 namespace gem5
 {
@@ -1041,6 +1042,7 @@ class DynInst : public ExecContext, public RefCounted
                 return;
         }
 
+        DPRINTF(RiscvMisc, "Push misc reg %i: %#lx\n", misc_reg, val);
         _destMiscRegIdx.push_back(misc_reg);
         _destMiscRegVal.push_back(val);
     }

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -758,6 +758,14 @@ Fetch::doSquash(const PCStateBase &new_pc, const DynInstPtr squashInst,
 }
 
 void
+Fetch::flushFetchBuffer()
+{
+    for (ThreadID i = 0; i < numThreads; ++i) {
+        fetchBufferValid[i] = false;
+    }
+}
+
+void
 Fetch::squashFromDecode(const PCStateBase &new_pc, const DynInstPtr squashInst,
         const InstSeqNum seq_num, ThreadID tid)
 {
@@ -1223,6 +1231,8 @@ Fetch::fetch(bool &status_change)
                 // current block.
                 break;
             }
+
+            DPRINTF(Fetch, "Supplying fetch from fetchBuffer\n");
 
             memcpy(dec_ptr->moreBytesPtr(),
                     fetchBuffer[tid] + blkOffset * instSize, instSize);

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -360,6 +360,8 @@ class Fetch
 
     RequestPort &getInstPort() { return icachePort; }
 
+    void flushFetchBuffer();
+
   private:
     DynInstPtr buildInst(ThreadID tid, StaticInstPtr staticInst,
             StaticInstPtr curMacroop, const PCStateBase &this_pc,


### PR DESCRIPTION
- Always flush TLB after write satp
- Invalidate buffered cachelines in fetch, because fetch
will not retranslate PC if it hits in buffered cachelines.
- And many log to locating the cause of inconsistent behavior

Change-Id: I0c4d95aad9284c979f31e1156e6e2a30e1444d08