### PR TITLE
arch-riscv: Fix the CSR register configuration

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -332,7 +332,7 @@ void ISA::clear()
         miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET) |
                                     (1ULL << FS_OFFSET);
     }
-    miscRegFile[MISCREG_MCOUNTEREN] = 0x0;
+    miscRegFile[MISCREG_MCOUNTEREN] = 0x7;
     miscRegFile[MISCREG_SCOUNTEREN] = 0;
     // don't set it to zero; software may try to determine the supported
     // triggers, starting at zero. simply set a different value here.

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -888,8 +888,8 @@ const uint64_t NEMU_SSTATUS_WMASK = NEMU_MSTATUS_WMASK & (0x80000003000de762UL);
 // const uint64_t NEMU_SSTATUS_WMASK = ((1 << 19) | (1 << 18) | (0x3 << 13) | (1 << 8) | (1 << 5) | (1 << 1) |(0x3
 // <<9));
 const uint64_t NEMU_SSTATUS_RMASK = 0x80000003000de762UL;
-// const uint64_t NEMU_COUNTER_MASK = 0xffffffffULL;
-const uint64_t NEMU_COUNTER_MASK = 0;
+const uint64_t NEMU_COUNTER_MASK = 0xffffffffULL;
+//const uint64_t NEMU_COUNTER_MASK = 0;
 
 const uint64_t NEMU_VS_MASK = ((1 << 10) | (1 << 6) | (1 << 2));
 const uint64_t NEMU_HS_MASK = ((1 << 12) | NEMU_VS_MASK);


### PR DESCRIPTION
Set the CY, TM, and IR bits in mcounteren to allow S-mode or U-mode access to cycle, time, and other related registers. Update NEMU_COUNTER_MASK to make register writes effective.