### PR TITLE
cpu-o3: refactor branch predictors latency

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -860,9 +860,10 @@ class TimedBaseFTBPredictor(SimObject):
     cxx_class = 'gem5::branch_prediction::ftb_pred::TimedBaseFTBPredictor'
     cxx_header = "cpu/pred/ftb/timed_base_pred.hh"
     
-    # TODO: parametrize numBr and numDelay
     numBr = Param.Unsigned(2, "Number of maximum branches per entry")
-    
+    # subclass are encouraged to explicitly declare latency as numDelay
+    numDelay = Param.Unsigned(1000, "Number of bubbles to put on a prediction")
+
 class DefaultFTB(TimedBaseFTBPredictor):
     type = 'DefaultFTB'
     cxx_class = 'gem5::branch_prediction::ftb_pred::DefaultFTB'
@@ -873,8 +874,8 @@ class DefaultFTB(TimedBaseFTBPredictor):
     instShiftAmt = Param.Unsigned(1, "Amount to shift PC to get inst bits")
     numThreads = Param.Unsigned(1, "Number of threads")
     numWays = Param.Unsigned(4, "Number of ways per set")
-    numDelay = Param.Unsigned(1, "Number of bubbles to put on a prediction")
-    
+    numDelay = 1
+
 class UFTB(DefaultFTB):
     numEntries = 32
     tagBits = 38
@@ -889,6 +890,7 @@ class RAS(TimedBaseFTBPredictor):
     numEntries = Param.Unsigned(32, "Number of entries in the RAS")
     ctrWidth = Param.Unsigned(8, "Width of the counter")
     numInflightEntries = Param.Unsigned(384, "Number of inflight entries")
+    numDelay = 1
 
 class uRAS(TimedBaseFTBPredictor):
     type = 'uRAS'
@@ -897,6 +899,7 @@ class uRAS(TimedBaseFTBPredictor):
     
     numEntries = Param.Unsigned(4, "Number of entries in the RAS")
     ctrWidth = Param.Unsigned(2, "Width of the counter")
+    numDelay = 0
 
 class FTBTAGE(TimedBaseFTBPredictor):
     type = 'FTBTAGE'
