### PR TITLE
cpu-o3: Disabled two-taken, added override bubble perf counter

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -346,7 +346,7 @@ def setKmhV3IdealParams(args, system):
 
         # ideal decoupled frontend
         if args.bp_type is None or args.bp_type == 'DecoupledBPUWithFTB':
-            cpu.branchPred.enableTwoTaken = True
+            cpu.branchPred.enableTwoTaken = False
             cpu.branchPred.numBr = 8    # numBr must be a power of 2, see getShuffledBrIndex()
             cpu.branchPred.predictWidth = 64
             cpu.branchPred.tage.enableSC = False # TODO(bug): When numBr changes, enabling SC will trigger an assert

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1019,7 +1019,7 @@ Scheduler::loadCancel(const DynInstPtr& inst)
         dfs.pop();
         // clear pending wake events scheduled by top
         auto& pendingEvents = specWakeEvents[top->seqNum];
-        for (auto it = pendingEvents.begin(); it != pendingEvents.end();) {
+        for (auto it = pendingEvents.begin(); it != pendingEvents.end(); it++) {
             cpu->deschedule(*it);
         }
         specWakeEvents.erase(top->seqNum);

--- a/src/cpu/pred/ftb/decoupled_bpred.cc
+++ b/src/cpu/pred/ftb/decoupled_bpred.cc
@@ -450,7 +450,9 @@ DecoupledBPUWithFTB::DBPFTBStats::DBPFTBStats(statistics::Group* parent, unsigne
     ADD_STAT(staticBranchNum, statistics::units::Count::get(), "the number of all (different) static branches"),
     ADD_STAT(staticBranchNumEverTaken, statistics::units::Count::get(), "the number of all (different) static branches that are once taken"),
     ADD_STAT(predsOfEachStage, statistics::units::Count::get(), "the number of preds of each stage that account for final pred"),
-    ADD_STAT(commitPredsFromEachStage, statistics::units::Count::get(), "the number of preds of each stage that account for a committed stream"),
+    ADD_STAT(overrideBubbleNum,  statistics::units::Count::get(), "the number of override bubbles"),
+    ADD_STAT(commitPredsFromEachStage, statistics::units::Count::get(),
+    "the number of preds of each stage that account for a committed stream"),
     ADD_STAT(fsqEntryDist, statistics::units::Count::get(), "the distribution of number of entries in fsq"),
     ADD_STAT(fsqEntryEnqueued, statistics::units::Count::get(), "the number of fsq entries enqueued"),
     ADD_STAT(fsqEntryCommitted, statistics::units::Count::get(), "the number of fsq entries committed at last"),
@@ -2125,6 +2127,7 @@ DecoupledBPUWithFTB::tryEnqFetchStream()
     if (numOverrideBubbles > 0) {
         DPRINTF(DecoupleBP, "Waiting for bubble caused by overriding, bubbles rest: %u\n", numOverrideBubbles);
         DPRINTF(Override, "Waiting for bubble caused by overriding, bubbles rest: %u\n", numOverrideBubbles);
+        dbpFtbStats.overrideBubbleNum++;
         return;
     }
     assert(!streamQueueFull());

--- a/src/cpu/pred/ftb/decoupled_bpred.hh
+++ b/src/cpu/pred/ftb/decoupled_bpred.hh
@@ -402,6 +402,7 @@ class DecoupledBPUWithFTB : public BPredUnit
         statistics::Scalar staticBranchNumEverTaken;
 
         statistics::Vector predsOfEachStage;
+        statistics::Scalar overrideBubbleNum;
         statistics::Vector commitPredsFromEachStage;
         statistics::Distribution fsqEntryDist;
         statistics::Scalar fsqEntryEnqueued;


### PR DESCRIPTION
This change disables the two-taken branch prediction at ideal configuration and adds a performance counter to track override bubbles.

Change-Id: I3feb9bf662811941ad561ab73e0ee8c5b9040840