### PR TITLE
mem-cache: findBlock shouldn't assume blk can always be found

### DIFF
--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1521,7 +1521,7 @@ public:
 
     const uint8_t* findBlock(Addr addr, bool is_secure) const override {
         auto blk = tags->findBlock(addr, is_secure);
-        return blk->data;
+        return blk ? blk->data: nullptr;
     }
 };
 


### PR DESCRIPTION
- CDP uses findBlock to get content of cache block, and CDP is speculative: CDP is placed in L2 and can be notified by L1 hits. But GEM5 employs **mostly**-inclusive cache, where an L1 hit does not guarantees L2 hit. So a CDP notification might misses in L2.
- To avoid segmentation fault when blk is not found, we always check whether blk is null

Change-Id: Ic0b20109ea42621cbf74c184daa00b0633123384