### PR TITLE
cpu-o3: Fix invalid iter de-reference when squashing inst

### DIFF
--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -367,10 +367,6 @@ ROB::doSquash(ThreadID tid)
 
         // printf("[ROB] squash seqNum %ld\n", (*squashIt[tid])->seqNum);
 
-        instList[tid].erase(squashIt[tid]);
-        --numInstsInROB;
-        --threadEntries[tid];
-
         (*squashIt[tid])->clearInROB();
         // head_inst->setCommitted();
         cpu->removeFrontInst(*squashIt[tid]);
@@ -392,7 +388,10 @@ ROB::doSquash(ThreadID tid)
         if ((*squashIt[tid]) == (*tail_thread))
             robTailUpdate = true;
 
-        squashIt[tid]--;
+        auto delIt = squashIt[tid]--;
+        instList[tid].erase(delIt);
+        --numInstsInROB;
+        --threadEntries[tid];
     }
 
 


### PR DESCRIPTION
Following segmentation fault was reported when running gem5 as library.
It was caused by move&de-reference `squashIt[tid]` iter of std::list
after erase() was performed on it. The iter of std::list should not be used after erase().

```
Program received signal SIGSEGV, Segmentation fault.
gem5::o3::ROB::doSquash (this=0x555555a459c8, tid=0) at build/RISCV/cpu/o3/rob.cc:400
400         if ((*squashIt[tid])->seqNum <= squashedSeqNum[tid]) {
(gdb) bt
#0  gem5::o3::ROB::doSquash (this=0x555555a459c8, tid=0) at build/RISCV/cpu/o3/rob.cc:400
#1  0x00007ffff6ec3829 in gem5::o3::ROB::squash (this=0x555555a459c8, squash_num=8, tid=0) at build/RISCV/cpu/o3/rob.cc:530
#2  0x00007ffff6dcfc4b in gem5::o3::Commit::commit (this=0x555555a449f8) at build/RISCV/cpu/o3/commit.cc:909
#3  0x00007ffff6dce340 in gem5::o3::Commit::tick (this=0x555555a449f8) at build/RISCV/cpu/o3/commit.cc:704
#4  0x00007ffff6df01c2 in gem5::o3::CPU::tick (this=0x555555a40d00) at build/RISCV/cpu/o3/cpu.cc:483
...
```