### PR TITLE
revamped uBTB

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -326,8 +326,6 @@ def addCommonOptions(parser, configure_xiangshan=False):
     parser.add_argument("--ideal-kmhv3", action= "store_true",
                         help="Use KunminghuV3 ideal params, which take priority over command-line arguments.")
 
-    parser.add_argument("--huge-ubtb", action="store_true", default=False,
-                        help="use huge UBTB")
 
     # for warmup without switching cpu
     parser.add_argument("--warmup-insts-no-switch", action="store", type=int,

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -372,11 +372,7 @@ def setKmhV3IdealParams(args, system):
                 cpu.branchPred.btb.numEntries = 16384
                 # TODO: BTB TAGE do not bave base table, do not support SC
                 cpu.branchPred.tage.tableSizes = [4096] * 14  # BTB TAGE may need larger table
-                if args.huge_ubtb:
-                    # for testing purpose, sometimes we want to disable abtb and use a large ubtb, this is
-                    # achieved by setting abtb's numDelay to an arbitrary large value, in this case 9.
-                    cpu.branchPred.abtb.numDelay = 9
-                    cpu.branchPred.ubtb.numEntries = 1024
+
             cpu.branchPred.tage.enableSC = False # TODO(bug): When numBr changes, enabling SC will trigger an assert
             cpu.branchPred.ftq_size = 256
             cpu.branchPred.fsq_size = 256

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -980,7 +980,7 @@ class DefaultBTB(TimedBaseBTBPredictor):
     numThreads = Param.Unsigned(1, "Number of threads")
     numWays = Param.Unsigned(8, "Number of ways per set")
     aheadPipelinedStages = Param.Unsigned(0, "Number of stages ahead pipelined")
-    numDelay = 1
+    numDelay = 2
     blockSize = 32  # max 64 byte block, 32 byte aligned
     entryHalfAligned = Param.Bool(True, "Whether the entries are half-aligned")
 
@@ -1013,7 +1013,7 @@ class BTBRAS(TimedBaseBTBPredictor):
     numEntries = Param.Unsigned(32, "Number of entries in the RAS")
     ctrWidth = Param.Unsigned(8, "Width of the counter")
     numInflightEntries = Param.Unsigned(384, "Number of inflight entries")
-    numDelay = 1
+    numDelay = 2
 
 class BTBuRAS(TimedBaseBTBPredictor):
     type = 'BTBuRAS'
@@ -1039,7 +1039,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
     numWays = Param.Unsigned(2, "Number of ways per set")
-    numDelay = 1
+    numDelay = 2
 
 class BTBITTAGE(TimedBaseBTBPredictor):
     type = 'BTBITTAGE'

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -984,6 +984,18 @@ class DefaultBTB(TimedBaseBTBPredictor):
     blockSize = 32  # max 64 byte block, 32 byte aligned
     entryHalfAligned = Param.Bool(True, "Whether the entries are half-aligned")
 
+class UBTB(TimedBaseBTBPredictor):
+    type = 'UBTB'
+    cxx_class = 'gem5::branch_prediction::btb_pred::UBTB'
+    cxx_header = 'cpu/pred/btb/btb_ubtb.hh'
+
+    numEntries = Param.Unsigned(32, "Number of entries in the uBTB")
+    tagBits = Param.Unsigned(38, "Number of bits in the tag")
+
+    aheadPipelinedStages = Param.Unsigned(0, "Number of stages ahead pipelined")
+    numDelay = 0
+    # blockSize = 32  not used in uBTB
+
 class ABTB(DefaultBTB):
     numEntries = 1024
     tagBits = 38
@@ -993,13 +1005,6 @@ class ABTB(DefaultBTB):
     aheadPipelinedStages = 1
     entryHalfAligned = False
 
-class UBTB(DefaultBTB):
-    numEntries = 32
-    tagBits = 38
-    numWays = 32
-    numDelay = 0
-    blockSize = 64  # blockSize does't make a difference when entryHalfAligned is False
-    entryHalfAligned = False
 class BTBRAS(TimedBaseBTBPredictor):
     type = 'BTBRAS'
     cxx_class = 'gem5::branch_prediction::btb_pred::BTBRAS'
@@ -1063,7 +1068,7 @@ class DecoupledBPUWithBTB(BranchPredictor):
     
     predictWidth = Param.Unsigned(64, "Maximum range in bytes that a single prediction can cover")
     numStages = Param.Unsigned(3, "Maximum number of stages in the pipeline")
-    ubtb = Param.DefaultBTB(UBTB(), "UBTB predictor")
+    ubtb = Param.UBTB(UBTB(), "UBTB predictor")
     abtb = Param.DefaultBTB(ABTB(), "ABTB predictor")
     btb = Param.DefaultBTB(DefaultBTB(), "BTB")
     tage = Param.BTBTAGE(BTBTAGE(), "TAGE predictor")

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -47,7 +47,8 @@ SimObject('BranchPredictor.py', sim_objects=[
     'MultiperspectivePerceptronTAGE8KB', 'TimedStreamPredictor',
     'StreamUBTB', 'StreamTAGE', 'StreamLoopDetector', 'StreamLoopPredictor',
     'DecoupledStreamBPU', 'DefaultFTB', 'DecoupledBPUWithFTB',
-    'TimedBaseFTBPredictor', 'FTBTAGE', 'FTBRAS', 'FTBuRAS', 'FTBITTAGE', 'DefaultBTB', 'DecoupledBPUWithBTB',
+    'TimedBaseFTBPredictor', 'FTBTAGE', 'FTBRAS', 'FTBuRAS', 'FTBITTAGE',
+    'DefaultBTB', 'UBTB', 'DecoupledBPUWithBTB',
     'TimedBaseBTBPredictor', 'BTBRAS', 'BTBTAGE', 'BTBITTAGE'], enums=["BpType"])
 
 DebugFlag('Indirect')
@@ -101,6 +102,7 @@ Source('btb/btb_tage.cc')
 Source('btb/btb_ittage.cc')
 Source('btb/folded_hist.cc')
 Source('btb/ras.cc')
+Source('btb/btb_ubtb.cc')
 # Source('btb/uras.cc')
 Source('general_arch_db.cc')
 DebugFlag('FreeList')
@@ -133,6 +135,7 @@ DebugFlag('Profiling')
 DebugFlag('JumpAheadPredictor')
 DebugFlag('DecoupleBPBTB')
 DebugFlag('BTB')
+DebugFlag('UBTB')
 DebugFlag('DBPBTBStats')
 DebugFlag('BTBStats')
 DebugFlag('AheadPipeline')

--- a/src/cpu/pred/btb/btb.cc
+++ b/src/cpu/pred/btb/btb.cc
@@ -940,6 +940,11 @@ DefaultBTB::BTBStats::BTBStats(statistics::Group* parent) :
         oldEntryWithNewUncond.prereq(oldEntryWithNewUncond);
         eraseSlotBehindUncond.prereq(eraseSlotBehindUncond);
     }
