### PR TITLE
arch-riscv: fix hpmCounter logic

### DIFF
--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -880,7 +880,7 @@ const uint64_t NEMU_SATP_MASK = NEMU_SATP_MODE_MASK |NEMU_SATP_ASID_MASK | NEMU_
 
 const uint64_t NEMU_SSTATUS_WMASK = ((1 << 19) | (1 << 18) | (0x3 << 13) | (1 << 8) | (1 << 5) | (1 << 1) |(0x3 <<9));
 const uint64_t NEMU_SSTATUS_RMASK = 0x80000003000de762UL;
-const uint64_t NEMU_COUNTER_MASK = 0;
+const uint64_t NEMU_COUNTER_MASK = 0xffffffffULL;
 
 const uint64_t NEMU_VS_MASK = ((1 << 10) | (1 << 6) | (1 << 2));
 const uint64_t NEMU_HS_MASK = ((1 << 12) | NEMU_VS_MASK);


### PR DESCRIPTION

<img width="854" alt="0277c32e33b5ff3474a74f488b451ea" src="https://github.com/user-attachments/assets/64a10855-5de5-4514-96fa-c77ab1d8c354" />

- when privilege mode is U, corresponding hpm counter can be read only when corresponding bit of scounteren and mcounteren are both set.
- make scounteren writeable

Change-Id: Ia8332471232db9a2b2ce732ea74dae6497428eef