### PR TITLE
cpu-o3: add `--disable-sc` param and fix a Segmentation Fault

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -269,6 +269,8 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         help="enable bp database for specified subdatabase, "
                         "basic branch trace is enabled by default even without specifying, "
                         "available subdatabase: basic, tage, ras, loop")
+    parser.add_argument("--disable-sc", default=False, action="store_true",
+                        help="enable sc (only for ftb branch predictor)")
     parser.add_argument("--enable-loop-buffer", default=False, action="store_true",
                         help="enable loop buffer (only for ftb branch predictor)")
     parser.add_argument("--enable-loop-predictor", default=False, action="store_true",

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -270,7 +270,7 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         "basic branch trace is enabled by default even without specifying, "
                         "available subdatabase: basic, tage, ras, loop")
     parser.add_argument("--disable-sc", default=False, action="store_true",
-                        help="enable sc (only for ftb branch predictor)")
+                        help="disable SC (enabled by default, only for FTBTAGE)")
     parser.add_argument("--enable-loop-buffer", default=False, action="store_true",
                         help="enable loop buffer (only for ftb branch predictor)")
     parser.add_argument("--enable-loop-predictor", default=False, action="store_true",

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -313,7 +313,7 @@ def build_test_system(np):
                                                     enableLoopPredictor=args.enable_loop_predictor,
                                                     enableJumpAheadPredictor=args.enable_jump_ahead_predictor
                                                     )
-                    test_sys.cpu[i].branchPred.tage.enableSC = (not args.disable_sc)
+                    test_sys.cpu[i].branchPred.tage.enableSC = not args.disable_sc
                     print("db_switches:", bp_db_switches)
                 else:
                     if enable_bp_db:

--- a/configs/example/fs.py
+++ b/configs/example/fs.py
@@ -313,6 +313,7 @@ def build_test_system(np):
                                                     enableLoopPredictor=args.enable_loop_predictor,
                                                     enableJumpAheadPredictor=args.enable_jump_ahead_predictor
                                                     )
+                    test_sys.cpu[i].branchPred.tage.enableSC = (not args.disable_sc)
                     print("db_switches:", bp_db_switches)
                 else:
                     if enable_bp_db:

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -89,7 +89,7 @@ def build_test_system(np, args):
                                             enableLoopPredictor=args.enable_loop_predictor,
                                             enableJumpAheadPredictor=args.enable_jump_ahead_predictor
                                             )
-            test_sys.cpu[i].branchPred.tage.enableSC = (not args.disable_sc)
+            test_sys.cpu[i].branchPred.tage.enableSC = not args.disable_sc
             test_sys.cpu[i].branchPred.isDumpMisspredPC = True
         else:
             test_sys.cpu[i].branchPred = ObjectList.bp_list.get(args.bp_type)

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -89,6 +89,7 @@ def build_test_system(np, args):
                                             enableLoopPredictor=args.enable_loop_predictor,
                                             enableJumpAheadPredictor=args.enable_jump_ahead_predictor
                                             )
+            test_sys.cpu[i].branchPred.tage.enableSC = (not args.disable_sc)
             test_sys.cpu[i].branchPred.isDumpMisspredPC = True
         else:
             test_sys.cpu[i].branchPred = ObjectList.bp_list.get(args.bp_type)

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -906,6 +906,7 @@ class FTBTAGE(TimedBaseFTBPredictor):
     cxx_class = 'gem5::branch_prediction::ftb_pred::FTBTAGE'
     cxx_header = "cpu/pred/ftb/ftb_tage.hh"
 
+    enableSC = Param.Bool(True, "Enable SC or not")
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([2048]*4, "the ITTAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([8]*4, "the T0~Tn entry's tag bit size")

--- a/src/cpu/pred/ftb/ftb_tage.cc
+++ b/src/cpu/pred/ftb/ftb_tage.cc
@@ -27,6 +27,7 @@ FTBTAGE::FTBTAGE(const Params& p)
       maxHistLen(p.maxHistLen),
       numTablesToAlloc(p.numTablesToAlloc),
       numBr(p.numBr),
+      enableSC(p.enableSC),
       sc(p.numBr, this)
 {
     tageBankStats = new TageBankStats * [numBr];
@@ -76,7 +77,6 @@ FTBTAGE::FTBTAGE(const Params& p)
         useAlt[i].resize(numBr, 0);
     }
     
-    enableSC = true;
     std::vector<TageBankStats *> statsPtr;
     for (int i = 0; i < numBr; i++) {
         statsPtr.push_back(tageBankStats[i]);
@@ -499,11 +499,18 @@ FTBTAGE::update(const FetchStream &entry)
         }
         if (enableDB) {
             TageMissTrace t;
-            t.set(startAddr, ftb_entry.slots[b].pc, b, phyBrIdx, mainFound, pred.mainCounter,
-                pred.mainUseful, pred.altCounter, pred.table, pred.index, getBaseTableIndex(startAddr),
-                pred.tag, pred.useAlt, pred.taken, this_cond_actually_taken, allocSuccess, allocFailure,
-                scMeta.scPreds[b].scUsed, scMeta.scPreds[b].scPred != scMeta.scPreds[b].tageTaken,
-                scMeta.scPreds[b].scPred == this_cond_actually_taken);
+            if (enableSC) {
+                t.set(startAddr, ftb_entry.slots[b].pc, b, phyBrIdx, mainFound, pred.mainCounter,
+                    pred.mainUseful, pred.altCounter, pred.table, pred.index, getBaseTableIndex(startAddr),
+                    pred.tag, pred.useAlt, pred.taken, this_cond_actually_taken, allocSuccess, allocFailure,
+                    scMeta.scPreds[b].scUsed, scMeta.scPreds[b].scPred != scMeta.scPreds[b].tageTaken,
+                    scMeta.scPreds[b].scPred == this_cond_actually_taken);
+            } else {
+                t.set(startAddr, ftb_entry.slots[b].pc, b, phyBrIdx, mainFound, pred.mainCounter,
+                    pred.mainUseful, pred.altCounter, pred.table, pred.index, getBaseTableIndex(startAddr),
+                    pred.tag, pred.useAlt, pred.taken, this_cond_actually_taken, allocSuccess, allocFailure,
+                    0, 0, 0);
+            }
             tageMissTrace->write_record(t);
         }
     }


### PR DESCRIPTION
* add `--disable-sc` command line parameter to disable SC.
* Fix segmentation fault when using `--enable-bp-db tage` with `enableSC=true`