### PR TITLE
cpu-o3: fix gem5.fast compilation

### DIFF
--- a/src/cpu/golden_global_mem.cc
+++ b/src/cpu/golden_global_mem.cc
@@ -103,6 +103,7 @@ GoldenGloablMem::pmemRead(uint64_t addr, int len)
             return *(uint64_t *)p;
         default:
             assert(0);
+            return 0;
     }
 }
 
@@ -125,6 +126,7 @@ GoldenGloablMem::pmemWrite(Addr addr, uint64_t data, int len)
             return;
         default:
             assert(0);
+            return;
     }
 }
 


### PR DESCRIPTION
In gem5.fast build, macro `assert` is removed, thus causing the compiler to complain about "not all branches have returned".

Change-Id: If865d0a45c2d467f374a70523c2806ccb4b5c51e