### PR TITLE
arch-riscv: Do not set mstatus.VS at boot

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -263,7 +263,7 @@ void ISA::clear()
     miscRegFile[MISCREG_IMPID] = 0;
     if (FullSystem) {
         // Xiangshan assume machine boots with FS off
-        miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET) | (1ULL <<VS_OFFSET);
+        miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET);
     } else {
         // SE assumes process starts with FS on
         miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET) |


### PR DESCRIPTION
To align with NEMU and XiangShan RTL to prevent difftest errors, we keep the VS=0 on mstatus at boot.

Change-Id: I1cf440074424787bc63f7d68740ddb1b32e2f526