### PR TITLE
Add cache bandwidth stats

### DIFF
--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -774,6 +774,8 @@ BaseCache::recvTimingResp(PacketPtr pkt)
 {
     assert(pkt->isResponse());
 
+    stats.bytesRecv += pkt->getSize();
+
     // all header delay should be paid for by the crossbar, unless
     // this is a prefetch response from above
     panic_if(pkt->headerDelay != 0 && pkt->cmd != MemCmd::HardPFResp,
@@ -2758,8 +2760,12 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
     ADD_STAT(overallAvgMshrUncacheableLatency, statistics::units::Rate<
                 statistics::units::Tick, statistics::units::Count>::get(),
              "average overall mshr uncacheable latency"),
+    ADD_STAT(bytesRecvPerCycle, statistics::units::Ratio::get(),
+             "average bandwidth receiving data from lower cache."),
     ADD_STAT(replacements, statistics::units::Count::get(),
              "number of replacements"),
+    ADD_STAT(bytesRecv, statistics::units::Count::get(),
+             "number of bytes received from lower cache."),
     ADD_STAT(wayPreHitTimes, statistics::units::Count::get(),
              "number of wayPreHitTimes"),
     ADD_STAT(wayPreIndexHitTimes, statistics::units::Count::get(),
@@ -3012,6 +3018,9 @@ BaseCache::CacheStats::regStats()
         overallAvgMshrUncacheableLatency.subname(i,
             system->getRequestorName(i));
     }
+
+    bytesRecvPerCycle.flags(total | nozero | nonan);
+    bytesRecvPerCycle = bytesRecv / simTicks * cache.clockPeriod();
 
     dataExpansions.flags(nozero | nonan);
     dataContractions.flags(nozero | nonan);

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -48,6 +48,8 @@
 #include "base/compiler.hh"
 #include "base/logging.hh"
 #include "base/output.hh"
+#include "base/statistics.hh"
+#include "base/stats/group.hh"
 #include "base/trace.hh"
 #include "base/types.hh"
 #include "debug/ArchDB.hh"
@@ -203,6 +205,9 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
         assert(popCount(sliceNum) == 1);
     }
 
+    for (int i = 0; i < getActualSliceNum(); i++) {
+        prevReqCycles.emplace_back(system->maxRequestors(), Cycles{0});
+    }
 
     if (dumpMissPC && cacheLevel) {
         registerExitCallback([this]() {
@@ -545,8 +550,24 @@ BaseCache::tryAccessTag(PacketPtr pkt)
 }
 
 void
+BaseCache::calReqInterval(PacketPtr pkt)
+{
+    RequestorID reqId = pkt->requestorId();
+    size_t sliceId = (getActualSliceNum() == 1) ? 0 : getSliceIdx(pkt->getAddr());
+    auto& prev = prevReqCycles[sliceId][reqId];
+    if (prev == 0) {
+        // first request
+        prev = curCycle();
+    } else {
+        (*stats.reqArriveInterval[sliceId])[reqId].sample(curCycle() - prev);
+        prev = curCycle();
+    }
+}
+
+void
 BaseCache::recvTimingReq(PacketPtr pkt)
 {
+    calReqInterval(pkt);
 
     if (pkt->isStorePFTrain()) {
         // send store prefetch train request
@@ -2807,6 +2828,19 @@ BaseCache::CacheStats::regStats()
 
     System *system = cache.system;
     const auto max_requestors = system->maxRequestors();
+
+    reqArriveInterval.resize(cache.getActualSliceNum());
+    for (int i = 0; i < reqArriveInterval.size(); i++) {
+        reqArriveInterval[i].reset(new statistics::VectorDistribution(this));
+        reqArriveInterval[i]
+        ->init(max_requestors, 0, 20, 1)
+            .name(csprintf("reqArriveInterval_Slice%d", i))
+            .desc("")
+            .flags(statistics::nozero);
+        for (int j = 0; j < max_requestors; j++) {
+            reqArriveInterval[i]->subname(j, system->getRequestorName(j));
+        }
+    }
 
     for (auto &cs : cmd)
         cs->regStatsFromParent();

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1237,8 +1237,14 @@ class BaseCache : public ClockedObject, CacheAccessor
         /** The average overall latency of an MSHR miss. */
         statistics::Formula overallAvgMshrUncacheableLatency;
 
+        /** The average bandwidth receiving data from lower cache. */
+        statistics::Formula bytesRecvPerCycle;
+
         /** Number of replacements of valid blocks. */
         statistics::Scalar replacements;
+
+        /** Number of bytes received */
+        statistics::Scalar bytesRecv;
 
         /**Number of waypre hit times */
         statistics::Scalar wayPreHitTimes;

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -50,6 +50,7 @@
 #include <cstdint>
 #include <queue>
 #include <string>
+#include <vector>
 
 #include "base/addr_range.hh"
 #include "base/compiler.hh"
@@ -595,6 +596,8 @@ class BaseCache : public ClockedObject, CacheAccessor
 
     bool tryAccessTag(PacketPtr pkt);
 
+    void calReqInterval(PacketPtr pkt);
+
     /**way prediction **/
     const int SETROFFSET = 6;
     const int SETMASK = 0x7f;
@@ -1086,6 +1089,9 @@ class BaseCache : public ClockedObject, CacheAccessor
 
     int squashedWays;
 
+    // the previous cycle calling RecvTimingReq (indexed by [sliceId][ReqId])
+    std::vector<std::vector<Cycles>> prevReqCycles;
+
   public:
     /** System we are currently operating in. */
     System *system;
@@ -1246,6 +1252,9 @@ class BaseCache : public ClockedObject, CacheAccessor
         /** Number of bytes received */
         statistics::Scalar bytesRecv;
 
+        /** Number of Cycles of the arriving interval between two requests. */
+        std::vector<std::unique_ptr<statistics::VectorDistribution>> reqArriveInterval;
+
         /**Number of waypre hit times */
         statistics::Scalar wayPreHitTimes;
 
@@ -1310,6 +1319,14 @@ class BaseCache : public ClockedObject, CacheAccessor
     getBlockSize() const
     {
         return blkSize;
+    }
+
+    size_t
+    getActualSliceNum() const
+    {
+        // This method is used for data statistics only
+        // If slice mechanism is off, the actual slice number is 1
+        return sliceNum <= 0 ? 1 : sliceNum;
     }
 
     const AddrRangeList &getAddrRanges() const { return addrRanges; }


### PR DESCRIPTION
- Added a counter `bytesRecvPerCycle` to track the average number of bytes received from lower cache per cycle.
- Added a counter `reqArriveInterval` to track the interval between requests from each requesters processed by the cache for each slice.