### PR TITLE
Passing raw binary cpt to initiate memory

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -567,8 +567,8 @@ def addFSOptions(parser):
                       default="",
                       help="The path of generic risc-v checkpoint restorer")
 
-    parser.add_argument("--raw-bbl", action= "store_true",
-                        help = "The kernel/bbl/app is not elf but binary")
+    parser.add_argument("--raw-cpt", action= "store_true",
+                        help = "The checkpoint file is not gz but binary")
 
     parser.add_argument("--mmc-img", action="store", type=str,
                         default=None, help="The path of mmc img")

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -131,10 +131,9 @@ def build_test_system(np):
         if args.generic_rv_cpt is not None :
             test_sys.workload.bootloader = ''
             test_sys.workload.xiangshan_cpt = True
-        else :
-            test_sys.workload.bootloader = args.kernel
-            test_sys.workload.xiangshan_cpt = False
-            if args.xiangshan_system and args.raw_bbl:
+            if args.xiangshan_system and args.raw_cpt:
+                test_sys.map_to_raw_cpt = True
+                print('Using raw bbl', args.kernel)
                 test_sys.workload.raw_bootloader = True
 
     elif args.kernel is not None:

--- a/src/arch/riscv/bare_metal/fs_workload.cc
+++ b/src/arch/riscv/bare_metal/fs_workload.cc
@@ -31,6 +31,7 @@
 
 #include "arch/riscv/faults.hh"
 #include "base/loader/object_file.hh"
+#include "debug/MemoryAccess.hh"
 #include "sim/system.hh"
 #include "sim/workload.hh"
 
@@ -83,11 +84,7 @@ BareMetal::initState()
             warn_if(!bootloader->buildImage().write(system->physProxy),
                     "Could not load sections to memory.");
         } else {
-            auto img = bootloader->buildImage();
-            assert(img.segments().size() == 1);
-            img.setSegAddr(0, _resetVect);
-            warn_if(!img.write(system->physProxy),
-                    "Could not load raw binary to memory.");
+            warn("Using raw cpt binary and mmap to it, no bootloader loaded.");
         }
     }
 

