### PR TITLE
cpu: Fix topdown duplicate statistics load_stall and store_stall

### DIFF
--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -499,9 +499,11 @@ CPU::CPUStats::CPUStats(CPU *cpu)
     
     Scheduler* scheduler = cpu->iew.getScheduler();
     const auto &stats = scheduler->getStats();
-    // coreBound = (EXEC_STALL_CYCLE - MEMSTALL_ANYLOAD - MEMSTALL_STORE)/CPU_CYCLE
-    coreBound = (stats.exec_stall_cycle - stats.memstall_any_load - stats.memstall_any_store) / cpu->baseStats.numCycles;
-    memoryBound = (stats.memstall_any_load + stats.memstall_any_store) / cpu->baseStats.numCycles;
+    // coreBound = (EXEC_STALL_CYCLE - MEMSTALL_ANYLOAD - MEMSTALL_STORE + MENSTALL_BOTH_LOAD_STALL)/CPU_CYCLE
+    coreBound = (stats.exec_stall_cycle - stats.memstall_any_load - stats.memstall_any_store
+                    + stats.menstall_both_load_stall) / cpu->baseStats.numCycles;
+    memoryBound = (stats.memstall_any_load + stats.memstall_any_store
+                    - stats.menstall_both_load_stall) / cpu->baseStats.numCycles;
     l1Bound = (stats.memstall_any_load - stats.memstall_l1miss) / cpu->baseStats.numCycles;
     l2Bound = (stats.memstall_l1miss - stats.memstall_l2miss) / cpu->baseStats.numCycles;
     l3Bound = (stats.memstall_l2miss - stats.memstall_l3miss) / cpu->baseStats.numCycles;

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -784,17 +784,26 @@ Scheduler::issueAndSelect()
     for (auto it : issueQues) {
         it->issueToFu();
     }
+    bool mentall_store = false, menstall_load = false;
+
     if (instsToFu.size() < intel_fewops) {
         stats.exec_stall_cycle++;
-        if (lsq->anyStoreNotExecute()) stats.memstall_any_store++;
+        if (lsq->anyStoreNotExecute()) {
+            stats.memstall_any_store++;
+            mentall_store = true;
+        }
     }
     if (instsToFu.size() == 0) {
         int misslevel = lsq->anyInflightLoadsNotComplete();
-        if (misslevel != 0) stats.memstall_any_load++;
+        if (misslevel != 0) {
+            stats.memstall_any_load++;
+            menstall_load = true;
+        }
         if ((misslevel & ((1<<1) - 1)) == ((1<<1) - 1)) stats.memstall_l1miss++;
         if ((misslevel & ((1<<2) - 1)) == ((1<<2) - 1)) stats.memstall_l2miss++;
         if ((misslevel & ((1<<3) - 1)) == ((1<<3) - 1)) stats.memstall_l3miss++;
     }
+    stats.menstall_both_load_stall += (menstall_load && mentall_store);
 
     // must wait for all insts was issued
     for (auto it : issueQues) {

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -222,6 +222,7 @@ class Scheduler : public SimObject
         statistics::Scalar memstall_l1miss;
         statistics::Scalar memstall_l2miss;
         statistics::Scalar memstall_l3miss;
+        statistics::Scalar menstall_both_load_stall;
     } stats;
 
     struct disp_policy


### PR DESCRIPTION
Fixed a situation where the core bound could be negative due to duplicate statistics in the new topdown duplicate load and store stall.

Change-Id: I5b4f4009c1bb8228fc70b594c4c6fc58c230e756