### PR TITLE
arch-riscv: skip diff when reading perfCnt CSRs

### DIFF
--- a/src/cpu/difftest.hh
+++ b/src/cpu/difftest.hh
@@ -228,7 +228,9 @@ enum DiffAt
     ValueDiff,
 };
 
-extern const std::vector<uint64_t> skipCSRs;
+void skipPerfCntCsr();
+
+extern std::vector<uint64_t> skipCSRs;
 
 extern uint8_t *pmemStart;
 extern uint64_t pmemSize;


### PR DESCRIPTION
make magic number more readable
skip diff when reading from these CSRs: 
* CSR_MCYCLE 
* CSR_MINSTRET 
* CSR_MMHPMCOUNTER3 -- CSR_MMHPMCOUNTER31
* CSR_MHPMCOUNTER03 -- CSR_MHPMCOUNTER31
* CSR_MMCOUNTINHIBIT -- CSR_MHPMEVENT31
* CSR_CYCLE -- CSR_HPMCOUNTER31

Change-Id: I56026af0388555efa08d4b2ca6ebaabde9b81e92