### PR TITLE
basic implement for estride value predictor

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -46,7 +46,7 @@ decode QUADRANT default Unknown::unknown() {
                 return std::make_shared<IllegalInstFault>("zero instruction",
                                                            machInst);
             Rp2 = sp + imm;
-        }}, uint64_t);
+        }}, uint64_t, {{IsIntAdd}});
         format CompressedLoad {
             0x1: c_fld({{
                 offset = CIMM3 << 3 | CIMM2 << 6;
@@ -129,7 +129,7 @@ decode QUADRANT default Unknown::unknown() {
                     }
                 }
                 Rc1_sd = Rc1_sd + imm;
-            }});
+            }}, int64_t, {{IsIntAdd}});
             0x1: c_addiw({{
                 imm = CIMM5;
                 if (CIMM1 > 0)
@@ -140,7 +140,7 @@ decode QUADRANT default Unknown::unknown() {
                             "source reg x0", machInst);
                 }
                 Rc1_sw = (int32_t)(Rc1_sw + imm);
-            }});
+            }}, int64_t, {{IsIntAdd}});
             0x2: c_li({{
                 imm = CIMM5;
                 if (CIMM1 > 0)
@@ -166,7 +166,7 @@ decode QUADRANT default Unknown::unknown() {
                                 "immediate = 0", machInst);
                     }
                     sp_sd = sp_sd + imm;
-                }});
+                }}, int64_t, {{IsIntAdd}});
                 default: c_lui({{
                     imm = CIMM5 << 12;
                     if (CIMM1 > 0)
@@ -217,7 +217,7 @@ decode QUADRANT default Unknown::unknown() {
                     0x0: decode CFUNCT2LOW {
                         0x0: c_sub({{
                             Rp1 = Rp1 - Rp2;
-                        }});
+                        }},{{IsIntAdd}});
                         0x1: c_xor({{
                             Rp1 = Rp1 ^ Rp2;
                         }});
@@ -231,10 +231,10 @@ decode QUADRANT default Unknown::unknown() {
                     0x1: decode CFUNCT2LOW {
                         0x0: c_subw({{
                             Rp1_sd = (int32_t)Rp1_sd - Rp2_sw;
-                        }});
+                        }},{{IsIntAdd}});
                         0x1: c_addw({{
                             Rp1_sd = (int32_t)Rp1_sd + Rp2_sw;
-                        }});
+                        }},{{IsIntAdd}});
                     }
                 }
             }
@@ -352,7 +352,7 @@ decode QUADRANT default Unknown::unknown() {
                     }}, IsIndirectControl, IsUncondControl, IsCall);
                     default: CompressedROp::c_add({{
                         Rc1_sd = Rc1_sd + Rc2_sd;
-                    }});
+                    }},{{IsIntAdd}});
                 }
             }
         }
