### PR TITLE
cpu-o3: fix a memory leak problem

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -633,7 +633,6 @@ LSQ::recvFunctionalCustomSignal(PacketPtr pkt, int sig)
                 it++;
             }
         }
-        delete pkt;
         panic_if(bus.size() > getLQEntries(), "elements on bus should never be greater than LQ size");
     } else {
         panic("unsupported sig %d in recvFunctionalCustomSignal\n", sig);

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -365,8 +365,9 @@ class BaseCache : public ClockedObject, CacheAccessor
         BaseCache* cache;
         PacketPtr pkt;
         int sig;
+        bool deletePkt;
       public:
-        SendCustomEvent(BaseCache* cache, PacketPtr pkt, int sig);
+        SendCustomEvent(BaseCache* cache, PacketPtr pkt, int sig, bool deletePkt);
         void process() override;
         const char* description() const override;
     };

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -990,7 +990,8 @@ Cache::sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt)
             if (sendHintTime == curTick()) {
                 BaseCache::cpuSidePort.sendCustomSignal(tgt_pkt, DcacheRespType::Hint);
             } else {
-                SendCustomEvent* hintEvent = new SendCustomEvent(this, tgt_pkt, DcacheRespType::Hint);
+                // set `deletePkt` as false because tgt_pkt should not be deleted by Hint event.
+                SendCustomEvent* hintEvent = new SendCustomEvent(this, tgt_pkt, DcacheRespType::Hint, false);
                 schedule(hintEvent, sendHintTime);
             }
             firstTgt = false;


### PR DESCRIPTION
After the cache refills the data, it sends a custom `Bus_Clear` packet to notify the LSU. This should only be sent by the Dcache, and neither L2 nor L3 should send this packet.

Calling `recvFunctionalCustomSignal` on the xbar does nothing, causing the custom packet to be lost, leading to a memory leak.

Thanks to @tastynoob finding this problem

Change-Id: Ie735660b66536908633daa6c25d76b7127add0b9