--- a/src/base/loader/image_file_data.cc
+++ b/src/base/loader/image_file_data.cc
@@ -104,6 +104,7 @@ doGzipLoad(int fd)
 
 ImageFileData::ImageFileData(const std::string &fname)
 {
+    inform("Loading file %s", fname);
     _filename = fname;
 
     // Open the file.
@@ -123,9 +124,15 @@ ImageFileData::ImageFileData(const std::string &fname)
     fatal_if(off < 0, "Failed to determine size of file %s.\n", fname);
     _len = static_cast<size_t>(off);
 
+    inform("File size is %d bytes", _len);
+
     // Mmap the whole shebang.
     _data = (uint8_t *)mmap(NULL, _len, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
+
+    inform("First 4 bytes are 0x%x 0x%x 0x%x 0x%x\n",
+           _data[0], _data[1], _data[2], _data[3]);
+    inform("Mapped start address is %p, %#lx", _data, (unsigned long)_data);
 
     panic_if(_data == MAP_FAILED, "Failed to mmap file %s.\n", fname);
 }

--- a/src/base/loader/memory_image.cc
+++ b/src/base/loader/memory_image.cc
@@ -27,6 +27,8 @@
  */
 
 #include "base/loader/memory_image.hh"
+#include "base/trace.hh"
+#include "debug/MemoryAccess.hh"
 #include "mem/port_proxy.hh"
 
 namespace gem5
@@ -41,9 +43,11 @@ MemoryImage::writeSegment(const Segment &seg, const PortProxy &proxy) const
 {
     if (seg.size != 0) {
         if (seg.data) {
+            DPRINTF(MemoryAccess, "Writing segment %s to memory %#lx, size: %#lx\n", seg.name, seg.base, seg.size);
             proxy.writeBlob(seg.base, seg.data, seg.size);
         } else {
             // no image: must be bss
+            DPRINTF(MemoryAccess, "Clearing bss at memory %#lx\n", seg.base);
             proxy.memsetBlob(seg.base, 0, seg.size);
         }
     }
@@ -54,8 +58,12 @@ bool
 MemoryImage::write(const PortProxy &proxy) const
 {
     for (auto &seg: _segments)
-        if (!writeSegment(seg, proxy))
+        if (!writeSegment(seg, proxy)) {
             return false;
+        } else {
+            DPRINTF(MemoryAccess, "Wrote segment %s, data addr: %#lx",
+                    seg.name, (uint64_t)seg.data);
+        }
     return true;
 }
 

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1309,7 +1309,8 @@ CPU::difftestStep(const DynInstPtr &inst)
             hasCommit = true;
             readGem5Regs();
             gem5RegFile[DIFFTEST_THIS_PC] = inst->pcState().instAddr();
-            fprintf(stderr, "Will start memcpy to NEMU\n");
+            fprintf(stderr, "Will start memcpy to NEMU from %#lx, size=%lu\n",
+                    (uint64_t)pmemStart, pmemSize);
             proxy->memcpy(0x80000000u, pmemStart + pmemSize * diff.cpu_id,
                           pmemSize, DUT_TO_REF);
             fprintf(stderr, "Will start regcpy to NEMU\n");

--- a/src/mem/abstract_mem.cc
+++ b/src/mem/abstract_mem.cc
@@ -112,6 +112,8 @@ AbstractMemory::setBackingStore(uint8_t* pmem_addr)
     backdoor.ptr(range.interleaved() ? nullptr : pmem_addr);
 
     pmemAddr = pmem_addr;
+
+    DPRINTF(MemoryAccess, "Backing store set to %#lx\n", (uint64_t)pmemAddr);
 }
 
 AbstractMemory::MemStats::MemStats(AbstractMemory &_mem)
@@ -393,6 +395,8 @@ AbstractMemory::access(PacketPtr pkt)
     assert(pkt->getAddrRange().isSubset(range));
 
     uint8_t *host_addr = toHostAddr(pkt->getAddr());
+    DPRINTF(MemoryAccess, "guest addr %#lx -> host_addr %#lx\n", pkt->getAddr(),
+            (uint64_t) host_addr);
 
     if (pkt->cmd == MemCmd::SwapReq) {
         if (pkt->isAtomicOp()) {

--- a/src/mem/physical.hh
+++ b/src/mem/physical.hh
@@ -175,6 +175,8 @@ class PhysicalMemory : public Serializable
 
     std::string xsCptPath;
 
+    bool mapToRawCpt{false};
+
     /**
      * Create the memory region providing the backing store for a
      * given address range that corresponds to a set of memories in
@@ -201,6 +203,7 @@ class PhysicalMemory : public Serializable
                    bool restore_from_gcpt,
                    const std::string& gcpt_restorer_path,
                    const std::string&gcpt_path,
+                   bool map_to_raw_cpt,
                    bool auto_unlink_shared_backstore);
 
     /**

--- a/src/mem/port_proxy.cc
+++ b/src/mem/port_proxy.cc
@@ -56,7 +56,7 @@ PortProxy::PortProxy(const RequestPort &port, unsigned int cache_line_size) :
 
 void
 PortProxy::readBlobPhys(Addr addr, Request::Flags flags,
-                        void *p, int size) const
+                        void *p, size_t size) const
 {
     for (ChunkGenerator gen(addr, size, _cacheLineSize); !gen.done();
          gen.next()) {
@@ -73,7 +73,7 @@ PortProxy::readBlobPhys(Addr addr, Request::Flags flags,
 
 void
 PortProxy::writeBlobPhys(Addr addr, Request::Flags flags,
-                         const void *p, int size) const
+                         const void *p, size_t size) const
 {
     for (ChunkGenerator gen(addr, size, _cacheLineSize); !gen.done();
          gen.next()) {
@@ -90,7 +90,7 @@ PortProxy::writeBlobPhys(Addr addr, Request::Flags flags,
 
 void
 PortProxy::memsetBlobPhys(Addr addr, Request::Flags flags,
-                          uint8_t v, int size) const
+                          uint8_t v, size_t size) const
 {
     // quick and dirty...
     uint8_t *buf = new uint8_t[size];

--- a/src/mem/port_proxy.hh
+++ b/src/mem/port_proxy.hh
@@ -120,19 +120,19 @@ class PortProxy : FunctionalRequestProtocol
      * Read size bytes memory at physical address and store in p.
      */
     void readBlobPhys(Addr addr, Request::Flags flags,
-                      void *p, int size) const;
+                      void *p, size_t size) const;
 
     /**
      * Write size bytes from p to physical address.
      */
     void writeBlobPhys(Addr addr, Request::Flags flags,
-                       const void *p, int size) const;
+                       const void *p, size_t size) const;
 
     /**
      * Fill size bytes starting at physical addr with byte value val.
      */
     void memsetBlobPhys(Addr addr, Request::Flags flags,
-                        uint8_t v, int size) const;
+                        uint8_t v, size_t size) const;
 
 
 
