### PR TITLE
Update CI workflow to save score in artifact

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -89,4 +89,10 @@ jobs:
               done
             exit 1
           fi
+      - name: Upload score
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-score
+          path: ${{ github.workspace }}/score.txt
           


### PR DESCRIPTION
added one step in the CI's workflow file to save score.txt in artifact. This streamlines the process of downloading the score of each CI test, enabling us to easily obtain performance status of each commit