### PR TITLE
cpu-o3: fix false positive in AddressSanitizer

### DIFF
--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -191,6 +191,15 @@ DynInst::operator new(size_t count, Arrays &arrays)
     return buf;
 }
 
+// Because of the custom "new" operator that allocates more bytes than the
+// size of the DynInst object, AddressSanitizer throw new-delete-type-mismatch.
+// Adding a custom delete function is enough to shut down this false positive
+void
+DynInst::operator delete(void *ptr)
+{
+    ::operator delete(ptr);
+}
+
 DynInst::~DynInst()
 {
     /*

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -104,6 +104,7 @@ class DynInst : public ExecContext, public RefCounted
     };
 
     static void *operator new(size_t count, Arrays &arrays);
+    static void  operator delete(void* ptr);
 
     /** BaseDynInst constructor given a binary instruction. */
     DynInst(const Arrays &arrays, const StaticInstPtr &staticInst,


### PR DESCRIPTION
AddressSanitizer found a new-delete-type-mismatch because of the custom new operator for DynInst.
Adding a custom delete operator for DynInstPtr fixes this issue. It has been fixed the same way in Mozilla:
https://bugzilla.mozilla.org/show_bug.cgi?id=1391500

Change-Id: I0ab4cb6d79cac88069cc2374a1deb499cdb15f02
Reviewed-on: https://gem5-review.googlesource.com/c/public/gem5/+/68357
Maintainer: Jason Lowe-Power <power.jg@gmail.com>
Reviewed-by: Jason Lowe-Power <power.jg@gmail.com>
Tested-by: kokoro <noreply+kokoro@google.com>