@@ -706,7 +706,7 @@ decode QUADRANT default Unknown::unknown() {
                     }},int64_t, {{ imm = 0; }}, IsMov);
                     default: addi({{
                         Rd_sd = Rs1_sd + imm;
-                    }});
+                    }}, int64_t, {{imm = sext<12>(IMM12)}}, {{IsIntAdd}});
                 }
                 0x2: slti({{
                     Rd = (Rs1_sd < imm) ? 1 : 0;
@@ -769,7 +769,7 @@ decode QUADRANT default Unknown::unknown() {
             format IOp {
                 0x0: addiw({{
                     Rd_sw = (int32_t)(Rs1_sw + imm);
-                }}, int32_t);
+                }}, int32_t, {{imm = sext<12>(IMM12)}}, {{IsIntAdd}});
                 0x1: decode FS3 {
                     0x0: slliw({{
                         Rd_sd = Rs1_sw << imm;
@@ -1103,10 +1103,10 @@ decode QUADRANT default Unknown::unknown() {
                     0x00: decode BS {
                         0x0: add({{
                             Rd = Rs1_sd + Rs2_sd;
-                        }});
+                        }}, {{IsIntAdd}});
                         0x1: sub({{
                             Rd = Rs1_sd - Rs2_sd;
-                        }});
+                        }}, {{IsIntAdd}});
                     }
                     0x01: decode BS {
                         0x0: mul({{
@@ -1328,16 +1328,16 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: decode FUNCT7 {
                     0x0: addw({{
                         Rd_sd = Rs1_sw + Rs2_sw;
-                    }});
+                    }}, {{IsIntAdd}});
                     0x1: mulw({{
                         Rd_sd = (int32_t)(Rs1_sw*Rs2_sw);
                     }}, IntMultOp);
                     0x4: add_uw({{
                         Rd = Rs1_uw + Rs2;
-                    }});
+                    }}, {{IsIntAdd}});
                     0x20: subw({{
                         Rd_sd = Rs1_sw - Rs2_sw;
-                    }});
+                    }}, {{IsIntAdd}});
                 }
                 0x1: decode FUNCT7 {
                     0x0: sllw({{

--- a/src/cpu/StaticInstFlags.py
+++ b/src/cpu/StaticInstFlags.py
@@ -54,6 +54,7 @@ class StaticInstFlags(Enum):
         'IsMov',
 
         'IsInteger',        # References integer regs.
+        'IsIntAdd',         # int add and sub instructions
         'IsFloating',       # References FP regs.
         'IsVector',         # References Vector regs.
         'IsVectorElem',     # References Vector reg elems.

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -45,6 +45,7 @@ from m5.objects.FUPool import *
 #from m5.objects.O3Checker import O3Checker
 from m5.objects.BranchPredictor import *
 from m5.SimObject import *
+from m5.objects.ValuePredictor import *
 
 class SMTFetchPolicy(ScopedEnum):
     vals = [ 'RoundRobin', 'Branch', 'IQCount', 'LSQCount' ]
@@ -215,4 +216,7 @@ class BaseO3CPU(BaseCPU):
     arch_db = Param.ArchDBer(Parent.any, "Arch DB")
 
     store_prefetch_train = Param.Bool(True, "Training store prefetcher with store addresses")
+
+    # value predictor
+    valuePred = Param.ValuePredictor(EStride(), "valuepred unit")
 

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -155,6 +155,10 @@ struct IEWStruct
     bool branchMispredict[MaxThreads];
     bool branchTaken[MaxThreads];
     bool includeSquashInst[MaxThreads];
+
+    // add flag for memory violation and VP
+    bool memoryViolation[MaxThreads];
+    bool valuePredictionError[MaxThreads];
 };
 
 struct IssueStruct

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1694,7 +1694,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     head_inst->commitCycle = cpu->curCycle();
 
     // for instruction who can be train for value predictor
-    if (head_inst->vpSupported){
+    if (head_inst->vpSupported && inst_fault == NoFault){
         gem5_assert(head_inst->isVerified(), "%s\n", head_inst->genDisassembly());
         assert(head_inst->commitCycle > head_inst->renameCycle);
 

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -62,6 +62,8 @@
 #include "cpu/o3/limits.hh"
 #include "cpu/o3/thread_state.hh"
 #include "cpu/timebuf.hh"
+#include "cpu/valuepred/es_metadata.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
 #include "debug/Activity.hh"
 #include "debug/Commit.hh"
 #include "debug/CommitRate.hh"
@@ -75,6 +77,7 @@
 #include "debug/HtmCpu.hh"
 #include "debug/InstCommited.hh"
 #include "debug/O3PipeView.hh"
+#include "debug/VPCOMMON.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/core.hh"
 #include "sim/cur_tick.hh"
@@ -114,7 +117,8 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
       canHandleInterrupts(true),
       avoidQuiesceLiveLock(false),
       stats(_cpu, this),
-      archDBer(params.arch_db)
+      archDBer(params.arch_db),
+      valuePredictor(params.valuePred)
 {
     if (commitWidth > MaxWidth)
         fatal("commitWidth (%d) is larger than compiled limit (%d),\n"
@@ -622,6 +626,9 @@ Commit::squashAll(ThreadID tid)
     rob->squash(squashed_inst, tid);
     changedROBNumEntries[tid] = true;
 
+    // value prediction also squash in this
+    valuePredictor->squash(squashed_inst);
+
     // Send back the sequence number of the squashed instruction.
     toIEW->commitInfo[tid].doneSeqNum = squashed_inst;
 
@@ -943,10 +950,16 @@ Commit::commit()
                     tid,
                     fromIEW->mispredictInst[tid]->pcState().instAddr(),
                     fromIEW->squashedSeqNum[tid]);
-            } else {
+            } else if (fromIEW->memoryViolation[tid]){
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to order violation [sn:%llu]\n",
                     tid, fromIEW->squashedSeqNum[tid]);
+            } else if (fromIEW->valuePredictionError[tid]){
+                // DPRINTF
+                DPRINTF(VPCOMMON, "Squashing due to value prediction error, "
+                            "seq_no: %llu\n", fromIEW->squashedSeqNum[0]);
+            } else{
+                panic("undefined in commit squash\n");
             }
 
             DPRINTF(Commit, "[tid:%i] Redirecting to PC %#x\n",
@@ -968,6 +981,9 @@ Commit::commit()
 
             rob->squash(squashed_inst, tid);
             changedROBNumEntries[tid] = true;
+
+            // squash value predictor
+            valuePredictor->squash(squashed_inst);
 
             toIEW->commitInfo[tid].doneSeqNum = squashed_inst;
 
@@ -1672,6 +1688,46 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     // the HTM UID is purely for correctness and debugging purposes
     if (head_inst->isHtmStart())
         iewStage->setLastRetiredHtmUid(tid, head_inst->getHtmTransactionUid());
+
+
+    // value prediction
+    head_inst->commitCycle = cpu->curCycle();
+
+    // for instruction who can be train for value predictor
+    if (head_inst->vpSupported){
+        gem5_assert(head_inst->isVerified(), "%s\n", head_inst->genDisassembly());
+        assert(head_inst->commitCycle > head_inst->renameCycle);
+
+        valuepred::ESUpdateMetaData *updateMetaData =
+                        dynamic_cast<valuepred::ESUpdateMetaData *>(valuepred::
+                                VPDataStructFactory::buildUpdateMetaData(ValuePredType::EStride));
+        updateMetaData->pc = head_inst->getPC();
+        updateMetaData->seq_no = head_inst->seqNum;
+        updateMetaData->actualValue = head_inst->actualValue;
+        updateMetaData->isMisprediction = head_inst->vpMisprediction;
+        updateMetaData->isLoadInst = head_inst->isLoad();
+        updateMetaData->inflightTime = head_inst->commitCycle - head_inst->renameCycle;
+        updateMetaData->disas = head_inst->staticInst->disassemble(updateMetaData->pc);
+        valuePredictor->updateValuePredictor(updateMetaData);
+
+        delete updateMetaData;
+
+        DPRINTF(VPCOMMON,
+            "Commit-Stage instruction commit and value "
+            "predictor update => "
+            "seq num: %lu pc: %lX "
+            "spec: %s "
+            "isMisPrediction: %s "
+            "predict value: %lu "
+            "real value: %lu "
+            "disas: %s\n",
+            head_inst->seqNum,
+            head_inst->getPC(),
+            head_inst->vpResult.speculative ? "spec" : "no spec ",
+            head_inst->vpMisprediction ? "yes" : "no", head_inst->vpResult.value,
+            head_inst->actualValue,
+            head_inst->genDisassembly());
+    }
 
     // Finally clear the head ROB entry.
     rob->retireHead(tid);

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -62,6 +62,7 @@
 #include "cpu/pred/general_arch_db.hh"
 #include "cpu/pred/stream/decoupled_bpred.hh"
 #include "cpu/timebuf.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
 #include "enums/CommitPolicy.hh"
 #include "sim/arch_db.hh"
 #include "sim/probe/probe.hh"
@@ -566,6 +567,9 @@ class Commit
     ArchDBer *archDBer;
 
     void dumpTicks(const DynInstPtr &inst);
+
+    // value prediction
+    valuepred::VPUnit *valuePredictor;
 };
 
 } // namespace o3

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1251,6 +1251,10 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
         thread[tid]->threadStats.numInsts++;
         cpuStats.committedInsts[tid]++;
 
+        if (thread[tid]->numInst % 10000 == 0) {
+            fprintf(stderr, "commit %lu insts\n", thread[tid]->numInst);
+        }
+
         if (this->nextDumpInstCount
                 && totalInsts() == this->nextDumpInstCount) {
             fprintf(stderr, "Will trigger stat dump and reset\n");

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -60,6 +60,7 @@
 #include "debug/Drain.hh"
 #include "debug/O3CPU.hh"
 #include "debug/Quiesce.hh"
+#include "debug/VPCOMMON.hh"
 #include "debug/ValueCommit.hh"
 #include "enums/MemoryMode.hh"
 #include "sim/async.hh"
@@ -1251,8 +1252,10 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
         thread[tid]->threadStats.numInsts++;
         cpuStats.committedInsts[tid]++;
 
-        if (thread[tid]->numInst % 10000 == 0) {
-            fprintf(stderr, "commit %lu insts\n", thread[tid]->numInst);
+        if (debug::VPCOMMON) {
+            if (thread[tid]->numInst % 10000 == 0) {
+                fprintf(stderr, "commit %lu insts\n", thread[tid]->numInst);
+            }
         }
 
         if (this->nextDumpInstCount

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -65,6 +65,7 @@
 #include "cpu/reg_class.hh"
 #include "cpu/static_inst.hh"
 #include "cpu/translation.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
 #include "debug/CommitTrace.hh"
 #include "debug/DecoupleBP.hh"
 #include "debug/HtmCpu.hh"
@@ -186,6 +187,8 @@ class DynInst : public ExecContext, public RefCounted
                                  /// instructions ahead of it
         SerializeAfter,          /// Needs to serialize instructions behind it
         SerializeHandled,        /// Serialization has been handled
+        Verified,				 /// VP instructions is verified
+        NeedFlush,				 /// VP instructions mispredicted and need flush
         NumStatus
     };
 
@@ -594,6 +597,7 @@ class DynInst : public ExecContext, public RefCounted
     bool isInstPrefetch() const { return staticInst->isInstPrefetch(); }
     bool isDataPrefetch() const { return staticInst->isDataPrefetch(); }
     bool isInteger()      const { return staticInst->isInteger(); }
+    bool isIntAdd()       const { return staticInst->isIntAdd(); }
     bool isFloating()     const { return staticInst->isFloating(); }
     bool isVector()       const { return staticInst->isVector(); }
     bool isControl()      const { return staticInst->isControl(); }
@@ -1418,6 +1422,45 @@ class DynInst : public ExecContext, public RefCounted
 
     /** get golden */
     uint8_t *getGolden() { return goldenData; }
+
+
+  public:
+    // value prediction
+    valuepred::VPResult vpResult = {false, 0};
+
+    RegVal actualValue = 0u;
+    bool vpMisprediction = false;
+    bool vpSupported = false;
+
+    bool isVerified() { return status[Verified]; }
+
+    void setVerified() { status.set(Verified); }
+
+    void resetVerified() { status.reset(Verified); }
+
+    // mark the time to support EStride Update
+    Cycles renameCycle;
+    Cycles commitCycle;
+
+    // ugly code
+    bool isNotSupportVP(){
+        return isNop() || isHInst() || isStore() ||
+            isAtomic() || isStoreConditional() ||
+            isInstPrefetch() || isDataPrefetch() ||
+            isFloating() || isVector() || isControl() ||
+            isCall() || isReturn() || isDirectCtrl() ||
+            isIndirectCtrl() || isCondCtrl() ||
+            isUncondCtrl() || isSerializing() ||
+            isSerializeAfter() || isSerializeBefore() ||
+            isSquashAfter() || isFullMemBarrier() ||
+            isReadBarrier() || isWriteBarrier() ||
+            isNonSpeculative() || isUpdateVsstatusSd() ||
+            isUpdateMstatusSd() || isQuiesce() ||
+            isUnverifiable() || isSyscall() ||
+            isDelayedCommit() || isHtmStop() ||
+            isHtmStart() || isHtmCancel() || isHtmCmd();
+    }
+
 };
 
 } // namespace o3

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -59,6 +59,8 @@
 #include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/valuepred/es_metadata.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
 #include "debug/Activity.hh"
 #include "debug/Counters.hh"
 #include "debug/DecoupleBPProbe.hh"
@@ -106,7 +108,8 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       numThreads(params.numThreads),
       numFetchingThreads(params.smtNumFetchingThreads),
       icachePort(this, _cpu),
-      finishTranslationEvent(this), fetchStats(_cpu, this)
+      finishTranslationEvent(this), fetchStats(_cpu, this),
+      valuePredictor(params.valuePred)
 {
     if (numThreads > MaxThreads)
         fatal("numThreads (%d) is larger than compiled limit (%d),\n"
@@ -1849,6 +1852,23 @@ Fetch::fetch(bool &status_change)
                 quiesce = true;
                 break;
             }
+
+
+            // do the value prediction.
+            // In EStride or other implementations of value predictors, since
+            // it takes time for the value predictor to produce a prediction,
+            // the value prediction is often started after the fetch phase.
+
+            // This simulate valuePredict in fetch the instructions
+            // no instruction information, every instructions take into valuePredictor.
+            valuepred::VPPredMetaData* vpPredMetaData =
+                    dynamic_cast<valuepred::ESPredMetaData *>(valuepred::VPDataStructFactory::
+                                                                    buildPredMetaData(ValuePredType::EStride));
+            vpPredMetaData->pc = instruction->getPC();
+            vpPredMetaData->seq_no = instruction->seqNum;
+            instruction->vpResult = valuePredictor->valuePredict(vpPredMetaData);
+            delete vpPredMetaData;
+
         } while ((curMacroop || dec_ptr->instReady()) &&
                  numInst < fetchWidth &&
                  fetchQueue[tid].size() < fetchQueueSize);

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -56,6 +56,7 @@
 #include "cpu/pred/ftb/decoupled_bpred.hh"
 #include "cpu/timebuf.hh"
 #include "cpu/translation.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
 #include "enums/SMTFetchPolicy.hh"
 #include "mem/packet.hh"
 #include "mem/port.hh"
@@ -654,6 +655,10 @@ class Fetch
     uint8_t* secondDataBuf;
 
     bool waitForVsetvl = false;
+
+  private:
+    // value prediction
+    valuepred::VPUnit *valuePredictor;
 };
 
 } // namespace o3

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -45,6 +45,7 @@
 
 #include "cpu/o3/iew.hh"
 
+#include <cstring>
 #include <queue>
 
 #include "base/output.hh"
@@ -90,7 +91,8 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       wbDelay(params.executeToWriteBackDelay),
       wbWidth(params.wbWidth),
       numThreads(params.numThreads),
-      iewStats(cpu)
+      iewStats(cpu),
+      valuePredictor(params.valuePred)
 {
     if (wbWidth > MaxWidth)
         fatal("wbWidth (%d) is larger than compiled limit (%d),\n"
@@ -600,6 +602,7 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
             inst->seqNum <= execWB->squashedSeqNum[tid]) {
         execWB->squash[tid] = true;
 
+        execWB->memoryViolation[tid] = true;
         execWB->squashedSeqNum[tid] = inst->seqNum;
         execWB->squashedStreamId[tid] = inst->getFsqId();
         execWB->squashedTargetId[tid] = inst->getFtqId();
@@ -621,6 +624,44 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
                 execWB->squashedLoopIter[tid]);
 
 
+    }
+}
+
+void
+IEW::squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid)
+{
+    DPRINTF(IEW,
+            "[tid:%i] value prediction error, squashing violator and younger "
+            "insts, PC: %s [sn:%llu].\n",
+            tid, inst->pcState(), inst->seqNum);
+    if (!execWB->squash[tid] || inst->seqNum <= execWB->squashedSeqNum[tid]) {
+        execWB->squash[tid] = true;
+
+        execWB->valuePredictionError[tid] = true;
+        execWB->squashedSeqNum[tid] = inst->seqNum;
+        execWB->squashedStreamId[tid] = inst->getFsqId();
+        execWB->squashedTargetId[tid] = inst->getFtqId();
+        execWB->squashedLoopIter[tid] = inst->getLoopIteration();
+        set(execWB->pc[tid], inst->pcState());
+
+                                // advance pc to next instruction
+        inst->staticInst->advancePC(*execWB->pc[tid]);
+
+        execWB->mispredictInst[tid] = NULL;
+
+        // Even speculatively executed value prediction instructions cannot
+                                // be squashed after obtaining a correct result.
+        execWB->includeSquashInst[tid] = false;
+
+        wroteToTimeBuffer = true;
+
+        DPRINTF(DecoupleBP,
+                "value prediction error (pc=%#lx) set stream id to %lu, target id "
+                "to %lu, loop iter to %u\n",
+                execWB->pc[tid]->instAddr(),
+                execWB->squashedStreamId[tid],
+                execWB->squashedTargetId[tid],
+                execWB->squashedLoopIter[tid]);
     }
 }
 
@@ -711,6 +752,29 @@ IEW::instToCommit(const DynInstPtr& inst)
 
     scheduler->bypassWriteback(inst);
     inst->completionTick = curTick();
+
+    // Value prediction may introduce unaligned memory accesses, and
+    // it is a question of how to accurately record the memory accesses
+    // introduced by value prediction. Now just record all non-aligned
+    // memory accesses.
+    if (inst->getFault() != NoFault && !std::strcmp(inst->getFault()->name(), "Address")){
+        // value prediction cause unaligned memory access
+        valuePredictor->stats.faultLoad++;
+    }
+
+    if (inst->vpSupported && inst->vpResult.speculative &&!inst->vpMisprediction){
+        // correct value prediction
+        valuePredictor->stats.VPcorrected++;
+    }
+
+    ThreadID tid = inst->threadNumber;  // todo: now think tid always zero
+    if (inst->vpSupported && inst->vpResult.speculative && inst->vpMisprediction) {
+        if (!fetchRedirect[tid] || !execWB->squash[tid] || execWB->squashedSeqNum[tid] > inst->seqNum) {
+            // deal with value prediction error
+            fetchRedirect[tid] = true;
+            squashDueToValuePrediction(inst, tid);
+        }
+    }
 
     DPRINTF(IEW, "Current wb cycle: %i, width: %i, numInst: %i\nwbActual:%i\n",
             wbCycle, wbWidth, wbNumInst, wbCycle * wbWidth + wbNumInst);