@@ -143,7 +143,7 @@ class PortProxy : FunctionalRequestProtocol
      * Returns true on success and false on failure.
      */
     virtual bool
-    tryReadBlob(Addr addr, void *p, int size) const
+    tryReadBlob(Addr addr, void *p, size_t size) const
     {
         readBlobPhys(addr, 0, p, size);
         return true;
@@ -154,7 +154,7 @@ class PortProxy : FunctionalRequestProtocol
      * Returns true on success and false on failure.
      */
     virtual bool
-    tryWriteBlob(Addr addr, const void *p, int size) const
+    tryWriteBlob(Addr addr, const void *p, size_t size) const
     {
         writeBlobPhys(addr, 0, p, size);
         return true;
@@ -165,7 +165,7 @@ class PortProxy : FunctionalRequestProtocol
      * Returns true on success and false on failure.
      */
     virtual bool
-    tryMemsetBlob(Addr addr, uint8_t val, int size) const
+    tryMemsetBlob(Addr addr, uint8_t val, size_t size) const
     {
         memsetBlobPhys(addr, 0, val, size);
         return true;
@@ -179,7 +179,7 @@ class PortProxy : FunctionalRequestProtocol
      * Same as tryReadBlob, but insists on success.
      */
     void
-    readBlob(Addr addr, void *p, int size) const
+    readBlob(Addr addr, void *p, size_t size) const
     {
         if (!tryReadBlob(addr, p, size))
             fatal("readBlob(%#x, ...) failed", addr);
@@ -189,7 +189,7 @@ class PortProxy : FunctionalRequestProtocol
      * Same as tryWriteBlob, but insists on success.
      */
     void
-    writeBlob(Addr addr, const void *p, int size) const
+    writeBlob(Addr addr, const void *p, size_t size) const
     {
         if (!tryWriteBlob(addr, p, size))
             fatal("writeBlob(%#x, ...) failed", addr);
@@ -199,7 +199,7 @@ class PortProxy : FunctionalRequestProtocol
      * Same as tryMemsetBlob, but insists on success.
      */
     void
-    memsetBlob(Addr addr, uint8_t v, int size) const
+    memsetBlob(Addr addr, uint8_t v, size_t size) const
     {
         if (!tryMemsetBlob(addr, v, size))
             fatal("memsetBlob(%#x, ...) failed", addr);

--- a/src/mem/translating_port_proxy.cc
+++ b/src/mem/translating_port_proxy.cc
@@ -86,7 +86,7 @@ TranslatingPortProxy::tryOnBlob(BaseMMU::Mode mode, TranslationGenPtr gen,
 }
 
 bool
-TranslatingPortProxy::tryReadBlob(Addr addr, void *p, int size) const
+TranslatingPortProxy::tryReadBlob(Addr addr, void *p, size_t size) const
 {
     constexpr auto mode = BaseMMU::Read;
     return tryOnBlob(mode, _tc->getMMUPtr()->translateFunctional(
@@ -99,7 +99,7 @@ TranslatingPortProxy::tryReadBlob(Addr addr, void *p, int size) const
 
 bool
 TranslatingPortProxy::tryWriteBlob(
-        Addr addr, const void *p, int size) const
+        Addr addr, const void *p, size_t size) const
 {
     constexpr auto mode = BaseMMU::Write;
     return tryOnBlob(mode, _tc->getMMUPtr()->translateFunctional(
@@ -111,7 +111,7 @@ TranslatingPortProxy::tryWriteBlob(
 }
 
 bool
-TranslatingPortProxy::tryMemsetBlob(Addr addr, uint8_t v, int size) const
+TranslatingPortProxy::tryMemsetBlob(Addr addr, uint8_t v, size_t size) const
 {
     constexpr auto mode = BaseMMU::Write;
     return tryOnBlob(mode, _tc->getMMUPtr()->translateFunctional(

--- a/src/mem/translating_port_proxy.hh
+++ b/src/mem/translating_port_proxy.hh
@@ -77,16 +77,16 @@ class TranslatingPortProxy : public PortProxy
 
     /** Version of tryReadblob that translates virt->phys and deals
       * with page boundries. */
-    bool tryReadBlob(Addr addr, void *p, int size) const override;
+    bool tryReadBlob(Addr addr, void *p, size_t size) const override;
 
     /** Version of tryWriteBlob that translates virt->phys and deals
       * with page boundries. */
-    bool tryWriteBlob(Addr addr, const void *p, int size) const override;
+    bool tryWriteBlob(Addr addr, const void *p, size_t size) const override;
 
     /**
      * Fill size bytes starting at addr with byte value val.
      */
-    bool tryMemsetBlob(Addr address, uint8_t  v, int size) const override;
+    bool tryMemsetBlob(Addr address, uint8_t  v, size_t size) const override;
 };
 
 } // namespace gem5

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -132,4 +132,5 @@ class System(SimObject):
     # Checkpoint image file for Xiangshan
     restore_from_gcpt = Param.Bool(False, "Restoring from Xiangshan gcpt")
     gcpt_file = Param.String("", "Xiangshan checkpoint image file")
+    map_to_raw_cpt = Param.Bool(False, "Map physical memory to raw cpt with mmap")
     gcpt_restorer_file = Param.String("", "GCPT restorer image file")

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -183,7 +183,7 @@ System::System(const Params &p)
       workload(p.workload),
       physmem(name() + ".physmem", p.memories, p.mmap_using_noreserve,
               p.shared_backstore, p.restore_from_gcpt, p.gcpt_restorer_file,
-              p.gcpt_file, p.auto_unlink_shared_backstore),
+              p.gcpt_file, p.map_to_raw_cpt, p.auto_unlink_shared_backstore),
       ShadowRomRanges(p.shadow_rom_ranges.begin(),
                       p.shadow_rom_ranges.end()),
       memoryMode(p.mem_mode),
@@ -552,7 +552,7 @@ void System::initState()
     SimObject::initState();
 
     if (physmem.tryRestoreFromXSCpt()) {
-        inform("Restoring from Generic Checkpoint\n");
+        inform("Restoring from Xiangshan RISC-V Checkpoint\n");
     }
 }
 


### PR DESCRIPTION
Usage:
- For a gz cpt: --generic-rv-cpt=cpt.gz
- For a raw binary cpt: --generic-rv-cpt=cpt.bin --raw-cpt

About raw binary cpt:
- We only allow to mmap to the cpt.bin to accelorate init stage
- We bypass the imageData of GEM5 in a dirty way, because it initiate the physical memory with the pmem proxy which runs slowly and always (unnecessarily) write to zero pages to break COW

Other changes:
- Fix the parameter type of ImageData Read/Write/Clear: using size_t instead of int to allow objects larger than 4GB