### PR TITLE
cpu-o3: Transform the lsqunit

### DIFF
--- a/configs/common/Caches.py
+++ b/configs/common/Caches.py
@@ -161,6 +161,7 @@ class L1ToL2Bus(CoherentXBar):
     forward_latency = 3 # l1 -> l2 req/snoop latency
     response_latency = 3 # l2 -> l1 resp latency
     snoop_response_latency = 1
+    hint_wakeup_ahead_cycles = 2 # send Hint to L1 N cycles in advance with TimingResp
 
     # Use a snoop-filter by default, and set the latency to zero as
     # the lookup is assumed to overlap with the frontend latency of

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -337,8 +337,10 @@ def setKmhV3IdealParams(args, system):
         cpu.mmu.itb.size = 96
         
         cpu.BankConflictCheck = False   # real bank conflict 0.2 score
+        cpu.EnableLdMissReplay = False
+        cpu.EnablePipeNukeCheck = False
 
-        cpu.scheduler = IdealScheduler()    
+        cpu.scheduler = IdealScheduler()
         # use centralized load/store issue queue, for hmmer
 
         # ideal decoupled frontend

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -339,6 +339,7 @@ def setKmhV3IdealParams(args, system):
         cpu.BankConflictCheck = False   # real bank conflict 0.2 score
         cpu.EnableLdMissReplay = False
         cpu.EnablePipeNukeCheck = False
+        cpu.StoreWbStage = 2 # store writeback at s2
 
         cpu.scheduler = IdealScheduler()
         # use centralized load/store issue queue, for hmmer

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -377,6 +377,7 @@ def setKmhV3IdealParams(args, system):
             system.l2_caches[i].slice_num = 0   # 4 -> 0, no slice
             system.tol2bus_list[i].forward_latency = 0  # 3->0
             system.tol2bus_list[i].response_latency = 0  # 3->0
+            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0
 
     if args.l3cache:
         system.l3.enable_wayprediction = False

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -679,7 +679,7 @@ decode QUADRANT default Unknown::unknown() {
         0x03: decode FUNCT3 {
             format FenceOp {
                 0x0: fence({{
-                }}, uint64_t, IsReadBarrier, IsWriteBarrier, No_OpClass);
+                }}, uint64_t, IsReadBarrier, IsWriteBarrier, MemReadOp);
                 0x1: fence_i({{
                 }}, uint64_t, IsNonSpeculative, IsSerializeAfter, No_OpClass);
             }

--- a/src/arch/riscv/isa/formats/amo.isa
+++ b/src/arch/riscv/isa/formats/amo.isa
@@ -151,6 +151,36 @@ def template LRSCMacroConstructor {{
     }
 }};
 