+    if (btb->aheadPipelinedStages == 0){
+        S0Predmiss.prereq(S0Predmiss);
+        S0PredUseUBTB.prereq(S0PredUseUBTB);
+        S0PredUseABTB.prereq(S0PredUseABTB);
+    }
 }
 
 } // namespace btb_pred

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2004-2005 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "cpu/pred/btb/btb_ubtb.hh"
+
+#include "base/intmath.hh"
+#include "base/trace.hh"
+#include "cpu/o3/dyn_inst.hh"
+#include "debug/Fetch.hh"
+#include "stream_struct.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+/*
+ * BTB Constructor
+ * Initializes:
+ * - BTB structure (sets and ways)
+ * - MRU tracking for each set
+ * - Address calculation parameters (index/tag masks and shifts)
+ */
+UBTB::UBTB(const Params &p)
+    : TimedBaseBTBPredictor(p),
+      ubtb(),
+      lastPred(),
+      meta(),
+      mruList(),
+      numEntries(p.numEntries),
+      tagBits(p.tagBits),
+      tagMask((1UL << p.tagBits) - 1),
+      ubtbStats(this)
+{
+    if (!isPowerOf2(numEntries)) {
+        fatal("uBTB entries is not a power of 2!");
+    }
+
+    // Initialize BTB structure and MRU tracking
+    ubtb.resize(numEntries);
+    mruList.clear();  // Start with empty list
+    for (auto it = ubtb.begin(); it != ubtb.end(); it++) {
+        it->valid = false;
+        mruList.push_back(it);
+    }
+    std::make_heap(mruList.begin(), mruList.end(), older());
+
+    hasDB = true;
+    dbName = "ubtb";
+}
+
+
+void
+UBTB::setTrace()
+{
+    if (enableDB) {
+        std::vector<std::pair<std::string, DataType>> fields_vec = {
+            std::make_pair("pc", UINT64),  std::make_pair("brType", UINT64), std::make_pair("target", UINT64),
+            std::make_pair("idx", UINT64), std::make_pair("mode", UINT64),   std::make_pair("hit", UINT64)};
+        ubtbTrace = _db->addAndGetTrace("uBTBTrace", fields_vec);
+        ubtbTrace->init_table();
+    }
+}
+
+/**
+ * Process BTB entries:
+ * 1. Sort entries by PC order
+ * 2. Remove entries before the start PC
+ */
+void
+UBTB::PredStatistics(const TickedUBTBEntry entry, Addr startAddr)
+{
+
+    // Update prediction statistics
+    if (entry.valid) {
+        Addr mbtb_end = (startAddr + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
+        assert(entry.pc >= startAddr && entry.pc < mbtb_end);
+        DPRINTF(UBTB, "UBTB: lookup hit: \n");
+        ubtbStats.predHit += 1;
+        printTickedUBTBEntry(entry);
+    } else {
+        ubtbStats.predMiss++;
+        DPRINTF(BTB, "BTB: lookup miss\n");
+    }
+
+    return;
+}
+
+/**
+ * Fill predictions for each pipeline stage:
+ * 1. Copy BTB entries
+ * 2. Set conditional branch predictions
+ * 3. Set indirect branch targets
+ */
+void
+UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPrediction> &stagePreds)
+{
+
+
+    for (int s = getDelay(); s < stagePreds.size(); ++s) {
+
+        DPRINTF(UBTB, "UBTB: assigning prediction for stage %d\n", s);
+
+        // Copy BTB entries to stage prediction
+        stagePreds[s].btbEntries.clear();
+        if (entry.valid) {
+            stagePreds[s].btbEntries.push_back(BTBEntry(entry));
+            if (entry.isCond) {
+                // the always taken field of BTBEntry is ignored in uBTB
+                // uBTB always assumes present entries to be taken
+                stagePreds[s].condTakens[entry.pc] = true; //(entry.ctr >= 0);
+
+            } else if (entry.isIndirect) {
+                // Set predicted target for indirect branches
+                DPRINTF(UBTB, "setting indirect target for pc %#lx to %#lx\n", entry.pc, entry.target);
+                stagePreds[s].indirectTargets[entry.pc] = entry.target;
+                if (entry.isReturn) {
+                    stagePreds[s].returnTarget = entry.target;
+                }
+            }
+        }
+
+        // Set predictions for each branch
+        stagePreds[s].predTick = curTick();
+    }
+}
+
+
+
+void
+UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::vector<FullBTBPrediction> &stagePreds)
+{
+    auto it = lookup(startAddr);
+    TickedUBTBEntry entry = (it != ubtb.end()) ? *it : TickedUBTBEntry();
+
+    PredStatistics(entry, startAddr);
+
+    // Fill predictions for each pipeline stage
+    fillStagePredictions(entry, stagePreds);
+
+    // Update metadata for later stages
+    lastPred.hit_entry = it;
+    meta.hit_entry = entry;
+}
+
+
+
+UBTB::UBTBSetIter
+UBTB::lookup(Addr startAddr)
+{
+    if (startAddr & 0x1) {
+        return ubtb.end();  // ignore false hit when lowest bit is 1
+    }
+
+    Addr current_tag = getTag(startAddr);
+
+    DPRINTF(UBTB, "UBTB: Doing tag comparison for tag %#lx\n", current_tag);
+
+    auto it = std::find_if(ubtb.begin(), ubtb.end(),
+                           [current_tag](const TickedUBTBEntry &way) { return way.valid && way.tag == current_tag; });
+
+    if (it != ubtb.end()) {
+        // Found a hit - verify no duplicates
+        auto duplicate = std::find_if(std::next(it), ubtb.end(), [current_tag](const TickedUBTBEntry &way) {
+            return way.valid && way.tag == current_tag;
+        });
+        assert(duplicate == ubtb.end() && "Multiple hits found in uBTB for the same tag!");
+
+        // go on to update the mruList
+        it->tick = curTick();  // Update timestamp for MRU
+        std::make_heap(mruList.begin(), mruList.end(), older());
+    }
+
+    return it;
+}
+
+
+
+
+void
+UBTB::replaceOldEntry(UBTBSetIter oldEntryIter, FullBTBPrediction &newPrediction)
+{
+    // replace the old entry with the new one
+    assert(newPrediction.getTakenEntry().valid);
+    TickedUBTBEntry newEntry = TickedUBTBEntry(newPrediction.getTakenEntry(), curTick());
+    newEntry.target =
+        newPrediction.getTarget(predictWidth);  // important! this is so that target set by RAS or ITTAGE is used
+    // important: update tag (mbtb and ubtb have different tags, even diffferent tag length)
+    newEntry.tag = getTag(newPrediction.bbStart);
+    *oldEntryIter = newEntry;
+}
+
+
+void
+UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
+{
+
+    // obtain meta from S0,
+    // note that the purpose of meta is different from the other sub-predictors,
+    // uBTB's meta is to record the hit entry of S0, and is used immediatly in the same BPU tick() to update uBTB
+    // while other predictor's meta are attached to a FetchStream entry and will be used to update the predictor at
+    // commit
+
+    UBTBSetIter s0EntryIter = lastPred.hit_entry;
+    auto s0TakenEntry = *lastPred.hit_entry;
+    auto s3TakenEntry = s3Pred.getTakenEntry();
+    if (s0TakenEntry.valid && !s3TakenEntry.valid) {
+        // S0 has a hit entry, but S3 is fall through
+        updateUCtr(s0EntryIter->uctr, false);
+        if (s0EntryIter->uctr == 0) {
+            s0EntryIter->valid = false;
+        }
+    } else if (!s0TakenEntry.valid && s3TakenEntry.valid) {
+        // TODO: generate new entry and replace another using LRU and uctr
+        UBTBSetIter toBeReplacedIter;
+        // First try to find an invalid entry in the set
+        bool foundInvalidEntry = false;
+
+        for (auto it = ubtb.begin(); it != ubtb.end(); ++it) {
+            if (!it->valid) {
+                toBeReplacedIter = it;
+                foundInvalidEntry = true;
+                break;
+            }
+        }
+
+        // If no invalid entry found, use LRU policy
+        if (!foundInvalidEntry) {
+            // Find the least recently used entry
+            std::make_heap(mruList.begin(), mruList.end(), older());
+            toBeReplacedIter = mruList.front();
+        }
+
+        // Replace the entry with the new prediction
+        replaceOldEntry(toBeReplacedIter, s3Pred);
+
+    } else if (s0TakenEntry.valid && s3TakenEntry.valid) {
+        // both S0 and S3 predict taken
+        if (s0TakenEntry.pc != s3Pred.controlAddr() || s0TakenEntry.target != s3Pred.getTarget(predictWidth)) {
+            // S0 and S3 predict different branch instruction
+            updateUCtr(s0EntryIter->uctr, false);
+            if (s0EntryIter->uctr == 0) {
+                // replace the old entry with the new one
+                replaceOldEntry(s0EntryIter, s3Pred);
+            }
+        } else {
+            // S0 and S3 predict the same (brpc and target)
+            updateUCtr(s0EntryIter->uctr, true);
+        }
+    } else {
+        // both S0 and S3 predict fall through, do nothing
+    }
+}
+
+/*
+ * for statistical purpose only
+ */
+void
+UBTB::update(const FetchStream &stream)
+{
+
+    auto meta = std::static_pointer_cast<UBTBMeta>(stream.predMetas[getComponentIdx()]);
+    // hit entries whose corresponding insts are acutally executed
+    Addr end_inst_pc = stream.updateEndInstPC;
+
+    auto pred_hit_entry = meta->hit_entry;
+
+
+    if (stream.exeTaken) {
+        if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
+            DPRINTF(BTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
+            ubtbStats.updateMiss++;
+        }
+    }
+
+
+
+    // Verify BTB state
+    assert(ubtb.size() <= numEntries);
+}
+
+
+
+void
+UBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
+{
+    auto meta = std::static_pointer_cast<UBTBMeta>(stream.predMetas[getComponentIdx()]);
+    auto &hit_entry = meta->hit_entry;
+    auto pc = inst->getPC();
+    auto npc = inst->getNPC();
+    bool this_branch_hit = hit_entry.pc == pc;
+
+
+    // bool this_branch_miss = !this_branch_hit;
+    bool cond_not_taken = inst->isCondCtrl() && !inst->branching();
+    bool this_branch_taken = stream.exeTaken && stream.getControlPC() == pc;  // all uncond should be taken
+    Addr this_branch_target = npc;
+    if (this_branch_hit) {
+        ubtbStats.allBranchHits++;
+        if (this_branch_taken) {
+            ubtbStats.allBranchHitTakens++;
+        } else {
+            ubtbStats.allBranchHitNotTakens++;
+        }
+        if (inst->isCondCtrl()) {
+            ubtbStats.condHits++;
+            if (this_branch_taken) {
+                ubtbStats.condHitTakens++;
+            } else {
+                ubtbStats.condHitNotTakens++;
+            }
+            // TODO: for now we assume uBTB hit means the branch is taken, this might change later
+            // bool pred_taken = hit_entry.ctr >= 0;
+            if (this_branch_taken) {
+                ubtbStats.condPredCorrect++;
+            } else {
+                ubtbStats.condPredWrong++;
+            }
+        }
+        if (inst->isUncondCtrl()) {
+            ubtbStats.uncondHits++;
+        }
+        // ignore non-speculative branches (e.g. syscall)
+        if (!inst->isNonSpeculative()) {
+            if (inst->isIndirectCtrl()) {
+                ubtbStats.indirectHits++;
+                Addr pred_target = hit_entry.target;
+                if (pred_target == this_branch_target) {
+                    ubtbStats.indirectPredCorrect++;
+                } else {
+                    ubtbStats.indirectPredWrong++;
+                }
+            }
+            if (inst->isCall()) {
+                ubtbStats.callHits++;
+            }
+            if (inst->isReturn()) {
+                ubtbStats.returnHits++;
+            }
+        }
+    } else {
+        ubtbStats.allBranchMisses++;
+        if (this_branch_taken) {
+            ubtbStats.allBranchMissTakens++;
+        } else {
+            ubtbStats.allBranchMissNotTakens++;
+        }
+        if (inst->isCondCtrl()) {
+            ubtbStats.condMisses++;
+            if (this_branch_taken) {
+                ubtbStats.condMissTakens++;
+                // if (isL0()) {
+                // only L0 BTB has saturating counters to predict conditional branches
+                // taken branches that is missed in btb must have been mispredicted
+                ubtbStats.condPredWrong++;
+                // }
+            } else {
+                ubtbStats.condMissNotTakens++;
+                // if (isL0()) {
+                // only L0 BTB has saturating counters to predict conditional branches
+                // taken branches that is missed in btb must have been mispredicted
+                ubtbStats.condPredCorrect++;
+                // }
+            }
+        }
+        if (inst->isUncondCtrl()) {
+            ubtbStats.uncondMisses++;
+        }
+        // ignore non-speculative branches (e.g. syscall)
+        if (!inst->isNonSpeculative()) {
+            if (inst->isIndirectCtrl()) {
+                ubtbStats.indirectMisses++;
+                ubtbStats.indirectPredWrong++;
+            }
+            if (inst->isCall()) {
+                ubtbStats.callMisses++;
+            }
+            if (inst->isReturn()) {
+                ubtbStats.returnMisses++;
+            }
+        }
+    }
+}
+
+UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
+    : statistics::Group(parent),
+
+      ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
+      ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
+      ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
+      ADD_STAT(updateHit, statistics::units::Count::get(), "hits encountered on update"),
+      ADD_STAT(updateExisting, statistics::units::Count::get(), "existing entries updated"),
+      ADD_STAT(updateReplace, statistics::units::Count::get(), "entries replaced"),
+      ADD_STAT(updateReplaceValidOne, statistics::units::Count::get(), "entries replaced with valid entry"),
+
+      ADD_STAT(S0Predmiss, statistics::units::Count::get(),
+               "misses encountered on S0 prediction, i.e. uBTB and ABTB miss"),
+      ADD_STAT(S0PredUseUBTB, statistics::units::Count::get(), "uBTB prediction used, i.e. uBTB hit"),
+      ADD_STAT(S0PredUseABTB, statistics::units::Count::get(), "aBTB prediction used, i.e. uBTB miss and ABTB hit"),
+
+      ADD_STAT(allBranchHits, statistics::units::Count::get(),
+               "all types of branches committed that was predicted hit"),
+      ADD_STAT(allBranchHitTakens, statistics::units::Count::get(),
+               "all types of taken branches committed was that predicted hit"),
+      ADD_STAT(allBranchHitNotTakens, statistics::units::Count::get(),
+               "all types of not taken branches committed was that predicted hit"),
+      ADD_STAT(allBranchMisses, statistics::units::Count::get(),
+               "all types of branches committed that was predicted miss"),
+      ADD_STAT(allBranchMissTakens, statistics::units::Count::get(),
+               "all types of taken branches committed was that predicted miss"),
+      ADD_STAT(allBranchMissNotTakens, statistics::units::Count::get(),
+               "all types of not taken branches committed was that predicted miss"),
+      ADD_STAT(condHits, statistics::units::Count::get(), "conditional branches committed that was predicted hit"),
+      ADD_STAT(condHitTakens, statistics::units::Count::get(),
+               "taken conditional branches committed was that predicted hit"),
+      ADD_STAT(condHitNotTakens, statistics::units::Count::get(),
+               "not taken conditional branches committed was that predicted hit"),
+      ADD_STAT(condMisses, statistics::units::Count::get(), "conditional branches committed that was predicted miss"),
+      ADD_STAT(condMissTakens, statistics::units::Count::get(),
+               "taken conditional branches committed was that predicted miss"),
+      ADD_STAT(condMissNotTakens, statistics::units::Count::get(),
+               "not taken conditional branches committed was that predicted miss"),
+      ADD_STAT(condPredCorrect, statistics::units::Count::get(),
+               "conditional branches committed was that correctly predicted by btb"),
+      ADD_STAT(condPredWrong, statistics::units::Count::get(),
+               "conditional branches committed was that mispredicted by btb"),
+      ADD_STAT(uncondHits, statistics::units::Count::get(), "unconditional branches committed that was predicted hit"),
+      ADD_STAT(uncondMisses, statistics::units::Count::get(),
+               "unconditional branches committed that was predicted miss"),
+      ADD_STAT(indirectHits, statistics::units::Count::get(), "indirect branches committed that was predicted hit"),
+      ADD_STAT(indirectMisses, statistics::units::Count::get(), "indirect branches committed that was predicted miss"),
+      ADD_STAT(indirectPredCorrect, statistics::units::Count::get(),
+               "indirect branches committed whose target was correctly predicted by btb"),
+      ADD_STAT(indirectPredWrong, statistics::units::Count::get(),
+               "indirect branches committed whose target was mispredicted by btb"),
+      ADD_STAT(callHits, statistics::units::Count::get(), "calls committed that was predicted hit"),
+      ADD_STAT(callMisses, statistics::units::Count::get(), "calls committed that was predicted miss"),
+      ADD_STAT(returnHits, statistics::units::Count::get(), "returns committed that was predicted hit"),
+      ADD_STAT(returnMisses, statistics::units::Count::get(), "returns committed that was predicted miss")
+
+{
+}
+
+}  // namespace btb_pred
+}  // namespace branch_prediction
+}  // namespace gem5

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2004-2005 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Branch Target Buffer (BTB) Implementation
+ *
+ * The BTB is a cache-like structure that stores information about branches:
+ * - Branch type (conditional, unconditional, indirect, call, return)
+ * - Branch target address
+ * - Branch prediction information (counter for conditional branches)
+ *
+ * Key Features:
+ * - N-way set associative organization
+ * - MRU (Most Recently Used) replacement policy
+ * - Support for multiple branch types
+ * - Support for multiple prediction stages (L0/L1 BTB)
+ */
+
+#ifndef __CPU_PRED_BTB_UBTB_HH__
+#define __CPU_PRED_BTB_UBTB_HH__
+
+#include <queue>
+
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "base/types.hh"
+#include "config/the_isa.hh"
+#include "cpu/pred/btb/stream_struct.hh"
+#include "cpu/pred/btb/timed_base_pred.hh"
+#include "debug/UBTB.hh"
+#include "params/UBTB.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+class UBTB : public TimedBaseBTBPredictor
+{
+  private:
+
+  public:
+
+    typedef UBTBParams Params;
+
+    UBTB(const Params& p);
+
+    /*
+     * Micro-BTB Entry with timestamp for MRU replacement
+     *
+     * This structure extends BranchInfo to implement a uBTB entry with:
+     * - valid: validity bit for this entry
+     * - tctr: 2-bit saturation counter for branch direction prediction
+     * - uctr: 2-bit saturation counter used by the replacement policy
+     * - tag: tag bits from fetch block address [23:1]
+     * - tick: timestamp used for MRU (Most Recently Used) replacement policy
+     */
+    typedef struct TickedUBTBEntry : public BTBEntry
+    {
+        unsigned uctr; //2-bit saturation counter used in replacement policy
+        uint64_t tick;  // timestamp for MRU replacement
+        TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0) {}
+        TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick) {}
+    }TickedUBTBEntry;
+
+    // A BTB set is a vector of entries (ways)
+    using UBTBSet = std::vector<TickedUBTBEntry>;
+    using UBTBSetIter = typename UBTBSet::iterator;
+    // MRU heap for each set
+    using UBTBHeap = std::vector<UBTBSetIter>;
+
+    /** Creates a BTB with the given number of entries, number of bits per
+     *  tag, and instruction offset amount.
+     *  @param numEntries Number of entries for the BTB.
+     *  @param tagBits Number of bits for each tag in the BTB.
+     *  @param instShiftAmt Offset amount for instructions to ignore alignment.
+     */
+    UBTB(unsigned numEntries, unsigned tagBits,
+               unsigned instShiftAmt, unsigned numThreads);
+
+    void tickStart() override{};
+
+    void tick() override{};
+
+    /*
+     * Main prediction function
+     * @param startAddr: start address of the fetch block
+     * @param history: branch history register
+     * @param stagePreds: predictions for each pipeline stage
+     *
+     * This function:
+     * 1. Looks up BTB entries for the fetch block
+     * 2. Updates prediction statistics
+     * 3. Fills predictions for each pipeline stage
+     */
+    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+                      std::vector<FullBTBPrediction> &stagePreds) override;
+
+    void updateUsingS3Pred(FullBTBPrediction &s3Pred);
+
+    /** Get prediction BTBMeta
+     *  @return Returns the prediction meta
+     */
+    std::shared_ptr<void> getPredictionMeta() override
+    {
+        std::shared_ptr<void> meta_void_ptr = std::make_shared<UBTBMeta>(meta);
+        return meta_void_ptr;
+    }
+    // not used
+    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override {}
+
+    void recoverHist(const boost::dynamic_bitset<> &history,
+        const FetchStream &entry, int shamt, bool cond_taken) override{};
+
+
+    void reset();
+
+    /** Updates the BTB with the branch info of a block and execution result.
+     *  This function:
+     *  1. Updates existing entries with new information
+     *  2. Adds new entries if necessary
+     *  3. Updates MRU information
+     */
+    void update(const FetchStream &stream) override;
+
+    void commitBranch(const FetchStream &stream, const DynInstPtr &inst) override;
+
+    void setTrace() override;
+
+    TraceManager *ubtbTrace;
+
+    void printTickedUBTBEntry(const TickedUBTBEntry &e) {
+        DPRINTF(UBTB, "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
+            cond:%d, indirect:%d, call:%d, return:%d, tick:%lu\n",
+            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
+    }
+
+    void dumpMruList() {
+        DPRINTF(UBTB, "MRU list:\n");
+        for (const auto &it: mruList) {
+            printTickedUBTBEntry(*it);
+        }
+    }
+
+
+
+  private:
+
+    typedef struct LastPred
+    {
+        UBTBSetIter hit_entry; // this might point to ubtb.end()
+
+        LastPred() {
+            // Default constructor - will be assigned proper value later
+        }
+    }LastPred;
+
+    typedef struct UBTBMeta
+    {
+        TickedUBTBEntry hit_entry;
+        UBTBMeta() {
+            hit_entry = TickedUBTBEntry();
+        }
+    }UBTBMeta;
+
+    // helper methods
+    /*
+     * Comparator for MRU heap
+     * Returns true if a's timestamp is larger than b's
+     * This creates a min-heap where the oldest entry is at the top
+     */
+    struct older
+    {
+        bool operator()(const UBTBSetIter &a, const UBTBSetIter &b) const
+        {
+            return a->tick > b->tick;
+        }
+    };
+
+    /** Returns the tag bits of a given address.
+     *  The tag is calculated as: (pc >> tagShiftAmt) & tagMask
+     *  where tagShiftAmt = idxShiftAmt + log2(numSets)
+     *  @param inst_PC The branch's address.
+     *  @return Returns the tag bits.
+     */
+    inline Addr getTag(Addr startPC) {
+        return (startPC >> 1) & tagMask;
+    }
+
+    /** Update the 2-bit saturating counter for conditional branches
+     *  Counter range: [-2, 1]
+     *  - Increment on taken (max 1)
+     *  - Decrement on not taken (min -2)
+     */
+    void updateTCtr(int &ctr, bool taken) {
+        if (taken && ctr < 1) {ctr++;}
+        if (!taken && ctr > -2) {ctr--;}
+    }
+
+    void updateUCtr(unsigned &ctr, bool inc) {
+        if (inc && ctr < 3) {ctr++;}
+        if (!inc && ctr > 0) {ctr--;}
+    }
+
+    UBTBSetIter lookup(Addr block_pc);
+
+    void PredStatistics(const TickedUBTBEntry entry, Addr startAddr);
+
+    /** Fill predictions for each pipeline stage based on BTB entries
+     *  @param entry The BTB entry containing branch info
+     *  @param stagePreds Predictions for each pipeline stage
+     */
+    void fillStagePredictions(const TickedUBTBEntry& entry,
+                              std::vector<FullBTBPrediction>& stagePreds);
+
+    void replaceOldEntry(UBTBSetIter oldEntry,FullBTBPrediction & newPrediction);
+
+
+
+
+
+
+
+    /** The BTB structure:
+     *  - Organized as numSets sets
+     *  - Each set has numWays ways
+     *  - Total size = numSets * numWays = numEntries
+     */
+    std::vector<TickedUBTBEntry> ubtb;
+
+
+    LastPred lastPred; // last prediction, set in putPCHistory, used in updateUsingS3Pred
+    UBTBMeta meta; // metadata for uBTB, set in putPCHistory, used in update, for the sole purpose of statistics
+
+    /** MRU tracking:
+     *  - One heap per set
+     *  - Each heap tracks the MRU order of entries in that set
+     *  - Oldest entry is at the top of heap
+     */
+    UBTBHeap mruList;
+
+    /** BTB configuration parameters */
+    unsigned numEntries;    // Total number of entries
+
+    /** Address calculation masks and shifts */
+    unsigned tagBits;      // Number of tag bits
+    Addr tagMask;          // Mask for extracting tag bits
+
+    enum Mode
+    {
+        READ, WRITE, EVICT
+    };
+
+    struct UBTBStats : public statistics::Group
+    {
+
+        statistics::Scalar predMiss;
+        statistics::Scalar predHit;
+        statistics::Scalar updateMiss;
+        statistics::Scalar updateHit;
+        statistics::Scalar updateExisting;
+        statistics::Scalar updateReplace;
+        statistics::Scalar updateReplaceValidOne;
+
+
+        statistics::Scalar S0Predmiss;
+        statistics::Scalar S0PredUseUBTB;
+        statistics::Scalar S0PredUseABTB;
+
+        // per branch statistics
+        statistics::Scalar allBranchHits;
+        statistics::Scalar allBranchHitTakens;
+        statistics::Scalar allBranchHitNotTakens;
+        statistics::Scalar allBranchMisses;
+        statistics::Scalar allBranchMissTakens;
+        statistics::Scalar allBranchMissNotTakens;
+
+        statistics::Scalar condHits;
+        statistics::Scalar condHitTakens;
+        statistics::Scalar condHitNotTakens;
+        statistics::Scalar condMisses;
+        statistics::Scalar condMissTakens;
+        statistics::Scalar condMissNotTakens;
+        statistics::Scalar condPredCorrect;
+        statistics::Scalar condPredWrong;
+
+        statistics::Scalar uncondHits;
+        statistics::Scalar uncondMisses;
+
+        statistics::Scalar indirectHits;
+        statistics::Scalar indirectMisses;
+        statistics::Scalar indirectPredCorrect;
+        statistics::Scalar indirectPredWrong;
+
+        statistics::Scalar callHits;
+        statistics::Scalar callMisses;
+
+        statistics::Scalar returnHits;
+        statistics::Scalar returnMisses;
+
+        UBTBStats(statistics::Group* parent);
+    } ubtbStats;
+
+
+};
+
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5
+
+#endif // __CPU_PRED_BTB_UBTB_HH__

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -88,8 +88,9 @@ class UBTB : public TimedBaseBTBPredictor
     {
         unsigned uctr; //2-bit saturation counter used in replacement policy
         uint64_t tick;  // timestamp for MRU replacement
-        TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0) {}
-        TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick) {}
+        int  numNTConds;
+        TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0), numNTConds(0) {}
+        TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick), numNTConds(0) {}
     }TickedUBTBEntry;
 
     // A BTB set is a vector of entries (ways)

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -81,14 +81,14 @@ class UBTB : public TimedBaseBTBPredictor
      * - valid: validity bit for this entry
      * - tctr: 2-bit saturation counter for branch direction prediction
      * - uctr: 2-bit saturation counter used by the replacement policy
