### PR TITLE
arch-riscv: Add Zicond instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1040,6 +1040,9 @@ decode QUADRANT default Unknown::unknown() {
                             Rd = Rs1/Rs2;
                         }
                     }}, IntDivOp);
+                    0x7: czero_eqz({{
+                        Rd = Rs2 == 0 ? 0 : Rs1;
+                    }});
                     0x20: sra({{
                         Rd_sd = Rs1_sd >> Rs2<5:0>;
                     }});
@@ -1093,6 +1096,9 @@ decode QUADRANT default Unknown::unknown() {
                     }}, IntDivOp);
                     0x5: maxu({{
                         Rd = Rs1 > Rs2 ? Rs1 : Rs2;
+                    }});
+                    0x7: czero_nez({{
+                        Rd = Rs2 != 0 ? 0 : Rs1;
                     }});
                     0x20: andn({{
                         Rd = Rs1 & (~Rs2);


### PR DESCRIPTION
This PR added RISC-V Integer Conditional Operations Extension, which is in the RVA23U64 Profile Mandatory Base. And the performance of conditional move instructions in micro-architecture is an interesting point to explore.

Zicond instructions added: czero.eqz, czero.nez

Changes based on spec:
https://github.com/riscvarchive/riscv-zicond/releases/download/v1.0.1/riscv-zicond_1.0.1.pdf

The same PR also on gem5 upstream: https://github.com/gem5/gem5/pull/1078