### PR TITLE
arch-riscv: allow reading CSR_TIME

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -362,13 +362,6 @@ def template CSRExecute {{
             }
             break;
           }
-          case CSR_TIME: {
-                std::string error = csprintf(
-                    "force accessing to time CSR generate fault\n");
-                olddata = 0;
-                return std::make_shared<IllegalInstFault>(error, machInst);
-                break;
-          }
           default:
             break;
         }


### PR DESCRIPTION
- Remove case statement for CSR_TIME in standard.isa
- Eliminate fault generation for accessing time CSR

This change aligns gem5 with latest NEMU gem5-ref_defconfig

I have tested it on all 1169 checkpoint of CI used ones, and also tested on DeterLoad generated checkpoints. 1169/1169 and 609/610 passed difftest with latest NEMU compiled with gem5-ref_defconfig.