-     * - tag: tag bits from fetch block address [23:1]
+     * - tag: tag bits from fetch block address [23:1]p
      * - tick: timestamp used for MRU (Most Recently Used) replacement policy
      */
     typedef struct TickedUBTBEntry : public BTBEntry
     {
         unsigned uctr; //2-bit saturation counter used in replacement policy
         uint64_t tick;  // timestamp for MRU replacement
-        int  numNTConds;
+        int  numNTConds; // number of conditional branches before the taken branch
         TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0), numNTConds(0) {}
         TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick), numNTConds(0) {}
     }TickedUBTBEntry;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -689,6 +689,11 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
         overrideReason = reason;
     }
 
+    // update ubtb using mbtb prediction
+    if (predsOfEachStage[numStages - 1].btbEntries.size() > 0) {
+        ubtb->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
+    }
+
     // 4. Record override bubbles and update statistics
     numOverrideBubbles = first_hit_stage;
     if (numOverrideBubbles > 0) {

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -15,6 +15,7 @@
 #include "cpu/pred/btb/btb.hh"
 #include "cpu/pred/btb/btb_ittage.hh"
 #include "cpu/pred/btb/btb_tage.hh"
+#include "cpu/pred/btb/btb_ubtb.hh"
 #include "cpu/pred/btb/fetch_target_queue.hh"
 #include "cpu/pred/btb/jump_ahead_predictor.hh"
 #include "cpu/pred/btb/loop_buffer.hh"
@@ -95,7 +96,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     const Addr MaxAddr{~(0ULL)};
 
-    DefaultBTB *ubtb{};
+    UBTB *ubtb{};
     DefaultBTB *abtb{};
     DefaultBTB *btb{};
     BTBTAGE *tage{};

--- a/src/cpu/pred/btb/test/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/test/decoupled_bpred.cc
@@ -144,19 +144,19 @@ void DecoupledBPUWithBTB::OverrideStats(OverrideReason overrideReason)
         
         // Track specific override reasons for statistics
         switch (overrideReason) {
-            case OverrideReason::validity:
+            case OverrideReason::FALL_THRU:
                 dbpBtbStats.overrideValidityMismatch++;
                 break;
-            case OverrideReason::controlAddr:
+            case OverrideReason::CONTROL_ADDR:
                 dbpBtbStats.overrideControlAddrMismatch++;
                 break;
-            case OverrideReason::target:
+            case OverrideReason::TARGET:
                 dbpBtbStats.overrideTargetMismatch++;
                 break;
-            case OverrideReason::end:
+            case OverrideReason::END:
                 dbpBtbStats.overrideEndMismatch++;
                 break;
-            case OverrideReason::histInfo:
+            case OverrideReason::HIST_INFO:
                 dbpBtbStats.overrideHistInfoMismatch++;
                 break;
             default:
@@ -196,7 +196,7 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
     // 3. Calculate override bubbles needed for pipeline consistency
     // Override bubbles are needed when earlier stages predict differently from later stages
     unsigned first_hit_stage = 0;
-    OverrideReason overrideReason = OverrideReason::no_override;
+    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
 
     // Find first stage that matches the chosen prediction
     while (first_hit_stage < numStages - 1) {


### PR DESCRIPTION
New, 32 entry uBTB that works with aBTB to produce a combined prediction at S1.
- its content is updated during BPU prediction pipeline
- it stores only one entry per FB (the first entry that it predict to jump)
32 entry uBTB + 1k entry aBTB is the default configuration if kmhv3-ideal is turned on and DecoupledBPUwithBTB is chosen as the BPU type.