### PR TITLE
cpu: The division unit is calibrated

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -616,8 +616,7 @@ InstructionQueue::execLatencyCheck(const DynInstPtr& inst, uint32_t& op_latency)
                     if (__isnanf(*((float*)(&rs1))) ||
                         __isnanf(*((float*)(&rs2))) ||
                         __isinff(*((float*)(&rs1))) ||
-                        __isinff(*((float*)(&rs2))) ||
-                        (*((float*)(&rs2)) - 1.0f < 1e-6f)) {
+                        __isinff(*((float*)(&rs2)))) {
                         op_latency = 2;
                         break;
                     }
@@ -627,8 +626,7 @@ InstructionQueue::execLatencyCheck(const DynInstPtr& inst, uint32_t& op_latency)
                     if (__isnan(*((double*)(&rs1))) ||
                         __isnan(*((double*)(&rs2))) ||
                         __isinf(*((double*)(&rs1))) ||
-                        __isinf(*((double*)(&rs2))) ||
-                        (*((double*)(&rs2)) - 1.0 < 1e-15)) {
+                        __isinf(*((double*)(&rs2)))) {
                         op_latency = 2;
                         break;
                     }


### PR DESCRIPTION
Change-Id: Ia22f29b7cbf28a5f71993ebdd0a20fa66d7985ae

The division unit of RTL does not speed up division by 1.
The original Gem5 model implemented this acceleration, which has now been removed.