### PR TITLE
cpu,difftest: use memcpy_init when init difftest

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -1449,15 +1449,16 @@ BaseCPU::difftestStep(ThreadID tid, InstSeqNum seq)
             diffAllStates->gem5RegFile.pc = diffInfo.pc->instAddr();
             if (noHypeMode) {
                 auto start = pmemStart + pmemSize * diffAllStates->diff.cpu_id;
-                warn("Start memcpy to NEMU from %#lx, size=%lu \n", (uint64_t)start, pmemSize);
+                warn("Start memcpy to NEMU from %#lx, size=%lu\n", (uint64_t)start, pmemSize);
                 diffAllStates->proxy->memcpy(0x80000000u, start, pmemSize, DUT_TO_REF);
             } else if (enableMemDedup) {
                 warn("Let ref share a COW mirror of root memory\n");
                 assert(diffAllStates->proxy->ref_get_backed_memory);
                 diffAllStates->proxy->ref_get_backed_memory(system->createCopyOnWriteBranch(), pmemSize);
             } else {
+                warn("MemDedup disabled, copying pmem to NEMU\n");
                 warn("Start memcpy to NEMU from %#lx, size=%lu\n", (uint64_t)pmemStart, pmemSize);
-                diffAllStates->proxy->memcpy(0x80000000u, pmemStart, pmemSize, DUT_TO_REF);
+                diffAllStates->proxy->memcpy_init(0x80000000u, pmemStart, pmemSize, DUT_TO_REF);
             }
             warn("Start regcpy to NEMU\n");
             diffAllStates->proxy->regcpy(&(diffAllStates->gem5RegFile), DUT_TO_REF);

--- a/src/cpu/difftest.cc
+++ b/src/cpu/difftest.cc
@@ -85,6 +85,10 @@ NemuProxy::NemuProxy(int coreid, const char *ref_so, bool enable_sdcard_diff, bo
         handle, "difftest_memcpy");
     assert(this->memcpy);
 
+    this->memcpy_init = (void (*)(paddr_t, void *, size_t, bool))dlsym(
+        handle, "difftest_memcpy_init");
+    assert(this->memcpy_init);
+
     regcpy = (void (*)(void *, bool))dlsym(handle, "difftest_regcpy");
     assert(regcpy);
 

--- a/src/cpu/difftest.hh
+++ b/src/cpu/difftest.hh
@@ -176,6 +176,8 @@ class RefProxy
   public:
     // public callable functions
     void (*ref_get_backed_memory)(void *backed_mem, size_t n) = nullptr;
+    void (*memcpy_init)(paddr_t nemu_addr, void *dut_buf, size_t n,
+                   bool direction) = nullptr;
     void (*memcpy)(paddr_t nemu_addr, void *dut_buf, size_t n,
                    bool direction) = nullptr;
     void (*regcpy)(void *dut, bool direction) = nullptr;


### PR DESCRIPTION
- Add `memcpy_init` function to NemuProxy class
- Use `memcpy_init` instead of `memcpy` when memory deduplication is disabled

This commit use memcpy_init instead of memcpy when init difftest. This is corresponded to NEMU commit
https://github.com/OpenXiangShan/NEMU/commit/3cc6d1515c06efdde9574a04ef96e664ce2c5ac3, which moves `nemu_large_memcpy` from memcpy to memcpy_init. This change fix the problem of NEMU side pmem is fully allocated on init.