### PR TITLE
cpu-o3: add parameters for sdCard difftest

### DIFF
--- a/src/cpu/difftest.cc
+++ b/src/cpu/difftest.cc
@@ -25,7 +25,7 @@ const char *reg_name[DIFFTEST_NR_REG] = {
     "mip",    "mie",   "mscratch", "sscratch", "mideleg", "medeleg",
     "mtval",  "stval", "mtvec",    "stvec",    "mode"};
 
-NemuProxy::NemuProxy(int coreid, const char *ref_so)
+NemuProxy::NemuProxy(int coreid, const char *ref_so, bool enable_sdcard_diff)
 {
     void *handle = dlmopen(LM_ID_NEWLM, ref_so, RTLD_LAZY | RTLD_DEEPBIND);
     printf("Using %s for difftest", ref_so);
@@ -78,10 +78,11 @@ NemuProxy::NemuProxy(int coreid, const char *ref_so)
         assert(nemu_difftest_set_mhartid);
         nemu_difftest_set_mhartid(coreid);
     }
-
-    sdcard_init = (void (*)(const char *, const char *))dlsym(
-        handle, "difftest_sdcard_init");
-    assert(sdcard_init);
+    if (enable_sdcard_diff) {
+        sdcard_init = (void (*)(const char *, const char *))dlsym(
+            handle, "difftest_sdcard_init");
+        assert(sdcard_init);
+    }
 
     auto nemu_init = (void (*)(void))dlsym(handle, "difftest_init");
     assert(nemu_init);

--- a/src/cpu/difftest.hh
+++ b/src/cpu/difftest.hh
@@ -113,7 +113,7 @@ class RefProxy
 class NemuProxy : public RefProxy
 {
   public:
-    NemuProxy(int coreid, const char *ref_so);
+    NemuProxy(int coreid, const char *ref_so, bool enable_sdcard_diff);
 
   private:
 };

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -313,16 +313,19 @@ CPU::CPU(const BaseO3CPUParams &params)
         diff.nemu_this_pc = 0x80000000u;
         diff.cpu_id = params.cpu_id;
         warn("cpu_id set to %d\n", params.cpu_id);
-        proxy = new NemuProxy(params.cpu_id, params.difftest_ref_so.c_str());
+        proxy = new NemuProxy(
+            params.cpu_id, params.difftest_ref_so.c_str(),
+            params.nemuSDimg.size() && params.nemuSDCptBin.size());
         warn("Difftest is enabled with ref so: %s.\n",
              params.difftest_ref_so.c_str());
         proxy->regcpy(gem5RegFile, REF_TO_DUT);
         diff.dynamic_config.ignore_illegal_mem_access = false;
         diff.dynamic_config.debug_difftest = false;
         proxy->update_config(&diff.dynamic_config);
-        if (params.nemuSDimg.size() && params.nemuSDCptBin.size())
+        if (params.nemuSDimg.size() && params.nemuSDCptBin.size()) {
             proxy->sdcard_init(params.nemuSDimg.c_str(),
                                params.nemuSDCptBin.c_str());
+        }
         diff.will_handle_intr = false;
     } else {
         warn("Difftest is disabled\n");

--- a/src/dev/riscv/nemu_mmc.cc
+++ b/src/dev/riscv/nemu_mmc.cc
@@ -103,7 +103,6 @@ NemuMMC::sdcard_io_handler(uint32_t offset)
 {
     // printf("444\n");
     assert(img_fp);
-    assert(sdfp);
     int idx = offset / 4;
     switch (idx) {
         case SDCMD:


### PR DESCRIPTION
- If the cpt image is empty, do not try to init sdcard
- Don't assert sdfp when accessing sdcard

Change-Id: I608e60daad09627b12cdc33952766496640dc46d