@@ -1105,6 +1169,21 @@ IEW::classifyInstToDispQue(ThreadID tid)
 
             if (!inst->isNop()) {
                 scheduler->addProducer(inst);
+            }
+
+
+            // for the vp, three scoreboards should ready at begin.
+            if (inst->vpResult.speculative) {
+                for (int i = 0; i < inst->numDestRegs(); i++) {
+                    auto dest = inst->renamedDestIdx(i);
+                    if (dest->isFixedMapping()) {
+                        continue;
+                    }
+                    // early set bypassScoreboard wait for check
+                    scheduler->scoreboard[dest->flatIndex()] = true;
+                    scheduler->bypassScoreboard[dest->flatIndex()] = true;
+                    scheduler->earlyScoreboard[dest->flatIndex()] = true;
+                }
             }
 
             inst->enterDQTick = curTick();

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -56,6 +56,7 @@
 #include "cpu/o3/rob.hh"
 #include "cpu/o3/scoreboard.hh"
 #include "cpu/timebuf.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
 #include "debug/IEW.hh"
 #include "sim/probe/probe.hh"
 
@@ -279,6 +280,11 @@ class IEW
      * violation.
      */
     void squashDueToMemOrder(const DynInstPtr &inst, ThreadID tid);
+
+    /** Sends commit proper information for a squash due to a value
+     * mispredict.
+     */
+    void squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid);
 
     /** Sets Dispatch to blocked, and signals back to other stages to block. */
     void block(ThreadID tid);
@@ -560,6 +566,9 @@ class IEW
     StallReason checkDispatchStall(ThreadID tid, int dq_id, const DynInstPtr &dispatch_inst);
 
     StallReason checkLSQStall(ThreadID tid, bool isLoad);
+
+    // value prediction
+    valuepred::VPUnit *valuePredictor;
 
   public:
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -953,15 +953,15 @@ Scheduler::bypassWriteback(const DynInstPtr& inst)
 
         // value prediction verify
         // mark: value prediction verification
-        if (inst->vpSupported) {
+        if (inst->vpSupported && inst->fault == NoFault) {
             assert(!inst->isVerified());
+
+            //if (inst->getFault() != NoFault) {
+            //    inst->setVerified();
+            //    return;
+            //}
+
             assert(inst->isExecuted());
-
-            if (inst->getFault() != NoFault) {
-                inst->setVerified();
-                return;
-            }
-
             assert(inst->resultSize() == 1);
 
             // convert result to instruction types

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -24,6 +24,7 @@
 #include "debug/Counters.hh"
 #include "debug/Dispatch.hh"
 #include "debug/Schedule.hh"
+#include "debug/VPCOMMON.hh"
 #include "enums/OpClass.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/eventq.hh"
@@ -45,6 +46,7 @@ namespace o3
 
 IssuePort::IssuePort(const IssuePortParams& params) : SimObject(params), fu(params.fu)
 {
+    // this remark that what calculate func can be do in this port
     mask.resize(Num_OpClasses, false);
     for (auto it0 : params.fu) {
         for (auto it1 : it0->opDescList) {
@@ -154,6 +156,7 @@ IssueQue::IssueQue(const IssueQueParams& params)
         }
     }
 
+    // init portBusy with no busy status
     portBusy.resize(outports, 0);
 }
 
@@ -182,6 +185,7 @@ IssueQue::checkScoreboard(const DynInstPtr& inst)
         // check bypass data ready or not
         if (!scheduler->bypassScoreboard[src->flatIndex()]) [[unlikely]] {
             auto dst_inst = scheduler->getInstByDstReg(src->flatIndex());
+            // Check that the value required by the instruction is generated
             if (!dst_inst || !dst_inst->isLoad()) {
                 panic("dst is not load");
             }
@@ -267,6 +271,12 @@ IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative)
 
         DPRINTF(Schedule, "was %s woken by p%lu [sn:%llu]\n", speculative ? "spec" : "wb", dst->flatIndex(),
                 inst->seqNum);
+
+        if (inst->vpResult.speculative){
+            gem5_assert(!subDepGraph[dst->flatIndex()].size(),
+                    "must no dependency in value prediction instruction dest register");
+        }
+
         for (auto& it : subDepGraph[dst->flatIndex()]) {
             int srcIdx = it.first;
             auto& consumer = it.second;
@@ -853,6 +863,13 @@ Scheduler::loadCancel(const DynInstPtr& inst)
     if (inst->canceled()) {
         return;
     }
+
+    // speculative value prediction load should not be cancel
+    // because the dependency issue has been resolved
+    if (inst->vpResult.speculative){
+        return;
+    }
+
     DPRINTF(Schedule, "[sn:%llu] %s cache miss, cancel consumers\n", inst->seqNum,
             enums::OpClassStrings[inst->opClass()]);
     inst->setCancel();
@@ -928,10 +945,47 @@ Scheduler::bypassWriteback(const DynInstPtr& inst)
     for (int i = 0; i < inst->numDestRegs(); i++) {
         auto dst = inst->renamedDestIdx(i);
         if (dst->isFixedMapping()) {
+            gem5_assert(!inst->vpSupported, "instruction whos dest reg can't renameable can't be value predict\n");
             continue;
         }
         bypassScoreboard[dst->flatIndex()] = true;
         DPRINTF(Schedule, "p%lu in bypassNetwork ready\n", dst->flatIndex());
+
+        // value prediction verify
+        // mark: value prediction verification
+        if (inst->vpSupported) {
+            assert(!inst->isVerified());
+            assert(inst->isExecuted());
+
+            if (inst->getFault() != NoFault) {
+                inst->setVerified();
+                return;
+            }
+
+            assert(inst->resultSize() == 1);
+
+            // convert result to instruction types
+            RegVal actualValue = inst->getResult().as<RegVal>();
+            inst->actualValue = actualValue;
+            if (actualValue != inst->vpResult.value) {
+                // check error
+                inst->vpMisprediction = true;
+            }
+
+            inst->setVerified();
+            DPRINTF(VPCOMMON,"After verified, the result is => "
+                        "inst seq: %lu pc: %lX "
+                        "spec: %s "
+                        "isMisprediction: %s "
+                        "pred_value: %lu exec_value: %lu\n"
+                        "disas: %s\n",
+                inst->seqNum, inst->getPC(),
+                inst->vpResult.speculative ? " spec " : " no spec ",
+                inst->vpMisprediction ? "yes" : "no",
+                inst->vpResult.value, actualValue,
+                inst->genDisassembly().c_str());
+        }
+
     }
 }
 

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -178,6 +178,8 @@ class SpecWakeupChannel : public SimObject
 
 class Scheduler : public SimObject
 {
+    // not good to use friend class
+    friend class IEW;
     friend class IssueQue;
     class SpecWakeupCompletion : public Event
     {

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -47,10 +47,14 @@
 #include "cpu/o3/dyn_inst.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/reg_class.hh"
+#include "cpu/valuepred/es_metadata.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
 #include "debug/Activity.hh"
+#include "debug/Counters.hh"
 #include "debug/O3PipeView.hh"
 #include "debug/Rename.hh"
-#include "debug/Counters.hh"
+#include "debug/VPCOMMON.hh"
+#include "enums/ValuePredType.hh"
 #include "params/BaseO3CPU.hh"
 
 namespace gem5
@@ -66,7 +70,8 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
       commitToRenameDelay(params.commitToRenameDelay),
       renameWidth(params.renameWidth),
       numThreads(params.numThreads),
-      stats(_cpu)
+      stats(_cpu),
+      valuePredictor(params.valuePred)
 {
     if (renameWidth > MaxWidth)
         fatal("renameWidth (%d) is larger than compiled limit (%d),\n"
@@ -1268,6 +1273,57 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
                             rename_result.second);
 
         ++stats.renamedOperands;
+
+        // do the value prediction.
+        // In EStride or other implementations of value predictors, since
+        // it takes time for the value predictor to produce a prediction,
+        // the value prediction is often started after the fetch phase,
+        // where the instructions are not decoded, so we can't use the
+        // information in dyninst. The reason for placing the value
+        // prediction in the Rename phase is that on gem5,
+        // the predictor does not require a delay to produce a result.
+
+        // This simulate valuePredict in fetch the instructions
+        // no instruction information, every instructions take into valuePredictor.
+        valuepred::VPPredMetaData* vpPredMetaData =
+                dynamic_cast<valuepred::ESPredMetaData *>(valuepred::VPDataStructFactory::
+                                                                buildPredMetaData(ValuePredType::EStride));
+        vpPredMetaData->pc = inst->getPC();
+        vpPredMetaData->seq_no = inst->seqNum;
+        inst->vpResult = valuePredictor->valuePredict(vpPredMetaData);
+
+
+        // This simulate in rename stage, we know the instruction information, we can control
+        // whether instruction support value prediction.
+        if (num_dest_regs != 1 || rename_result.first->isFixedMapping() ||
+            mov_elim || inst->isNotSupportVP()) {
+            inst->vpSupported = false;
+            continue;
+        }
+
+        valuePredictor->stats.VPsupported++;
+        inst->vpSupported = true;
+        inst->renameCycle = cpu->curCycle();
+        if (inst->vpResult.speculative){
+            valuePredictor->stats.VPpredicted++;
+            gem5_assert(!scoreboard->getReg(rename_result.first),
+                            "before set the scoreboard, the scoreboard must unset before");
+            // set the scoreboard, let the back-to-back rename inst mark reg ready
+            scoreboard->setReg(rename_result.first);
+            inst->setRegOperand(inst->staticInst.get(), 0, inst->vpResult.value);
+            // must pop result here
+            inst->popResult();
+            DPRINTF(VPCOMMON,
+                    "Rename-Stage instruction[%s] generate "
+                    "prediction value."
+                    "seq num: %lu pc: %lX "
+                    "prediction value: %lu \n",
+                    inst->staticInst->disassemble(inst->getPC()), inst->seqNum, inst->getPC(), inst->vpResult.value);
+        }else{
+            // value prediction not taken
+        }
+        delete vpPredMetaData;
+
     }
 }
 

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -1274,25 +1274,6 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
 
         ++stats.renamedOperands;
 
-        // do the value prediction.
-        // In EStride or other implementations of value predictors, since
-        // it takes time for the value predictor to produce a prediction,
-        // the value prediction is often started after the fetch phase,
-        // where the instructions are not decoded, so we can't use the
-        // information in dyninst. The reason for placing the value
-        // prediction in the Rename phase is that on gem5,
-        // the predictor does not require a delay to produce a result.
-
-        // This simulate valuePredict in fetch the instructions
-        // no instruction information, every instructions take into valuePredictor.
-        valuepred::VPPredMetaData* vpPredMetaData =
-                dynamic_cast<valuepred::ESPredMetaData *>(valuepred::VPDataStructFactory::
-                                                                buildPredMetaData(ValuePredType::EStride));
-        vpPredMetaData->pc = inst->getPC();
-        vpPredMetaData->seq_no = inst->seqNum;
-        inst->vpResult = valuePredictor->valuePredict(vpPredMetaData);
-
-
         // This simulate in rename stage, we know the instruction information, we can control
         // whether instruction support value prediction.
         if (num_dest_regs != 1 || rename_result.first->isFixedMapping() ||
@@ -1322,7 +1303,6 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
         }else{
             // value prediction not taken
         }
-        delete vpPredMetaData;
 
     }
 }

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -53,6 +53,7 @@
 #include "cpu/o3/iew.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/timebuf.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
 #include "sim/probe/probe.hh"
 
 namespace gem5
@@ -559,6 +560,8 @@ class Rename
     StallReason checkRenameStallFromIEW(ThreadID tid);
 
     SquashVersion localSquashVer;
+
+    valuepred::VPUnit *valuePredictor;
 };
 
 } // namespace o3

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -164,6 +164,7 @@ class StaticInst : public RefCounted, public StaticInstFlags
                                          isDataPrefetch(); }
 
     bool isInteger()      const { return flags[IsInteger]; }
