### PR TITLE
cpu-o3: fix fsqrt execute clock cycle

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -583,19 +583,17 @@ InstructionQueue::execLatencyCheck(const DynInstPtr& inst, uint32_t& op_latency)
                     if (__isnanf(*((float*)(&rs1))) ||
                         __isnanf(*((float*)(&rs2))) ||
                         __isinff(*((float*)(&rs1))) ||
-                        __isinff(*((float*)(&rs2))) ||
-                        (*((float*)(&rs2)) - 1.0f < 1e-6f)) {
+                        __isinff(*((float*)(&rs2)))) {
                         op_latency = 2;
                         break;
                     }
-                    op_latency = 10;
+                    op_latency = 8;
                     break;
                 case 64:
                     if (__isnan(*((double*)(&rs1))) ||
                         __isnan(*((double*)(&rs2))) ||
                         __isinf(*((double*)(&rs1))) ||
-                        __isinf(*((double*)(&rs2))) ||
-                        (*((double*)(&rs2)) - 1.0 < 1e-15)) {
+                        __isinf(*((double*)(&rs2)))) {
                         op_latency = 2;
                         break;
                     }


### PR DESCRIPTION
Remove fsqrt's acceleration optimization when rs2 is approximately equal to 1, and the fsqrt_s clock is corrected to 8.

Change-Id: I2c835f9856a3ef6b003b24aaeb0d96ff49812f43