### PR TITLE
cpu-o3: disable some mechanism for splitDataReq

### DIFF
--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -638,7 +638,7 @@ class LSQ
         bool
         isNormalLd()
         {
-            return isLoad() && !mainReq()->isLLSC() && !mainReq()->isUncacheable() && !isSplit();
+            return isLoad() && !isSplit() && !mainReq()->isLLSC() && !mainReq()->isUncacheable();
         }
 
         virtual std::string name() const { return "LSQRequest"; }
@@ -696,7 +696,6 @@ class LSQ
       protected:
         uint32_t numFragments;
         uint32_t numReceivedPackets;
-        uint32_t numCustomHintReceived;
         RequestPtr _mainReq;
         PacketPtr _mainPacket;
 
@@ -709,7 +708,6 @@ class LSQ
                        nullptr),
             numFragments(0),
             numReceivedPackets(0),
-            numCustomHintReceived(0),
             _mainReq(nullptr),
             _mainPacket(nullptr)
         {


### PR DESCRIPTION
Since `splitDataRequest` may have some packets hit in cache while others miss, and the response latency of each packet can be inconsistent, this could lead to corner cases affecting functional correctness. 

To reduce the complexity of handling `splitDataRequest`, disable these mechanism for `splitDataRequest`:
1. cache miss replay and early wakeup
2. nuke replay

Change-Id: I0dacbeda1f58d02b6f1f32cbc544ff3b3ff2fbc9