+    bool isIntAdd()       const { return flags[IsIntAdd]; }
     bool isFloating()     const { return flags[IsFloating]; }
     bool isVector()       const { return flags[IsVector]; }
     bool isVectorConfig() const { return opClass() == VectorConfigOp; }

--- a/src/cpu/valuepred/SConscript
+++ b/src/cpu/valuepred/SConscript
@@ -1,0 +1,19 @@
+Import('*')
+
+SimObject('ValuePredictor.py',
+          sim_objects=[
+            'ValuePredictor',
+            'EStride'
+          ],
+          enums=['ValuePredType'])
+
+Source('valuepred_unit.cc')
+Source('enhanced_stride.cc')
+Source('valuepred_metadata.cc')
+
+DebugFlag('VPCOMMON')
+DebugFlag('EStride')
+
+
+CompoundFlag('VP', ['VPCOMMON', 'EStride'])
+

--- a/src/cpu/valuepred/ValuePredictor.py
+++ b/src/cpu/valuepred/ValuePredictor.py
@@ -1,0 +1,37 @@
+from m5.params import *
+from m5.proxy import *
+from m5.SimObject import *
+
+class ValuePredType(ScopedEnum):
+    # vals will contains value predictor type
+    vals = ["EStride"]
+
+class ValuePredictor(SimObject):
+    type = "ValuePredictor"
+    cxx_class = "gem5::valuepred::VPUnit"
+    cxx_header = "cpu/valuepred/valuepred_unit.hh"
+    abstract = True
+
+class EStride(ValuePredictor):
+    type = "EStride"
+    cxx_class = "gem5::valuepred::EStride"
+    cxx_header = "cpu/valuepred/enhanced_stride.hh"
+    abstract = False
+
+    # default params reference 1st cvp paper
+    ways = Param.Int(3, "ways of the EStride")
+    strideWidth = Param.Int(20, "Indicates the number of bits used for stride"
+                            "must <= 32")
+    tagWidth = Param.Int(16, "tag-width")
+    logESTBEntrys = Param.Int(5, "log 2 of ES table entry counts")
+    logMaxConfidence = Param.Int(5, "log 2 of max confidence number")
+    thresholdPercent = Param.Float(0.25, "threshold percent of confidence")
+
+    # inflight window configuration
+    idealWindow = Param.Bool(True, "The key in the ideal window is a 64-bit pc, not hashed")
+    inflightWindowTagLength = Param.Int(64, "inflight window tag length")
+
+    # about update strategy
+    # still not use
+    enableTimeMsgInUpdate = Param.Bool(True, "enable use instruction"
+                                       "inflight time in update")

--- a/src/cpu/valuepred/ValuePredictor.py
+++ b/src/cpu/valuepred/ValuePredictor.py
@@ -23,7 +23,7 @@ class EStride(ValuePredictor):
     strideWidth = Param.Int(20, "Indicates the number of bits used for stride"
                             "must <= 32")
     tagWidth = Param.Int(16, "tag-width")
-    logESTBEntrys = Param.Int(5, "log 2 of ES table entry counts")
+    logESTBEntrys = Param.Int(7, "log 2 of ES table entry counts")
     logMaxConfidence = Param.Int(5, "log 2 of max confidence number")
     thresholdPercent = Param.Float(0.25, "threshold percent of confidence")
 

--- a/src/cpu/valuepred/enhanced_stride.cc
+++ b/src/cpu/valuepred/enhanced_stride.cc
@@ -131,6 +131,10 @@ EStride::EStride(const Params &params)
     // call back to dump stats
     registerExitCallback([this]() {
         auto outhandle = simout.create("EStride.txt", false, true);
+
+        int ESSize = ways * entryCounts * (tagWidth + logMaxConfidence + strideWidth + 64 + 2 + 1);
+        *outhandle->stream() << "EStride Size: " << (1.0 * ESSize) / (8 * 1024)  << "KB" << std::endl;
+
         *outhandle->stream() << "VPcorrect: " << stats.VPcorrected.value() << std::endl;
         *outhandle->stream() << "VPpredicted: " << stats.VPpredicted.value() << std::endl;
         *outhandle->stream() << "faultLoad: " << stats.faultLoad.value() << std::endl;

--- a/src/cpu/valuepred/enhanced_stride.cc
+++ b/src/cpu/valuepred/enhanced_stride.cc
@@ -21,7 +21,7 @@ EStride::InflightWindow::InflightWindow(int windowTagLength, bool idealWindow)
       windowTagLength(windowTagLength),
       idealWindow(idealWindow),
       windowActiveCount(0),
-      lastSeqNo(0u)
+      lastSeqNo(0ul)
 {
     // simple hash plan
     if (idealWindow) {
@@ -90,29 +90,22 @@ EStride::EStride(const Params &params)
       strideWidth(params.strideWidth),
       tagWidth(params.tagWidth),
       logESTBEntrys(params.logESTBEntrys),
+      entryCounts(1 << logESTBEntrys),
       logMaxConfidence(params.logMaxConfidence),
+      MAXCONFIDENCE(1 << logMaxConfidence),
+      confidenceThreshold(static_cast<int>(params.thresholdPercent * MAXCONFIDENCE)),
       inflightWindow(params.inflightWindowTagLength, params.idealWindow),
       enableTimeMsgInUpdate(params.enableTimeMsgInUpdate),
       esstats(this)
 {
     // assertion
-    static_assert(sizeof(int) >= 4, "error because int < 4 bytes \n");
     gem5_assert(ways, "EStride ways must > 0 \n");
-    gem5_assert(strideWidth, "EStride strideWidth  must > 0 \n");
+    gem5_assert(strideWidth, "EStride strideWidth must > 0 \n");
+    gem5_assert(strideWidth < 64, "EStride strideWidth must < 64 \n");
     gem5_assert(tagWidth, "EStride tagWidth must > 0 \n");
     gem5_assert(logESTBEntrys, "EStride logESTBEntrys must > 0 \n");
     gem5_assert(logMaxConfidence, "EStride logMaxConfidence must > 0 \n");
     gem5_assert(params.inflightWindowTagLength, "EStride inflightWindowTagLength must > 0 \n");
-
-    // we can also enable the test for data type
-    assert(logESTBEntrys < (sizeof(int) * 8));
-    entryCounts = 1 << logESTBEntrys;
-
-    // generate max confidence
-    assert(logMaxConfidence < (sizeof(int) * 8));
-    MAXCONFIDENCE = 1 << logMaxConfidence;
-    confidenceThreshold = static_cast<int>(params.thresholdPercent * MAXCONFIDENCE);
-
 
     // init stats
     ESTables.resize(ways);
@@ -123,6 +116,7 @@ EStride::EStride(const Params &params)
     esstats.allocate.init(ways, entryCounts);
     esstats.strideNotEquals.init(ways, entryCounts);
     esstats.strideEquals.init(ways, entryCounts);
+    // The global inflight window size should be slightly larger than the ROB.
     esstats.inflightSH.init(400);
 
     DPRINTF(EStride, "================================== EStride Params ==================================\n");
@@ -188,13 +182,13 @@ EStride::EStride(const Params &params)
 
 //*********************** auxilary method **************************
 
-int
-EStride::extendStride(int entryStride)
+int64_t
+EStride::extendStride(int64_t entryStride)
 {
-    int mask = (1 << strideWidth) - 1;
+    int64_t mask = (1 << strideWidth) - 1;
     entryStride &= mask;
 
-    int sign_bit = 1 << (strideWidth - 1);
+    int64_t sign_bit = 1 << (strideWidth - 1);
 
     if (entryStride & sign_bit) {
         entryStride |= (~mask);
@@ -205,7 +199,7 @@ EStride::extendStride(int entryStride)
     return entryStride;
 }
 
-unsigned
+uint32_t
 EStride::pcHashToWayIndex(Addr pc, int way)
 {
     uint64_t hash = pc;
@@ -220,7 +214,7 @@ EStride::pcHashToWayIndex(Addr pc, int way)
     return hash & ((1u << logESTBEntrys) - 1);
 }
 
-unsigned
+uint32_t
 EStride::pcHashToTag(Addr pc, int way)
 {
     int j = ways - way;
@@ -228,7 +222,7 @@ EStride::pcHashToTag(Addr pc, int way)
         j = 0;
     }
 
-    int hash = pc;
+    uint64_t hash = pc;
     for (int k = 1; k <= ways + 1; k++) {
         int shift = ((k * logESTBEntrys) - j) % 64;
         if (shift < 0) {
@@ -240,15 +234,15 @@ EStride::pcHashToTag(Addr pc, int way)
     return hash & ((1 << tagWidth) - 1);
 }
 
-unsigned
-EStride::compareTags(unsigned tag1, unsigned tag2)
+uint32_t
+EStride::compareTags(uint32_t tag1, uint32_t tag2)
 {
     return ((tag1 & ((1 << tagWidth) - 1)) ^ (tag2 & ((1 << tagWidth) - 1)));
 }
 
 
-EStride::updateConfDecision
-EStride::decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int stride)
+EStride::UpdateConfDecision
+EStride::decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int64_t stride)
 {
     // todo: different update strategy
     // todo: The current update strategy is close to 100% probability and will
@@ -281,48 +275,56 @@ EStride::decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int stride)
     }
 
     bool finalUpdate = shouldUpdate & ((std::abs(stride) > 1) || !esUpdateMetaData->isLoadInst ||
-                                       ((stride == -1) & ((random_mt.random<int>() & 1) == 0)) ||
-                                       ((stride == 1) & ((random_mt.random<int>() & 3) == 0)));
+                                       ((stride == -1) & ((random_mt.random<int32_t>() & 1) == 0)) ||
+                                       ((stride == 1) & ((random_mt.random<int32_t>() & 3) == 0)));
 
     return {finalUpdate, 1};
 }
 
-unsigned
+uint32_t
 EStride::tryDecUseful(const ESEntry &entry)
 {
-    unsigned k = 2 + 2 * (entry.confidence > MAXCONFIDENCE / 8) + 2 * (entry.confidence >= MAXCONFIDENCE / 4);
-    unsigned mask = (1 << k) - 1;
+    uint32_t k = 2 + 2 * (entry.confidence > MAXCONFIDENCE / 8) + 2 * (entry.confidence >= MAXCONFIDENCE / 4);
+    uint32_t mask = (1 << k) - 1;
 
-    return random_mt.random<int>() & mask;
+    return random_mt.random<uint32_t>() & mask;
 }
 //****************************************************************
 
 VPResult
 EStride::doPredict(ESPredMetaData *esPredMetaData, int inflights)
 {
-    std::string indexMarker, tagMarker;
-    std::vector<unsigned> indexEachWays(ways);
+    std::vector<uint32_t> indexEachWays(ways);
     for (size_t i = 0; i < indexEachWays.size(); i++) {
         indexEachWays[i] = pcHashToWayIndex(esPredMetaData->pc, i);
-        indexMarker += std::to_string(indexEachWays[i]);
-        indexMarker += " ";
     }
 
-    std::vector<unsigned> tagEachWays(ways);
+    std::vector<uint32_t> tagEachWays(ways);
     for (size_t i = 0; i < tagEachWays.size(); i++) {
         tagEachWays[i] = pcHashToTag(esPredMetaData->pc, i);
-        tagMarker += std::to_string(tagEachWays[i]);
-        tagMarker += " ";
     }
 
-    DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX index each way: %s\n", esPredMetaData->seq_no, esPredMetaData->pc,
-            indexMarker.c_str());
-    DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX tag each way: %s\n", esPredMetaData->seq_no, esPredMetaData->pc,
-            tagMarker.c_str());
+    if (debug::EStride) {
+        std::string indexMarker, tagMarker;
+        for (size_t i = 0; i < indexEachWays.size(); i++) {
+            indexMarker += std::to_string(indexEachWays[i]);
+            indexMarker += " ";
+        }
+
+        for (size_t i = 0; i < tagEachWays.size(); i++) {
+            tagMarker += std::to_string(tagEachWays[i]);
+            tagMarker += " ";
+        }
+
+        DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX index each way: %s\n", esPredMetaData->seq_no,
+                esPredMetaData->pc, indexMarker.c_str());
+        DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX tag each way: %s\n", esPredMetaData->seq_no,
+                esPredMetaData->pc, tagMarker.c_str());
+    }
 
     bool found = false;
     int way;
