### PR TITLE
cpu-o3: fix old mem topdown logic

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -401,6 +401,11 @@ class DynInst : public ExecContext, public RefCounted
      */
     LSQ::LSQRequest *savedRequest = nullptr;
 
+    /**
+     * Saved Cache miss memory request
+     */
+    LSQ::LSQRequest *pendingCacheReq = nullptr;
+
     /////////////////////// Checker //////////////////////
     // Need a copy of main request pointer to verify on writes.
     RequestPtr reqToVerify;

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1511,6 +1511,7 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
         _hasStaleTranslation = false;
     }
     LSQRequest::_inst->hasPendingCacheReq(false);
+    LSQRequest::_inst->pendingCacheReq = nullptr;
     return true;
 }
 
@@ -1554,6 +1555,7 @@ LSQ::SplitDataRequest::recvTimingResp(PacketPtr pkt)
             _hasStaleTranslation = false;
         }
         LSQRequest::_inst->hasPendingCacheReq(false);
+        LSQRequest::_inst->pendingCacheReq = nullptr;
     }
     return true;
 }
@@ -1756,6 +1758,7 @@ LSQ::SingleDataRequest::sendPacketToCache()
         if (!bank_conflict) {
             _numOutstandingPackets = 1;
             LSQRequest::_inst->hasPendingCacheReq(true);
+            LSQRequest::_inst->pendingCacheReq = this;
         }
     }
     if (bank_conflict) {
@@ -1792,6 +1795,7 @@ LSQ::SplitDataRequest::sendPacketToCache()
 
     if (_numOutstandingPackets == _packets.size()) {
         LSQRequest::_inst->hasPendingCacheReq(true);
+        LSQRequest::_inst->pendingCacheReq = this;
         return true;
     }
     return false;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -992,8 +992,6 @@ LSQUnit::loadReplayHelper(DynInstPtr inst, LSQRequest* request, bool cacheMiss, 
     // Reset DTB translation state
     inst->translationStarted(false);
     inst->translationCompleted(false);
-    // set as not able to issue
-    inst->clearCanIssue();
     if (cacheMiss) {
         // set it as waiting for dcache refill
         inst->waitingCacheRefill(true);


### PR DESCRIPTION
Due to the previous refactoring of the LSU pipeline, some of the memory stall logic in the old topdown is no longer applicable. This commit modified related logic to accommodate the current design.

Change-Id: I3c4dded8d026c34e7d1b83f326ee9ba148330532