### PR TITLE
mem: Calibrate latency for SimpleMemory.

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -69,6 +69,11 @@ class MemBus(L3ToMemBus):
     badaddr_responder = BadAddr()
     default = Self.badaddr_responder.pio
 
+class SimpleMemBus(L3ToMemBus):
+    badaddr_responder = BadAddr()
+    default = Self.badaddr_responder.pio
+    response_latency = 3 + 9 + 180
+
 def attach_9p(parent, bus):
     viopci = PciVirtIO()
     viopci.vio = VirtIO9PDiod()
@@ -657,7 +662,7 @@ def makeBareMetalRiscvSystem(mem_mode, mdesc=None, cmdline=None):
     self.system_port = self.membus.cpu_side_ports
     return self
 
-def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=False):
+def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=False, simple_mem=False):
     self = System()
     if not mdesc:
         # generic system
@@ -669,7 +674,10 @@ def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=
 
     self.iobus = IOXBar()
     if not ruby:
-        self.membus = MemBus()
+        if simple_mem:
+            self.membus = SimpleMemBus()
+        else:
+            self.membus = MemBus()
 
         self.bridge = Bridge(delay='50ns')
         self.bridge.mem_side_port = self.iobus.cpu_side_ports

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -74,7 +74,13 @@ def build_test_system(np, args):
     ruby = False
     if hasattr(args, 'ruby') and args.ruby:
         ruby = True
-    test_sys = makeBareMetalXiangshanSystem('timing', SysConfig(mem=args.mem_size), None, np=np, ruby=ruby)
+
+    simple_mem =False
+    if args.mem_type == 'SimpleMemory':
+        simple_mem = True
+
+    test_sys = makeBareMetalXiangshanSystem('timing', SysConfig(mem=args.mem_size), None,
+                                            np=np, ruby=ruby, simple_mem=simple_mem)
     test_sys.num_cpus = np
 
     test_sys.xiangshan_system = True

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -144,7 +144,7 @@ SimpleMemory::recvTimingReq(PacketPtr pkt)
 
     // calculate an appropriate tick to release to not exceed
     // the bandwidth limit
-    Tick duration = pkt->getSize() * bandwidth;
+    Tick duration = 4 * clockPeriod();// pkt->getSize() * bandwidth;
 
     // only consider ourselves busy if there is any need to wait
     // to avoid extra events being scheduled for (infinitely) fast
@@ -164,7 +164,7 @@ SimpleMemory::recvTimingReq(PacketPtr pkt)
         // atomic response
         assert(pkt->isResponse());
 
-        Tick when_to_send = curTick() + receive_delay + getLatency();
+        Tick when_to_send = curTick() + receive_delay;// + getLatency();
 
         // typically this should be added at the end, so start the
         // insertion sort with the last element, also make sure not to


### PR DESCRIPTION
MemBus response_latency and SimpleMemory duration are calibrated to approximate a simple Xiangshan const latency memory model. Use Param --mem-type=SimpleMemory

Change-Id: If8257309f20db875b1671efeec6c954a70254e20