### PR TITLE
cpu: difftest now treates strictly ordered instructions as mmio

### DIFF
--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1701,10 +1701,8 @@ CPU::diffWithNEMU(const DynInstPtr &inst)
 {
     int diff_at = DiffAt::NoneDiff;
     bool npc_match = false;
-    bool is_mmio =
-        ((0x38000000u <= inst->physEffAddr) &&
-         (inst->physEffAddr <= 0x39000000u)) ||
-        (0x40600000u <= inst->physEffAddr && inst->physEffAddr <= 0x41600000u);
+
+    bool is_mmio = inst->strictlyOrdered();
 
     if (inst->isStoreConditional()){
         diff.sync.lrscValid = inst->lockedWriteSuccess();


### PR DESCRIPTION
- Deprecate hard-coded addresses
- The MMIO region will be marked as strictly ordered in tlb
- This patch might incur false negative in difftest, but is more
flexible than previous hard-coded address ranges

Change-Id: Iead92243e8518ca575cd5c10dee02eff5ea8450f