### PR TITLE
mem: enlarge snoop filter

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -130,6 +130,7 @@ def config_cache(options, system):
 
             # system.tol2bus_list.append(L2XBar(clk_domain = system.cpu_clk_domain, width=256))
             system.l2_caches[i].cpu_side = system.tol2bus_list[i].mem_side_ports
+            system.tol2bus_list[i].snoop_filter.max_capacity = "16MB"
 
             if options.ideal_cache:
                 assert not options.l3cache, \
@@ -168,6 +169,7 @@ def config_cache(options, system):
             system.l3 = L3Cache(clk_domain=system.cpu_clk_domain,
                                         **_get_cache_opts('l3', options))
             system.tol3bus = L2XBar(clk_domain=system.cpu_clk_domain, width=256)
+            system.tol3bus.snoop_filter.max_capacity = "32MB"
             system.l3.cpu_side = system.tol3bus.mem_side_ports
             system.l3.mem_side = system.membus.cpu_side_ports
 


### PR DESCRIPTION
max capacity exceed reported when modeling large caches

Change-Id: I745e99af5ee1e0bb766c9c6374412871966804ad