-    size_t index;
+    uint32_t index;
     ESEntry entryCopy;
     for (int i = 0; i < ways; ++i) {
         const ESEntry &entry = ESTables[i][indexEachWays[i]];
@@ -345,18 +347,18 @@ EStride::doPredict(ESPredMetaData *esPredMetaData, int inflights)
     DPRINTF(EStride, "[ESPredict][way: %d index: %u][confidence: %d  useful: %d lastValue: %lu]\n", way, index,
             entryCopy.confidence, entryCopy.useful, entryCopy.lastValue);
 
+    uint64_t predValue = (uint64_t)((int64_t)entryCopy.lastValue + (inflights + 1) * extendStride(entryCopy.stride));
+
     if (entryCopy.confidence < confidenceThreshold) {
         DPRINTF(EStride,
                 "[ESPredict]=> seq_no:%lu pc:%lX confidence not enough in ES[way: %d index: %u inflights: %d]\n",
                 esPredMetaData->seq_no, esPredMetaData->pc, way, index, inflights);
-        return {false,
-                (uint64_t)((int64_t)entryCopy.lastValue + (inflights + 1) * (int64_t)extendStride(entryCopy.stride))};
+        return {false, predValue};
     }
 
     DPRINTF(EStride, "[ESPredict]=> seq_no:%lu pc:%lX get prediction in [way: %d index: %u inflights: %d]\n",
             esPredMetaData->seq_no, esPredMetaData->pc, way, index, inflights);
-    return {true,
-            (uint64_t)((int64_t)entryCopy.lastValue + (inflights + 1) * (int64_t)extendStride(entryCopy.stride))};
+    return {true, predValue};
 }
 
 VPResult
@@ -383,34 +385,44 @@ EStride::updateValuePredictor(VPUpdateMetaData *updateMetaData)
     // the first step update inflights window
     inflightWindow.removeFromWindow(esUpdateMetaData->pc, esUpdateMetaData->seq_no);
 
-    std::string indexMarker, tagMarker;
-
     // Given the nature of the current hash method, the same PC gets the
     // same hash value every time it is computed. So instead of storing
     // the hash value in dyninst, we now compute it each time it is used.
     std::vector<unsigned> indexEachWays(ways);
     for (size_t i = 0; i < indexEachWays.size(); i++) {
         indexEachWays[i] = pcHashToWayIndex(esUpdateMetaData->pc, i);
-        indexMarker += std::to_string(indexEachWays[i]);
-        indexMarker += " ";
     }
 
     std::vector<unsigned> tagEachWays(ways);
     for (size_t i = 0; i < tagEachWays.size(); i++) {
         tagEachWays[i] = pcHashToTag(esUpdateMetaData->pc, i);
-        tagMarker += std::to_string(tagEachWays[i]);
-        tagMarker += " ";
     }
 
-    DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX index each way: %s\n", updateMetaData->seq_no, updateMetaData->pc,
-            indexMarker.c_str());
-    DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX tag each way: %s\n", updateMetaData->seq_no, updateMetaData->pc,
-            tagMarker.c_str());
+
+    if (debug::EStride) {
+        std::string indexMarker, tagMarker;
+
+        for (size_t i = 0; i < indexEachWays.size(); i++) {
+            indexMarker += std::to_string(indexEachWays[i]);
+            indexMarker += " ";
+        }
+
+        for (size_t i = 0; i < tagEachWays.size(); i++) {
+            tagMarker += std::to_string(tagEachWays[i]);
+            tagMarker += " ";
+        }
+
+        DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX index each way: %s\n", updateMetaData->seq_no,
+                updateMetaData->pc, indexMarker.c_str());
+        DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX tag each way: %s\n", updateMetaData->seq_no,
+                updateMetaData->pc, tagMarker.c_str());
+    }
+
 
     // try to find
     bool found = false;
