### PR TITLE
configs: Make L1D and L2 writeback clean blocks

### DIFF
--- a/configs/common/Caches.py
+++ b/configs/common/Caches.py
@@ -68,6 +68,8 @@ class L1_DCache(L1Cache):
     data_latency = 1
     response_latency = 1
     mshrs = 16
+    # always writeback clean when lower level is exclusive
+    writeback_clean = True
 
 class L2Cache(Cache):
     tag_latency = 2
@@ -77,6 +79,8 @@ class L2Cache(Cache):
     tgts_per_mshr = 20
     clusivity='mostly_excl'
     prefetch_on_access = True
+    # always writeback clean when lower level is exclusive
+    writeback_clean = True
 
 class L3Cache(Cache):
     tag_latency = 2
@@ -85,6 +89,7 @@ class L3Cache(Cache):
     mshrs = 64
     tgts_per_mshr = 20
     clusivity='mostly_excl'
+    writeback_clean = False
 
 class IOCache(Cache):
     assoc = 8


### PR DESCRIPTION
- When modeling execlusive cache in Ln, L(n-1) should always writeback clean blocks