### PR TITLE
cpu-o3: fix some runtime undifined error found by ubsan.

### DIFF
--- a/src/mem/cache/mshr.cc
+++ b/src/mem/cache/mshr.cc
@@ -73,7 +73,11 @@ MSHR::MSHR(const std::string &name)
 MSHR::TargetList::TargetList(const std::string &name)
     :   Named(name),
         needsWritable(false), hasUpgrade(false),
-        allocOnFill(false), hasFromCache(false)
+        allocOnFill(false), hasFromCache(false),
+        hasFromPref(false), hasFromCPU(false),
+        pfSource(PF_NONE), pfDepth(0),
+        blkAddr(0), blkSize(0),
+        canMergeWrites(true), writesBitmap(0)
 {}
 
 

--- a/src/mem/cache/mshr.hh
+++ b/src/mem/cache/mshr.hh
@@ -225,6 +225,9 @@ class MSHR : public QueueEntry, public Printable
             hasFromCache = false;
             hasFromPref = false;
             hasFromCPU = false;
+
+            pfSource = PF_NONE;
+            pfDepth = 0;
         }
 
         /**

--- a/src/mem/cache/prefetch/opt.hh
+++ b/src/mem/cache/prefetch/opt.hh
@@ -46,6 +46,9 @@ class OptPrefetcher : public Queued
           uint64_t region_offset_64;
           ACT64Entry()
             : TaggedEntry(),
+              pc(0),
+              regionAddr(0),
+              is_secure(false),
               region_bits_64(0),
               decr_mode(false),
               access_cnt(0),


### PR DESCRIPTION
- Compiled GEM5 by adding `--with-ubsan`
- Updated `doGzipLoad` function to use `std::string` and `std::vector` for better memory management and safety.
- Enhanced `MSHR` and `TargetList` constructors by adding new member variables for improved functionality and tracking.
- Still have some runtime error to fix, difficult to fix.

Change-Id: I510b7b66930b5335837e1efb73d437a1b07a358a