@@ -911,6 +914,7 @@ class FTBTAGE(TimedBaseFTBPredictor):
     histLengths = VectorParam.Unsigned([8, 13, 32, 119], "the FTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
+    numDelay = 1
 
 class FTBITTAGE(TimedBaseFTBPredictor):
     type = 'FTBITTAGE'
@@ -925,7 +929,8 @@ class FTBITTAGE(TimedBaseFTBPredictor):
     histLengths = VectorParam.Unsigned([4, 8, 13, 16, 32], "the FTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    
+    numDelay = 2
+
 class DecoupledBPUWithFTB(BranchPredictor):
     type = 'DecoupledBPUWithFTB'
     cxx_class = 'gem5::branch_prediction::ftb_pred::DecoupledBPUWithFTB'

--- a/src/cpu/pred/ftb/ftb.cc
+++ b/src/cpu/pred/ftb/ftb.cc
@@ -51,7 +51,6 @@ DefaultFTB::DefaultFTB(const Params &p)
     numBr(p.numBr),
     numWays(p.numWays),
     numSets(numEntries / numWays),
-    numDelay(p.numDelay),
     ftbStats(this)
 {
     assert(numEntries % numWays == 0);

--- a/src/cpu/pred/ftb/ftb.hh
+++ b/src/cpu/pred/ftb/ftb.hh
@@ -91,8 +91,6 @@ class DefaultFTB : public TimedBaseFTBPredictor
 
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPrediction &pred) override;
 
-    unsigned getDelay() override {return numDelay;}
-
     /** Creates a FTB with the given number of entries, number of bits per
      *  tag, and instruction offset amount.
      *  @param numEntries Number of entries for the FTB.
@@ -255,9 +253,8 @@ class DefaultFTB : public TimedBaseFTBPredictor
 
     unsigned numSets;
 
-    unsigned numDelay;
-
-    typedef struct FTBMeta {
+    typedef struct FTBMeta
+    {
         bool hit;
         bool l0_hit;
         FTBEntry entry;

--- a/src/cpu/pred/ftb/ftb_ittage.cc
+++ b/src/cpu/pred/ftb/ftb_ittage.cc
@@ -20,16 +20,16 @@ namespace branch_prediction {
 
 namespace ftb_pred{
 
-FTBITTAGE::FTBITTAGE(const Params& p):
-TimedBaseFTBPredictor(p),
-numPredictors(p.numPredictors),
-tableSizes(p.tableSizes),
-tableTagBits(p.TTagBitSizes),
-tablePcShifts(p.TTagPcShifts),
-histLengths(p.histLengths),
-maxHistLen(p.maxHistLen),
-numTablesToAlloc(p.numTablesToAlloc),
-numBr(p.numBr)
+FTBITTAGE::FTBITTAGE(const Params& p)
+    : TimedBaseFTBPredictor(p),
+      numPredictors(p.numPredictors),
+      tableSizes(p.tableSizes),
+      tableTagBits(p.TTagBitSizes),
+      tablePcShifts(p.TTagPcShifts),
+      histLengths(p.histLengths),
+      maxHistLen(p.maxHistLen),
+      numTablesToAlloc(p.numTablesToAlloc),
+      numBr(p.numBr)
 {
     DPRINTF(FTBITTAGE || debugFlag, "FTBITTAGE constructor numBr=%d\n", numBr);
     tageTable.resize(numPredictors);

--- a/src/cpu/pred/ftb/ftb_ittage.hh
+++ b/src/cpu/pred/ftb/ftb_ittage.hh
@@ -95,8 +95,6 @@ class FTBITTAGE : public TimedBaseFTBPredictor
 
     void update(const FetchStream &entry) override;
 
-    unsigned getDelay() override { return 2; }
-
     void commitBranch(const FetchStream &stream, const DynInstPtr &inst) override;
 
     // check folded hists after speculative update and recover

--- a/src/cpu/pred/ftb/ftb_tage.cc
+++ b/src/cpu/pred/ftb/ftb_tage.cc
@@ -17,17 +17,17 @@ namespace branch_prediction {
 
 namespace ftb_pred{
 
-FTBTAGE::FTBTAGE(const Params& p):
-TimedBaseFTBPredictor(p),
-numPredictors(p.numPredictors),
-tableSizes(p.tableSizes),
-tableTagBits(p.TTagBitSizes),
-tablePcShifts(p.TTagPcShifts),
-histLengths(p.histLengths),
-maxHistLen(p.maxHistLen),
-numTablesToAlloc(p.numTablesToAlloc),
-numBr(p.numBr),
-sc(p.numBr, this)
+FTBTAGE::FTBTAGE(const Params& p)
+    : TimedBaseFTBPredictor(p),
+      numPredictors(p.numPredictors),
+      tableSizes(p.tableSizes),
+      tableTagBits(p.TTagBitSizes),
+      tablePcShifts(p.TTagPcShifts),
+      histLengths(p.histLengths),
+      maxHistLen(p.maxHistLen),
+      numTablesToAlloc(p.numTablesToAlloc),
+      numBr(p.numBr),
+      sc(p.numBr, this)
 {
     tageBankStats = new TageBankStats * [numBr];
     for (int i = 0; i < numBr; i++) {

--- a/src/cpu/pred/ftb/ftb_tage.hh
+++ b/src/cpu/pred/ftb/ftb_tage.hh
@@ -94,8 +94,6 @@ class FTBTAGE : public TimedBaseFTBPredictor
 
     void update(const FetchStream &entry) override;
 
-    unsigned getDelay() override { return 1; }
-
     void commitBranch(const FetchStream &stream, const DynInstPtr &inst) override;
 
     void setTrace() override;

--- a/src/cpu/pred/ftb/ras.hh
+++ b/src/cpu/pred/ftb/ras.hh
@@ -71,8 +71,6 @@ class RAS : public TimedBaseFTBPredictor
 
         void specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPrediction &pred) override;
 
-        unsigned getDelay() override {return 1;}
-
         void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
 
         void update(const FetchStream &entry) override;

--- a/src/cpu/pred/ftb/timed_base_pred.cc
+++ b/src/cpu/pred/ftb/timed_base_pred.cc
@@ -10,7 +10,8 @@ namespace ftb_pred
 {
 
 TimedBaseFTBPredictor::TimedBaseFTBPredictor(const Params &p)
-    : SimObject(p)
+    : SimObject(p),
+    numDelay(p.numDelay)
 {
 }
 

--- a/src/cpu/pred/ftb/timed_base_pred.hh
+++ b/src/cpu/pred/ftb/timed_base_pred.hh
@@ -43,7 +43,7 @@ class TimedBaseFTBPredictor: public SimObject
     virtual void specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPrediction &pred) {}
     virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) {}
     virtual void update(const FetchStream &entry) {}
-    virtual unsigned getDelay() {return 0;}
+    unsigned getDelay() { return numDelay; }
     // do some statistics on a per-branch and per-predictor basis
     virtual void commitBranch(const FetchStream &entry, const DynInstPtr &inst) {}
 
@@ -59,6 +59,9 @@ class TimedBaseFTBPredictor: public SimObject
     }
     virtual void setTrace() {}
     DataBase *_db;
+
+  private:
+    unsigned int numDelay;
 };
 
 } // namespace ftb_pred

--- a/src/cpu/pred/ftb/uras.hh
+++ b/src/cpu/pred/ftb/uras.hh
@@ -42,8 +42,6 @@ class uRAS : public TimedBaseFTBPredictor
 
         void specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPrediction &pred) override;
 
-        unsigned getDelay() override {return 0;}
-
         void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
 
         void update(const FetchStream &entry) override;


### PR DESCRIPTION
use params instead of hard coded magic number

Change-Id: I252ba2c582c285b6a7051b9207c7a4542e8fe9aa