### PR TITLE
Fix a compile error

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1261,7 +1261,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *e3 = NULL;
     TlbEntry *e2 = NULL;
     TlbEntry *e1 = NULL;
-    Addr paddr;
+    Addr paddr = 0;
     Fault fault;
     STATUS status = tc->readMiscReg(MISCREG_STATUS);
     PrivilegeMode pmode = getMemPriv(tc, mode);


### PR DESCRIPTION
modify tlb.cc to fix a compile error when using gcc 11.4

```
In file included from build/RISCV/arch/generic/pcstate.hh:49,
                 from build/RISCV/arch/generic/isa.hh:45,
                 from build/RISCV/arch/riscv/isa.hh:39,
                 from build/RISCV/arch/riscv/tlb.hh:38,
                 from build/RISCV/arch/riscv/tlb.cc:32:
build/RISCV/arch/riscv/tlb.cc: In member function ‘gem5::Fault gem5::RiscvISA::TLB::doTranslate(const RequestPtr&, gem5::ThreadContext*, gem5::BaseMMU::Translation*, gem5::BaseMMU::Mode, bool&)’:
build/RISCV/base/trace.hh:188:54: error: ‘paddr’ may be used uninitialized [-Werror=maybe-uninitialized]
  188 |         ::gem5::Trace::getDebugLogger()->dprintf_flag(   \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
  189 |             ::gem5::curTick(), name(), #x, __VA_ARGS__); \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
build/RISCV/arch/riscv/tlb.cc:1436:9: note: in expansion of macro ‘DPRINTF’
 1436 |         DPRINTF(TLB, "translate(vpn=%#x, asid=%#x): %#x pc%#x\n", vaddr,
      |         ^~~~~~~
build/RISCV/base/trace.hh:75:10: note: by argument 8 of type ‘const long unsigned int&’ to ‘void gem5::Trace::Logger::dprintf_flag(gem5::Tick, const string&, const string&, const char*, const Args& ...) [with Args = {long unsigned int, gem5::BitfieldType<gem5::bitfield_backend::Unsigned<long unsigned int, 59, 44> >, long unsigned int, long unsigned int}]’ declared here
   75 |     void dprintf_flag(Tick when, const std::string &name,
      |          ^~~~~~~~~~~~
build/RISCV/arch/riscv/tlb.cc:1264:10: note: ‘paddr’ declared here
 1264 |     Addr paddr;
      |          ^~~~~
```