### PR TITLE
mem: fix ruby `cacheSatisfied` bug

### DIFF
--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -498,7 +498,6 @@ RubyPort::ruby_custom_signal_callback(PacketPtr pkt)
 
     DPRINTF(RubyPort, "Sent custom signal back to LSQ with sender state %#lx\n", sender_state);
     port->sendCustomSignal(pkt, DcacheRespType::Miss);
-    pkt->cacheSatisfied = false;
 }
 
 void

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -650,6 +650,7 @@ Sequencer::notifyMissCallback(Addr address, bool is_upgrade, bool is_busy)
     // cancel pending loads' speculation
     for (auto &seq_req: seq_req_list) {
         if (seq_req.pkt->isRead() && !seq_req.pkt->isWrite()) {
+            seq_req.pkt->cacheSatisfied = false;
             ruby_custom_signal_callback(seq_req.pkt);
             stat.loadcancel++;
         }


### PR DESCRIPTION
`cacheSatisfied` should be set when real cache miss happens in ruby

This PR should resolve the segment fault that frequently occurs when running Ruby tests in CI recently.

Change-Id: I5d6624bddeb36195e4bcdcc3bc0b2afcddd8b5ff