+// Strictly order-preserving LRSC
+def template LRSCStrictMacroConstructor {{
+    %(class_name)s::%(class_name)s(ExtMachInst machInst):
+        %(base_class)s("%(mnemonic)s", machInst, %(op_class)s)
+    {
+        %(constructor)s;
+
+        StaticInstPtr rel_fence;
+        StaticInstPtr lrsc;
+        StaticInstPtr acq_fence;
+
+        rel_fence = new MemFenceMicro(machInst, No_OpClass);
+        rel_fence->setFlag(IsFirstMicroop);
+        rel_fence->setFlag(IsReadBarrier);
+        rel_fence->setFlag(IsWriteBarrier);
+        rel_fence->setFlag(IsDelayedCommit);
+
+        // set up atomic rmw op
+        lrsc = new %(class_name)sMicro(machInst, this);
+        lrsc->setFlag(IsDelayedCommit);
+
+        acq_fence = new MemFenceMicro(machInst, No_OpClass);
+        acq_fence->setFlag(IsLastMicroop);
+        acq_fence->setFlag(IsReadBarrier);
+        acq_fence->setFlag(IsWriteBarrier);
+
+        microops = {rel_fence, lrsc, acq_fence};
+    }
+}};
+
 def template LRSCMicroConstructor {{
     %(class_name)s::%(class_name)sMicro::%(class_name)sMicro(
         ExtMachInst machInst, %(class_name)s *_p)
@@ -435,7 +465,7 @@ def format LoadReserved(memacc_code, postacc_code={{ }}, ea_code={{EA = Rs1;}},
     macro_iop = InstObjParams(name, Name, 'LoadReserved', macro_ea_code,
                               macro_inst_flags)
     header_output = LRSCDeclare.subst(macro_iop)
-    decoder_output = LRSCMacroConstructor.subst(macro_iop)
+    decoder_output = LRSCStrictMacroConstructor.subst(macro_iop)
     decode_block = BasicDecode.subst(macro_iop)
 
     exec_output = ''
@@ -463,7 +493,7 @@ def format StoreCond(memacc_code, postacc_code={{ }}, ea_code={{EA = Rs1;}},
     macro_iop = InstObjParams(name, Name, 'StoreCond', macro_ea_code,
                               macro_inst_flags)
     header_output = LRSCDeclare.subst(macro_iop)
-    decoder_output = LRSCMacroConstructor.subst(macro_iop)
+    decoder_output = LRSCStrictMacroConstructor.subst(macro_iop)
     decode_block = BasicDecode.subst(macro_iop)
 
     exec_output = ''

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -188,6 +188,8 @@ class BaseO3CPU(BaseCPU):
     LFSTEntrySize = Param.Unsigned(4,"The number of store table inst in every entry of LFST can contain")
     SSITSize = Param.Unsigned(8192, "Store set ID table size")
     BankConflictCheck = Param.Bool(True, "open Bank conflict check")
+    EnableLdMissReplay = Param.Bool(True, "Replay Cache missed load instrution from ReplayQ if True")
+    EnablePipeNukeCheck = Param.Bool(True, "Replay load if Raw violation is detected in loadPipe if True")
 
 
     numRobs = Param.Unsigned(1, "Number of Reorder Buffers");

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -175,6 +175,8 @@ class BaseO3CPU(BaseCPU):
     SbufferEvictThreshold = Param.Unsigned(7, "store buffer eviction threshold")
     storeBufferInactiveThreshold = Param.Unsigned(800, "store buffer writeback timeout threshold")
 
+    StoreWbStage = Param.Unsigned(4, "Which PipeLine Stage store instruction writeback, 4 means S4")
+
     LSQDepCheckShift = Param.Unsigned(0,
             "Number of places to shift addr before check")
     LSQCheckLoads = Param.Bool(True,

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -171,6 +171,9 @@ class BaseO3CPU(BaseCPU):
     LQEntries = Param.Unsigned(80, "Number of load queue entries")
     SQEntries = Param.Unsigned(64, "Number of store queue entries")
 
+    LdPipeStages = Param.Unsigned(4, "Number of load pipeline stages")
+    StPipeStages = Param.Unsigned(5, "Number of store pipeline stages")
+
     SbufferEntries = Param.Unsigned(16, "Number of store buffer entries")
     SbufferEvictThreshold = Param.Unsigned(7, "store buffer eviction threshold")
     storeBufferInactiveThreshold = Param.Unsigned(800, "store buffer writeback timeout threshold")

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -65,6 +65,7 @@ if env['CONF']['TARGET_ISA'] != 'null':
     DebugFlag('IQ')
     DebugFlag('LSQ')
     DebugFlag('LSQUnit')
+    DebugFlag('Hint')
     DebugFlag('TagReadFail')
     DebugFlag('StoreBuffer')
     DebugFlag('MemDepUnit')

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -194,7 +194,7 @@ class DynInst : public ExecContext, public RefCounted
         NotAnInst,
         TranslationStarted,
         TranslationCompleted,
-        CacheRefilledAfterMiss,
+        WaitingCacheRefill,
         PossibleLoadViolation,
         HitExternalSnoop,
         EffAddrValid,
@@ -463,13 +463,13 @@ class DynInst : public ExecContext, public RefCounted
     }
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
 
-    /** True if Dcache refilled after Dcache miss. */
+    /** True if inst is waiting for Dcache refill. */
     bool
-    cacheRefilledAfterMiss() const
+    waitingCacheRefill() const
     {
-        return instFlags[CacheRefilledAfterMiss];
+        return instFlags[WaitingCacheRefill];
     }
-    void cacheRefilledAfterMiss(bool f) { instFlags[CacheRefilledAfterMiss] = f; }
+    void waitingCacheRefill(bool f) { instFlags[WaitingCacheRefill] = f; }
 
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -194,6 +194,7 @@ class DynInst : public ExecContext, public RefCounted
         NotAnInst,
         TranslationStarted,
         TranslationCompleted,
+        CacheRefilledAfterMiss,
         PossibleLoadViolation,
         HitExternalSnoop,
         EffAddrValid,
@@ -461,6 +462,14 @@ class DynInst : public ExecContext, public RefCounted
         return instFlags[TranslationCompleted];
     }
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
+
+    /** True if Dcache refilled after Dcache miss. */
+    bool
+    cacheRefilledAfterMiss() const
+    {
+        return instFlags[CacheRefilledAfterMiss];
+    }
+    void cacheRefilledAfterMiss(bool f) { instFlags[CacheRefilledAfterMiss] = f; }
 
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming
@@ -1395,6 +1404,10 @@ class DynInst : public ExecContext, public RefCounted
         return squashVer.getVersion();
     }
 
+    ssize_t getLqIdx()
+    {
+        return lqIdx;
+    }
 
     Addr getPC()
     {

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -195,6 +195,7 @@ class DynInst : public ExecContext, public RefCounted
         TranslationStarted,
         TranslationCompleted,
         WaitingCacheRefill,
+        HasPendingCacheReq,
         PossibleLoadViolation,
         HitExternalSnoop,
         EffAddrValid,
@@ -470,6 +471,14 @@ class DynInst : public ExecContext, public RefCounted
         return instFlags[WaitingCacheRefill];
     }
     void waitingCacheRefill(bool f) { instFlags[WaitingCacheRefill] = f; }
+
+    /** True if inst is has pending cache request. */
+    bool
+    hasPendingCacheReq() const
+    {
+        return instFlags[HasPendingCacheReq];
+    }
+    void hasPendingCacheReq(bool f) { instFlags[HasPendingCacheReq] = f; }
 
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1471,7 +1471,7 @@ IEW::executeInsts()
             // Tell the LDSTQ to execute this instruction (if it is a load).
             if (inst->isAtomic()) {
                 // AMOs are treated like store requests
-                fault = ldstQueue.executeStore(inst);
+                fault = ldstQueue.executeAmo(inst);
 
                 if (inst->isTranslationDelayed() &&
                     fault == NoFault) {

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -683,6 +683,12 @@ IEW::blockMemInst(const DynInstPtr& inst)
 }
 
 void
+IEW::cacheMissLdReplay(const DynInstPtr& inst)
+{
+    instQueue.cacheMissLdReplay(inst);
+}
+
+void
 IEW::cacheUnblocked()
 {
     instQueue.cacheUnblocked();

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -209,6 +209,9 @@ class IEW
     /** Moves memory instruction onto the list of cache blocked instructions */
     void blockMemInst(const DynInstPtr &inst);
 
+    /** Moves load instruction onto the Set of cache missed instructions */
+    void cacheMissLdReplay(const DynInstPtr &inst);
+
     /** Notifies that the cache has become unblocked */
     void cacheUnblocked();
 

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -252,6 +252,17 @@ class IEW
 
     bool flushAllStores(ThreadID tid) { return ldstQueue.flushAllStores(tid); }
 
+    /** Check if we need to squash after a load/store/branch is executed. */
+    void SquashCheckAfterExe(DynInstPtr inst);
+
+    void notifyExecuted(const DynInstPtr &inst) { instQueue.notifyExecuted(inst); }
+
+    /**
+     * Defers a memory instruction when its DTB translation incurs a hw
+     * page table walk.
+     */
+    void deferMemInst(const DynInstPtr &deferred_inst) { instQueue.deferMemInst(deferred_inst); }
+
     /** Check misprediction  */
     void checkMisprediction(const DynInstPtr &inst);
 

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -931,14 +931,14 @@ InstructionQueue::getCacheMissInstToExecute()
 {
     for (auto it = cacheMissLdInsts.begin(); it != cacheMissLdInsts.end();
          ++it) {
-        if ((*it)->cacheRefilledAfterMiss() || (*it)->isSquashed()) {
+        if (!(*it)->waitingCacheRefill() || (*it)->isSquashed()) {
             DPRINTF(IQ, "CacheMissed load inst [sn:%llu] PC %s is ready to "
                     "execute\n", (*it)->seqNum, (*it)->pcState());
             DynInstPtr mem_inst = std::move(*it);
             cacheMissLdInsts.erase(it);
             return mem_inst;
         }
-        if (!(*it)->cacheRefilledAfterMiss()) {
+        if ((*it)->waitingCacheRefill()) {
             DPRINTF(
                 IQ,
                 "CacheMissed load inst [sn:%llu] PC %s has not been waken up "

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -697,7 +697,7 @@ InstructionQueue::scheduleReadyInsts()
         assert(op_latency < 64);
         DPRINTF(Schedule, "[sn:%llu] start execute %u cycles\n", issued_inst->seqNum, op_latency);
         cpu->perfCCT->updateInstPos(issued_inst->seqNum, PerfRecord::AtFU);
-        if (op_latency <= 1) {
+        if (op_latency <= 1 || issued_inst->isLoad() || issued_inst->isStore()) {
             i2e_info->size++;
             instsToExecute.push_back(issued_inst);
         }

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -876,11 +876,6 @@ InstructionQueue::cacheMissLdReplay(const DynInstPtr &deferred_inst)
 {
     DPRINTF(IQ, "Get Cache Missed Load, insert to Replay Queue "
             "[sn:%llu]\n", deferred_inst->seqNum);
-    // Reset DTB translation state
-    deferred_inst->translationStarted(false);
-    deferred_inst->translationCompleted(false);
-
-    deferred_inst->clearCanIssue();
     cacheMissLdInsts.insert(deferred_inst);
 }
 

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -88,6 +88,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       enableBankConflictCheck(params.BankConflictCheck),
       _enableLdMissReplay(params.EnableLdMissReplay),
       _enablePipeNukeCheck(params.EnablePipeNukeCheck),
+      _storeWbStage(params.StoreWbStage),
       waitingForStaleTranslation(false),
       staleTranslationWaitTxnId(0),
       lsqPolicy(params.smtLSQPolicy),
@@ -104,6 +105,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     if (!_enableLdMissReplay && _enablePipeNukeCheck) {
         panic("LSQ can not support pipeline nuke replay when EnableLdMissReplay is False");
     }
+    assert(_storeWbStage >= 2 && _storeWbStage <= 4);
 
     //**********************************************
     //************ Handle SMT Parameters ***********

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -138,7 +138,8 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     // TODO: Parameterize the load/store pipeline stages
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         thread.emplace_back(maxLQEntries, maxSQEntries, params.SbufferEntries,
-            params.SbufferEvictThreshold, params.storeBufferInactiveThreshold, 4, 5);
+            params.SbufferEvictThreshold, params.storeBufferInactiveThreshold,
+            params.LdPipeStages, params.StPipeStages);
         thread[tid].init(cpu, iew_ptr, params, this, tid);
         thread[tid].setDcachePort(&dcachePort);
     }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1249,7 +1249,7 @@ LSQ::LSQRequest::LSQRequest(
     : _state(State::NotIssued),
     numTranslatedFragments(0),
     numInTranslationFragments(0),
-    _port(*port), _inst(inst), _data(data), _fwd_data_pkt(nullptr),
+    _port(*port), _inst(inst), _data(data),
     _res(res), _addr(addr), _size(size),
     _flags(flags_),
     _numOutstandingPackets(0),
@@ -1338,9 +1338,6 @@ LSQ::LSQRequest::~LSQRequest()
 
     for (auto r: _packets)
         delete r;
-
-    if (_fwd_data_pkt)
-        delete  _fwd_data_pkt;
 };
 
 ContextID

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -748,6 +748,15 @@ class LSQ
     /** Executes a store. */
     Fault executeStore(const DynInstPtr &inst);
 
+    /** Iq issues a load to load pipeline. */
+    void issueToLoadPipe(const DynInstPtr &inst);
+
+    /** Iq issues a store to store pipeline. */
+    void issueToStorePipe(const DynInstPtr &inst);
+
+    /** Process instructions in each load/store pipeline stages. */
+    void executePipeSx();
+
     /**
      * Commits loads up until the given sequence number for a specific thread.
      */

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -76,6 +76,18 @@ class IEW;
 class LSQUnit;
 class StoreBufferEntry;
 
+/** The Flag of Load/Store inst in Pipeline. */
+enum LdStFlags
+{
+    Valid = 0,
+    Replayed,
+    CacheMiss,
+    Squashed,
+    Num_Flags
+};
+
+constexpr uint64_t LdStFlagNum = LdStFlags::Num_Flags;
+
 class LSQ
 {
   public:
@@ -742,11 +754,8 @@ class LSQ
     /** Inserts a store into the LSQ. */
     void insertStore(const DynInstPtr &store_inst);
 
-    /** Executes a load. */
-    Fault executeLoad(const DynInstPtr &inst);
-
-    /** Executes a store. */
-    Fault executeStore(const DynInstPtr &inst);
+    /** Executes an amo inst. */
+    Fault executeAmo(const DynInstPtr &inst);
 
     /** Iq issues a load to load pipeline. */
     void issueToLoadPipe(const DynInstPtr &inst);

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -290,7 +290,6 @@ class LSQ
         PacketDataPtr _data;
         std::vector<PacketPtr> _packets;
         std::vector<RequestPtr> _reqs;
-        PacketPtr _fwd_data_pkt;
         std::vector<Fault> _fault;
         uint64_t* _res;
         const Addr _addr;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1017,6 +1017,9 @@ class LSQ
 
     RequestPort &getDataPort() { return dcachePort; }
 
+    bool enableLdMissReplay() const { return _enableLdMissReplay; }
+    bool enablePipeNukeCheck() const { return _enablePipeNukeCheck; }
+
   protected:
     /** D-cache is blocked */
     bool _cacheBlocked;
@@ -1037,6 +1040,9 @@ class LSQ
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
 
     bool enableBankConflictCheck;
+
+    bool _enableLdMissReplay;
+    bool _enablePipeNukeCheck;
 
     /** If the LSQ is currently waiting for stale translations */
     bool waitingForStaleTranslation;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1019,6 +1019,7 @@ class LSQ
 
     bool enableLdMissReplay() const { return _enableLdMissReplay; }
     bool enablePipeNukeCheck() const { return _enablePipeNukeCheck; }
+    int storeWbStage() const { return _storeWbStage; }
 
   protected:
     /** D-cache is blocked */
@@ -1043,6 +1044,8 @@ class LSQ
 
     bool _enableLdMissReplay;
     bool _enablePipeNukeCheck;
+
+    int _storeWbStage;
 
     /** If the LSQ is currently waiting for stale translations */
     bool waitingForStaleTranslation;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1457,36 +1457,14 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
 }
 
 Fault
-LSQUnit::storePipeS2(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::emptyStorePipeSx(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag, uint64_t stage)
 {
+    // empty store pipe stage, Does not perform any operation
     Fault fault = inst->getFault();
     assert(!inst->isSquashed());
 
-    DPRINTF(LSQUnit, "StorePipeS2: Executing store PC %s [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
-    return fault;
-}
-
-Fault
-LSQUnit::storePipeS3(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
-{
-    Fault fault = inst->getFault();
-    assert(!inst->isSquashed());
-
-    DPRINTF(LSQUnit, "StorePipeS3: Executing store PC %s [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
-    return fault;
-}
-
-Fault
-LSQUnit::storePipeS4(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
-{
-    Fault fault = inst->getFault();
-    assert(!inst->isSquashed());
-
-    DPRINTF(LSQUnit, "StorePipeS4: Executing store PC %s [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
-
+    DPRINTF(LSQUnit, "StorePipeS%d: Executing store PC %s [sn:%lli] flags: %s\n",
+            stage, inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
     return fault;
 }
 
@@ -1521,13 +1499,9 @@ LSQUnit::executeStorePipeSx()
                         iewStage->SquashCheckAfterExe(inst);
                         break;
                     case 2:
-                        fault = storePipeS2(inst, flag);
-                        break;
                     case 3:
-                        fault = storePipeS3(inst, flag);
-                        break;
                     case 4:
-                        fault = storePipeS4(inst, flag);
+                        fault = emptyStorePipeSx(inst, flag, i);
                         break;
                     default:
                         panic("unsupported storepipe length");
@@ -2551,16 +2525,18 @@ LSQUnit::recvRetry()
 void
 LSQUnit::dumpLoadPipe()
 {
-    DPRINTF(LSQUnit, "Dumping LoadPipe:\n");
-    for (int i = 0; i < loadPipeSx.size(); i++) {
-        DPRINTF(LSQUnit, "Load S%d:, size: %d\n", i, loadPipeSx[i]->size);
-        for (int j = 0; j < loadPipeSx[i]->size; j++) {
-            DPRINTF(LSQUnit, "  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
-                    loadPipeSx[i]->insts[j]->pcState(),
-                    loadPipeSx[i]->insts[j]->threadNumber,
-                    loadPipeSx[i]->insts[j]->seqNum,
-                    getLdStFlagStr(loadPipeSx[i]->flags[j])
-            );
+    if (GEM5_UNLIKELY(::gem5::debug::LSQUnit)) {
+        DPRINTFN("Dumping LoadPipe:\n");
+        for (int i = 0; i < loadPipeSx.size(); i++) {
+            DPRINTFN("Load S%d:, size: %d\n", i, loadPipeSx[i]->size);
+            for (int j = 0; j < loadPipeSx[i]->size; j++) {
+                DPRINTFN("  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
+                        loadPipeSx[i]->insts[j]->pcState(),
+                        loadPipeSx[i]->insts[j]->threadNumber,
+                        loadPipeSx[i]->insts[j]->seqNum,
+                        getLdStFlagStr(loadPipeSx[i]->flags[j])
+                );
+            }
         }
     }
 }
@@ -2568,16 +2544,18 @@ LSQUnit::dumpLoadPipe()
 void
 LSQUnit::dumpStorePipe()
 {
-    DPRINTF(LSQUnit, "Dumping StorePipe:\n");
-    for (int i = 0; i < storePipeSx.size(); i++) {
-        DPRINTF(LSQUnit, "Store S%d:, size: %d\n", i, storePipeSx[i]->size);
-        for (int j = 0; j < storePipeSx[i]->size; j++) {
-            DPRINTF(LSQUnit, "  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
-                    storePipeSx[i]->insts[j]->pcState(),
-                    storePipeSx[i]->insts[j]->threadNumber,
-                    storePipeSx[i]->insts[j]->seqNum,
-                    getLdStFlagStr(storePipeSx[i]->flags[j])
-            );
+    if (GEM5_UNLIKELY(::gem5::debug::LSQUnit)) {
+        DPRINTFN("Dumping StorePipe:\n");
+        for (int i = 0; i < storePipeSx.size(); i++) {
+            DPRINTFN("Store S%d:, size: %d\n", i, storePipeSx[i]->size);
+            for (int j = 0; j < storePipeSx[i]->size; j++) {
+                DPRINTFN("  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
+                        storePipeSx[i]->insts[j]->pcState(),
+                        storePipeSx[i]->insts[j]->threadNumber,
+                        storePipeSx[i]->insts[j]->seqNum,
+                        getLdStFlagStr(storePipeSx[i]->flags[j])
+                );
+            }
         }
     }
 }

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -453,7 +453,8 @@ class LSQUnit
     int numStoresToSbuffer() { return storesToWB; }
 
     /** get description string from load/store pipeLine flag. */
-    std::string getLdStFlagStr(const std::bitset<LdStFlagNum>& flag) {
+    std::string getLdStFlagStr(const std::bitset<LdStFlagNum>& flag)
+    {
         std::string res{};
         for (int i = 0; i < LdStFlagNum; i++) {
             if (flag.test(i)) {
@@ -464,6 +465,8 @@ class LSQUnit
         }
         return res;
     }
+
+    LSQ* getLsq() { return lsq; }
 
     /** Returns if the LSQ unit will writeback on this cycle. */
     bool

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -484,6 +484,8 @@ class LSQUnit
     void recvRetry();
 
     unsigned int cacheLineSize();
+
+    PacketPtr makeFullFwdPkt(DynInstPtr load_inst, LSQRequest *request);
   private:
     /** Reset the LSQ state */
     void resetState();

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -552,9 +552,7 @@ class LSQUnit
 
     Fault storePipeS0(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
     Fault storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault storePipeS2(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault storePipeS3(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault storePipeS4(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
+    Fault emptyStorePipeSx(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag, uint64_t stage);
 
     /** Wrap function. */
     void executePipeSx();

--- a/src/mem/XBar.py
+++ b/src/mem/XBar.py
@@ -116,6 +116,10 @@ class CoherentXBar(BaseXBar):
     max_outstanding_snoops = Param.Int(512, "Max. outstanding snoops allowed")
 
     # Maximum routing table size for sanity checks
+    hint_wakeup_ahead_cycles = Param.Int(0, "How many cycles" \
+        "sending a Hint to LSU waking up the missed load before TimingResp")
+
+    # Maximum routing table size for sanity checks
     max_routing_table_size = Param.Int(512, "Max. routing table size")
 
     # Determine how this crossbar handles packets where caches have

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -1832,7 +1832,8 @@ BaseCache::access(PacketPtr pkt, CacheBlk *&blk, Cycles &lat,
         incSquashedDemandHitCount(pkt, blk);
 
         // Calculate access latency based on the need to access the data array
-        if (pkt->isRead()) {
+        if (pkt->isRead() || pkt->isWrite()) {
+            // Read and Write can succeed after the data block is ready if Cache Hit
             lat = calculateAccessLatency(blk, pkt->headerDelay, tag_latency);
 
             // When a block is compressed, it must first be decompressed

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -652,17 +652,19 @@ BaseCache::recvTimingReq(PacketPtr pkt)
         }
 
         handleTimingReqHit(pkt, blk, request_time, first_acc_after_pf);
-        if (cacheLevel == 1 && pkt->isResponse() && pkt->isRead() && lat > 1) {
-            // send cache miss signal
-            cpuSidePort.sendCustomSignal(pkt, DcacheRespType::Miss);
+        if (cacheLevel == 1 && pkt->isResponse() && pkt->isRead() && !pkt->isWrite() && lat > 1) {
+            // cache block not ready, send cancel signal
+            cpuSidePort.sendCustomSignal(pkt, DcacheRespType::Block_Not_Ready);
+            pkt->cacheSatisfied = false;
         }
     } else {
         if (cacheLevel != 1) {
             calculateSliceBusy(pkt);
         }
-        if (cacheLevel == 1 && pkt->needsResponse() && pkt->isRead()) {
+        if (cacheLevel == 1 && pkt->needsResponse() && pkt->isRead() && !pkt->isWrite()) {
             // send cache miss signal
             cpuSidePort.sendCustomSignal(pkt, DcacheRespType::Miss);
+            pkt->cacheSatisfied = false;
         }
 
         // ArchDB: for now we only track packet which has PC

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -265,6 +265,8 @@ class BaseCache : public ClockedObject, CacheAccessor
 
         virtual void recvFunctionalSnoop(PacketPtr pkt);
 
+        virtual void recvFunctionalCustomSignal(PacketPtr pkt, int sig);
+
       public:
 
         MemSidePort(const std::string &_name, BaseCache *_cache,
@@ -353,6 +355,18 @@ class BaseCache : public ClockedObject, CacheAccessor
         PacketPtr pkt;
       public:
         SendTimingRespEvent(BaseCache* cache, PacketPtr pkt);
+        void process() override;
+        const char* description() const override;
+    };
+
+    class SendCustomEvent : public Event
+    {
+      private:
+        BaseCache* cache;
+        PacketPtr pkt;
+        int sig;
+      public:
+        SendCustomEvent(BaseCache* cache, PacketPtr pkt, int sig);
         void process() override;
         const char* description() const override;
     };
@@ -627,6 +641,8 @@ class BaseCache : public ClockedObject, CacheAccessor
     virtual void serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt,
                                     CacheBlk *blk) = 0;
 
+    virtual void sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt) = 0;
+
     /**
      * Handles a response (cache line fill/write ack) from the bus.
      * @param pkt The response packet
@@ -709,6 +725,8 @@ class BaseCache : public ClockedObject, CacheAccessor
     QueueEntry* getNextQueueEntry();
 
     bool hasHintsWaiting();
+
+    void recvFunctionalCustomSignal(PacketPtr pkt, int sig);
 
     /**
      * Insert writebacks into the write buffer

--- a/src/mem/cache/cache.hh
+++ b/src/mem/cache/cache.hh
@@ -103,6 +103,8 @@ class Cache : public BaseCache
     void serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt,
                             CacheBlk *blk) override;
 
+    void sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt) override;
+
     void recvTimingSnoopReq(PacketPtr pkt) override;
 
     void recvTimingSnoopResp(PacketPtr pkt) override;

--- a/src/mem/cache/mshr.hh
+++ b/src/mem/cache/mshr.hh
@@ -474,6 +474,11 @@ class MSHR : public QueueEntry, public Printable
     { return targets.size() + deferredTargets.size(); }
 
     /**
+     * add a target to ready_targets according to the target type
+     */
+    void pushReadyTargets(TargetList &ready_targets, Target &tgt);
+
+    /**
      * Extracts the subset of the targets that can be serviced given a
      * received response. This function returns the targets list
      * unless the response is a ReadRespWithInvalidate. The
@@ -487,6 +492,11 @@ class MSHR : public QueueEntry, public Printable
      */
     TargetList extractServiceableTargets(PacketPtr pkt);
 
+    /**
+     * works the same as extractServiceableTargets
+     * but this func will not erase the original TargetList
+     */
+    TargetList copyServiceableTargets(PacketPtr pkt);
     /**
      * Returns true if there are targets left.
      * @return true if there are targets

--- a/src/mem/cache/noncoherent_cache.cc
+++ b/src/mem/cache/noncoherent_cache.cc
@@ -322,6 +322,18 @@ NoncoherentCache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt,
 }
 
 void
+NoncoherentCache::sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt)
+{
+    MSHR::TargetList targets = mshr->copyServiceableTargets(pkt);
+    for (auto &target: targets) {
+        Packet *tgt_pkt = target.pkt;
+        if (target.source == MSHR::Target::FromCPU) {
+            BaseCache::cpuSidePort.sendCustomSignal(tgt_pkt, DcacheRespType::Hint);
+        }
+    }
+}
+
+void
 NoncoherentCache::recvTimingResp(PacketPtr pkt)
 {
     assert(pkt->isResponse());

--- a/src/mem/cache/noncoherent_cache.hh
+++ b/src/mem/cache/noncoherent_cache.hh
@@ -85,6 +85,8 @@ class NoncoherentCache : public BaseCache
     void serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt,
                             CacheBlk *blk) override;
 
+    void sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt) override;
+
     void recvTimingResp(PacketPtr pkt) override;
 
     void recvTimingSnoopReq(PacketPtr pkt) override {

--- a/src/mem/coherent_xbar.hh
+++ b/src/mem/coherent_xbar.hh
@@ -49,6 +49,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "base/types.hh"
 #include "mem/snoop_filter.hh"
 #include "mem/xbar.hh"
 #include "params/CoherentXBar.hh"
@@ -249,6 +250,27 @@ class CoherentXBar : public BaseXBar
 
     };
 
+    class CustomHintEvent : public Event
+    {
+      public:
+        /** Constructs a the custom hint event. */
+        CustomHintEvent(PortID id, PacketPtr pkt, CoherentXBar* xbar);
+
+        /** Processes the event. */
+        void process();
+
+        /** Returns the description of this event. */
+        const char *description() const;
+
+      private:
+        /** The pkt ptr. */
+        PacketPtr _pkt;
+        /** The cpu side port id. */
+        PortID _id;
+        /** The xbar ptr. */
+        CoherentXBar* _xbar;
+    };
+
     std::vector<SnoopRespPort*> snoopRespPorts;
 
     std::vector<QueuedResponsePort*> snoopPorts;
@@ -291,6 +313,9 @@ class CoherentXBar : public BaseXBar
 
     /** Is this crossbar the point of unification? **/
     const bool pointOfUnification;
+
+    /** How many Cycles to send Hint in advance with TimingResp.*/
+    const Cycles hintWakeUpAheadCycles;
 
     /**
      * Upstream caches need this packet until true is returned, so
@@ -431,6 +456,8 @@ class CoherentXBar : public BaseXBar
     virtual ~CoherentXBar();
 
     virtual void regStats();
+
+    QueuedResponsePort * getCpuSidePort(PortID id) { return cpuSidePorts[id]; }
 };
 
 } // namespace gem5

--- a/src/mem/packet.cc
+++ b/src/mem/packet.cc
@@ -68,6 +68,8 @@ MemCmd::commandInfo[] =
 {
     /* InvalidCmd */
     { {}, InvalidCmd, "InvalidCmd" },
+    /* CustomBusClear - Clear the bus data at LSU */
+    { {}, CustomBusClear, "CustomBusClear" },
     /* ReadReq - Read issued by a non-caching agent such as a CPU or
      * device, with no restrictions on alignment. */
     { {IsRead, IsRequest, NeedsResponse}, ReadResp, "ReadReq" },

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -1598,6 +1598,8 @@ class Packet : public Printable
 
     bool tagReadFail = false;
 
+    bool cacheSatisfied = true;
+
     bool fromBOP() const { return pfSource == PrefetchSourceType::HWP_BOP; }
     
     PrefetchSourceType getPFSource() const { return static_cast<PrefetchSourceType>(pfSource); }

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -83,6 +83,7 @@ class MemCmd
     enum Command
     {
         InvalidCmd,
+        CustomBusClear,
         ReadReq,
         ReadResp,
         ReadRespWithInvalidate,

--- a/src/mem/packet_queue.cc
+++ b/src/mem/packet_queue.cc
@@ -41,6 +41,7 @@
 #include "mem/packet_queue.hh"
 
 #include "base/trace.hh"
+#include "debug/Cache.hh"
 #include "debug/Drain.hh"
 #include "debug/PacketQueue.hh"
 

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -91,6 +91,7 @@ enum DcacheRespType
 {
     NONE = 0,
     Hit,
+    Block_Not_Ready,
     Miss,
     NUM_Resp_Type
 };

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -93,6 +93,8 @@ enum DcacheRespType
     Hit,
     Block_Not_Ready,
     Miss,
+    Hint,
+    Bus_Clear,
     NUM_Resp_Type
 };
 

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -497,6 +497,7 @@ RubyPort::ruby_custom_signal_callback(PacketPtr pkt)
 
     DPRINTF(RubyPort, "Sent custom signal back to LSQ with sender state %#lx\n", sender_state);
     port->sendCustomSignal(pkt, DcacheRespType::Miss);
+    pkt->cacheSatisfied = false;
 }
 
 void

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -49,6 +49,7 @@
 #include "mem/packet_access.hh"
 #include "mem/ruby/protocol/AccessPermission.hh"
 #include "mem/ruby/slicc_interface/AbstractController.hh"
+#include "mem/ruby/slicc_interface/RubySlicc_Util.hh"
 #include "mem/simple_mem.hh"
 #include "sim/full_system.hh"
 #include "sim/system.hh"
@@ -676,7 +677,12 @@ RubyPort::MemResponsePort::hitCallback(PacketPtr pkt)
         // Send a response in the same cycle. There is no need to delay the
         // response because the response latency is already incurred in the
         // Ruby protocol.
-        schedTimingResp(pkt, curTick());
+        if (pkt->isRead() && !pkt->isWrite() && !pkt->fromCache()) {
+            // send resp right now, make sure load has certain latency
+            respQueue.sendTiming(pkt);
+        } else {
+            schedTimingResp(pkt, curTick());
+        }
     } else {
         delete pkt;
     }

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -383,7 +383,7 @@ Sequencer::insertRequest(PacketPtr pkt, RubyRequestType primary_type,
 
     if (seq_req_list.size() > 1) {
         if (cache_block_busy) {
-            if (pkt->isRead()) {
+            if (pkt->isRead() && !pkt->isWrite()) {
                 DPRINTF(RubySequencer, "Pkt %#lx %s is delayed because blk is busy doing ruby stuff\n",
                     pkt, pkt->cmdString());
                 ruby_custom_signal_callback(pkt);
@@ -649,7 +649,7 @@ Sequencer::notifyMissCallback(Addr address, bool is_upgrade, bool is_busy)
 
     // cancel pending loads' speculation
     for (auto &seq_req: seq_req_list) {
-        if (seq_req.pkt->isRead()) {
+        if (seq_req.pkt->isRead() && !seq_req.pkt->isWrite()) {
             ruby_custom_signal_callback(seq_req.pkt);
             stat.loadcancel++;
         }
@@ -693,7 +693,7 @@ Sequencer::TBEFullCancel(Addr address)
 
     // cancel pending loads' speculation
     for (auto &seq_req: seq_req_list) {
-        if (seq_req.pkt->isRead()) {
+        if (seq_req.pkt->isRead() && !seq_req.pkt->isWrite()) {
             ruby_custom_signal_callback(seq_req.pkt);
             stat.loadcancel++;
         }


### PR DESCRIPTION
## Background
In order to align the behavior of the LSU module with the RTL, this PR makes the following modifications:
+ Uses TimeBuffer to visualize the load and store pipelines.
+ Distributes the operational details of the load and store pipelines across the corresponding pipeline stages.
+ Adds nuke replay operation to reduce RAW violations.
+ Aligns miss load replay behavior with RTL and adds early wake-up.

### 1. Pipeline Construction
Related commits:
+ [f5039874530fdd4ec7ca8097e13c8c3d20607e84](https://github.com/OpenXiangShan/GEM5/pull/265/commits/f5039874530fdd4ec7ca8097e13c8c3d20607e84)
+ [89fdfd0a589d5390e12d2c016fa99d6b59f4e1c1](https://github.com/OpenXiangShan/GEM5/pull/265/commits/89fdfd0a589d5390e12d2c016fa99d6b59f4e1c1)
+ [bfbf7c957c2a873aee9105664d1228233ceb4f92](https://github.com/OpenXiangShan/GEM5/pull/265/commits/bfbf7c957c2a873aee9105664d1228233ceb4f92)

**Original design:** Load/store operations are delayed by a certain number of cycles and then all operations (TLB, Cache lookup, exception check, etc.) are completed in one cycle using `executeLoad/executeStore`.

**New design:** TimeBuffer is set according to the corresponding pipeline stages. Instructions are first dispatched to TimeBuffer `s0`, and over time they pass through the stages of the pipeline to complete the corresponding operations.

<details>
  <summary>Code Details</summary>

  **Original design:**

  + The operation was delayed by `op_latency - 1` cycles before being sent to the corresponding function unit. https://github.com/OpenXiangShan/GEM5/blob/2d1995aa9820b5b26b68002e698960b628e072cb/src/cpu/o3/inst_queue.cc#L700-L708
  + After reaching the function unit, the load/store calls `executeLoad/executeStore` to complete the corresponding operations. https://github.com/OpenXiangShan/GEM5/blob/2d1995aa9820b5b26b68002e698960b628e072cb/src/cpu/o3/iew.cc#L1407-L1437
  + `executeLoad/executeStore` completes all operations. https://github.com/OpenXiangShan/GEM5/blob/2d1995aa9820b5b26b68002e698960b628e072cb/src/cpu/o3/lsq_unit.cc#L906-L979 https://github.com/OpenXiangShan/GEM5/blob/2d1995aa9820b5b26b68002e698960b628e072cb/src/cpu/o3/lsq_unit.cc#L1003-L1067

   **New design:**

  + The load/store operations are directly sent to the function unit. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/inst_queue.cc#L711-L719
  + After reaching the function unit, load/store operations call `issueToLoadPipe/issueToStorePipe` to send the instructions to the `s0` of the load/store pipeline. `loadPipeSx`/`storePipeSx` is the corresponding pipeline timebuffer, `loadPipeSx[0]` means s0 stage of load pipeline.  https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.hh#L658-L682 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/iew.cc#L1473-L1503 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1053-L1081
  + Over time, the instructions gradually enter the subsequent pipeline stages (`s1`, `s2`, etc.). The corresponding instructions are fetched from the load/store pipeline at each stage and the operations are executed. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1314-L1367 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1493-L1559
</details>

### 2. Nuke Replay
Related commit:
+ [bfbf7c957c2a873aee9105664d1228233ceb4f92](https://github.com/OpenXiangShan/GEM5/pull/265/commits/bfbf7c957c2a873aee9105664d1228233ceb4f92)

> Scenario:
> ```asm
> sw s1, 0(s0)
> lw s2, 0(s0)
> ```
> The load needs to forward data from the store, and both load and store are issued simultaneously from the IQ into the pipeline, arriving at `s1` in the load/store pipeline at the same time.

**Original design:** If the load executes first, since the store in the same cycle hasn't finished (and hasn't updated the SQ), the load can't detect the dependency and thus can't forward data from the store. Then the store in the same cycle executes, a RAW violation will be detected, causing the pipeline to be flushed.

**What about RTL behavior:** The described situation does not occur in the RTL because the store instruction in the s1 pipeline stage (the cycle before the SQ is updated) checks whether there is a load instruction on the load pipeline with the same address and data that has not forwarded from it, and causes that load instruction to be replayed.

**New design:** When the load reaches `s1` or `s2`, it checks whether there are stores still in `s1` that haven't executed and match the address. If so, the load will be replayed. This is called the pipeline nuke replay. After the store in `s1` completes, the address and data are updated to the SQ, allowing the replayed load to correctly forward data without causing a RAW violation.

> **You can use `EnablePipeNukeCheck` to control whether to enable this feature. In addition, if you want to use this feature, make sure `EnableLdMissReplay` is set to `True`.**

<details>
  <summary>Code Details</summary>

**RTL design:**
  + store instructions at store pipeline `s1` query load pipeline `s1/s2`, causing the matched load to be replayed https://github.com/OpenXiangShan/XiangShan/blob/0051450372ae5a03ce9d36afdbdd34b9a19f4785/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala#L971-L995 https://github.com/OpenXiangShan/XiangShan/blob/0051450372ae5a03ce9d36afdbdd34b9a19f4785/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala#L1228-L1248 https://github.com/OpenXiangShan/XiangShan/blob/0051450372ae5a03ce9d36afdbdd34b9a19f4785/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala#L1357-L1381

 **Gem5 New design:**

  + The `pipeLineNukeCheck` is where the load in `s1` checks for pipeline nuke. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1159-L1179
  + The `pipeLineNukeCheck` for load in `s2` checks for pipeline nuke. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1250-L1258
  + Check logic. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L743-L762
  + If the load in `s1` or `s2` triggers a pipeline nuke, a fast load replay is performed in `s2`. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1273-L1282
  + If the load needs to perform a pipeline nuke replay, the pipeline flag of this load will be marked as `Nuke`, and the RAW violation check will skip this load. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L955-L961
</details>

### 3. Miss Load Replay  
Commits related to this modification:  
+ [ee53d22929c24e56c386efc13190b74c90f8997c](https://github.com/OpenXiangShan/GEM5/pull/265/commits/ee53d22929c24e56c386efc13190b74c90f8997c)  
+ [c3cd30088a4d5a57a47b54a43c53473436b5650c](https://github.com/OpenXiangShan/GEM5/pull/265/commits/c3cd30088a4d5a57a47b54a43c53473436b5650c)  

**Original design:** A miss load directly writes back after receiving the `TimingResp`, with no limit on the number and no re-entering pipeline behavior.

**New design:** A miss load receives a custom `Hint` signal two cycles before receiving the `TimingResp`, which wakes up the relevant instructions and reissues them into the pipeline. The relevant data becomes stable in the `bus` after `TimingResp` reaching the LSU, and the reissued load will forward data from the `bus`. If data cannot be forwarded, it will access the cache again. After the cache refilled the data to itself completely, a `Bus_Clear` request is sent to the LSU to clear the corresponding data in the `bus`. 

> **You can use `EnableLdMissReplay` to control whether to enable this feature.**

<details>  
  <summary>Code details</summary>  

  **Original design:**

  + A miss load directly calls `completeDataAccess` for write-back after receiving the `TimingResp` https://github.com/OpenXiangShan/GEM5/blob/2d1995aa9820b5b26b68002e698960b628e072cb/src/cpu/o3/lsq.cc#L1349-L1362

  **New design:**

  + A miss load enters a `cache miss load replayQueue` https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1259-L1271
  + When the refill data reaches the bus between L2 and L1, a `Hint` signal is returned a few cycles ahead of the `TimingResp` https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/mem/coherent_xbar.cc#L518-L522
  + After the `Hint` reaches L1, it queries the MSHR and sends a wake-up signal to the relevant load requests in the cache block. The loads that receive the wake-up signal are awakened from the replayQueue https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/mem/cache/cache.cc#L963-L999 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq.cc#L1524-L1537
  + The actual `TimingResp` arrives a few cycles after the `Hint` and stabilizes the data on the bus https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq.cc#L1434-L1475
  + The reissued load checks the bus before accessing the cache. If data is available on the bus, it directly uses the data from the bus (via `forwardFrmBus(load_inst, request)`), and accesses the cache only if no data is found on the bus. https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L2995-L3023
  + Sure, it is also possible that the Hint is sent too early, causing the reissued load reaching the pipeline and find that the TimingResp has not yet arrived. In this case, the load will speculatively wait for one more cycle, i.e., wait until s2. If the TimingResp arrives, it can forward data from the bus in s2 and then write back. If s2 still hasn't received the TimingResp, it will re-enter the cache miss replay queue.(**Note: this scenario will be very rare.**) https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L2995-L3002 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq_unit.cc#L1221-L1244
  + After the cache refill data is ready within the cache, a `Bus_Clear` is sent to the LSU to clear the relevant data from the bus https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/mem/cache/base.cc#L2041-L2052 https://github.com/OpenXiangShan/GEM5/blob/cf1302416f681eded0b2ba9f229dc27434cdfb83/src/cpu/o3/lsq.cc#L586-L602
</details>

### 4. Misc
During the alignment process, some functionality correctness issues and minor misalignments were also discovered, and they are all documented in this section.

#### 4.1 fence opType
Commits related to this modification:  
+ [5e118d7bfbffc7d18a4ad52b73330e61221e7713](https://github.com/OpenXiangShan/GEM5/pull/265/commits/5e118d7bfbffc7d18a4ad52b73330e61221e7713)  

**Original design:**

the fence instruction will be dispatched to mem's dispatchQueue, but its opType is `No_OpClass`, which will cause it to wait for the integer issue queue IQ2(IntMisc) to have free items before it can continue execution.
If the subsequent instructions of the fence instruction occupy the intIQ2, the fence cannot be executed and cpu deadlocks.

**new design:** 

Change the opType of the fence instruction to `MemReadOp` to prevent this situation (in fact, the fence will not be dispatched to IQ)

#### 4.2 LRSC
Commits related to this modification:  
+ [af375fa600564b38392501242e9aa1ddd19d2b56](https://github.com/OpenXiangShan/GEM5/pull/265/commits/af375fa600564b38392501242e9aa1ddd19d2b56)  

LR Instruction can be executed speculatively, which causes RAW violations in some corner cases.
**To reduce complexity and ensure consistency with the RTL design, avoid speculative execution for the LR, and strictly maintain order.**

#### 4.3 store writeback
Commits related to this modification:  
+ [3891ceb1bcc9cb2245b02c61e1fad3ecbefc6758](https://github.com/OpenXiangShan/GEM5/pull/265/commits/3891ceb1bcc9cb2245b02c61e1fad3ecbefc6758)

Previously, the store was written back in s2, but it is written back in s4 in RTL design. So align the timing of this operation. **The write-back timing has a significant impact on high IPC programs like hmmer (~13%), with earlier write-back being more beneficial for improving performance.**

> **You can set `StoreWbStage` to 2 or 4 or N to control which stage the store is written back.**
