### PR TITLE
Revert ta ma

### DIFF
--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -101,7 +101,7 @@ jobs:
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
       - name: XS-GEM5 - Test xiangshan.py simulation scripts
         run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
           export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
           export GEM5_HOME=$(pwd)
           mkdir -p $GEM5_HOME/util/xs_scripts/test_v

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -55,7 +55,6 @@ struct VectorMicroInfo
     int32_t microVs2 = ~0;
     int32_t microVs3 = ~0;
 
-    uint32_t nf = 1;
     uint32_t fn = ~0; // segment idx
     uint32_t offset = ~0; // vload/store baseAddr offset
 };
@@ -101,6 +100,35 @@ inline uint8_t checked_vtype(bool vill, uint8_t vtype) {
     return vtype;
 }
 
+class VectorNonSplitInst : public RiscvStaticInst
+{
+  public:
+    int oldDstIdx = -1;
+    int vmsrcIdx = -1;
+    int vlsrcIdx = -1;
+  protected:
+    const int microIdx = 0; // just for convenience
+    const bool vm;
+    const uint8_t vsew;
+    const int8_t vlmul;
+    const uint32_t sew;
+    const float vflmul;
+    VectorNonSplitInst(const char* mnem, ExtMachInst _machInst,
+                   OpClass __opClass)
+        : RiscvStaticInst(mnem, _machInst, __opClass),
+        vm(_machInst.vm),
+        vsew(_machInst.vtype8.vsew),
+        vlmul(vtype_vlmul(_machInst.vtype8)),
+        sew( (8 << vsew) ),
+        vflmul( vlmul < 0 ? (1.0 / (1 << (-vlmul))) : (1 << vlmul) )
+    {
+        this->flags[IsVector] = true;
+    }
+
+    std::string generateDisassembly(
+        Addr pc, const loader::SymbolTable *symtab) const override;
+};
+
 class VectorMacroInst : public RiscvMacroInst
 {
   protected:
@@ -129,10 +157,6 @@ public:
     int oldDstIdx = -1;
     int vmsrcIdx = -1;
     int vlsrcIdx = -1;
-    const bool vta,vma;
-
-    virtual bool oldVdEliminable() { return true; }
-
 protected:
     const uint8_t microIdx;
     const bool vm;
@@ -143,33 +167,37 @@ protected:
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
                     uint8_t _microIdx)
         : RiscvMicroInst(mnem, _machInst, __opClass),
-        vta(_machInst.vtype8.vta),
-        vma(_machInst.vtype8.vma),
         microIdx(_microIdx),
         vm(_machInst.vm),
         vsew(_machInst.vtype8.vsew),
         vlmul(vtype_vlmul(_machInst.vtype8)),
-        sew((8 << vsew)),
-        vflmul(vlmul < 0 ? (1.0 / (1 << (-vlmul))) : (1 << vlmul))
+        sew( (8 << vsew) ),
+        vflmul( vlmul < 0 ? (1.0 / (1 << (-vlmul))) : (1 << vlmul) )
     {
         this->flags[IsVector] = true;
     }
 };
 
-class VectorNonSplitInst : public VectorMicroInst
+class VectorNopMicroInst : public RiscvMicroInst
 {
-  protected:
-    VectorNonSplitInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass)
-        : VectorMicroInst(mnem, _machInst, __opClass, 0)
+public:
+    VectorNopMicroInst(ExtMachInst _machInst)
+        : RiscvMicroInst("vnop", _machInst, No_OpClass)
+    {}
+
+    Fault execute(ExecContext* xc, Trace::InstRecord* traceData)
+        const override
     {
-        this->flags[IsVector] = true;
-        this->setFirstMicroop();
-        this->setLastMicroop();
+        return NoFault;
     }
 
-    std::string generateDisassembly(
-        Addr pc, const loader::SymbolTable *symtab) const override;
+    std::string generateDisassembly(Addr pc, const loader::SymbolTable *symtab)
+      const override
+    {
+        std::stringstream ss;
+        ss << mnemonic;
+        return ss.str();
+    }
 };
 
 class VectorArithMicroInst : public VectorMicroInst
@@ -384,9 +412,7 @@ class VlWholeMicroInst : public VectorMemMicroInst
     VlWholeMicroInst(const char *mnem, ExtMachInst _machInst,
                      OpClass __opClass, uint8_t _microIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microIdx)
-    {
-        this->flags[IsLoad] = true;
-    }
+    {}
 
     std::string generateDisassembly(
       Addr pc, const loader::SymbolTable *symtab) const override;
@@ -436,9 +462,7 @@ class VlStrideMicroInst : public VectorMemMicroInst
     VlStrideMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint8_t _microIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microIdx)
-    {
-        this->flags[IsLoad] = true;
-    }
+    {}
 
     std::string generateDisassembly(
         Addr pc, const loader::SymbolTable *symtab) const override;
@@ -488,9 +512,7 @@ class VlIndexMicroInst : public VectorMemMicroInst
     VlIndexMicroInst(const char *mnem, ExtMachInst _machInst,
                     OpClass __opClass, uint32_t _microIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microIdx)
