### PR TITLE
cpu-o3: ideal: larger mshr

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -365,6 +365,7 @@ def setKmhV3IdealParams(args, system):
             cpu.icache.enable_wayprediction = False
             cpu.dcache.enable_wayprediction = False
             cpu.dcache.tag_load_read_ports = 100 # 3->100
+            cpu.dcache.mshrs = 32
 
     if args.l2cache:
         for i in range(args.num_cpus):
@@ -376,6 +377,7 @@ def setKmhV3IdealParams(args, system):
 
     if args.l3cache:
         system.l3.enable_wayprediction = False
+        system.l3.mshrs = 128
 
 if __name__ == '__m5_main__':
     # Add args


### PR DESCRIPTION
larger mshr allow more prefetcher requests,
dcache mshr from 16 to 32, l3 mshr from 64 to 128, mcf score form 28 to 29, total int score from 19.23 to 19.29

Change-Id: I5cea0eb6610b7bc5241de15992cc2e91de599da6