### PR TITLE
mem: Added Chisel DB

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -143,7 +143,9 @@ def config_cache(options, system):
     for i in range(options.num_cpus):
         if options.caches:
             icache = icache_class(**_get_cache_opts('l1i', options))
-            dcache = dcache_class(**_get_cache_opts('l1d', options))
+            dcache = dcache_class(enable_chisel_db=options.enable_chisel_db,
+                                  chisel_db_file=options.chisel_db_file,
+                                  **_get_cache_opts('l1d', options))
 
             # If we have a walker cache specified, instantiate two
             # instances here

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -190,6 +190,13 @@ def addNoISAOptions(parser):
                         default="{}/build/riscv64-nemu-interpreter-so".format(
                             os.environ['NEMU_HOME']),
                         help="The shared lib file used to do difftest")
+    # ChiselDB option
+    parser.add_argument("--enable-chisel-db",
+                        action="store_true",
+                        help="enable chisel database")
+    parser.add_argument("--chisel-db-file",
+                        action="store",
+                        help="Where to save database")
 
 
 # Add common options that assume a non-NULL ISA.

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -152,6 +152,9 @@ class BaseCache(ClockedObject):
     # data cache.
     write_allocator = Param.WriteAllocator(NULL, "Write allocator")
 
+    enable_arch_db = Param.Bool(False, "Enable arch db")
+    arch_db_file = Param.String("", "Where to save arch db")
+
 class Cache(BaseCache):
     type = 'Cache'
     cxx_header = 'mem/cache/cache.hh'

--- a/src/mem/cache/SConscript
+++ b/src/mem/cache/SConscript
@@ -40,6 +40,8 @@ Source('mshr_queue.cc')
 Source('noncoherent_cache.cc')
 Source('write_queue.cc')
 Source('write_queue_entry.cc')
+Source('arch_db.cc')
+env.Append(LIBS=['sqlite3'])
 
 DebugFlag('Cache')
 DebugFlag('CacheComp')
@@ -50,6 +52,7 @@ DebugFlag('CacheVerbose')
 DebugFlag('HWPrefetch')
 DebugFlag('MSHR')
 DebugFlag('HWPrefetchQueue')
+DebugFlag('ArchDB')
 
 # CacheTags is so outrageously verbose, printing the cache's entire tag
 # array on each timing access, that you should probably have to ask for

--- a/src/mem/cache/arch_db.cc
+++ b/src/mem/cache/arch_db.cc
@@ -1,0 +1,83 @@
+
+#include "arch_db.hh"
+
+bool dump;
+sqlite3 *mem_db;
+char * zErrMsg;
+int rc;
+
+
+namespace gem5{
+
+static int callback(void *NotUsed, int argc, char **argv, char **azColName){
+  return 0;
+}
+
+void init_db_L1MissTrace() {
+  // create table
+  char sql[] = "CREATE TABLE L1MissTrace(" \
+    "ID INTEGER PRIMARY KEY AUTOINCREMENT," \
+    "PC INT NOT NULL," \
+    "SOURCE INT NOT NULL," \
+    "PADDR INT NOT NULL," \
+    "VADDR INT NOT NULL," \
+    "STAMP INT NOT NULL," \
+    "SITE TEXT);";
+  rc = sqlite3_exec(mem_db, sql, callback, 0, &zErrMsg);
+  if (rc != SQLITE_OK) {
+    fatal("SQL error: %s\n", zErrMsg);
+  } else {
+    warn("Table created: L1MissTrace\n");
+  }
+}
+
+void L1MissTrace_write(
+  uint64_t pc,
+  uint64_t source,
+  uint64_t paddr,
+  uint64_t vaddr,
+  uint64_t stamp,
+  const char * site
+) {
+  if (!dump) return;
+  char sql[512];
+  sprintf(sql,
+    "INSERT INTO L1MissTrace(PC,SOURCE,PADDR,VADDR, STAMP, SITE) " \
+    "VALUES(%ld, %ld, %ld, %ld, %ld, '%s');",
+    pc,source,paddr,vaddr, stamp, site
+  );
+  rc = sqlite3_exec(mem_db, sql, callback, 0, &zErrMsg);
+  if (rc != SQLITE_OK) {
+    fatal("SQL error: %s\n", zErrMsg);
+  };
+}
+
+void init_db(bool en){
+  dump = en;
+  if (!en) return;
+  rc = sqlite3_open(":memory:", &mem_db);
+  if (rc) {
+    fatal("Can't open database: %s\n", sqlite3_errmsg(mem_db));
+  }
+  init_db_L1MissTrace();
+}
+
+void save_db(const char *zFilename) {
+  warn("saving memdb to %s ...\n", zFilename);
+  sqlite3 *disk_db;
+  sqlite3_backup *pBackup;
+  rc = sqlite3_open(zFilename, &disk_db);
+  if (rc == SQLITE_OK){
+    pBackup = sqlite3_backup_init(disk_db, "main", mem_db, "main");
+    if (pBackup){
+      (void)sqlite3_backup_step(pBackup, -1);
+      (void)sqlite3_backup_finish(pBackup);
+    }
+    rc = sqlite3_errcode(disk_db);
+  }
+  sqlite3_close(disk_db);
+}
+
+
+} // namespace gem5
+