-    {
-        this->flags[IsLoad] = true;
-    }
+    {}
 
     std::string generateDisassembly(
         Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -339,7 +339,7 @@ void ISA::clear()
     miscRegFile[MISCREG_TSELECT] = 1;
     // NMI is always enabled.
     miscRegFile[MISCREG_NMIE] = 1;
-
+    // sync with NEMU
     miscRegFile[MISCREG_VTYPE] = (1lu<<63);
     miscRegFile[MISCREG_HSTATUS] = (uint64_t)2<<32;
     miscRegFile[MISCREG_VSSTATUS] = miscRegFile[MISCREG_STATUS] & NEMU_SSTATUS_RMASK;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3908,7 +3908,7 @@ decode QUADRANT default Unknown::unknown() {
                         // (vm=0) of vfmv.s.f are reserved
                         0x1: VectorNonSplitFormat::vfmv_s_f({{
                             auto fd = ftype_freg<et>(freg(Fs1_bits));
-                            COPY_OLD_VD();
+                            std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
                             if (rVl) {
                                 Vd_vu[0] = fd.v;
                             }
@@ -4171,7 +4171,7 @@ decode QUADRANT default Unknown::unknown() {
                         // The encodings corresponding to the masked versions
                         // (vm=0) of vmv.s.x are reserved.
                         0x1: VectorNonSplitFormat::vmv_s_x({{
-                            COPY_OLD_VD();
+                            std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
                             if (rVl) {
                                 Vd_vu[0] = Rs1_vu;
                             }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2398,16 +2398,14 @@ decode QUADRANT default Unknown::unknown() {
                 }
                 format VectorReduceIntWideningFormat {
                     0x30: vwredsumu_vs({{
-                        std::plus<vwui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vwu[0] = reduce_loop(std::plus<vwu>(),
+                            Vs1_vwu, Vs2_vu);
+                        uint32_t ignore_this = rVl;
                     }}, OPIVV, VectorIntegerReduceOp);
                     0x31: vwredsum_vs({{
-                        std::plus<vwui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vwu[0] = reduce_loop(std::plus<vwi>(),
+                            Vs1_vwi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPIVV, VectorIntegerReduceOp);
                 }
                 format VectorIntMaskFormat {
@@ -2513,12 +2511,10 @@ decode QUADRANT default Unknown::unknown() {
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, VectorFloatArithOp);
                 0x01: VectorReduceFloatFormat::vfredusum_vs({{
-                    [](const vu& src1, const vu& src2) {
+                    Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fadd<et>(ftype<et>(src1), ftype<et>(src2));
-                    };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                    }, Vs1_vu, Vs2_vu);
+                    uint32_t ignore_this = rVl;
                 }}, OPFVV, VectorFloatReduceOp);
                 0x02: VectorFloatFormat::vfsub_vv({{
                     auto fd = fsub<et>(ftype<et>(Vs2_vu[i]),
@@ -2526,12 +2522,10 @@ decode QUADRANT default Unknown::unknown() {
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, VectorFloatArithOp);
                 0x03: VectorReduceFloatFormat::vfredosum_vs({{
-                    [](const vu& src1, const vu& src2) {
+                    Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fadd<et>(ftype<et>(src1), ftype<et>(src2));
-                    };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                    }, Vs1_vu, Vs2_vu);
+                    uint32_t ignore_this = rVl;
                 }}, OPFVV, VectorFloatReduceOp);
                 0x04: VectorFloatFormat::vfmin_vv({{
                     auto fd = fmin<et>(ftype<et>(Vs2_vu[i]),
@@ -2539,12 +2533,10 @@ decode QUADRANT default Unknown::unknown() {
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, VectorFloatArithOp);
                 0x05: VectorReduceFloatFormat::vfredmin_vs({{
-                    [](const vu& src1, const vu& src2) {
+                    Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fmin<et>(ftype<et>(src1), ftype<et>(src2));
-                    };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                    }, Vs1_vu, Vs2_vu);
+                    uint32_t ignore_this = rVl;
                 }}, OPFVV, VectorFloatReduceOp);
                 0x06: VectorFloatFormat::vfmax_vv({{
                     auto fd = fmax<et>(ftype<et>(Vs2_vu[i]),
@@ -2552,12 +2544,10 @@ decode QUADRANT default Unknown::unknown() {
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, VectorFloatArithOp);
                 0x07: VectorReduceFloatFormat::vfredmax_vs({{
-                    [](const vu& src1, const vu& src2) {
+                    Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fmax<et>(ftype<et>(src1), ftype<et>(src2));
-                    };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                    }, Vs1_vu, Vs2_vu);
+                    uint32_t ignore_this = rVl;
                 }}, OPFVV, VectorFloatReduceOp);
                 0x08: VectorFloatFormat::vfsgnj_vv({{
                     Vd_vu[i] = fsgnj<et>(ftype<et>(Vs2_vu[i]),
@@ -2790,20 +2780,16 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_vu[i] = fd.v;
                     }}, OPFVV, VectorFloatArithOp);
                     0x31: VectorReduceFloatWideningFormat::vfwredusum_vs({{
-                        [](const vwu& src1, const vu& src2) {
+                        Vd_vwu[0] = reduce_loop([](const vwu& src1, const vu& src2) {
                             return fadd<ewt>(ftype<ewt>(src1), f_to_wf<et>(ftype<et>(src2)));
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        }, Vs1_vwu, Vs2_vu);
+                        uint32_t ignore_this = rVl;
                     }}, OPFVV, VectorFloatReduceOp);
                     0x33: VectorReduceFloatWideningFormat::vfwredosum_vs({{
-                        [](const vwu& src1, const vu& src2) {
+                        Vd_vwu[0] = reduce_loop([](const vwu& src1, const vu& src2) {
                             return fadd<ewt>(ftype<ewt>(src1), f_to_wf<et>(ftype<et>(src2)));
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        }, Vs1_vwu, Vs2_vu);
+                        uint32_t ignore_this = rVl;
                     }}, OPFVV, VectorFloatReduceOp);
                 }
                 format VectorFloatWideningFormat {
@@ -2871,60 +2857,52 @@ decode QUADRANT default Unknown::unknown() {
             0x2: decode VFUNCT6 {
                 format VectorReduceIntFormat {
                     0x0: vredsum_vs({{
-                        std::plus<vui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop(std::plus<vi>(), Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x1: vredand_vs({{
-                        std::bit_and<vui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop(std::bit_and<vi>(), Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x2: vredor_vs({{
-                        std::bit_or<vui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop(std::bit_or<vi>(), Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x3: vredxor_vs({{
-                        std::bit_xor<vui>();
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop(std::bit_xor<vi>(), Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x4: vredminu_vs({{
-                        [](const vui& src1, const vui& src2) {
-                            return std::min<vui>(src1, src2);
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vu[0] =
+                            reduce_loop([](const vu& src1, const vu& src2) {
+                                return std::min<vu>(src1, src2);
+                            }, Vs1_vu, Vs2_vu);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x5: vredmin_vs({{
-                        [](const vui& src1, const vui& src2) {
-                            return std::min<vui>(src1, src2);
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop([](const vi& src1, const vi& src2) {
+                                return std::min<vi>(src1, src2);
+                            }, Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x6: vredmaxu_vs({{
-                        [](const vui& src1, const vui& src2) {
-                            return std::max<vui>(src1, src2);
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vu[0] =
+                            reduce_loop([](const vu& src1, const vu& src2) {
+                                return std::max<vu>(src1, src2);
+                            }, Vs1_vu, Vs2_vu);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                     0x7: vredmax_vs({{
-                        [](const vui& src1, const vui& src2) {
-                            return std::max<vui>(src1, src2);
-                        };
-                        [[maybe_unused]] auto _1 = Vd;
-                        [[maybe_unused]] auto _2 = Vs2;
-                        [[maybe_unused]] auto _3 = rVl;
+                        Vd_vi[0] =
+                            reduce_loop([](const vi& src1, const vi& src2) {
+                                return std::max<vi>(src1, src2);
+                            }, Vs1_vi, Vs2_vi);
+                        uint32_t ignore_this = rVl;
                     }}, OPMVV, VectorIntegerReduceOp);
                 }
                 format VectorIntFormat {

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1118,45 +1118,6 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     decode_block = VectorFloatDecodeBlock.subst(iop)
 }};
 
-def format VectorReduceIntWideningFormat(code, category, *flags) {{
-    iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
-                        flags)
-    inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
-    src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
-    src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
-    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
-    set_dest_reg_idx = setDestWrapper(dest_reg_id)
-    set_src_reg_idx = setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
-    # We always need old rd as src vreg
-    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
-    set_src_reg_idx += setSrcVL()
-    set_src_reg_idx += setSrcVm()
-    vm_decl_rd = vmDeclAndReadData()
-
-    microiop = InstObjParams(name + "_micro",
-        Name + "Micro",
-        'VectorArithMicroInst',
-        {'code': code,
-         'set_dest_reg_idx': set_dest_reg_idx,
-         'set_src_reg_idx': set_src_reg_idx,
-         'vm_decl_rd': vm_decl_rd,
-         'copy_old_vd': copyOldVd(2)},
-        flags)
-
-    # Because of the use of templates, we had to put all parts in header to
-    # keep the compiler happy.
-    header_output = \
-        VectorReduceMicroDeclare.subst(microiop) + \
-        VectorReduceMicroConstructor.subst(microiop) + \
-        VectorReduceIntWideningMicroExecute.subst(microiop) + \
-        VectorReduceMacroDeclare.subst(iop) + \
-        VectorReduceMacroConstructor.subst(iop)
-    decode_block = VectorIntWideningDecodeBlock.subst(iop)
-}};
-
 def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
@@ -1255,6 +1216,45 @@ def format VectorIntVxsatFormat(code, category, *flags) {{
         VectorIntVxsatMacroConstructor.subst(iop)
 
     decode_block = VectorIntDecodeBlock.subst(iop)
+}};
+
+def format VectorReduceIntWideningFormat(code, category, *flags) {{
+    iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
+                        flags)
+    inst_name, inst_suffix = name.split("_", maxsplit=1)
+    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
+    src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
+    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    set_dest_reg_idx = setDestWrapper(dest_reg_id)
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
+    set_src_reg_idx += setSrcVL()
+    set_src_reg_idx += setSrcVm()
+    vm_decl_rd = vmDeclAndReadData()
+
+    microiop = InstObjParams(name + "_micro",
+        Name + "Micro",
+        'VectorArithMicroInst',
+        {'code': code,
+         'set_dest_reg_idx': set_dest_reg_idx,
+         'set_src_reg_idx': set_src_reg_idx,
+         'vm_decl_rd': vm_decl_rd,
+         'copy_old_vd': copyOldVd(2)},
+        flags)
+
+    # Because of the use of templates, we had to put all parts in header to
+    # keep the compiler happy.
+    header_output = \
+        VectorReduceMicroDeclare.subst(microiop) + \
+        VectorReduceMicroConstructor.subst(microiop) + \
+        VectorReduceIntWideningMicroExecute.subst(microiop) + \
+        VectorReduceMacroDeclare.subst(iop) + \
+        VectorReduceMacroConstructor.subst(iop)
+    decode_block = VectorIntWideningDecodeBlock.subst(iop)
 }};
 
 let {{

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1030,28 +1030,25 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
-
-    set_dest_reg_idx = "if (pos == LastUop) {" + setDestWrapper(dest_reg_id) + "}\n"
-    set_dest_reg_idx += "else {" + setDestWrapper("RegId(VecRegClass, VecTempReg0)") + "}\n"
-
-    set_src_reg_idx = ""
-    set_src_reg_idx += "if (pos == LastUop) {" + setOldDestWrapper(old_dest_reg_id) + "}\n"
-    set_src_reg_idx += "if (pos != FirstUop) {" + setSrcWrapper("RegId(VecRegClass, VecTempReg0)") + "}\n"
-    set_src_reg_idx += "if (pos != LastUop) {" + setSrcWrapper(src2_reg_id) + "}\n"
-    set_src_reg_idx += "if (pos == LastUop) {" + setSrcWrapper(src1_reg_id) + "}\n"
-
+    set_dest_reg_idx = setDestWrapper(dest_reg_id)
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
+    type_def = '''
+        using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
+        using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
+    '''
 
-    if name.endswith('u_vs') :
-        type_def = '''
-            using vui [[maybe_unused]] = std::make_unsigned_t<ElemType>;
-        '''
-    else:
-        type_def = '''
-            using vui [[maybe_unused]] = std::make_signed_t<ElemType>;
-        '''
+    code = """
+    if (microIdx * elem_num_per_vreg < rVl) {
+        %s
+    }
+    """ % (code)
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -1079,20 +1076,16 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-
     dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
-
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
-
-    set_src_reg_idx = ""
-    set_src_reg_idx += "if (pos == LastUop) {" + setOldDestWrapper(old_dest_reg_id) + "}"
-    set_src_reg_idx += "if (pos != FirstUop) {" + setSrcWrapper("RegId(VecRegClass, VecTempReg0)") + "}"
-    set_src_reg_idx += "if (pos != LastUop) {" + setSrcWrapper(src2_reg_id) + "}"
-    set_src_reg_idx += "if (pos == LastUop) {" + setSrcWrapper(src1_reg_id) + "}"
-
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
@@ -1100,6 +1093,8 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
         using et = ElemType;
         using vu = decltype(et::v);
     '''
+
+    code = fflags_wrapper(code)
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -1132,27 +1127,14 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
-
-    set_src_reg_idx = ""
-    set_src_reg_idx += "if (pos == LastUop) {" + setOldDestWrapper(old_dest_reg_id) + "}"
-    set_src_reg_idx += "if (pos != FirstUop) {" + setSrcWrapper("RegId(VecRegClass, VecTempReg0)") + "}"
-    set_src_reg_idx += "if (pos != LastUop) {" + setSrcWrapper(src2_reg_id) + "}"
-    set_src_reg_idx += "if (pos == LastUop) {" + setSrcWrapper(src1_reg_id) + "}"
-
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
-
-    if name.endswith('u_vs') :
-        type_def = """
-        using vui [[maybe_unused]] = std::make_unsigned_t<ElemType>;
-        using vwui [[maybe_unused]] = typename double_width<vui>::type;
-        """
-    else :
-        type_def = """
-        using vui [[maybe_unused]] = std::make_signed_t<ElemType>;
-        using vwui [[maybe_unused]] = typename double_width<vui>::type;
-        """
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -1161,7 +1143,6 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'vm_decl_rd': vm_decl_rd,
-         'type_def': type_def,
          'copy_old_vd': copyOldVd(2)},
         flags)
 
@@ -1185,18 +1166,14 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
-
-    set_src_reg_idx = ""
-    set_src_reg_idx += "if (pos == LastUop) {" + setOldDestWrapper(old_dest_reg_id) + "}"
-    set_src_reg_idx += "if (pos != FirstUop) {" + setSrcWrapper("RegId(VecRegClass, VecTempReg0)") + "}"
-    set_src_reg_idx += "if (pos != LastUop) {" + setSrcWrapper(src2_reg_id) + "}"
-    set_src_reg_idx += "if (pos == LastUop) {" + setSrcWrapper(src1_reg_id) + "}"
-
+    set_src_reg_idx = setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+    # Treat tail undisturbed/agnostic as the same
+    # We always need old rd as src vreg
+    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
-
-
     type_def = '''
         using et = ElemType;
         using vu [[maybe_unused]] = decltype(et::v);

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -119,9 +119,6 @@ template<typename ElemType>
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -337,9 +334,6 @@ template<typename ElemType>
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -481,9 +475,6 @@ template<typename ElemType>
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -688,9 +679,6 @@ template<typename ElemType>
         vmi.rs = i * elem_num_per_vreg;
         vmi.re = (i+1) * elem_num_per_vreg;
         vmi.microVd = VD + i;
-        if (vmi.microVd >= 32) {
-            break;
-        }
         microop = new %(class_name)sMicro<ElemType>(_machInst, i, vmi);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
@@ -736,8 +724,8 @@ template<typename ElemType>
     _numTypedDestRegs[VecRegClass]++;
 
     setSrcRegIdx(_numSrcRegs++, RegId(VecRegClass, _machInst.vs2));
-    SET_VL_SRC();
     SET_OLDDST_SRC();
+    SET_VL_SRC();
     if (_microIdx != 0) {
         setSrcRegIdx(_numSrcRegs++, RegId(VecRegClass, VecTempReg0));
     }
@@ -926,9 +914,6 @@ template<typename ElemType>
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1032,9 +1017,6 @@ template<typename ElemType>
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1128,9 +1110,6 @@ def template VMvWholeMicroConstructor {{
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1242,11 +1221,8 @@ template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
 {
-    vmi.rs = 0;
-    vmi.re = 1;
     %(set_reg_idx_arr)s;
     %(constructor)s;
-    SET_OLDDST_SRC();
     %(set_vm_idx)s;
 }
 
@@ -1344,26 +1320,7 @@ public:
     %(class_name)s(ExtMachInst _machInst,
                    uint8_t _microIdx);
     Fault execute(ExecContext* xc, Trace::InstRecord* traceData)const override;
-    std::string generateDisassembly(Addr pc,
-        const Loader::SymbolTable *symtab) const override
-    {
-        std::stringstream ss;
-        if (pos==FirstUop) {
-            ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", ";
-            ss << registerName(srcRegIdx(0));
-        }
-        if (pos==MiddleUop) {
-            ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", ";
-            ss << registerName(srcRegIdx(1)) << "," << registerName(srcRegIdx(0));
-        }
-        if (pos==LastUop) {
-            ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", ";
-            ss << registerName(srcRegIdx(2)) << "," << registerName(srcRegIdx(1));
-        }
-
-        if (machInst.vm == 0) ss << ", v0.t";
-        return ss.str();
-    }
+    using %(base_class)s::generateDisassembly;
 };
 
 }};
@@ -1376,9 +1333,6 @@ template<typename ElemType>
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1581,10 +1535,6 @@ template<typename ElemType, typename IndexType>
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
-
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1740,9 +1690,6 @@ template<typename ElemType>
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microIdx)
 {
-    uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = _microIdx * elem_num_per_vreg;
-    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     this->vxsatptr = vxsatptr;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1844,7 +1791,7 @@ template<typename ElemType>
             vmi.re = (i+1) * elem_num_per_vreg;
             vmi.microVd = VD + i;
             vmi.microVs2 = new_vs2;
-            if (vmi.microVd >= 32 || vmi.microVs2 >= 32) {
+            if (vmi.microVs2 >= 32) {
                 break;
             }
             microop = new %(class_name)sMicro<ElemType>(_machInst, micro_idx++, vmi);
@@ -1858,9 +1805,6 @@ template<typename ElemType>
                 vmi.re = (i+1) * elem_num_per_vreg;
                 vmi.microVd = VD + i;
                 vmi.microVs2 = VS2 + i - j - 1;
-                if (vmi.microVd >= 32) {
-                    break;
-                }
                 if (vmi.microVs2 < 0) {
                     vmi.microVs2 = 0;
                 }
@@ -1905,9 +1849,6 @@ template<typename ElemType>
             vmi.re = (i+1) * elem_num_per_vreg;
             vmi.microVd = VD + i;
             vmi.microVs2 = elem_gen_idx(VS2 + i, off, sew/8);
-            if (vmi.microVd >= 32) {
-                break;
-            }
             if (vmi.microVs2 >= 32) {
                 vmi.microVs2 = 31;
             }
@@ -1922,9 +1863,6 @@ template<typename ElemType>
                 vmi.re = (i+1) * elem_num_per_vreg;
                 vmi.microVd = VD + i;
                 vmi.microVs2 = VS2 + j;
-                if (vmi.microVd >= 32) {
-                    break;
-                }
                 if (vmi.microVs2 >= 32) {
                     vmi.microVs2 = 31;
                 }

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -6,7 +6,7 @@ output header {{
 #define COPY_OLD_VD() \
     [[maybe_unused]] RiscvISA::vreg_t old_vd; \
     [[maybe_unused]] decltype(Vd) old_Vd = nullptr; \
-    assert(oldDstIdx > -1); \
+    assert(oldDstIdx > 0); \
     xc->getRegOperand(this, oldDstIdx, &old_vd); \
     old_Vd = old_vd.as<std::remove_reference_t<decltype(Vd[0])> >(); \
     memcpy(Vd, old_Vd, VLENB);
@@ -1301,6 +1301,8 @@ def template VectorReduceMacroDeclare {{
 
 template<typename ElemType>
 class %(class_name)s : public %(base_class)s {
+private:
+    %(reg_idx_arr_decl)s;
 public:
     %(class_name)s(ExtMachInst _machInst);
     using %(base_class)s::generateDisassembly;
@@ -1319,13 +1321,10 @@ template<typename ElemType>
     StaticInstPtr microop;
 
     for (int i = 0; i < num_microops; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, i, (i == 0 ? 0 : 1));
+        microop = new %(class_name)sMicro<ElemType>(_machInst, i);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
     }
-    microop = new %(class_name)sMicro<ElemType>(_machInst, num_microops, 2);
-    microop->setDelayedCommit();
-    this->microops.push_back(microop);
     this->microops.front()->setFirstMicroop();
     this->microops.back()->setLastMicroop();
 }
@@ -1338,20 +1337,12 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // first microop: vtmp0 <- reduce_loop(vs2)
-    // middle microop: vtmp0 <- vtmp0 + reduce_loop(vs2)
-    // last microop: vd <= oldvd + vtmp0 + vs1
     // vs2, vs1, vd, vm
     RegId srcRegIdxArr[8];
     RegId destRegIdxArr[1];
 public:
-    enum MicroopPos {
-        FirstUop = 0,  // 0
-        MiddleUop = 1, // 1
-        LastUop = 2,   // 2
-    } pos;
     %(class_name)s(ExtMachInst _machInst,
-                   uint8_t _microIdx, int pos);
+                   uint8_t _microIdx);
     Fault execute(ExecContext* xc, Trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const Loader::SymbolTable *symtab) const override
@@ -1381,14 +1372,13 @@ def template VectorReduceMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint8_t _microIdx, int pos)
+                                         uint8_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microIdx)
 {
-    this->pos = (MicroopPos)pos;
     uint32_t elem_num_per_vreg = VLEN / sew;
-    vmi.rs = 0;
-    vmi.re = 1;
+    vmi.rs = _microIdx * elem_num_per_vreg;
+    vmi.re = (_microIdx+1) * elem_num_per_vreg;
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
@@ -1410,31 +1400,20 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     }
 
-    auto &tmp_d0 =
-    *(RiscvISAInst::VecRegContainer *)
-    xc->getWritableRegOperand(
-        this, 0);
-    auto Vd = tmp_d0.as<vui>();
-
-    uint64_t rVl = 0;
-    assert(vlsrcIdx > 0);
-    rVl = xc->getRegOperand(this, vlsrcIdx);
+    %(op_decl)s;
+    %(op_rd)s;
+    %(vm_decl_rd)s;
+    COPY_OLD_VD();
 
     uint32_t microvlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
     uint32_t elem_num_per_vreg = microvlmax;
-
-    %(vm_decl_rd)s;
-    vui vtmp, vs1;
-    vui *Vs2=nullptr;
-
-    auto func = %(code)s;
     auto reduce_loop =
-        [&, this](bool middle, vui vtmp) {
-            ElemType microop_result = middle ? vtmp : Vs2[0];
+        [&, this](const auto& f, const auto* _, const auto* vs2) {
+            ElemType microop_result = this->microIdx != 0 ? old_Vd[0] : Vs1[0];;
             for (uint32_t i = 0; i < microvlmax; i++) {
                 uint32_t ei = i + microvlmax * this->microIdx;
                 if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                    microop_result = func(microop_result, Vs2[i]);
+                    microop_result = f(microop_result, Vs2[i]);
                 } else if (ei >= rVl) {
                     break;
                 }
@@ -1442,41 +1421,8 @@ Fault
             return microop_result;
         };
 
-    vui result;
-    if (pos == FirstUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vui>();
-        result = reduce_loop(false, 0);
-    } else if (pos == MiddleUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vui>()[0];
-
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vui>();
-        result = reduce_loop(true, vtmp);
-    } else {
-        COPY_OLD_VD();
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vui>()[0];
-        xc->getRegOperand(this, 2,
-            &tmp_s0);
-        vs1 = tmp_s0.as<vui>()[0];
-        result = func(vtmp, vs1);
-    }
-    Vd[0] = result;
-
-    xc->setRegOperand(this,0, &tmp_d0);
-    if (traceData) {
-        traceData->setData(tmp_d0);
-    }
-
+    %(code)s;
+    %(op_wb)s;
     return NoFault;
 }
 
@@ -1494,163 +1440,30 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     }
 
-    auto &tmp_d0 =
-    *(RiscvISAInst::VecRegContainer *)
-    xc->getWritableRegOperand(
-        this, 0);
-    auto Vd = tmp_d0.as<vu>();
-
-    uint64_t rVl = 0;
-    assert(vlsrcIdx > 0);
-    rVl = xc->getRegOperand(this, vlsrcIdx);
-
-    uint32_t microvlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    uint32_t elem_num_per_vreg = microvlmax;
-
+    %(op_decl)s;
+    %(op_rd)s;
     %(vm_decl_rd)s;
-    vu vtmp, vs1;
-    vu *Vs2=nullptr;
+    COPY_OLD_VD();
 
-    auto func = %(code)s;
-    auto reduce_loop =
-        [&, this](bool middle, vu vtmp) {
-            vu microop_result = middle ? vtmp : Vs2[0];
-            for (uint32_t i = 0; i < microvlmax; i++) {
-                uint32_t ei = i + microvlmax * this->microIdx;
-                if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                    microop_result = func(microop_result, Vs2[i]).v;
-                } else if (ei >= rVl) {
-                    break;
+    uint32_t micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+    if (micro_vlmax * this->microIdx < rVl) {
+        Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
+
+        auto reduce_loop =
+            [&, this](const auto& f, const auto* _, const auto* vs2) {
+                vu tmp_val = Vd[0];
+                for (uint32_t i = 0; i < micro_vlmax; i++) {
+                    uint32_t ei = i + micro_vlmax * this->microIdx;
+                    if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
+                        tmp_val = f(tmp_val, Vs2[i]).v;
+                    }
                 }
-            }
-            return microop_result;
-        };
-
-    vu result;
-    if (pos == FirstUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vu>();
-        result = reduce_loop(false, 0);
-    } else if (pos == MiddleUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vu>()[0];
-
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vu>();
-        result = reduce_loop(true, vtmp);
-    } else {
-        COPY_OLD_VD();
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vu>()[0];
-        xc->getRegOperand(this, 2,
-            &tmp_s0);
-        vs1 = tmp_s0.as<vu>()[0];
-        result = func(vtmp, vs1).v;
-    }
-    RegVal FFLAGS = xc->readMiscReg(MISCREG_FFLAGS);
-    std::feclearexcept(FE_ALL_EXCEPT);
-    FFLAGS |= softfloat_exceptionFlags;
-    if (softfloat_exceptionFlags) {
-        softfloat_exceptionFlags = 0;
-        xc->setMiscReg(MISCREG_FFLAGS, FFLAGS);
+                return tmp_val;
+            };
+        %(code)s;
     }
 
-    Vd[0] = result;
-
-    xc->setRegOperand(this,0, &tmp_d0);
-    if (traceData) {
-        traceData->setData(tmp_d0);
-    }
-
-    return NoFault;
-}
-
-}};
-
-def template VectorReduceIntWideningMicroExecute {{
-
-template <typename ElemType>
-Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  Trace::InstRecord* traceData) const
-{
-    %(type_def)s;
-    if (machInst.vill) {
-        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
-    }
-
-    auto &tmp_d0 =
-    *(RiscvISAInst::VecRegContainer *)
-    xc->getWritableRegOperand(
-        this, 0);
-    auto Vd = tmp_d0.as<vwui>();
-
-    uint64_t rVl = 0;
-    assert(vlsrcIdx > 0);
-    rVl = xc->getRegOperand(this, vlsrcIdx);
-
-    uint32_t microvlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    uint32_t elem_num_per_vreg = microvlmax;
-
-    %(vm_decl_rd)s;
-    vwui vtmp, vs1;
-    vui *Vs2=nullptr;
-
-    auto func = %(code)s;
-    auto reduce_loop =
-        [&, this](bool middle, vwui vtmp) {
-            vwui microop_result = middle ? vtmp : Vs2[0];
-            for (uint32_t i = 0; i < microvlmax; i++) {
-                uint32_t ei = i + microvlmax * this->microIdx;
-                if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                    microop_result = func(microop_result, Vs2[i]);
-                } else if (ei >= rVl) {
-                    break;
-                }
-            }
-            return microop_result;
-        };
-
-    vui result;
-    if (pos == FirstUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vui>();
-        result = reduce_loop(false, 0);
-    } else if (pos == MiddleUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vwui>()[0];
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vui>();
-        result = reduce_loop(true, vtmp);
-    } else {
-        COPY_OLD_VD();
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vwui>()[0];
-        xc->getRegOperand(this, 2,
-            &tmp_s0);
-        vs1 = tmp_s0.as<vwui>()[0];
-        result = func(vtmp, vs1);
-    }
-    Vd[0] = result;
-
-    xc->setRegOperand(this,0, &tmp_d0);
-    if (traceData) {
-        traceData->setData(tmp_d0);
-    }
+    %(op_wb)s;
     return NoFault;
 }
 
@@ -1668,80 +1481,30 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     }
 
-    auto &tmp_d0 =
-    *(RiscvISAInst::VecRegContainer *)
-    xc->getWritableRegOperand(
-        this, 0);
-    auto Vd = tmp_d0.as<vwu>();
-
-    uint64_t rVl = 0;
-    assert(vlsrcIdx > 0);
-    rVl = xc->getRegOperand(this, vlsrcIdx);
-
-    uint32_t microvlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    uint32_t elem_num_per_vreg = microvlmax;
-
+    %(op_decl)s;
+    %(op_rd)s;
     %(vm_decl_rd)s;
-    vwu vtmp, vs1;
-    vu *Vs2=nullptr;
+    COPY_OLD_VD();
 
-    auto func = %(code)s;
-    auto reduce_loop =
-        [&, this](bool middle, vwu vtmp) {
-            vwu microop_result = middle ? vtmp : Vs2[0];
-            for (uint32_t i = 0; i < microvlmax; i++) {
-                uint32_t ei = i + microvlmax * this->microIdx;
-                if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                    microop_result = func(microop_result, Vs2[i]).v;
-                } else if (ei >= rVl) {
-                    break;
+    uint32_t micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+    if (micro_vlmax * this->microIdx < rVl) {
+        Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
+
+        auto reduce_loop =
+            [&, this](const auto& f, const auto* _, const auto* vs2) {
+                vwu tmp_val = Vd[0];
+                for (uint32_t i = 0; i < micro_vlmax; i++) {
+                    uint32_t ei = i + micro_vlmax * this->microIdx;
+                    if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
+                        tmp_val = f(tmp_val, Vs2[i]).v;
+                    }
                 }
-            }
-            return microop_result;
-        };
-
-    vwu result;
-    if (pos == FirstUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vu>();
-        result = reduce_loop(false, 0);
-    } else if (pos == MiddleUop) {
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 0,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vwu>()[0];
-
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        Vs2 = tmp_s0.as<vu>();
-        result = reduce_loop(true, vtmp);
-    } else {
-        COPY_OLD_VD();
-        RiscvISAInst::VecRegContainer tmp_s0;
-        xc->getRegOperand(this, 1,
-            &tmp_s0);
-        vtmp = tmp_s0.as<vwu>()[0];
-        xc->getRegOperand(this, 2,
-            &tmp_s0);
-        vs1 = tmp_s0.as<vwu>()[0];
-        result = func(vtmp, vs1).v;
-    }
-    Vd[0] = result;
-    RegVal FFLAGS = xc->readMiscReg(MISCREG_FFLAGS);
-    std::feclearexcept(FE_ALL_EXCEPT);
-    FFLAGS |= softfloat_exceptionFlags;
-    if (softfloat_exceptionFlags) {
-        softfloat_exceptionFlags = 0;
-        xc->setMiscReg(MISCREG_FFLAGS, FFLAGS);
+                return tmp_val;
+            };
+        %(code)s;
     }
 
-    xc->setRegOperand(this,0, &tmp_d0);
-    if (traceData) {
-        traceData->setData(tmp_d0);
-    }
-
+    %(op_wb)s;
     return NoFault;
 }
 
@@ -1986,6 +1749,52 @@ template<typename ElemType>
     _numDestRegs = 0;
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
+}
+
+}};
+
+def template VectorReduceIntWideningMicroExecute {{
+
+template <typename ElemType>
+Fault
+%(class_name)s<ElemType>::execute(ExecContext* xc,
+                                  Trace::InstRecord* traceData) const
+{
+    using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
+    using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
+    using vwu [[maybe_unused]] = typename double_width<vu>::type;
+    using vwi [[maybe_unused]] = typename double_width<vi>::type;
+
+    if (machInst.vill) {
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    }
+
+    %(op_decl)s;
+    %(op_rd)s;
+    %(vm_decl_rd)s;
+    COPY_OLD_VD();
+
+    uint32_t micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+    if (micro_vlmax * this->microIdx < rVl) {
+
+        Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
+        auto reduce_loop =
+            [&, this](const auto& f, const auto* _, const auto* vs2) {
+                vwu tmp_val = Vd[0];
+                for (uint32_t i = 0; i < micro_vlmax; i++) {
+                    uint32_t ei = i + micro_vlmax * this->microIdx;
+                    if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
+                        tmp_val = f(tmp_val, Vs2[i]);
+                    }
+                }
+                return tmp_val;
+            };
+
+        %(code)s;
+    }
+
+    %(op_wb)s;
+    return NoFault;
 }
 
 }};

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -54,7 +54,6 @@ def template VleConstructor {{
 
     StaticInstPtr microop;
     VectorMicroInfo vmi;
-    vmi.nf = nf;
     if (nf == 1) { // sequence load
         const uint32_t num_microops = emul;
         for (int i = 0; i < num_microops; ++i) {
@@ -69,6 +68,7 @@ def template VleConstructor {{
             microop = new %(class_name)sMicro(_machInst, i, vmi);
             microop->setDelayedCommit();
             microop->setFlag(IsLoad);
+            microop->setNF(1);
             this->microops.push_back(microop);
         }
     } else {
@@ -83,13 +83,12 @@ def template VleConstructor {{
                 vmi.fn = fn;
                 vmi.microVd = elem_gen_idx(VD + fn * emul, i, eew/8);
                 vmi.offset = (i*nf+fn) * eew / 8;
-                if (vmi.microVd >= 32) {
-                    break;
-                }
                 microop = new %(class_name)sMicro(_machInst, i*(fn+1), vmi);
 
                 // segment vl related
                 microop->resetOpClass(VectorSegUnitStrideLoadOp);
+                microop->setNF(nf);
+                microop->setFlag(IsSegLoad);
 
                 microop->setDelayedCommit();
                 microop->setFlag(IsLoad);
@@ -322,9 +321,6 @@ def template VleffConstructor {{
         vmi.rs = i * elem_num_per_vreg;
         vmi.re = (i + 1) * elem_num_per_vreg;
         vmi.microVd = VD + i;
-        if (vmi.microVd >= 32) {
-            break;
-        }
         microop = new %(class_name)sMicro(_machInst, i, vmi);
         microop->setDelayedCommit();
         microop->setFlag(IsLoad);
@@ -434,9 +430,6 @@ def template VlWholeConstructor {{
         vmi.rs = 0;
         vmi.re = VLEN / eew;
         vmi.microVd = VD + i;
-        if (vmi.microVd >= 32) {
-            break;
-        }
         microop = new %(class_name)sMicro(_machInst, i, vmi);
         microop->setDelayedCommit();
         microop->setFlag(IsLoad);
@@ -518,7 +511,6 @@ def template VlStrideConstructor {{
 
     StaticInstPtr microop;
     VectorMicroInfo vmi;
-    vmi.nf = nf;
     uint32_t vlmax = VLEN / sew * vflmul;
     for (int i=0; i < vlmax; i++) {
         for (int fn=0; fn < nf; fn++) {
@@ -529,17 +521,17 @@ def template VlStrideConstructor {{
             vmi.fn = fn;
             vmi.microVd = elem_gen_idx(VD + fn * emul, i, eew/8);
             vmi.offset = fn * eew / 8;
-            if (vmi.microVd >= 32) {
-                break;
-            }
             microop = new %(class_name)sMicro(_machInst, i*fn, vmi);
             microop->setDelayedCommit();
             microop->setFlag(IsLoad);
 
+            microop->setNF(nf);
             if (nf > 1) {
                 // segment vl related
                 microop->resetOpClass(VectorSegStridedLoadOp);
+                microop->setFlag(IsSegLoad);
             }
+
             this->microops.push_back(microop);
         }
     }
@@ -641,7 +633,6 @@ template<typename ElemType>
 
     StaticInstPtr microop;
     VectorMicroInfo vmi;
-    vmi.nf = nf;
     uint32_t vlmax = VLEN / sew * vflmul;
     for (int i = 0; i < vlmax; i++) {
         for (int fn = 0; fn < nf; fn++) {
@@ -660,9 +651,11 @@ template<typename ElemType>
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsLoad);
 
+            microop->setNF(nf);
             if (nf > 1) {
                 // segment vl related
                 microop->resetOpClass(VectorSegIndexedLoadOp);
+                microop->setFlag(IsSegLoad);
             }
 
             this->microops.push_back(microop);

--- a/src/arch/riscv/regs/vector.hh
+++ b/src/arch/riscv/regs/vector.hh
@@ -59,28 +59,18 @@ using ConstVecPredReg =
 using VecPredRegContainer = VecPredReg::Container;
 
 const int NumVecStandardRegs = 32;
-const int NumVecInternalRegs = 10;
-const int VecTempReg0 = NumVecStandardRegs;
-const int VecTempReg1 = VecTempReg0 + 1;
-const int VecTempReg2 = VecTempReg1 + 1;
-const int VecTempReg3 = VecTempReg2 + 1;
-const int VecTempReg4 = VecTempReg3 + 1;
-const int VecTempReg5 = VecTempReg4 + 1;
-const int VecTempReg6 = VecTempReg5 + 1;
-const int VecTempReg7 = VecTempReg6 + 1;
+const int NumVecInternalRegs = 8;
 const int NumVecRegs = NumVecStandardRegs + NumVecInternalRegs;
-
-// dont write this reg, it's value should always be ~0
-inline const auto VecOnesReg = RegId(VecRegClass, 41);
 
 const std::vector<std::string> VecRegNames = {
     "v0",   "v1",   "v2",   "v3",   "v4",   "v5",   "v6",   "v7",
     "v8",   "v9",   "v10",  "v11",  "v12",  "v13",  "v14",  "v15",
     "v16",  "v17",  "v18",  "v19",  "v20",  "v21",  "v22",  "v23",
     "v24",  "v25",  "v26",  "v27",  "v28",  "v29",  "v30",  "v31",
-    "vtmp0", "vtmp1", "vtmp2", "vtmp3", "vtmp4", "vtmp5", "vtmp6", "vtmp7",
-    "vones", "reserved"
+    "vtmp0", "vtmp1", "vtmp2", "vtmp3", "vtmp4", "vtmp5", "vtmp6", "vtmp7"
 };
+
+const int VecTempReg0 = NumVecStandardRegs;
 
 static inline VecElemRegClassOps<RiscvISA::VecElem>
     vecRegElemClassOps(NumVecElemPerVecReg);

--- a/src/cpu/StaticInstFlags.py
+++ b/src/cpu/StaticInstFlags.py
@@ -58,6 +58,7 @@ class StaticInstFlags(Enum):
         'IsFloating',       # References FP regs.
         'IsVector',         # References Vector regs.
         'IsVectorElem',     # References Vector reg elems.
+        'IsSegLoad',        # is segment load in RVV
 
         'IsLoad',           # Reads from memory (load or prefetch).
         'IsStore',          # Writes to memory.

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1885,27 +1885,12 @@ Commit::updateComInstStats(const DynInstPtr &inst)
     if (inst->isVector()) {
         stats.vectorInstructions[tid]++;
         if (!inst->isMicroop() || inst->isLastMicroop()) {
-            auto vecInst = dynamic_cast<RiscvISA::VectorMicroInst *>(inst->staticInst.get());
             if (inst->opClass() == enums::VectorSegUnitStrideLoad) {
-                stats.segUnitStrideNF.sample(vecInst->vmi.nf);
+                stats.segUnitStrideNF.sample(inst->staticInst->getNF());
             } else if (inst->opClass() == enums::VectorSegStridedLoad) {
-                stats.segStrideNF.sample(vecInst->vmi.nf);
+                stats.segStrideNF.sample(inst->staticInst->getNF());
             } else if (inst->opClass() == enums::VectorSegIndexedLoad) {
-                stats.segIndexedNF.sample(vecInst->vmi.nf);
-            }
-        }
-        if (inst->isMicroop()) {
-            auto vecInst = dynamic_cast<RiscvISA::VectorMicroInst *>(inst->staticInst.get());
-            if (vecInst->vma) {
-                stats.vectorVma++;
-            } else {
-                stats.vectorVmu++;
-            }
-
-            if (vecInst->vta) {
-                stats.vectorVta++;
-            } else {
-                stats.vectorVtu++;
+                stats.segIndexedNF.sample(inst->staticInst->getNF());
             }
         }
     }

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -253,12 +253,7 @@ CPU::CPU(const BaseO3CPUParams &params)
                 commitRenameMap[tid].setEntry(rid, phys_reg);
             }
         }
-        // set default value
-        uint8_t ones[RiscvISA::VLENB];
-        memset(ones, 0xff, RiscvISA::VLENB);
-        setArchReg(RiscvISA::VecOnesReg, ones, tid);
     }
-    vecOnesPhysRegId = commitRenameMap[0].lookup(RiscvISA::VecOnesReg);
 
     rename.setRenameMap(renameMap);
     commit.setRenameMap(commitRenameMap);

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -128,7 +128,6 @@ class CPU : public BaseCPU
     /** Overall CPU status. */
     Status _status;
 
-    PhysRegIdPtr vecOnesPhysRegId;
   private:
 
     /** The tick event used for scheduling CPU ticks. */

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -48,7 +48,6 @@
 #include <list>
 #include <string>
 
-#include "arch/riscv/insts/vector.hh"
 #include "base/refcnt.hh"
 #include "base/trace.hh"
 #include "config/the_isa.hh"
@@ -69,7 +68,6 @@
 #include "debug/DecoupleBP.hh"
 #include "debug/HtmCpu.hh"
 #include "debug/RiscvMisc.hh"
-#include "debug/Schedule.hh"
 
 namespace gem5
 {
@@ -1064,38 +1062,6 @@ class DynInst : public ExecContext, public RefCounted
     void setInstListIt(ListIt _instListIt) { instListIt = _instListIt; }
 
   public:
-    bool checkOldVdElim()
-    {
-        if (isVector() && !isStore()) {
-            auto vecinst = dynamic_cast<RiscvISA::VectorMicroInst *>(staticInst.get());
-            if (vecinst->vlsrcIdx <= 0 || vecinst->oldDstIdx <= 0) {
-                return false;
-            }
-            if (!readySrcIdx(vecinst->vlsrcIdx)) {
-                return false;
-            }
-
-            uint64_t vl = getRegOperand(staticInst.get(), vecinst->vlsrcIdx);
-            bool set = vecinst->vmi.rs < RiscvISA::vtype_VLMAX(vecinst->machInst.vtype8);
-            bool eleFullCover = vecinst->vmi.re <= vl;
-            bool oldVdElim = set && ((vl > 0 && vecinst->vma && vecinst->vta) || (vecinst->vma && eleFullCover));
-            DPRINTF(Schedule, "[sn:%llu] vl: %llu, rs: %llu, re: %llu, set: %d, eleFullCover: %d, oldVdElim: %d\n",
-                    seqNum, vl, vecinst->vmi.rs, vecinst->vmi.re, set, eleFullCover, oldVdElim);
-            if (oldVdElim) {
-                DPRINTF(Schedule, "[sn:%llu] old vd elim\n", seqNum);
-                renameSrcReg(vecinst->oldDstIdx, cpu->vecOnesPhysRegId);
-                if (!readySrcIdx(vecinst->oldDstIdx)) {
-                    markSrcRegReady(vecinst->oldDstIdx);
-                }
-            } else {
-                DPRINTF(Schedule, "[sn:%llu] assert failed\n", seqNum);
-                assert(srcRegIdx(vecinst->oldDstIdx) != RiscvISA::VecOnesReg);
-            }
-            return oldVdElim;
-        }
-        return false;
-    }
-
 
 
     /** Returns the number of consecutive store conditional failures. */

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -1068,12 +1068,13 @@ class DynInst : public ExecContext, public RefCounted
     {
         if (isVector() && !isStore()) {
             auto vecinst = dynamic_cast<RiscvISA::VectorMicroInst *>(staticInst.get());
-            if (vecinst->vlsrcIdx < 0 || vecinst->oldDstIdx < 0) {
+            if (vecinst->vlsrcIdx <= 0 || vecinst->oldDstIdx <= 0) {
                 return false;
             }
             if (!readySrcIdx(vecinst->vlsrcIdx)) {
                 return false;
             }
+
             uint64_t vl = getRegOperand(staticInst.get(), vecinst->vlsrcIdx);
             bool set = vecinst->vmi.rs < RiscvISA::vtype_VLMAX(vecinst->machInst.vtype8);
             bool eleFullCover = vecinst->vmi.re <= vl;

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "arch/riscv/insts/vector.hh"
 #include "base/logging.hh"
 #include "base/stats/group.hh"
 #include "base/stats/info.hh"
@@ -231,7 +230,6 @@ IssueQue::checkScoreboard(const DynInstPtr& inst)
             return false;
         }
     }
-    inst->checkOldVdElim();
     return true;
 }
 
@@ -345,9 +343,6 @@ IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative)
             }
             consumer->markSrcRegReady(srcIdx);
 
-            if (!speculative && consumer->srcRegIdx(srcIdx) == RiscvISA::VecRenamedVLReg) [[unlikely]] {
-                consumer->checkOldVdElim();
-            }
 
             DPRINTF(Schedule, "[sn:%llu] src%d was woken\n", consumer->seqNum, srcIdx);
             addIfReady(consumer);
@@ -547,9 +542,6 @@ IssueQue::insert(const DynInstPtr& inst)
             }
         }
     }
-
-    inst->checkOldVdElim();
-
     if (!addToDepGraph) {
         assert(inst->readyToIssue());
     }
@@ -1124,7 +1116,7 @@ Scheduler::loadCancel(const DynInstPtr& inst)
                 for (auto& it : iq->subDepGraph[dst->flatIndex()]) {
                     int srcIdx = it.first;
                     auto& depInst = it.second;
-                    if (depInst->readySrcIdx(srcIdx) && depInst->renamedSrcIdx(srcIdx) != cpu->vecOnesPhysRegId) {
+                    if (depInst->readySrcIdx(srcIdx)) {
                         DPRINTF(Schedule, "cancel [sn:%llu], clear src p%d ready\n", depInst->seqNum,
                                 depInst->renamedSrcIdx(srcIdx)->flatIndex());
                         depInst->issueQue->cancel(depInst);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -48,6 +48,7 @@
 #include <list>
 #include <string>
 
+#include "arch/riscv/insts/vector.hh"
 #include "base/compiler.hh"
 #include "base/logging.hh"
 #include "base/trace.hh"

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -113,6 +113,8 @@ class StaticInst : public RefCounted, public StaticInstFlags
 
     std::array<uint8_t, RMiscRegClass + 1> _numTypedDestRegs = {};
 
+    unsigned nf = 0;
+
   public:
 
     /// @name Register information.
@@ -169,11 +171,7 @@ class StaticInst : public RefCounted, public StaticInstFlags
     bool isFloating()     const { return flags[IsFloating]; }
     bool isVector()       const { return flags[IsVector]; }
     bool isVectorConfig() const { return opClass() == VectorConfigOp; }
-    bool isVecSegLoad()   const
-    {
-        return opClass() == VectorSegUnitStrideLoadOp || opClass() == VectorSegUnitStrideMaskLoadOp ||
-               opClass() == VectorSegStridedLoadOp || opClass() == VectorSegIndexedLoadOp;
-    }
+    bool isSegLoad()      const { return flags[IsSegLoad]; }
 
     bool isControl()      const { return flags[IsControl]; }
     bool isCall()         const { return flags[IsCall]; }
@@ -230,6 +228,9 @@ class StaticInst : public RefCounted, public StaticInstFlags
     OpClass opClass() const { return _opClass; }
 
     void resetOpClass(OpClass op_class) { _opClass = op_class; }
+
+    void setNF(unsigned _nf) { nf = _nf; }
+    unsigned getNF() { return nf; }
 
     /// Return logical index (architectural reg num) of i'th destination reg.
     /// Only the entries from 0 through numDestRegs()-1 are valid.


### PR DESCRIPTION
This pr revert the vector "ta/ma" function, because it still has bug in xs-dev.
We will refactor one new vector soon.