-    size_t way;
-    size_t index;
+    int way;
+    uint32_t index;
     for (size_t i = 0; i < ways; ++i) {
         const ESEntry &entry = ESTables[i][indexEachWays[i]];
         // todo maybe change the occupied
@@ -432,9 +444,9 @@ EStride::updateValuePredictor(VPUpdateMetaData *updateMetaData)
         // update stride and judge is mispredict, and update lastValue
         DPRINTF(EStride, "activate value - last value: %lu-%lu, appear before: %s \n", esUpdateMetaData->actualValue,
                 entry.lastValue, entry.NotFirstAppear ? "not" : "yes");
-        bool misprediction = !(esUpdateMetaData->actualValue ==
-                               (uint64_t)((int64_t)entry.lastValue + (int64_t)extendStride(entry.stride)));
-        int actualStride = esUpdateMetaData->actualValue - entry.lastValue;
+        bool misprediction =
+            !(esUpdateMetaData->actualValue == (uint64_t)((int64_t)entry.lastValue + extendStride(entry.stride)));
+        int64_t actualStride = esUpdateMetaData->actualValue - entry.lastValue;
         entry.lastValue = esUpdateMetaData->actualValue;
 
         if (entry.NotFirstAppear) {
@@ -450,7 +462,7 @@ EStride::updateValuePredictor(VPUpdateMetaData *updateMetaData)
                     fluentInstructions[esUpdateMetaData->pc].first += 1;
                 }
 
-                updateConfDecision decision = decideToUpdate(esUpdateMetaData, actualStride);
+                UpdateConfDecision decision = decideToUpdate(esUpdateMetaData, actualStride);
                 if (decision.first) {
                     entry.confidence = std::min(MAXCONFIDENCE, entry.confidence + decision.second);
                 }
@@ -487,7 +499,7 @@ EStride::updateValuePredictor(VPUpdateMetaData *updateMetaData)
         DPRINTF(EStride, "try to allocate new entry\n");
 
         // random find begin of the way-number to find allocate entry
-        unsigned wayBegin = random_mt.random<unsigned>() % ways;
+        uint32_t wayBegin = random_mt.random<uint32_t>() % ways;
 
         // the entry have no stride at first allocate time
 

--- a/src/cpu/valuepred/enhanced_stride.cc
+++ b/src/cpu/valuepred/enhanced_stride.cc
@@ -1,0 +1,553 @@
+#include "cpu/valuepred/enhanced_stride.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#include "base/output.hh"
+#include "base/random.hh"
+#include "cpu/o3/dyn_inst.hh"
+#include "cpu/valuepred/es_metadata.hh"
+#include "debug/EStride.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+//*********************** InflightWindow *************************
+EStride::InflightWindow::InflightWindow(int windowTagLength, bool idealWindow)
+    : Named("inflightWindow"),
+      windowTagLength(windowTagLength),
+      idealWindow(idealWindow),
+      windowActiveCount(0),
+      lastSeqNo(0u)
+{
+    // simple hash plan
+    if (idealWindow) {
+        hashMethod = [](Addr x, int targetLength) -> uint64_t { return x; };
+    } else {
+        hashMethod = [](Addr x, int targetLength) -> uint64_t {
+            x ^= (x >> 33);
+            x *= 0xff51afd7ed558ccd;
+            x ^= (x >> 33);
+            x *= 0xc4ceb9fe1a85ec53;
+            x ^= (x >> 33);
+            return x & ((1 << targetLength) - 1);
+        };
+    }
+}
+
+int
+EStride::InflightWindow::addToInflightWindow(Addr pc)
+{
+
+    uint64_t key = hashMethod(pc, windowTagLength);
+
+    ++windowActiveCount;
+    DPRINTF(EStride, "inflight window add[count: %d]  => pc: %lX \n", windowActiveCount, pc);
+
+    return windows[key]++;
+}
+
+void
+EStride::InflightWindow::removeFromWindow(Addr pc, uint64_t seq_no)
+{
+    if (seq_no <= lastSeqNo) {
+        return;
+    }
+
+    --windowActiveCount;
+    assert(windowActiveCount >= 0);
+    DPRINTF(EStride, "inflight window remove[count: %d]  => pc: %lX \n", windowActiveCount, pc);
+
+    uint64_t key = hashMethod(pc, windowTagLength);
+    assert(windows.count(key));
+    assert(windows[key] > 0);
+
+    int inflightCount = windows[key];
+    --windows[key];
+    if (windows[key] == 0) {
+        windows.erase(key);
+    }
+}
+
+void
+EStride::InflightWindow::squash(uint64_t seq_no)
+{
+    DPRINTF(EStride, "squash make inflight count window be zero\n");
+    windows.clear();
+    windowActiveCount = 0;
+    lastSeqNo = seq_no;
+}
+
+//****************************************************************
+
+
+EStride::EStride(const Params &params)
+    : VPUnit(params),
+      ways(params.ways),
+      strideWidth(params.strideWidth),
+      tagWidth(params.tagWidth),
+      logESTBEntrys(params.logESTBEntrys),
+      logMaxConfidence(params.logMaxConfidence),
+      inflightWindow(params.inflightWindowTagLength, params.idealWindow),
+      enableTimeMsgInUpdate(params.enableTimeMsgInUpdate),
+      esstats(this)
+{
+    // assertion
+    static_assert(sizeof(int) >= 4, "error because int < 4 bytes \n");
+    gem5_assert(ways, "EStride ways must > 0 \n");
+    gem5_assert(strideWidth, "EStride strideWidth  must > 0 \n");
+    gem5_assert(tagWidth, "EStride tagWidth must > 0 \n");
+    gem5_assert(logESTBEntrys, "EStride logESTBEntrys must > 0 \n");
+    gem5_assert(logMaxConfidence, "EStride logMaxConfidence must > 0 \n");
+    gem5_assert(params.inflightWindowTagLength, "EStride inflightWindowTagLength must > 0 \n");
+
+    // we can also enable the test for data type
+    assert(logESTBEntrys < (sizeof(int) * 8));
+    entryCounts = 1 << logESTBEntrys;
+
+    // generate max confidence
+    assert(logMaxConfidence < (sizeof(int) * 8));
+    MAXCONFIDENCE = 1 << logMaxConfidence;
+    confidenceThreshold = static_cast<int>(params.thresholdPercent * MAXCONFIDENCE);
+
+
+    // init stats
+    ESTables.resize(ways);
+    for (auto &table : ESTables) {
+        table.resize(entryCounts);
+    }
+
+    esstats.allocate.init(ways, entryCounts);
+    esstats.strideNotEquals.init(ways, entryCounts);
+    esstats.strideEquals.init(ways, entryCounts);
+    esstats.inflightSH.init(400);
+
+    DPRINTF(EStride, "================================== EStride Params ==================================\n");
+    DPRINTF(EStride, "ways: %7d | strideWidth: %7d bits | tagWidth %7d bits\n", ways, strideWidth, tagWidth);
+    DPRINTF(EStride, "EStride table entrys: %7d\n", entryCounts);
+    DPRINTF(EStride, "MAXCONFIDENCE: %7d | confidenceThreshold %7d\n", MAXCONFIDENCE, confidenceThreshold);
+    DPRINTF(EStride, "inflightWindowTagLength: %7d \n", params.inflightWindowTagLength);
+    DPRINTF(EStride, "enableTimeMsgInUpdate(need pmu support): %s\n", enableTimeMsgInUpdate ? "yes" : "no");
+    DPRINTF(EStride, "==================================  end of Params ==================================\n");
+
+
+    // call back to dump stats
+    registerExitCallback([this]() {
+        auto outhandle = simout.create("EStride.txt", false, true);
+        *outhandle->stream() << "VPcorrect: " << stats.VPcorrected.value() << std::endl;
+        *outhandle->stream() << "VPpredicted: " << stats.VPpredicted.value() << std::endl;
+        *outhandle->stream() << "faultLoad: " << stats.faultLoad.value() << std::endl;
+        *outhandle->stream() << "VPaccuracy: " << stats.VPaccuracy.total() << std::endl;
+        *outhandle->stream() << "VPsupported: " << stats.VPsupported.value() << std::endl;
+        *outhandle->stream() << "VPcoverage: " << stats.VPcoverage.total() << std::endl;
+
+        *outhandle->stream() << std::endl;
+        *outhandle->stream() << "Right Stride:" << std::endl;
+        for (auto j = 0; j < this->entryCounts; ++j) {
+            for (auto i = 0; i < this->ways; ++i) {
+                *outhandle->stream() << "[" << i << "," << j << "] = " << esstats.strideEquals[i][j].value() << "  ";
+            }
+            *outhandle->stream() << std::endl;
+        }
+
+        *outhandle->stream() << std::endl;
+        *outhandle->stream() << "Error Stride:" << std::endl;
+        for (auto j = 0; j < this->entryCounts; ++j) {
+            for (auto i = 0; i < this->ways; ++i) {
+                *outhandle->stream() << "[" << i << "," << j << "] = " << esstats.strideNotEquals[i][j].value()
+                                     << "  ";
+            }
+            *outhandle->stream() << std::endl;
+        }
+
+        *outhandle->stream() << std::endl;
+        *outhandle->stream() << "allocate:" << std::endl;
+        for (auto j = 0; j < this->entryCounts; ++j) {
+            for (auto i = 0; i < this->ways; ++i) {
+                *outhandle->stream() << "[" << i << "," << j << "] = " << esstats.allocate[i][j].value() << "  ";
+            }
+            *outhandle->stream() << std::endl;
+        }
+
+        *outhandle->stream() << std::endl;
+        *outhandle->stream() << "fluent instructions:" << std::endl;
+        for (const auto &[pc, countAndInsts] : fluentInstructions) {
+            const auto &[count, inst] = countAndInsts;
+            if (count < 1000) {
+                continue;
+            }
+
+            *outhandle->stream() << "pc: " << pc << " instruction: " << inst << " total count: " << count << std::endl;
+        }
+        simout.close(outhandle);
+    });
+}
+
+//*********************** auxilary method **************************
+
+int
+EStride::extendStride(int entryStride)
+{
+    int mask = (1 << strideWidth) - 1;
+    entryStride &= mask;
+
+    int sign_bit = 1 << (strideWidth - 1);
+
+    if (entryStride & sign_bit) {
+        entryStride |= (~mask);
+    } else {
+        entryStride &= mask;
+    }
+
+    return entryStride;
+}
+
+unsigned
+EStride::pcHashToWayIndex(Addr pc, int way)
+{
+    uint64_t hash = pc;
+    for (int k = 1; k <= ways; k++) {
+        int shift = ((k * logESTBEntrys) - way) % 64;
+        if (shift < 0) {
+            shift += 64;
+        }
+        hash ^= (pc >> shift);
+    }
+
+    return hash & ((1u << logESTBEntrys) - 1);
+}
+
+unsigned
+EStride::pcHashToTag(Addr pc, int way)
+{
+    int j = ways - way;
+    if (j < 0) {
+        j = 0;
+    }
+
+    int hash = pc;
+    for (int k = 1; k <= ways + 1; k++) {
+        int shift = ((k * logESTBEntrys) - j) % 64;
+        if (shift < 0) {
+            shift += 64;
+        }
+        hash ^= (pc >> shift);
+    }
+
+    return hash & ((1 << tagWidth) - 1);
+}
+
+unsigned
+EStride::compareTags(unsigned tag1, unsigned tag2)
+{
+    return ((tag1 & ((1 << tagWidth) - 1)) ^ (tag2 & ((1 << tagWidth) - 1)));
+}
+
+
+EStride::updateConfDecision
+EStride::decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int stride)
+{
+    // todo: different update strategy
+    // todo: The current update strategy is close to 100% probability and will
+    // have to be changed subsequently.
+    auto tryUpdateOnce = [&]() -> bool {
+        // uint64_t inflightTime = esUpdateMetaData->inflightTime;
+        // int quick = inflightTime <= FASTINSTTIME;
+        // int notl1miss = inflightTime <= L1HITMAXTIME;
+        // int notl2miss = inflightTime <= L2HITMAXTIME;
+        // int notl3miss = inflightTime <= L3HITMAXTIME;
+        // int isLoad = esUpdateMetaData->isLoadInst;
+
+        // int denominator = (1 << (notl1miss + notl2miss + notl3miss + 2 * quick + 2 * !isLoad)) - 1;
+
+        // return (!esUpdateMetaData->actualValue || stride) && ((random_mt.random<int>() & denominator) == 0);
+
+
+        // try once func should support more func to DSE
+        return true;
+    };
+
+
+    bool shouldUpdate = tryUpdateOnce();
+    // Longer strides will get more update possibilities.
+    if (std::abs(stride) >= 8) {
+        shouldUpdate |= tryUpdateOnce();
+    }
+    if (std::abs(stride) >= 64) {
+        shouldUpdate |= tryUpdateOnce();
+    }
+
+    bool finalUpdate = shouldUpdate & ((std::abs(stride) > 1) || !esUpdateMetaData->isLoadInst ||
+                                       ((stride == -1) & ((random_mt.random<int>() & 1) == 0)) ||
+                                       ((stride == 1) & ((random_mt.random<int>() & 3) == 0)));
+
+    return {finalUpdate, 1};
+}
+
+unsigned
+EStride::tryDecUseful(const ESEntry &entry)
+{
+    unsigned k = 2 + 2 * (entry.confidence > MAXCONFIDENCE / 8) + 2 * (entry.confidence >= MAXCONFIDENCE / 4);
+    unsigned mask = (1 << k) - 1;
+
+    return random_mt.random<int>() & mask;
+}
+//****************************************************************
+
+VPResult
+EStride::doPredict(ESPredMetaData *esPredMetaData, int inflights)
+{
+    std::string indexMarker, tagMarker;
+    std::vector<unsigned> indexEachWays(ways);
+    for (size_t i = 0; i < indexEachWays.size(); i++) {
+        indexEachWays[i] = pcHashToWayIndex(esPredMetaData->pc, i);
+        indexMarker += std::to_string(indexEachWays[i]);
+        indexMarker += " ";
+    }
+
+    std::vector<unsigned> tagEachWays(ways);
+    for (size_t i = 0; i < tagEachWays.size(); i++) {
+        tagEachWays[i] = pcHashToTag(esPredMetaData->pc, i);
+        tagMarker += std::to_string(tagEachWays[i]);
+        tagMarker += " ";
+    }
+
+    DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX index each way: %s\n", esPredMetaData->seq_no, esPredMetaData->pc,
+            indexMarker.c_str());
+    DPRINTF(EStride, "[ESPredict] seq_no:%lu pc: %lX tag each way: %s\n", esPredMetaData->seq_no, esPredMetaData->pc,
+            tagMarker.c_str());
+
+    bool found = false;
+    int way;
+    size_t index;
+    ESEntry entryCopy;
+    for (int i = 0; i < ways; ++i) {
+        const ESEntry &entry = ESTables[i][indexEachWays[i]];
+        if (!compareTags(entry.tag, tagEachWays[i])) {
+            found = true;
+            way = i;
+            index = indexEachWays[i];
+            entryCopy = entry;
+            break;
+        }
+    }
+
+
+    if (!found) {
+        DPRINTF(EStride, "[ESPredict]=> seq_no:%lu pc:%lX not found in ES\n", esPredMetaData->seq_no,
+                esPredMetaData->pc);
+        return {false, 0};
+    }
+
+    DPRINTF(EStride, "[ESPredict][way: %d index: %u][confidence: %d  useful: %d lastValue: %lu]\n", way, index,
+            entryCopy.confidence, entryCopy.useful, entryCopy.lastValue);
+
+    if (entryCopy.confidence < confidenceThreshold) {
+        DPRINTF(EStride,
+                "[ESPredict]=> seq_no:%lu pc:%lX confidence not enough in ES[way: %d index: %u inflights: %d]\n",
+                esPredMetaData->seq_no, esPredMetaData->pc, way, index, inflights);
+        return {false,
+                (uint64_t)((int64_t)entryCopy.lastValue + (inflights + 1) * (int64_t)extendStride(entryCopy.stride))};
+    }
+
+    DPRINTF(EStride, "[ESPredict]=> seq_no:%lu pc:%lX get prediction in [way: %d index: %u inflights: %d]\n",
+            esPredMetaData->seq_no, esPredMetaData->pc, way, index, inflights);
+    return {true,
+            (uint64_t)((int64_t)entryCopy.lastValue + (inflights + 1) * (int64_t)extendStride(entryCopy.stride))};
+}
+
+VPResult
+EStride::valuePredict(VPPredMetaData *predMetaData)
+{
+    gem5_assert(predMetaData, "can't pass nullptr to vpunit\n");
+    ESPredMetaData *esPredMetaData = dynamic_cast<ESPredMetaData *>(predMetaData);
+
+
+    // value prediction
+    int inflights = inflightWindow.addToInflightWindow(esPredMetaData->pc);
+    esstats.inflightSH.sample(inflights, 1);
+
+    return doPredict(esPredMetaData, inflights);
+}
+
+void
+EStride::updateValuePredictor(VPUpdateMetaData *updateMetaData)
+{
+    gem5_assert(updateMetaData, "can't pass nullptr to vpunit\n");
+    ESUpdateMetaData *esUpdateMetaData = dynamic_cast<ESUpdateMetaData *>(updateMetaData);
+
+
+    // the first step update inflights window
+    inflightWindow.removeFromWindow(esUpdateMetaData->pc, esUpdateMetaData->seq_no);
+
+    std::string indexMarker, tagMarker;
+
+    // Given the nature of the current hash method, the same PC gets the
+    // same hash value every time it is computed. So instead of storing
+    // the hash value in dyninst, we now compute it each time it is used.
+    std::vector<unsigned> indexEachWays(ways);
+    for (size_t i = 0; i < indexEachWays.size(); i++) {
+        indexEachWays[i] = pcHashToWayIndex(esUpdateMetaData->pc, i);
+        indexMarker += std::to_string(indexEachWays[i]);
+        indexMarker += " ";
+    }
+
+    std::vector<unsigned> tagEachWays(ways);
+    for (size_t i = 0; i < tagEachWays.size(); i++) {
+        tagEachWays[i] = pcHashToTag(esUpdateMetaData->pc, i);
+        tagMarker += std::to_string(tagEachWays[i]);
+        tagMarker += " ";
+    }
+
+    DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX index each way: %s\n", updateMetaData->seq_no, updateMetaData->pc,
+            indexMarker.c_str());
+    DPRINTF(EStride, "[ESUpdate] seq_no:%lu pc: %lX tag each way: %s\n", updateMetaData->seq_no, updateMetaData->pc,
+            tagMarker.c_str());
+
+    // try to find
+    bool found = false;
+    size_t way;
+    size_t index;
+    for (size_t i = 0; i < ways; ++i) {
+        const ESEntry &entry = ESTables[i][indexEachWays[i]];
+        // todo maybe change the occupied
+        if (!compareTags(entry.tag, tagEachWays[i])) {
+            found = true;
+            way = i;
+            index = indexEachWays[i];
+            break;
+        }
+    }
+
+
+    if (found) {
+        // update
+        ESEntry &entry = ESTables[way][index];
+        DPRINTF(EStride, "[way: %d index: %u][confidence: %d  useful: %d lastValue: %lu]\n", way, index,
+                entry.confidence, entry.useful, entry.lastValue);
+
+        // update stride and judge is mispredict, and update lastValue
+        DPRINTF(EStride, "activate value - last value: %lu-%lu, appear before: %s \n", esUpdateMetaData->actualValue,
+                entry.lastValue, entry.NotFirstAppear ? "not" : "yes");
+        bool misprediction = !(esUpdateMetaData->actualValue ==
+                               (uint64_t)((int64_t)entry.lastValue + (int64_t)extendStride(entry.stride)));
+        int actualStride = esUpdateMetaData->actualValue - entry.lastValue;
+        entry.lastValue = esUpdateMetaData->actualValue;
+
+        if (entry.NotFirstAppear) {
+            DPRINTF(EStride, "activate stride - entry stride = %d - %d \n", actualStride, entry.stride);
+            if (!misprediction) {
+                DPRINTF(EStride, "right stride\n");
+                esstats.strideEquals[way][index]++;
+
+                // mark down some instruction message
+                if (!fluentInstructions.count(esUpdateMetaData->pc)) {
+                    fluentInstructions[esUpdateMetaData->pc] = {1, std::string(esUpdateMetaData->disas)};
+                } else {
+                    fluentInstructions[esUpdateMetaData->pc].first += 1;
+                }
+
+                updateConfDecision decision = decideToUpdate(esUpdateMetaData, actualStride);
+                if (decision.first) {
+                    entry.confidence = std::min(MAXCONFIDENCE, entry.confidence + decision.second);
+                }
+
+                if (decision.first && entry.useful < 3) {
+                    entry.useful++;
+                }
+
+                if (entry.confidence >= confidenceThreshold) {
+                    entry.useful = 3;
+                }
+            } else {
+                // misprediction
+                // update confidence and useful
+
+                DPRINTF(EStride, "error stride\n");
+                esstats.strideNotEquals[way][index]++;
+                int confDec = (1 << ((logMaxConfidence + 1) / 2));
+                if (entry.confidence - confDec > 0) {
+                    entry.confidence -= confDec;
+                } else {
+                    entry.confidence = 0;
+                    entry.useful = 0;
+                }
+                entry.NotFirstAppear = 0;
+            }
+        } else {
+            DPRINTF(EStride, "[ESFirstStride]before stride: %d => after stride: %d\n", entry.stride, actualStride);
+            entry.stride = actualStride;
+            entry.NotFirstAppear++;
+        }
+
+    } else {
+        DPRINTF(EStride, "try to allocate new entry\n");
+
+        // random find begin of the way-number to find allocate entry
+        unsigned wayBegin = random_mt.random<unsigned>() % ways;
+
+        // the entry have no stride at first allocate time
+
+        // first find no confidence
+        for (size_t i = 0; i < ways; ++i) {
+            ESEntry &entry = ESTables[wayBegin][indexEachWays[wayBegin]];
+            if (entry.confidence == 0) {
+                DPRINTF(EStride, "allocate by confidence: [way: %d index: %u] \n", wayBegin, indexEachWays[wayBegin]);
+                esstats.allocate[wayBegin][indexEachWays[wayBegin]]++;
+                entry.tag = tagEachWays[wayBegin];
+                entry.confidence = 1;
+                entry.stride = 0;
+                entry.lastValue = esUpdateMetaData->actualValue;
+                entry.useful = 0;
+                entry.NotFirstAppear = 0;
+                return;
+            }
+            wayBegin = (wayBegin + 1) % ways;
+        }
+
+        // second find not useful
+        for (size_t i = 0; i < ways; ++i) {
+            ESEntry &entry = ESTables[wayBegin][indexEachWays[wayBegin]];
+            if (entry.useful == 0) {
+                DPRINTF(EStride, "allocate by useful: [way: %d index: %u] \n", wayBegin, indexEachWays[wayBegin]);
+                esstats.allocate[wayBegin][indexEachWays[wayBegin]]++;
+                entry.tag = tagEachWays[wayBegin];
+                entry.confidence = 1;
+                entry.stride = 0;
+                entry.lastValue = esUpdateMetaData->actualValue;
+                entry.useful = 0;
+                entry.NotFirstAppear = 0;
+                return;
+            }
+            wayBegin = (wayBegin + 1) % ways;
+        }
+
+        // can't allocate, just random dec some useful count
+        ESEntry &entry = ESTables[wayBegin][indexEachWays[wayBegin]];
+        DPRINTF(EStride, "try dec useful \n");
+        if (tryDecUseful(entry) == 0) {
+            DPRINTF(EStride, "[dec useful count]=> way: %d index: %d", wayBegin, indexEachWays[wayBegin]);
+            entry.useful -= 1;
+        }
+    }
+}
+
+void
+EStride::specUpdateValuePredictor(VPSpecUpdateMetaData *specUpdateMetaData)
+{
+    gem5_assert(specUpdateMetaData, "can't pass nullptr to vpunit\n");
+    return;
+}
+
+void
+EStride::squash(const uint64_t seq_no)
+{
+    inflightWindow.squash(seq_no);
+}
+
+}
+
+}

