### PR TITLE
cpu-o3: refactor KunminghuV3 ideal params configuration

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -321,6 +321,9 @@ def addCommonOptions(parser, configure_xiangshan=False):
     parser.add_argument("--xiangshan-ecore", action= "store_true",
                         help="Use efficient core of xiangshan")
 
+    parser.add_argument("--ideal-kmhv3", action= "store_true",
+                        help="Use KunminghuV3 ideal params, which take priority over command-line arguments.")
+
     # for warmup without switching cpu
     parser.add_argument("--warmup-insts-no-switch", action="store", type=int,
         default=20*10**6,

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -319,7 +319,7 @@ def setKmhV3IdealParams(args, system):
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
         cpu.fetchToDecodeDelay = 2
-        cpu.decodeWidth = 10
+        cpu.decodeWidth = 8
         cpu.renameWidth = 8
         cpu.dispWidth = [10, 10, 10] # 6->10
         cpu.commitWidth = 12
@@ -333,8 +333,9 @@ def setKmhV3IdealParams(args, system):
         cpu.numROBEntries = 640
         cpu.numDQEntries = [32, 16, 16] # 32->36
         cpu.mmu.itb.size = 96
+        cpu.SbufferEvictThreshold = 8
 
-        cpu.scheduler.disableAllRegArb()
+        # cpu.scheduler.disableAllRegArb()
 
         for iq in cpu.scheduler.IQs:
             if iq.name.startswith('intIQ'):

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -369,6 +369,7 @@ def setKmhV3IdealParams(args, system):
             cpu.dcache.size = '128kB'
             cpu.icache.enable_wayprediction = False
             cpu.dcache.enable_wayprediction = False
+            cpu.dcache.tag_load_read_ports = 100 # 3->100
 
     if args.l2cache:
         for i in range(args.num_cpus):

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -314,6 +314,67 @@ def build_test_system(np, args):
 
     return test_sys
 
+def setKmhV3IdealParams(args, system):
+    for cpu in system.cpu:
+        cpu.commitToFetchDelay = 2
+        cpu.fetchQueueSize = 64
+        cpu.fetchToDecodeDelay = 2
+        cpu.decodeWidth = 10
+        cpu.renameWidth = 8
+        cpu.dispWidth = [10, 10, 10] # 6->10
+        cpu.commitWidth = 12
+        cpu.squashWidth = 12
+        cpu.replayWidth = 12
+        cpu.LQEntries = 128
+        cpu.SQEntries = 96
+        cpu.SbufferEntries = 24
+        cpu.numPhysIntRegs = 354
+        cpu.numPhysFloatRegs = 384
+        cpu.numROBEntries = 640
+        cpu.numDQEntries = [32, 16, 16] # 32->36
+        cpu.mmu.itb.size = 96
+
+        for iq in cpu.scheduler.IQs:
+            if iq.name.startswith('intIQ'):
+                iq.size = 2 * 24
+            if iq.name.startswith('load'):
+                iq.size = 32
+            if iq.name.startswith('store'):
+                iq.size = 32
+            if iq.name.startswith('fpIQ'):
+                iq.size = 32
+
+        # ideal decoupled frontend
+        if args.bp_type is None or args.bp_type == 'DecoupledBPUWithFTB':
+            # cpu.branchPred.enableTwoTaken = True
+            cpu.branchPred.numBr = 4
+            cpu.branchPred.tage.enableSC = False # TODO(bug): When numBr changes, enabling SC will trigger an assert
+            cpu.branchPred.ftq_size = 256
+            cpu.branchPred.fsq_size = 256
+            cpu.branchPred.uftb.numEntries = 1024
+            cpu.branchPred.ftb.numEntries = 16384
+            cpu.branchPred.tage.numPredictors = 9
+            cpu.branchPred.tage.baseTableSize = 4096
+            cpu.branchPred.tage.tableSizes = [4096] * 9
+            cpu.branchPred.tage.TTagBitSizes = [8] * 9
+            cpu.branchPred.tage.TTagPcShifts = [1] * 9
+            cpu.branchPred.tage.histLengths = [8, 13, 21, 35, 57, 93, 151, 246, 401]
+
+        # ideal l1 caches
+        if args.caches:
+            cpu.icache.size = '128kB'
+            cpu.dcache.size = '128kB'
+            cpu.icache.enable_wayprediction = False
+            cpu.dcache.enable_wayprediction = False
+
+    if args.l2cache:
+        for i in range(args.num_cpus):
+            system.l2_caches[i].size = '2MB'
+            system.l2_caches[i].enable_wayprediction = False
+
+    if args.l3cache:
+        system.l3.enable_wayprediction = False
+
 if __name__ == '__m5_main__':
     # Add args
     parser = argparse.ArgumentParser()
@@ -342,6 +403,10 @@ if __name__ == '__m5_main__':
     TestMemClass = Simulation.setMemClass(args)
 
     test_sys = build_test_system(args.num_cpus, args)
+
+    # Set ideal parameters here with the highest priority, over command-line arguments
+    if args.ideal_kmhv3:
+        setKmhV3IdealParams(args, test_sys)
 
     root = Root(full_system=True, system=test_sys)
 

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -334,6 +334,8 @@ def setKmhV3IdealParams(args, system):
         cpu.numDQEntries = [32, 16, 16] # 32->36
         cpu.mmu.itb.size = 96
 
+        cpu.scheduler.disableAllRegArb()
+
         for iq in cpu.scheduler.IQs:
             if iq.name.startswith('intIQ'):
                 iq.size = 2 * 24

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -860,7 +860,7 @@ class TimedBaseFTBPredictor(SimObject):
     cxx_class = 'gem5::branch_prediction::ftb_pred::TimedBaseFTBPredictor'
     cxx_header = "cpu/pred/ftb/timed_base_pred.hh"
     
-    numBr = Param.Unsigned(2, "Number of maximum branches per entry")
+    numBr = Param.Unsigned(Parent.numBr, "Number of maximum branches per entry")
     # subclass are encouraged to explicitly declare latency as numDelay
     numDelay = Param.Unsigned(1000, "Number of bubbles to put on a prediction")
 
@@ -906,8 +906,10 @@ class FTBTAGE(TimedBaseFTBPredictor):
     cxx_class = 'gem5::branch_prediction::ftb_pred::FTBTAGE'
     cxx_header = "cpu/pred/ftb/ftb_tage.hh"
 
+    enableSC = Param.Bool(True, "Enable SC or not")
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([2048]*4, "the ITTAGE T0~Tn length")
+    baseTableSize = Param.Unsigned(2048, "The FTB TAGE base table length")
+    tableSizes = VectorParam.Unsigned([2048]*4, "the FTB TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([8]*4, "the T0~Tn entry's tag bit size")
     TTagPcShifts = VectorParam.Unsigned([1] * 4, "when the T0~Tn entry's tag generating, PC right shift")
 
@@ -942,7 +944,7 @@ class DecoupledBPUWithFTB(BranchPredictor):
     maxHistLen = Param.Unsigned(970, "The length of history")
     numBr = Param.Unsigned(2, "Number of maximum branches per entry")
     numStages = Param.Unsigned(3, "Number of stages in the pipeline")
-    ftb = Param.DefaultFTB(DefaultFTB(numBr=2), "FTB")
+    ftb = Param.DefaultFTB(DefaultFTB(), "FTB")
     tage = Param.FTBTAGE(FTBTAGE(), "TAGE predictor")
     ittage = Param.FTBITTAGE(FTBITTAGE(), "ITTAGE predictor")
     uftb = Param.DefaultFTB(UFTB(), "UFTB predictor")

--- a/src/cpu/pred/ftb/ftb.cc
+++ b/src/cpu/pred/ftb/ftb.cc
@@ -175,7 +175,10 @@ Addr
 DefaultFTB::getIndex(Addr instPC)
 {
     // Need to shift PC over by the word offset.
-    return (instPC >> instShiftAmt) & idxMask;
+    // return (instPC >> instShiftAmt) & idxMask;
+    // use xor to mix tag and index bits
+    Addr idx = ((instPC >> instShiftAmt) ^ (instPC >> (tagShiftAmt)));
+    return idx & idxMask;
 }
 
 inline

--- a/src/cpu/pred/ftb/ftb_tage.cc
+++ b/src/cpu/pred/ftb/ftb_tage.cc
@@ -20,6 +20,7 @@ namespace ftb_pred{
 FTBTAGE::FTBTAGE(const Params& p)
     : TimedBaseFTBPredictor(p),
       numPredictors(p.numPredictors),
+      baseTableSize(p.baseTableSize),
       tableSizes(p.tableSizes),
       tableTagBits(p.TTagBitSizes),
       tablePcShifts(p.TTagPcShifts),
@@ -27,6 +28,7 @@ FTBTAGE::FTBTAGE(const Params& p)
       maxHistLen(p.maxHistLen),
       numTablesToAlloc(p.numTablesToAlloc),
       numBr(p.numBr),
+      enableSC(p.enableSC),
       sc(p.numBr, this)
 {
     tageBankStats = new TageBankStats * [numBr];
@@ -42,7 +44,7 @@ FTBTAGE::FTBTAGE(const Params& p)
     tableIndexMasks.resize(numPredictors);
     tableTagBits.resize(numPredictors);
     tableTagMasks.resize(numPredictors);
-    baseTable.resize(2048); // need modify
+    baseTable.resize(baseTableSize);
     for (unsigned int i = 0; i < p.numPredictors; ++i) {
         //initialize ittage predictor
         assert(tableSizes.size() >= numPredictors);
@@ -76,7 +78,6 @@ FTBTAGE::FTBTAGE(const Params& p)
         useAlt[i].resize(numBr, 0);
     }
     
-    enableSC = true;
     std::vector<TageBankStats *> statsPtr;
     for (int i = 0; i < numBr; i++) {
         statsPtr.push_back(tageBankStats[i]);

--- a/src/cpu/pred/ftb/ftb_tage.hh
+++ b/src/cpu/pred/ftb/ftb_tage.hh
@@ -131,6 +131,8 @@ class FTBTAGE : public TimedBaseFTBPredictor
 
     const unsigned numPredictors;
 
+    unsigned baseTableSize;
+
     std::vector<unsigned> tableSizes;
     std::vector<unsigned> tableIndexBits;
     std::vector<bitset> tableIndexMasks;


### PR DESCRIPTION
This commit is NOT expected to impact performance.
* Added a new runtime parameter '--ideal-kmhv3'. Parameters reset in the `setKmhV3IdealParams` function now take the highest priority, overriding command-line arguments
* Parameterized `baseTableSize` and `enableSC` in the FTBTAGE class for easier customization
* Unified `numBr` into the DecoupledBPUWithFTB class in BranchPredictor.py for better consistency