### PR TITLE
arch-riscv: add sv48 warning message

### DIFF
--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -87,6 +87,7 @@ class TLB : public BaseTLB
     bool openBackPre;
     bool backPrePrecision;
     bool forwardPrePrecision;
+    uint64_t controlNum;
     uint64_t allForwardPre;
     uint64_t removeNoUseForwardPre;
     uint64_t removeNoUseBackPre;


### PR DESCRIPTION
So far, xs-gem5 has not yet implemented sv48 (though I will find time to implement it as soon as possible). To avoid situations where slices with sv48 cause deadlocks and make debugging difficult, a function has been added to identify sv48 addresses based on their structure. If the first five addresses appear to be sv48, a warning will be issued. However, since the determination is based on address patterns and is not entirely accurate, the address will still be sent to the MMU for translation. The warning serves only as a reminder, and if a deadlock occurs, developers may want to consider whether the slice is using sv48.

Change-Id: Ie5883e7a16860dde592009263e26310729fcf721