--- a/src/cpu/valuepred/enhanced_stride.hh
+++ b/src/cpu/valuepred/enhanced_stride.hh
@@ -1,0 +1,180 @@
+#ifndef __ENHANCED_STTIDE_HH__
+#define __ENHANCED_STTIDE_HH__
+
+#include <climits>
+#include <cstdint>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "base/types.hh"
+#include "cpu/valuepred/es_metadata.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
+#include "params/EStride.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+class EStride : public VPUnit
+{
+
+  private:
+    using Params = EStrideParams;
+    using updateConfDecision = std::pair<bool, int>;
+
+    // some instruction latency, these are pre-existing data.
+    // todo: This data needs to be updated to the real observed data
+    // in the simulator and used when the ES is updated.
+    static constexpr uint64_t FASTINSTTIME = 100u;
+    static constexpr uint64_t L1HITMAXTIME = 100u;
+    static constexpr uint64_t L2HITMAXTIME = 100u;
+    static constexpr uint64_t L3HITMAXTIME = 100u;
+
+  private:
+    class ESEntry
+    {
+      public:
+        unsigned tag = 0;
+        int confidence = 0;
+        // todo: we can also control the bits of stride
+        int stride = 0;
+        RegVal lastValue = 0;
+        // now only use 2 bits useful
+        // todo: we can also control the bits of useful
+        int useful = 0;
+        unsigned NotFirstAppear = 0;
+    };
+
+    // The core of the separately wrapped inflight instruction window is just
+    // a map. **Note that the number of instructions in inflight is not the same
+    // as the number of instructions with the same pc in the ROB, and many
+    // instructions inflighted at the front of the pipeline have not yet
+    // entered the ROB.**
+    class InflightWindow : public Named
+    {
+      public:
+        int windowTagLength;
+        bool idealWindow;
+        std::unordered_map<uint64_t, int> windows;
+
+        // just a count for debug
+        int windowActiveCount;
+
+        uint64_t lastSeqNo;
+
+      public:
+        std::string name() const override { return "inflight window"; }
+
+        InflightWindow(int windowTagLength, bool idealWindow);
+
+        // Returns the number of inflights and updates
+        // the inflight window.
+        int addToInflightWindow(Addr pc);
+
+        // remove from window in commit stage
+        void removeFromWindow(Addr pc, uint64_t seq_no);
+
+        // clear in squash
+        void squash(uint64_t seq_no);
+
+      private:
+        // now not support hashMethod for inflight window
+        using HashMethod = uint64_t (*)(uint64_t, int);
+        HashMethod hashMethod;
+    };
+
+
+  private:
+    const int ways;
+    const int strideWidth;
+    const int tagWidth;
+    const int logESTBEntrys;
+    const int logMaxConfidence;
+    InflightWindow inflightWindow;
+    const bool enableTimeMsgInUpdate;
+
+  private:
+    int entryCounts;
+    int confidenceThreshold;
+    int MAXCONFIDENCE;
+
+    std::vector<std::vector<ESEntry>> ESTables;
+
+  private:
+    // This function really implements the prediction function.
+    VPResult doPredict(ESPredMetaData *esPredMetaData, int inflights);
+
+    // extend strideWidth-bits stride to 32-bits stride for calculate
+    int extendStride(int entryStride);
+
+    // Pass in pc and the nth way, and hash to get the index of the nth way.
+    unsigned pcHashToWayIndex(Addr pc, int way);
+    // Pass in pc and the nth way, and hash to get the tag of the nth way.
+    unsigned pcHashToTag(Addr pc, int way);
+
+    // return not-zero value if not equals
+    unsigned compareTags(unsigned tag1, unsigned tag2);
+
+    // Returns a decision about whether to update the entry.
+    updateConfDecision decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int stride);
+
+    // in update time, when we can't allocate new entry, try dec useful count
+    unsigned tryDecUseful(const ESEntry &entry);
+
+  public:
+    EStride(const Params &params);
+
+    std::string name() const override { return "EStride"; }
+
+    virtual VPResult valuePredict(VPPredMetaData *predMetaData) override;
+
+    virtual void updateValuePredictor(VPUpdateMetaData *updateMetaData) override;
+
+    // In reality, the value prediction at the beginning of the fetch phase
+    // needs to be updated speculatively to ensure that the number of inflight
+    // instructions is updated in time for the back-to-back execution. However,
+    // the simulator's value prediction works in the rename phase, where all
+    // instructions are about to enter or have already entered the ROB, and
+    // speculative updates may no longer be needed.
+    virtual void specUpdateValuePredictor(VPSpecUpdateMetaData *specUpdateMetaData) override;
+
+    virtual void squash(const uint64_t seq_no) override;
+
+
+
+    // for dump some data
+  private:
+    std::unordered_map<Addr, std::pair<int, std::string>> fluentInstructions;
+
+  public:
+    struct EStrideStats : public statistics::Group
+    {
+        statistics::Vector2d allocate;
+        statistics::Vector2d strideNotEquals;
+        statistics::Vector2d strideEquals;
+
+        // Records the number of inflight instructions with the
+        // same hash value in the inflight window when the
+        // inflight window is accessed for value prediction.
+        statistics::SparseHistogram inflightSH;
+
+        EStrideStats(statistics::Group *parent)
+            : statistics::Group(parent),
+              ADD_STAT(allocate, "Record the assignment of valuepred_unit entries"),
+              ADD_STAT(strideNotEquals, "Record the situations of stride not equals"),
+              ADD_STAT(strideEquals, "Record the situations of stride equals"),
+              ADD_STAT(inflightSH, "Records the number of inflight instructions")
+        {
+        }
+    } esstats;
+};
+
+}
+
+}
+
+
+#endif

