### PR TITLE
util: add --debug-cycle to help debug print

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -152,6 +152,8 @@ AddOption('--pgo-use', action='store', default=None,
           help='Use pgo profiling results')
 AddOption('--unit-test', action='store_true',
           help='Enable unit test build')
+AddOption('--debug-cycle', action='store_true',
+          help='Enable print cycle in DPRINTF')
 AddOption('--rvv-impl', action='store', default='base',
           choices=['base', 'simple'],
           help='Select the implementation of the RVV extension to use')
@@ -380,6 +382,13 @@ for variant_path in variant_paths:
     # Make a copy of the build-root environment to use for this config.
     env = main.Clone()
     env['BUILDDIR'] = variant_path
+
+    # Check for unit test mode and define UNIT_TEST macro if enabled
+    # This is used to replace debug/DecoupleBP.hh with test_dprintf.hh
+    if GetOption('unit_test'):
+        env.Append(CPPDEFINES=['UNIT_TEST'])
+    if GetOption('debug_cycle'):
+        env.Append(CPPDEFINES=['DEBUG_SHOW_CYCLES'])
 
     try:
         # try-except section is required because

--- a/src/SConscript
+++ b/src/SConscript
@@ -665,6 +665,10 @@ envs['debug'].Append(CPPDEFINES=['DEBUG', 'TRACING_ON=1'])
 envs['opt'].Append(CCFLAGS=['-g'], CPPDEFINES=['TRACING_ON=1'])
 envs['fast'].Append(CPPDEFINES=['NDEBUG', 'TRACING_ON=0'])
 
+if GetOption('debug_cycle'):
+    for target in ['debug', 'opt', 'fast']:
+        envs[target].Append(CPPDEFINES=['DEBUG_SHOW_CYCLES'])
+
 # For Link Time Optimization, the optimisation flags used to compile
 # individual files are decoupled from those used at link time
 # (i.e. you can compile with -O3 and perform LTO with -O0), so we need

--- a/src/base/trace.hh
+++ b/src/base/trace.hh
@@ -33,14 +33,15 @@
 #define __BASE_TRACE_HH__
 
 #include <ostream>
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "base/compiler.hh"
 #include "base/cprintf.hh"
 #include "base/debug.hh"
 #include "base/match.hh"
 #include "base/types.hh"
+#include "sim/core.hh"
 #include "sim/cur_tick.hh"
 
 // Return the global context name "global".  This function gets called when
@@ -183,12 +184,24 @@ struct StringWrap
             ::gem5::curTick(), name(), data, count, #x); \
 } while (0)
 
-#define DPRINTF(x, ...) do {                     \
-    if (GEM5_UNLIKELY(TRACING_ON && (::gem5::debug::x))) {   \
-        ::gem5::Trace::getDebugLogger()->dprintf_flag(   \
-            ::gem5::curTick(), name(), #x, __VA_ARGS__); \
-    }                                            \
-} while (0)
+#ifdef DEBUG_SHOW_CYCLES
+    #define DPRINTF(x, ...) do {                     \
+        if (GEM5_UNLIKELY(TRACING_ON && (::gem5::debug::x))) {   \
+            ::gem5::Trace::getDebugLogger()->dprintf_flag(   \
+                ::gem5::curTick(), name(), #x, \
+                "[c: %llu] %s", \
+                ::gem5::curTick() / ::gem5::getCpuClockPeriod(), \
+                ::gem5::csprintf(__VA_ARGS__).c_str()); \
+        } \
+    } while (0)
+#else
+    #define DPRINTF(x, ...) do {                     \
+        if (GEM5_UNLIKELY(TRACING_ON && (::gem5::debug::x))) {   \
+            ::gem5::Trace::getDebugLogger()->dprintf_flag(   \
+                ::gem5::curTick(), name(), #x, __VA_ARGS__); \
+        }                                            \
+    } while (0)
+#endif
 
 #define DPRINTFS(x, s, ...) do {                        \
     if (GEM5_UNLIKELY(TRACING_ON && (::gem5::debug::x))) {          \

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -69,6 +69,7 @@
 #include "mem/page_table.hh"
 #include "params/BaseCPU.hh"
 #include "sim/clocked_object.hh"
+#include "sim/core.hh"
 #include "sim/full_system.hh"
 #include "sim/process.hh"
 #include "sim/root.hh"
@@ -382,6 +383,9 @@ BaseCPU::init()
 
         verifyMemoryMode();
     }
+
+    // Set CPU clock period for debug printing
+    setCpuClockPeriod(clockPeriod());
 }
 
 void

--- a/src/sim/clocked_object.hh
+++ b/src/sim/clocked_object.hh
@@ -212,6 +212,15 @@ class Clocked
      */
     Tick nextCycle() const { return clockEdge(Cycles(1)); }
 
+    /**
+     * Calculate current CPU cycle for debug printing purposes.
+     * This provides a convenient way to convert current tick to cycle count
+     * without using magic numbers.
+     *
+     * @return Current cycle count based on this object's clock domain
+     */
+    uint64_t cpuCycle() const { return curTick() / clockPeriod(); }
+
     uint64_t frequency() const { return sim_clock::Frequency / clockPeriod(); }
 
     Tick clockPeriod() const { return clockDomain.clockPeriod(); }

--- a/src/sim/core.cc
+++ b/src/sim/core.cc
@@ -81,6 +81,9 @@ bool _clockFrequencyFixed = false;
 // Default to 1 THz (1 Tick == 1 ps)
 Tick _ticksPerSecond = 1e12;
 
+// Default CPU clock period for debug printing (3GHz = 333 ticks per cycle)
+Tick _cpuClockPeriod = 333;
+
 } // anonymous namespace
 
 void
@@ -122,6 +125,10 @@ setClockFrequency(Tick tps)
     _ticksPerSecond = tps;
 }
 Tick getClockFrequency() { return _ticksPerSecond; }
+
+Tick getCpuClockPeriod() { return _cpuClockPeriod; }
+
+void setCpuClockPeriod(Tick period) { _cpuClockPeriod = period; }
 
 void
 setOutputDir(const std::string &dir)

--- a/src/sim/core.hh
+++ b/src/sim/core.hh
@@ -100,6 +100,12 @@ bool clockFrequencyFixed();
 void setClockFrequency(Tick ticksPerSecond);
 Tick getClockFrequency(); // Ticks per second.
 
+/** Get CPU clock period for debug printing.
+ * Uses default 3GHz (333 ticks per cycle) if not overridden.
+ */
+Tick getCpuClockPeriod();
+void setCpuClockPeriod(Tick period);
+
 void setOutputDir(const std::string &dir);
 
 void registerExitCallback(const std::function<void()> &callback);


### PR DESCRIPTION
it will enable print cycle in DPRINTF,
print tick is difficult to debug, print cycle helps, DPRINTF print like:
  31635: system.cpu.branchPred: [c: 95] DecoupledBPUWithFTB::tick()
c: 95 means cycle, 95 = 31635 / 333, 333 is ticks for 1 cycle in 3GHz, use cpu->clockPeriod() is greater, but not all class have cpu member.

Change-Id: I0ff1f3e3290842e6ba110393705c003616103924