### PR TITLE
mem: fix the delta condition of berti

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -47,7 +47,6 @@ def create_prefetcher(cpu, cache_level, options):
         prefetcher.max_prefetch_requests_with_pending_translation = 128
         prefetcher.region_size = 64*16  # 64B * blocks per region
 
-        prefetcher.berti.use_byte_addr = True
         prefetcher.berti.aggressive_pf = False
         prefetcher.berti.trigger_pht = True
 

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -312,7 +312,7 @@ class BertiPrefetcher(QueuedPrefetcher):
         LRURP(),
         "Replacement policy of history table"
     )
-    use_byte_addr = Param.Bool(True, "Use byte address")
+    use_byte_addr = Param.Bool(False, "Use byte address")
     trigger_pht = Param.Bool(True, "Use Berti's prediction to trigger PHT")
     dump_top_deltas = Param.Bool(True, "Dump top deltas on exit")
 

--- a/src/mem/cache/prefetch/berti.cc
+++ b/src/mem/cache/prefetch/berti.cc
@@ -148,13 +148,13 @@ void BertiPrefetcher::searchTimelyDeltas(
     DPRINTF(BertiPrefetcher, "latency: %lu, demand_cycle: %lu, history count: %lu\n", search_latency, demand_cycle,
             entry.history.size());
     std::list<int64_t> new_deltas;
-    int delta_thres = useByteAddr ? blkSize : 8;
+    int delta_thres = useByteAddr ? blkSize : 1;
     for (auto it = entry.history.rbegin(); it != entry.history.rend(); it++) {
         int64_t delta = trigger_addr - it->vAddr;
         DPRINTF(BertiPrefetcher, "delta (%x - %x) = %ld\n", trigger_addr, it->vAddr, delta);
 
         // skip short deltas
-        if (labs(delta) <= delta_thres) {
+        if (labs(delta) < delta_thres) {
             continue;
         }
 


### PR DESCRIPTION
Change-Id: I0afccf50a0d665a1bdd905715347abf4f5b5213b

1. when not using byte address, berti will use cacheline address to train. In this case, the delta_thres should be 1, which means that if the delta is greater than or equal to 1, it will be a useful delta. The old value 8 is too great for prefetching by cacheline address.
2. the condition of delta_thres should be "<" not "<=", because when the absolute of  delta is equal to the delta_thres, it still means that this delta will cause a cross of cacheline.

Performance data which is based on commit `6d5f63ce8d` is as follows:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/0e794650-5035-404b-915f-6bd5370914c8" />