### PR TITLE
cpu-o3: fix potential bug in sta

### DIFF
--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1527,15 +1527,14 @@ IEW::executeInsts()
                     inst->forwardOldRegs();
             }
 
-            inst->setExecuted();
-
             if (!inst->isSplitStoreData()) {
+                inst->setExecuted();
                 instToCommit(inst);
             } else {
+                DPRINTF(IEW, "Execute: Split store data, [sn:%lli]\n", inst->seqNum);
                 // STD is ready, wake up corresponding load if any
                 instQueue.resolveSTLFFailInst(inst->seqNum);
-                if (inst->sqIt->splitStoreFinish() && !inst->sqIt->writebacked()) {
-                    inst->sqIt->writebacked() = true;
+                if (inst->sqIt->splitStoreFinish()) {
                     instToCommit(inst->sqIt->instruction());
                 }
             }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -959,6 +959,8 @@ class LSQ
     /** Debugging function to print out instructions from a specific thread. */
     void dumpInsts(ThreadID tid) const;
 
+    bool isMisaligned(const DynInstPtr& inst, LSQRequest* request);
+
     /** Executes a read operation, using the load specified at the load
      * index.
      */


### PR DESCRIPTION
Add two new states (_staFinish and _stdFinish) to store queue entry to track store address and store data pipeline completion separately.

_addrReady and _dataReady is used to judge whether load can forward from this store only.

This helps prevent bugs in corner cases.

Change-Id: Idb5bf1828dffc9b1a1487f4c8f0fbb285bfab09b