### PR TITLE
cpu-o3, mem-ruby: Enhance goldenmem

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -232,7 +232,7 @@ class CHI_L1Controller(CHI_Cache_Controller):
     Default parameters for a L1 Cache controller
     """
 
-    def __init__(self, ruby_system, sequencer, cache, prefetcher, is_dcache=False):
+    def __init__(self, ruby_system, sequencer, cache, prefetcher, is_dcache=False, enable_difftest=False):
         super().__init__(ruby_system)
         self.sequencer = sequencer
         self.cache = cache
@@ -256,6 +256,7 @@ class CHI_L1Controller(CHI_Cache_Controller):
         self.dealloc_backinv_unique = False
         self.dealloc_backinv_shared = False
         self.is_dcache = is_dcache
+        self.enable_difftest = enable_difftest
         # Some reasonable default TBE params
         self.number_of_TBEs = 32+8
         self.number_of_repl_TBEs = 16
@@ -501,7 +502,7 @@ class CHI_RNF(CHI_Node):
                 version=Versions.getSeqId(), ruby_system=ruby_system
             )
             cpu.data_sequencer = RubySequencer(
-                version=Versions.getSeqId(), ruby_system=ruby_system
+                version=Versions.getSeqId(), ruby_system=ruby_system, is_data_sequencer=True
             )
 
             self._seqs.append(
@@ -531,7 +532,7 @@ class CHI_RNF(CHI_Node):
             )
 
             cpu.l1d = CHI_L1Controller(
-                ruby_system, cpu.data_sequencer, l1d_cache, l1d_pf, is_dcache=True
+                ruby_system, cpu.data_sequencer, l1d_cache, l1d_pf, is_dcache=True, enable_difftest = True
             )
 
             cpu.inst_sequencer.dcache = NULL

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -736,6 +736,7 @@ class BaseCPU : public ClockedObject
         bool curInstStrictOrdered{false};
         gem5::Addr physEffAddr;
         gem5::Addr effSize;
+        uint8_t *goldenValue;
         uint64_t amoOldGoldenValue;
         // Register address causing difftest error
         bool errorRegsValue[96];// 32 regs + 32fprs +32 vprs
@@ -797,6 +798,8 @@ class BaseCPU : public ClockedObject
     uint8_t *getGoldenMemPtr() { return goldenMemPtr; }
 
     gem5::GoldenGloablMem *goldenMemManager() { return _goldenMemManager; }
+
+    void checkL1DRefill(Addr paddr, const uint8_t *refill_data, size_t size);
 };
 
 } // namespace gem5

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1335,6 +1335,7 @@ Commit::diffInst(ThreadID tid, const DynInstPtr &inst) {
         inst->strictlyOrdered();
     cpu->diffInfo.physEffAddr = inst->physEffAddr;
     cpu->diffInfo.effSize = inst->effSize;
+    cpu->diffInfo.goldenValue = inst->getGolden();
     cpu->difftestStep(tid, inst->seqNum);
 }
 

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -387,6 +387,9 @@ class DynInst : public ExecContext, public RefCounted
     ssize_t sqIdx = -1;
     typename LSQUnit::SQIterator sqIt;
 
+    /** If load data is from cache then it must be golden */
+    uint8_t goldenData[8] = {0};
+
     int pf_source  = -1; // if load cache line is prefetched
     /////////////////////// TLB Miss //////////////////////
     /**
@@ -1402,6 +1405,12 @@ class DynInst : public ExecContext, public RefCounted
     {
         return pc->as<RiscvISA::PCState>().branching();
     }
+
+    /** set golden */
+    void setGolden(uint8_t *golden) { memcpy(goldenData, golden, effSize); }
+
+    /** get golden */
+    uint8_t *getGolden() { return goldenData; }
 };
 
 } // namespace o3

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -101,6 +101,7 @@ class LSQ
         virtual bool recvTimingResp(PacketPtr pkt);
         virtual void recvTimingSnoopReq(PacketPtr pkt);
         virtual void recvFunctionalCustomSignal(PacketPtr pkt, int sig);
+        virtual void* recvGetCPUPtr();
 
         virtual void
         recvFunctionalSnoop(PacketPtr pkt)
@@ -260,6 +261,7 @@ class LSQ
         uint32_t _numOutstandingPackets;
         AtomicOpFunctorPtr _amo_op;
         bool _hasStaleTranslation;
+        bool _sbufferBypass;
 
         struct FWDPacket
         {
@@ -916,6 +918,8 @@ class LSQ
     void recvTimingSnoopReq(PacketPtr pkt);
 
     void recvFunctionalCustomSignal(PacketPtr pkt, int sig);
+
+    void* getCPUPtr();
 
     Fault pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
                       unsigned int size, Addr addr, Request::Flags flags,

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -556,6 +556,8 @@ class LSQUnit
     BaseMMU *getMMUPtr();
 
   private:
+    System *system;
+
     /** Pointer to the CPU. */
     CPU *cpu;
 

--- a/src/cpu/utils.hh
+++ b/src/cpu/utils.hh
@@ -94,6 +94,18 @@ isAnyActiveElement(const std::vector<bool>::const_iterator& it_start,
     return (it_tmp != it_end);
 }
 
+inline std::string
+goldenDiffStr(uint8_t *dut_ptr, uint8_t* golden_ptr, size_t size) {
+    assert(size <= 8);
+    uint64_t dut_value = 0;
+    uint64_t golden_value = 0;
+    memcpy(&dut_value, dut_ptr, size);
+    memcpy(&golden_value, golden_ptr, size);
+    std::stringstream ss;
+    ss << std::hex << "Dut value: " << dut_value << " , golden value: " << golden_value << " ";
+    return ss.str();
+}
+
 } // namespace gem5
 
 #endif // __CPU_UTILS_HH__

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -325,6 +325,16 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
         }
     }
 
+    void* sendGetCPUPtr()
+    {
+        try {
+            warn("Peer is %s\n", _requestPort->name());
+            return FunctionalResponseProtocol::sendGetCPUPtr(_requestPort);
+        } catch (UnboundPortException) {
+            reportUnbound();
+        }
+    }
+
   public:
     /* The atomic protocol. */
 

--- a/src/mem/protocol/functional.cc
+++ b/src/mem/protocol/functional.cc
@@ -59,6 +59,12 @@ void FunctionalRequestProtocol::sendFunctionalCustomSignal(
     return peer->recvFunctionalCustomSignal(pkt, sig);
 }
 
+void* FunctionalRequestProtocol::recvGetCPUPtr()
+{
+    panic("recvGetCPUPtr not implemented\n");
+    return nullptr;
+}
+
 /* The response protocol. */
 
 void
@@ -73,6 +79,11 @@ void FunctionalResponseProtocol::sendFunctionalCustomSignal(
     FunctionalRequestProtocol *peer, PacketPtr pkt, int sig) const
 {
     return peer->recvFunctionalCustomSignal(pkt, sig);
+}
+
+void* FunctionalResponseProtocol::sendGetCPUPtr(FunctionalRequestProtocol *peer) const
+{
+    return peer->recvGetCPUPtr();
 }
 
 } // namespace gem5

--- a/src/mem/protocol/functional.hh
+++ b/src/mem/protocol/functional.hh
@@ -73,6 +73,8 @@ class FunctionalRequestProtocol
      * Receive a functional custom signals
      */
     virtual void recvFunctionalCustomSignal(PacketPtr pkt, int sig) {};
+
+    virtual void* recvGetCPUPtr();
 };
 
 class FunctionalResponseProtocol
@@ -95,6 +97,8 @@ class FunctionalResponseProtocol
     virtual void recvFunctional(PacketPtr pkt) = 0;
 
     void sendFunctionalCustomSignal(FunctionalRequestProtocol *peer, PacketPtr pkt, int sig) const;
+
+    void* sendGetCPUPtr(FunctionalRequestProtocol *peer) const;
 
     /**
      * Receive a functional custom signals

--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -123,6 +123,7 @@ structure (Sequencer, external = "yes") {
                     Cycles, Cycles, Cycles);
 
   void notifyMissCallback(Addr, bool, bool);
+  void checkL1DRefill(Addr, DataBlock, WriteMask);
   void TBEFullCancel(Addr);
 
   void writeCallback(Addr, DataBlock);

--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -2157,6 +2157,9 @@ action(Receive_ReqDataResp, desc="") {
         tbe.dataBlkValid.clear();
       }
       tbe.dataBlk.copyPartial(in_msg.dataBlk, in_msg.bitMask);
+      if (is_dcache && enable_difftest) {
+        sequencer.checkL1DRefill(tbe.addr, in_msg.dataBlk, in_msg.bitMask);
+      }
       assert(tbe.dataBlkValid.isOverlap(in_msg.bitMask) == false);
       tbe.dataBlkValid.orMask(in_msg.bitMask);
     }

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -179,7 +179,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
   bool use_prefetcher, default="false";
 
   bool is_dcache := "False";
-
+  bool enable_difftest := "False";
   // Message Queues
 
   // Interface to the network

--- a/src/mem/ruby/system/RubyPort.hh
+++ b/src/mem/ruby/system/RubyPort.hh
@@ -45,6 +45,7 @@
 #include <cassert>
 #include <string>
 
+#include "cpu/base.hh"
 #include "mem/ruby/common/MachineID.hh"
 #include "mem/ruby/network/MessageBuffer.hh"
 #include "mem/ruby/protocol/RequestStatus.hh"
@@ -234,6 +235,9 @@ class RubyPort : public ClockedObject
     std::vector<MemResponsePort *> retryList;
 
     bool m_isCPUSequencer;
+  public:
+    bool m_isDataSequencer;
+    BaseCPU* cpu;
 };
 
 } // namespace ruby

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -129,6 +129,8 @@ class Sequencer : public RubyPort
 
     void notifyMissCallback(Addr address, bool is_upgrade, bool is_snoop);
 
+    void checkL1DRefill(Addr address, const DataBlock& data, WriteMask mask);
+
     void TBEFullCancel(Addr address);
 
     void atomicCallback(Addr address,
@@ -321,6 +323,8 @@ class Sequencer : public RubyPort
     std::vector<statistics::Counter> m_IncompleteTimes;
 
     EventFunctionWrapper deadlockCheckEvent;
+
+    bool isDataSequencer;
 
     // support for LL/SC
 

--- a/src/mem/ruby/system/Sequencer.py
+++ b/src/mem/ruby/system/Sequencer.py
@@ -88,6 +88,7 @@ class RubyPort(ClockedObject):
     support_data_reqs = Param.Bool(True, "data cache requests supported")
     support_inst_reqs = Param.Bool(True, "inst cache requests supported")
     is_cpu_sequencer = Param.Bool(True, "connected to a cpu")
+    is_data_sequencer = Param.Bool(False, "Is this sequencer for the dcache?")
 
 
 class RubyPortProxy(RubyPort):


### PR DESCRIPTION
Previously golden mem is checked only when inst commits, if golden value changes between cache access and commit, difftest will throw an error. Two changes are made:
1. Check L1D refill cache block with golden mem
2. When load accesses DCache, check with golden mem, and save golden value to DynInst. When it commits, and value doesn't match NEMU val, then compare with inst-local golden value

Change-Id: I7bfee53a622d7f0513b457c531df49c1c5e32035