--- a/src/mem/cache/arch_db.hh
+++ b/src/mem/cache/arch_db.hh
@@ -1,0 +1,31 @@
+
+#ifndef __MEM_CACHE_CHISEL_DB_H__
+#define __MEM_CACHE_CHISEL_DB_H__
+
+#include <sqlite3.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "base/logging.hh"
+
+namespace gem5{
+
+
+void init_db(bool en);
+void save_db(const char * filename);
+void L1MissTrace_write(
+  uint64_t pc,
+  uint64_t source,
+  uint64_t paddr,
+  uint64_t vaddr,
+  uint64_t stamp,
+  const char * site
+);
+
+} // namesapce gem5
+
+#endif

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -47,12 +47,14 @@
 
 #include "base/compiler.hh"
 #include "base/logging.hh"
+#include "debug/ArchDB.hh"
 #include "debug/Cache.hh"
 #include "debug/CacheComp.hh"
 #include "debug/CachePort.hh"
 #include "debug/CacheRepl.hh"
 #include "debug/CacheVerbose.hh"
 #include "debug/HWPrefetch.hh"
+#include "mem/cache/arch_db.hh"
 #include "mem/cache/compressors/base.hh"
 #include "mem/cache/mshr.hh"
 #include "mem/cache/prefetch/base.hh"
@@ -61,6 +63,7 @@
 #include "mem/cache/tags/super_blk.hh"
 #include "params/BaseCache.hh"
 #include "params/WriteAllocator.hh"
+#include "sim/core.hh"
 #include "sim/cur_tick.hh"
 
 namespace gem5
@@ -109,6 +112,7 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       noTargetMSHR(nullptr),
       missCount(p.max_miss_count),
       addrRanges(p.addr_ranges.begin(), p.addr_ranges.end()),
+      enableArchDB(p.enable_arch_db),
       system(p.system),
       stats(*this)
 {
@@ -134,6 +138,14 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
         "Compressed cache %s does not have a compression algorithm", name());
     if (compressor)
         compressor->setCache(this);
+
+    if (enableArchDB){
+        fatal_if(p.arch_db_file == "" || p.arch_db_file == "None",
+                 "Arch db file path is not given!");
+        init_db(enableArchDB);
+        registerExitCallback([p](){ save_db(p.arch_db_file.c_str()); });
+    }
+
 }
 
 BaseCache::~BaseCache()
@@ -457,6 +469,24 @@ BaseCache::recvTimingReq(PacketPtr pkt)
 
         handleTimingReqHit(pkt, blk, request_time);
     } else {
+        // ArchDB: for now we only track packet which has PC
+        // and is normal load/store
+        // TODO: for now there are some bugs in vaddrs
+        if (enableArchDB && pkt->req->hasPC() &&
+            (pkt->isRead() || pkt->isWrite())){
+            Addr pc = pkt->req->getPC();
+            Addr vaddr = pkt->req->getVaddr();
+            Addr paddr = pkt->req->getPaddr();
+            uint8_t source = pkt->isRead() ? 0 : 1;
+            uint64_t curCycle = ticksToCycles(curTick());
+            DPRINTF(ArchDB,
+                "ArchDB: insert record [%x %d %x %x %x %s]\n",
+                pc, source, paddr, vaddr, curCycle, this->name()
+            );
+            L1MissTrace_write(
+              pc, source, paddr, vaddr, curCycle, this->name().c_str());
+        }
+
         handleTimingReqMiss(pkt, blk, forward_time, request_time);
 
         ppMiss->notify(pkt);

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -981,6 +981,9 @@ class BaseCache : public ClockedObject
      * Normally this is all possible memory addresses. */
     const AddrRangeList addrRanges;
 
+    /** ArchDB */
+    bool enableArchDB;
+
   public:
     /** System we are currently operating in. */
     System *system;


### PR DESCRIPTION
This allows dcache dump its miss traces into a sqlite3 database.

Change-Id: I22b486d97ee6e3b96d647969d983d327cde31a7f
- usage: --enable-chisel-db --chisel-db-file=file_path.db
- TODO: maybe we should rename chisel-db to arch-db?