--- a/src/cpu/valuepred/enhanced_stride.hh
+++ b/src/cpu/valuepred/enhanced_stride.hh
@@ -1,3 +1,5 @@
+//The interfaces and implementations in EStride
+//are partially based on the cvp1st paper implementation.
 #ifndef __ENHANCED_STTIDE_HH__
 #define __ENHANCED_STTIDE_HH__
 

--- a/src/cpu/valuepred/enhanced_stride.hh
+++ b/src/cpu/valuepred/enhanced_stride.hh
@@ -23,7 +23,7 @@ class EStride : public VPUnit
 
   private:
     using Params = EStrideParams;
-    using updateConfDecision = std::pair<bool, int>;
+    using UpdateConfDecision = std::pair<bool, int>;
 
     // some instruction latency, these are pre-existing data.
     // todo: This data needs to be updated to the real observed data
@@ -37,10 +37,10 @@ class EStride : public VPUnit
     class ESEntry
     {
       public:
-        unsigned tag = 0;
+        uint32_t tag = 0;
         int confidence = 0;
         // todo: we can also control the bits of stride
-        int stride = 0;
+        int64_t stride = 0;
         RegVal lastValue = 0;
         // now only use 2 bits useful
         // todo: we can also control the bits of useful
@@ -92,14 +92,14 @@ class EStride : public VPUnit
     const int strideWidth;
     const int tagWidth;
     const int logESTBEntrys;
+    const int entryCounts;
     const int logMaxConfidence;
+    const int MAXCONFIDENCE;
+    const int confidenceThreshold;
     InflightWindow inflightWindow;
     const bool enableTimeMsgInUpdate;
 
   private:
-    int entryCounts;
-    int confidenceThreshold;
-    int MAXCONFIDENCE;
 
     std::vector<std::vector<ESEntry>> ESTables;
 
@@ -108,21 +108,21 @@ class EStride : public VPUnit
     VPResult doPredict(ESPredMetaData *esPredMetaData, int inflights);
 
     // extend strideWidth-bits stride to 32-bits stride for calculate
-    int extendStride(int entryStride);
+    int64_t extendStride(int64_t entryStride);
 
     // Pass in pc and the nth way, and hash to get the index of the nth way.
-    unsigned pcHashToWayIndex(Addr pc, int way);
+    uint32_t pcHashToWayIndex(Addr pc, int way);
     // Pass in pc and the nth way, and hash to get the tag of the nth way.
-    unsigned pcHashToTag(Addr pc, int way);
+    uint32_t pcHashToTag(Addr pc, int way);
 
     // return not-zero value if not equals
-    unsigned compareTags(unsigned tag1, unsigned tag2);
+    uint32_t compareTags(uint32_t tag1, uint32_t tag2);
 
     // Returns a decision about whether to update the entry.
-    updateConfDecision decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int stride);
+    UpdateConfDecision decideToUpdate(const ESUpdateMetaData *esUpdateMetaData, int64_t stride);
 
     // in update time, when we can't allocate new entry, try dec useful count
-    unsigned tryDecUseful(const ESEntry &entry);
+    uint32_t tryDecUseful(const ESEntry &entry);
 
   public:
     EStride(const Params &params);
@@ -147,7 +147,7 @@ class EStride : public VPUnit
 
     // for dump some data
   private:
-    std::unordered_map<Addr, std::pair<int, std::string>> fluentInstructions;
+    std::unordered_map<Addr, std::pair<int32_t, std::string>> fluentInstructions;
 
   public:
     struct EStrideStats : public statistics::Group

--- a/src/cpu/valuepred/es_metadata.hh
+++ b/src/cpu/valuepred/es_metadata.hh
@@ -1,0 +1,42 @@
+#ifndef __ES_METADATA_HH__
+#define __ES_METADATA_HH__
+
+#include <string_view>
+
+#include "cpu/valuepred/valuepred_metadata.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+class ESPredMetaData : public VPPredMetaData
+{
+  public:
+    virtual ~ESPredMetaData() {};
+};
+
+class ESUpdateMetaData : public VPUpdateMetaData
+{
+  public:
+    bool isLoadInst = false;
+    uint64_t inflightTime = 0;
+    // for debug
+    std::string_view disas;
+
+    virtual ~ESUpdateMetaData() {};
+};
+
+class ESSpecUpdateMetaData : public VPSpecUpdateMetaData
+{
+  public:
+    virtual ~ESSpecUpdateMetaData() {};
+};
+
+}
+
+}
+
+
+#endif

--- a/src/cpu/valuepred/valuepred_metadata.cc
+++ b/src/cpu/valuepred/valuepred_metadata.cc
@@ -1,0 +1,49 @@
+#include "cpu/valuepred/valuepred_metadata.hh"
+
+#include <cassert>
+
+#include "cpu/valuepred/es_metadata.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+VPPredMetaData*
+VPDataStructFactory::buildPredMetaData(ValuePredType type)
+{
+    switch (type) {
+        case ValuePredType::EStride:
+            return new ESPredMetaData();
+        default:
+            assert(0);
+    }
+}
+
+VPUpdateMetaData*
+VPDataStructFactory::buildUpdateMetaData(ValuePredType type)
+{
+    switch (type) {
+        case ValuePredType::EStride:
+            return new ESUpdateMetaData();
+        default:
+            assert(0);
+    }
+}
+
+VPSpecUpdateMetaData*
+VPDataStructFactory::buildSpecUpdateMetaData(ValuePredType type)
+{
+    switch (type) {
+        case ValuePredType::EStride:
+            return new ESSpecUpdateMetaData();
+        default:
+            assert(0);
+    }
+}
+
+
+}
+
+}

--- a/src/cpu/valuepred/valuepred_metadata.hh
+++ b/src/cpu/valuepred/valuepred_metadata.hh
@@ -1,0 +1,62 @@
+#ifndef __VALUEPRED_METADATA_HH_
+#define __VALUEPRED_METADATA_HH_
+
+#include "base/types.hh"
+#include "enums/ValuePredType.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+class VPPredMetaData
+{
+  public:
+    Addr pc;
+    uint64_t seq_no;
+    virtual ~VPPredMetaData() {};
+};
+
+class VPUpdateMetaData
+{
+  public:
+    Addr pc;
+    uint64_t seq_no;
+    RegVal actualValue;
+    bool isMisprediction;
+    virtual ~VPUpdateMetaData() {};
+};
+
+class VPSpecUpdateMetaData
+{
+  public:
+    virtual ~VPSpecUpdateMetaData() {};
+};
+
+class VPResult
+{
+  public:
+    // is value prediction taken?
+    bool speculative = false;
+    // prediction value
+    RegVal value = 0;
+};
+
+// This factory class constructs predictor-related data structures
+// based on the type of predictor passed in.
+class VPDataStructFactory
+{
+  public:
+    static VPPredMetaData* buildPredMetaData(ValuePredType type);
+    static VPUpdateMetaData* buildUpdateMetaData(ValuePredType type);
+    static VPSpecUpdateMetaData* buildSpecUpdateMetaData(ValuePredType type);
+};
+
+}
+
+}
+
+
+
+#endif

--- a/src/cpu/valuepred/valuepred_unit.cc
+++ b/src/cpu/valuepred/valuepred_unit.cc
@@ -1,0 +1,29 @@
+#include "cpu/valuepred/valuepred_unit.hh"
+
+#include "base/stats/group.hh"
+#include "base/stats/units.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+VPUnit::VPUnit(const Params &params) : SimObject(params), stats(this) {}
+
+VPUnit::ValuePredUnitStats::ValuePredUnitStats(VPUnit *vp)
+    : statistics::Group(vp),
+      ADD_STAT(VPcorrected, statistics::units::Count::get(), "number of correct vp"),
+      ADD_STAT(VPpredicted, statistics::units::Count::get(), "number of predicted vp"),
+      ADD_STAT(faultLoad, statistics::units::Count::get(), "fault counts"),
+      ADD_STAT(VPaccuracy, statistics::units::Ratio::get(), "the accuracy of value predictor",
+               VPcorrected / VPpredicted),
+      ADD_STAT(VPsupported, statistics::units::Count::get(), "number of vp support"),
+      ADD_STAT(VPcoverage, statistics::units::Ratio::get(), "the coverage of vp", VPpredicted / VPsupported)
+{
+}
+
+
+}
+
+}

--- a/src/cpu/valuepred/valuepred_unit.hh
+++ b/src/cpu/valuepred/valuepred_unit.hh
@@ -1,0 +1,65 @@
+#ifndef __VALUEPRED_UNIT_HH__
+#define __VALUEPRED_UNIT_HH__
+
+#include <string>
+
+#include "base/statistics.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
+#include "params/ValuePredictor.hh"
+#include "sim/sim_object.hh"
+#include "sim/stats.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+
+
+class VPUnit : public SimObject
+{
+  private:
+    using Params = ValuePredictorParams;
+
+  public:
+    VPUnit(const Params &params);
+
+    std::string name() const { return "valuePredict.base"; }
+
+    // Do the value predict.
+    virtual VPResult valuePredict(VPPredMetaData *predMetadata) = 0;
+
+    // In commit time, update value predictor
+    virtual void updateValuePredictor(VPUpdateMetaData *updateMetadata) = 0;
+
+    // Some value predictor need speculative update to support back-to-back predict.
+    virtual void specUpdateValuePredictor(VPSpecUpdateMetaData *specupdateMetadata) = 0;
+
+    // If predict error, squash the inflight instructions in value predictor.
+    virtual void squash(const uint64_t seq_no) = 0;
+
+  public:
+    struct ValuePredUnitStats : public statistics::Group
+    {
+        ValuePredUnitStats(VPUnit *vp);
+
+        statistics::Scalar VPcorrected;
+        statistics::Scalar VPpredicted;
+        // Value prediction may result in unaligned memory accesses,
+        // and we need to record this.
+        statistics::Scalar faultLoad;
+        statistics::Formula VPaccuracy;
+        statistics::Scalar VPsupported;
+        statistics::Formula VPcoverage;
+
+    } stats;
+};
+
+
+}
+
+
+}
+
+#endif


### PR DESCRIPTION
related roadmap: #188 

This PR is solely intended to track code related to value prediction and does not currently need to be merged into xs-dev.

**Implemented features in the current code:**

1. Modified the o3 CPU architecture to support value prediction.
2. Designed a basic interface for the value predictor and implemented a simple Estride value predictor.
3. Configured related parameters for Estride, including the number of bits saved for stride and the size of the inflight window, allowing for basic design space exploration.

**Known issues:**
1. The current Estride update strategy is still very basic. **A new update strategy based on instruction execution time is needed**, aligning with the original Estride design.
2. when entry size  <= 16 will raising fault.

spec benchmark scoring is still ongoing.

