### PR TITLE
Cherry-pick multiple commits from mainline gem5 for VLA fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -514,13 +514,6 @@ for variant_path in variant_paths:
         with gem5_scons.Configure(env) as conf:
             conf.CheckCxxFlag('-Wno-c99-designator')
             conf.CheckCxxFlag('-Wno-defaulted-function-deleted')
-            # Poor code quality workaround, should be fixed in the future.
-            conf.CheckCxxFlag('-Wno-error=unused-private-field')
-            conf.CheckCxxFlag('-Wno-error=infinite-recursion')
-            conf.CheckCxxFlag('-Wno-error=array-parameter')
-            conf.CheckCxxFlag('-Wno-error=uninitialized-const-reference')
-            conf.CheckCxxFlag('-Wno-error=vla-extension')
-            conf.CheckCxxFlag('-Wno-error=vla-cxx-extension')
 
         env.Append(TCMALLOC_CCFLAGS=['-fno-builtin'])
 

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -266,7 +266,7 @@ class ArmFaultVals : public ArmFault
     static FaultVals vals;
 
   public:
-    ArmFaultVals<T>(ExtMachInst mach_inst = 0, uint32_t _iss = 0) :
+    ArmFaultVals(ExtMachInst mach_inst = 0, uint32_t _iss = 0) :
         ArmFault(mach_inst, _iss) {}
     FaultName name() const override { return vals.name; }
     FaultOffset offset(ThreadContext *tc) override;

--- a/src/arch/arm/nativetrace.cc
+++ b/src/arch/arm/nativetrace.cc
@@ -89,8 +89,8 @@ Trace::ArmNativeTrace::ThreadState::update(NativeTrace *parent)
         diffVector >>= 1;
     }
 
-    uint64_t values[changes];
-    parent->read(values, sizeof(values));
+    auto values = std::make_unique<uint64_t[]>(changes);
+    parent->read(values.get(), changes * sizeof(uint64_t));
     int pos = 0;
     for (int i = 0; i < STATE_NUMVALS; i++) {
         if (changed[i]) {

--- a/src/arch/generic/linux/threadinfo.hh
+++ b/src/arch/generic/linux/threadinfo.hh
@@ -160,9 +160,10 @@ class ThreadInfo
         if (!get_data("task_struct_comm_size", size))
             return "FailureIn_curTaskName";
 
-        char buffer[size + 1];
+        std::string buffer;
+        buffer.reserve(size + 1);
         TranslatingPortProxy(tc).readString(
-                buffer, task_struct + offset, size);
+                buffer.data(), task_struct + offset, size);
 
         return buffer;
     }

--- a/src/arch/mips/tlb.cc
+++ b/src/arch/mips/tlb.cc
@@ -59,7 +59,7 @@ using namespace MipsISA;
 TLB::TLB(const Params &p) : BaseTLB(p), size(p.size), nlu(0)
 {
     table = new PTE[size];
-    memset(table, 0, sizeof(PTE[size]));
+    memset(table, 0, sizeof(PTE) * size);
     smallPages = 0;
 }
 
@@ -186,7 +186,7 @@ void
 TLB::flushAll()
 {
     DPRINTF(TLB, "flushAll\n");
-    memset(table, 0, sizeof(PTE[size]));
+    memset(table, 0, sizeof(PTE) * size);
     lookupTable.clear();
     nlu = 0;
 }

--- a/src/arch/power/tlb.cc
+++ b/src/arch/power/tlb.cc
@@ -62,7 +62,7 @@ using namespace PowerISA;
 TLB::TLB(const Params &p) : BaseTLB(p), size(p.size), nlu(0)
 {
     table = new PowerISA::PTE[size];
-    memset(table, 0, sizeof(PowerISA::PTE[size]));
+    memset(table, 0, sizeof(PowerISA::PTE) * size);
     smallPages = 0;
 }
 
@@ -184,7 +184,7 @@ void
 TLB::flushAll()
 {
     DPRINTF(TLB, "flushAll\n");
-    memset(table, 0, sizeof(PowerISA::PTE[size]));
+    memset(table, 0, sizeof(PowerISA::PTE) * size);
     lookupTable.clear();
     nlu = 0;
 }

--- a/src/arch/x86/bios/intelmp.cc
+++ b/src/arch/x86/bios/intelmp.cc
@@ -85,22 +85,17 @@ writeOutField(PortProxy& proxy, Addr addr, T val)
 uint8_t
 writeOutString(PortProxy& proxy, Addr addr, std::string str, int length)
 {
-    char cleanedString[length + 1];
-    cleanedString[length] = 0;
-
+    std::string nullPadded(length, '\0');
+    memcpy(nullPadded.data(), str.data(), std::min<int>(str.length(), length));
     if (str.length() > length) {
-        memcpy(cleanedString, str.c_str(), length);
         warn("Intel MP configuration table string \"%s\" "
-             "will be truncated to \"%s\".\n", str, (char *)&cleanedString);
-    } else {
-        memcpy(cleanedString, str.c_str(), str.length());
-        memset(cleanedString + str.length(), 0, length - str.length());
+             "will be truncated to \"%s\".\n", str, nullPadded);
     }
-    proxy.writeBlob(addr, &cleanedString, length);
+    proxy.writeBlob(addr, nullPadded.data(), length);
 
     uint8_t checkSum = 0;
     for (int i = 0; i < length; i++)
-        checkSum += cleanedString[i];
+        checkSum += nullPadded[i];
 
     return checkSum;
 }

--- a/src/arch/x86/linux/se_workload.cc
+++ b/src/arch/x86/linux/se_workload.cc
@@ -159,10 +159,10 @@ EmuLinux::pageFault(ThreadContext *tc)
         SETranslatingPortProxy proxy(tc);
         // at this point we should have 6 values on the interrupt stack
         int size = 6;
-        uint64_t is[size];
+        size_t is_bytes = sizeof(uint64_t) * size;
+        auto is = std::make_unique<uint64_t[]>(size);
         // reading the interrupt handler stack
-        proxy.readBlob(ISTVirtAddr + PageBytes - size * sizeof(uint64_t),
-                       &is, sizeof(is));
+        proxy.readBlob(ISTVirtAddr + PageBytes - is_bytes, is.get(), is_bytes);
         panic("Page fault at addr %#x\n\tInterrupt handler stack:\n"
                 "\tss: %#x\n"
                 "\trsp: %#x\n"

--- a/src/base/addr_range.hh
+++ b/src/base/addr_range.hh
@@ -523,14 +523,14 @@ class AddrRange
         }
 
         // Get the LSB set from each mask
-        int masks_lsb[masks.size()];
+        auto masks_lsb = std::make_unique<int[]>(masks.size());
         for (unsigned int i = 0; i < masks.size(); i++) {
             masks_lsb[i] = ctz64(masks[i]);
         }
 
         // we need to sort the list of bits we will discard as we
         // discard them one by one starting.
-        std::sort(masks_lsb, masks_lsb + masks.size());
+        std::sort(masks_lsb.get(), masks_lsb.get() + masks.size());
 
         for (unsigned int i = 0; i < masks.size(); i++) {
             const int intlv_bit = masks_lsb[i];
@@ -562,13 +562,13 @@ class AddrRange
         }
 
         // Get the LSB set from each mask
-        int masks_lsb[masks.size()];
+        auto masks_lsb = std::make_unique<int[]>(masks.size());
         for (unsigned int i = 0; i < masks.size(); i++) {
             masks_lsb[i] = ctz64(masks[i]);
         }
 
         // Add bits one-by-one from the LSB side.
-        std::sort(masks_lsb, masks_lsb + masks.size());
+        std::sort(masks_lsb.get(), masks_lsb.get() + masks.size());
         for (unsigned int i = 0; i < masks.size(); i++) {
             const int intlv_bit = masks_lsb[i];
             if (intlv_bit > 0) {

--- a/src/base/cprintf_formats.hh
+++ b/src/base/cprintf_formats.hh
@@ -227,10 +227,7 @@ _formatString(std::ostream &out, const T &data, Format &fmt)
         int flen = foo.str().size();
 
         if (fmt.width > flen) {
-            char spaces[fmt.width - flen + 1];
-            std::memset(spaces, ' ', fmt.width - flen);
-            spaces[fmt.width - flen] = 0;
-
+            std::string spaces(fmt.width - flen, ' ');
             if (fmt.flushLeft)
                 out << foo.str() << spaces;
             else

--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -40,6 +40,7 @@
 
 #include "base/random.hh"
 
+#include <algorithm>
 #include <sstream>
 
 #include "base/logging.hh"

--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -973,10 +973,10 @@ BaseRemoteGDB::cmdDetach(GdbCommand::Context &ctx)
 bool
 BaseRemoteGDB::cmdRegR(GdbCommand::Context &ctx)
 {
-    char buf[2 * regCachePtr->size() + 1];
-    buf[2 * regCachePtr->size()] = '\0';
-    mem2hex(buf, regCachePtr->data(), regCachePtr->size());
-    send(buf);
+    std::string buf;
+    buf.reserve(2 * regCachePtr->size());
+    mem2hex(buf.data(), regCachePtr->data(), regCachePtr->size());
+    send(buf.c_str());
     return true;
 }
 
@@ -1048,14 +1048,14 @@ BaseRemoteGDB::cmdMemR(GdbCommand::Context &ctx)
     if (!acc(addr, len))
         throw CmdError("E05");
 
-    char buf[len];
-    if (!read(addr, len, buf))
+    auto buf = std::make_unique<char[]>(len);
+    if (!read(addr, len, buf.get()))
         throw CmdError("E05");
 
-    char temp[2 * len + 1];
-    temp[2 * len] = '\0';
-    mem2hex(temp, buf, len);
-    send(temp);
+    std::string temp;
+    temp.reserve(2 * len);
+    mem2hex(temp.data(), buf.get(), len);
+    send(temp.c_str());
     return true;
 }
 
@@ -1071,13 +1071,13 @@ BaseRemoteGDB::cmdMemW(GdbCommand::Context &ctx)
         throw CmdError("E07");
     if (len * 2 > ctx.len - (p - ctx.data))
         throw CmdError("E08");
-    char buf[len];
-    p = (char *)hex2mem(buf, p, len);
+    auto buf = std::make_unique<char[]>(len);
+    p = (char *)hex2mem(buf.get(), p, len);
     if (p == NULL)
         throw CmdError("E09");
     if (!acc(addr, len))
         throw CmdError("E0A");
-    if (!write(addr, len, buf))
+    if (!write(addr, len, buf.get()))
         throw CmdError("E0B");
     send("OK");
     return true;

--- a/src/base/stats/units.hh
+++ b/src/base/stats/units.hh
@@ -352,9 +352,9 @@ class Rate : public Base
         "otherwise, it would be a Ratio");
 
   private:
-    Rate<T1,T2>() {}
+    Rate() {}
   public:
-    Rate<T1,T2>(Rate<T1,T2> const&) = delete;
+    Rate(Rate const&) = delete;
     void operator=(Rate<T1,T2> const&) = delete;
     static Rate<T1,T2>*
     get()

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -930,7 +930,7 @@ InstructionQueue::getCacheMissInstToExecute()
         if (!(*it)->waitingCacheRefill() || (*it)->isSquashed()) {
             DPRINTF(IQ, "CacheMissed load inst [sn:%llu] PC %s is ready to "
                     "execute\n", (*it)->seqNum, (*it)->pcState());
-            DynInstPtr mem_inst = std::move(*it);
+            DynInstPtr mem_inst = *it;
             cacheMissLdInsts.erase(it);
             return mem_inst;
         }

--- a/src/cpu/testers/traffic_gen/gups_gen.cc
+++ b/src/cpu/testers/traffic_gen/gups_gen.cc
@@ -80,17 +80,17 @@ GUPSGen::startup()
 {
     int block_size = 64; // Write the initial values in 64 byte blocks.
     uint64_t stride_size = block_size / elementSize;
+    auto write_data = std::make_unique<uint8_t[]>(block_size);
     if (initMemory) {
         for (uint64_t start_index = 0; start_index < tableSize;
                                     start_index += stride_size) {
-            uint8_t write_data[block_size];
             for (uint64_t offset = 0; offset < stride_size; offset++) {
                 uint64_t value = start_index + offset;
-                std::memcpy(write_data + offset * elementSize,
+                std::memcpy(write_data.get() + offset * elementSize,
                             &value, elementSize);
             }
             Addr addr = indexToAddr(start_index);
-            PacketPtr pkt = getWritePacket(addr, block_size, write_data);
+            PacketPtr pkt = getWritePacket(addr, block_size, write_data.get());
             port.sendFunctionalPacket(pkt);
             delete pkt;
         }

--- a/src/dev/arm/gic_v3_its.cc
+++ b/src/dev/arm/gic_v3_its.cc
@@ -1276,21 +1276,22 @@ Gicv3Its::moveAllPendingState(
     Gicv3Redistributor *rd1, Gicv3Redistributor *rd2)
 {
     const uint64_t largest_lpi_id = 1ULL << (rd1->lpiIDBits + 1);
-    uint8_t lpi_pending_table[largest_lpi_id / 8];
+    const uint64_t table_size = largest_lpi_id / 8;
+    auto lpi_pending_table = std::make_unique<uint8_t[]>(table_size);
 
     // Copying the pending table from redistributor 1 to redistributor 2
     rd1->memProxy->readBlob(
-        rd1->lpiPendingTablePtr, (uint8_t *)lpi_pending_table,
-        sizeof(lpi_pending_table));
+        rd1->lpiPendingTablePtr, lpi_pending_table.get(),
+        table_size);
 
     rd2->memProxy->writeBlob(
-        rd2->lpiPendingTablePtr, (uint8_t *)lpi_pending_table,
-        sizeof(lpi_pending_table));
+        rd2->lpiPendingTablePtr, lpi_pending_table.get(),
+        table_size);
 
     // Clearing pending table in redistributor 2
     rd1->memProxy->memsetBlob(
-        rd1->lpiPendingTablePtr,
-        0, sizeof(lpi_pending_table));
+        rd1->lpiPendingTablePtr, 0,
+        table_size);
 
     rd2->updateDistributor();
 }

--- a/src/dev/arm/gic_v3_redistributor.cc
+++ b/src/dev/arm/gic_v3_redistributor.cc
@@ -830,17 +830,17 @@ Gicv3Redistributor::update()
 
         const uint32_t largest_lpi_id = 1 << (lpiIDBits + 1);
         const uint32_t number_lpis = largest_lpi_id - SMALLEST_LPI_ID + 1;
-
-        uint8_t lpi_pending_table[largest_lpi_id / 8];
-        uint8_t lpi_config_table[number_lpis];
+        const size_t table_size = largest_lpi_id / 8;
+        auto lpi_pending_table = std::make_unique<uint8_t[]>(table_size);
+        auto lpi_config_table = std::make_unique<uint8_t[]>(number_lpis);
 
         memProxy->readBlob(lpiPendingTablePtr,
-                           lpi_pending_table,
-                           sizeof(lpi_pending_table));
+                           lpi_pending_table.get(),
+                           table_size);
 
         memProxy->readBlob(lpiConfigurationTablePtr,
-                           lpi_config_table,
-                           sizeof(lpi_config_table));
+                           lpi_config_table.get(),
+                           number_lpis);
 
         for (int lpi_id = SMALLEST_LPI_ID; lpi_id < largest_lpi_id;
              lpi_id++) {

--- a/src/dev/virtio/base.cc
+++ b/src/dev/virtio/base.cc
@@ -116,9 +116,9 @@ VirtDescriptor::dump() const
             _index, desc.addr, desc.len, desc.flags, desc.next);
 
     if (isIncoming()) {
-        uint8_t data[desc.len];
-        read(0, data, desc.len);
-        DDUMP(VIO, data, desc.len);
+        auto data = std::make_unique<uint8_t[]>(desc.len);
+        read(0, data.get(), desc.len);
+        DDUMP(VIO, data.get(), desc.len);
     }
 }
 

--- a/src/dev/virtio/base.hh
+++ b/src/dev/virtio/base.hh
@@ -477,7 +477,7 @@ class VirtQueue : public Serializable
             Index index;
         };
 
-        VirtRing<T>(PortProxy &proxy, ByteOrder bo, uint16_t size) :
+        VirtRing(PortProxy &proxy, ByteOrder bo, uint16_t size) :
             header{0, 0}, ring(size), _proxy(proxy), _base(0), byteOrder(bo)
         {}
 
@@ -550,7 +550,7 @@ class VirtQueue : public Serializable
 
       private:
         // Remove default constructor
-        VirtRing<T>();
+        VirtRing();
 
         /** Guest physical memory proxy */
         PortProxy &_proxy;

--- a/src/dev/virtio/base.hh
+++ b/src/dev/virtio/base.hh
@@ -522,9 +522,9 @@ class VirtQueue : public Serializable
             readHeader();
 
             /* Read and byte-swap the elements in the ring */
-            T temp[ring.size()];
+            auto temp = std::make_unique<T[]>(ring.size());
             _proxy.readBlob(_base + sizeof(header),
-                            temp, sizeof(T) * ring.size());
+                            temp.get(), sizeof(T) * ring.size());
             for (int i = 0; i < ring.size(); ++i)
                 ring[i] = gtoh(temp[i], byteOrder);
         }
@@ -535,11 +535,11 @@ class VirtQueue : public Serializable
             assert(_base != 0);
             /* Create a byte-swapped copy of the ring and write it to
              * guest memory. */
-            T temp[ring.size()];
+            auto temp = std::make_unique<T[]>(ring.size());
             for (int i = 0; i < ring.size(); ++i)
                 temp[i] = htog(ring[i], byteOrder);
             _proxy.writeBlob(_base + sizeof(header),
-                             temp, sizeof(T) * ring.size());
+                             temp.get(), sizeof(T) * ring.size());
             writeHeader();
         }
 

--- a/src/dev/virtio/console.cc
+++ b/src/dev/virtio/console.cc
@@ -105,9 +105,9 @@ VirtIOConsole::TermTransQueue::onNotifyDescriptor(VirtDescriptor *desc)
 
     // Copy the data from the guest and forward it to the
     // terminal.
-    const size_t size(desc->chainSize());
-    uint8_t data[size];
-    desc->chainRead(0, data, size);
+    const size_t size = desc->chainSize();
+    auto data = std::make_unique<uint8_t[]>(size);
+    desc->chainRead(0, data.get(), size);
     for (int i = 0; i < desc->size(); ++i)
         parent.device.writeData(data[i]);
 

--- a/src/mem/cache/cache_blk.hh
+++ b/src/mem/cache/cache_blk.hh
@@ -506,7 +506,7 @@ class CacheBlk : public TaggedEntry
 
   protected:
     /** The current coherence status of this block. @sa CoherenceBits */
-    unsigned coherence;
+    unsigned coherence = 0;
 
     // The following setters have been marked as protected because their
     // respective variables should only be modified at 2 moments:

--- a/src/mem/cache/compressors/multi.cc
+++ b/src/mem/cache/compressors/multi.cc
@@ -139,9 +139,8 @@ Multi::compress(const std::vector<Chunk>& chunks, Cycles& comp_lat,
 
     // Each sub-compressor can have its own chunk size; therefore, revert
     // the chunks to raw data, so that they handle the conversion internally
-    uint64_t data[blkSize / sizeof(uint64_t)];
-    std::memset(data, 0, blkSize);
-    fromChunks(chunks, data);
+    auto data = std::make_unique<uint64_t[]>(blkSize/8);
+    fromChunks(chunks, data.get());
 
     // Find the ranking of the compressor outputs
     std::priority_queue<std::shared_ptr<Results>,
@@ -150,7 +149,7 @@ Multi::compress(const std::vector<Chunk>& chunks, Cycles& comp_lat,
     for (unsigned i = 0; i < compressors.size(); i++) {
         Cycles temp_decomp_lat;
         auto temp_comp_data =
-            compressors[i]->compress(data, comp_lat, temp_decomp_lat);
+            compressors[i]->compress(data.get(), comp_lat, temp_decomp_lat);
         temp_comp_data->setSizeBits(temp_comp_data->getSizeBits() +
             numEncodingBits);
         results.push(std::make_shared<Results>(i, std::move(temp_comp_data),
@@ -160,9 +159,8 @@ Multi::compress(const std::vector<Chunk>& chunks, Cycles& comp_lat,
 
     // Assign best compressor to compression data
     const unsigned best_index = results.top()->index;
-    std::unique_ptr<CompressionData> multi_comp_data =
-        std::unique_ptr<MultiCompData>(
-            new MultiCompData(best_index, std::move(results.top()->compData)));
+    auto multi_comp_data = std::make_unique<MultiCompData>(
+            best_index, std::move(results.top()->compData));
     DPRINTF(CacheComp, "Best compressor: %d\n", best_index);
 
     // Set decompression latency of the best compressor

--- a/src/mem/cache/replacement_policies/replaceable_entry.hh
+++ b/src/mem/cache/replacement_policies/replaceable_entry.hh
@@ -74,7 +74,7 @@ class ReplaceableEntry
     uint32_t _way;
 
   public:
-    ReplaceableEntry() = default;
+    ReplaceableEntry() : _set(0), _way(0) {};
     virtual ~ReplaceableEntry() = default;
 
     /**

--- a/src/mem/ruby/network/garnet/Router.cc
+++ b/src/mem/ruby/network/garnet/Router.cc
@@ -250,16 +250,14 @@ Router::printFaultVector(std::ostream& out)
 {
     int temperature_celcius = BASELINE_TEMPERATURE_CELCIUS;
     int num_fault_types = m_network_ptr->fault_model->number_of_fault_types;
-    float fault_vector[num_fault_types];
-    get_fault_vector(temperature_celcius, fault_vector);
+    auto fault_vector = std::make_unique<float[]>(num_fault_types);
+    get_fault_vector(temperature_celcius, fault_vector.get());
     out << "Router-" << m_id << " fault vector: " << std::endl;
-    for (int fault_type_index = 0; fault_type_index < num_fault_types;
-         fault_type_index++) {
-        out << " - probability of (";
-        out <<
-        m_network_ptr->fault_model->fault_type_to_string(fault_type_index);
-        out << ") = ";
-        out << fault_vector[fault_type_index] << std::endl;
+    for (int i = 0; i < num_fault_types; i++) {
+        out << " - probability of ("
+            << m_network_ptr->fault_model->fault_type_to_string(i)
+            << ") = "
+            << fault_vector[i] << std::endl;
     }
 }
 

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -1225,14 +1225,13 @@ template <class KEY, class VALUE>
 std::ostream &
 operator<<(std::ostream &out, const std::unordered_map<KEY, VALUE> &map)
 {
-    for (const auto &table_entry : map) {
-        out << "[ " << table_entry.first << " =";
-        for (const auto &seq_req : table_entry.second) {
+    for (const auto &[key, values] : map) {
+        out << "[ " << key << " =";
+        for (const auto &seq_req : values) {
             out << " " << RubyRequestType_to_string(seq_req.m_second_type);
         }
+        out << " ]";
     }
-    out << " ]";
-
     return out;
 }
 

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -82,8 +82,6 @@ struct SequencerRequest
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const SequencerRequest& obj);
-
 class Sequencer : public RubyPort
 {
   public:

--- a/src/python/embedded.cc
+++ b/src/python/embedded.cc
@@ -75,9 +75,9 @@ EmbeddedPython::getList()
 py::object
 EmbeddedPython::getCode() const
 {
-    Bytef marshalled[len];
+    auto marshalled = std::make_unique<Bytef[]>(len);
     uLongf unzlen = len;
-    int ret = uncompress(marshalled, &unzlen, (const Bytef *)code, zlen);
+    int ret = uncompress(marshalled.get(), &unzlen, code, zlen);
     if (ret != Z_OK) {
         std::cerr << "Could not uncompress code: " << zError(ret) << std::endl;
         std::abort();
@@ -85,7 +85,7 @@ EmbeddedPython::getCode() const
     assert(unzlen == (uLongf)len);
 
     auto marshal = py::module_::import("marshal");
-    return marshal.attr("loads")(py::bytes((char *)marshalled, len));
+    return marshal.attr("loads")(py::bytes((char*)marshalled.get(), len));
 }
 
 bool

--- a/src/sim/process.cc
+++ b/src/sim/process.cc
@@ -351,14 +351,15 @@ Process::replicatePage(Addr vaddr, Addr new_paddr, ThreadContext *old_tc,
         new_paddr = seWorkload->allocPhysPages(1);
 
     // Read from old physical page.
-    uint8_t buf_p[pTable->pageSize()];
-    SETranslatingPortProxy(old_tc).readBlob(vaddr, buf_p, sizeof(buf_p));
+    const size_t buf_size = pTable->pageSize();
+    auto buf_p = std::make_unique<uint8_t[]>(buf_size);
+    SETranslatingPortProxy(old_tc).readBlob(vaddr, buf_p.get(), buf_size);
 
     // Create new mapping in process address space by clobbering existing
     // mapping (if any existed) and then write to the new physical page.
     bool clobber = true;
-    pTable->map(vaddr, new_paddr, sizeof(buf_p), clobber);
-    SETranslatingPortProxy(new_tc).writeBlob(vaddr, buf_p, sizeof(buf_p));
+    pTable->map(vaddr, new_paddr, buf_size, clobber);
+    SETranslatingPortProxy(new_tc).writeBlob(vaddr, buf_p.get(), buf_size);
 }
 
 bool

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -1192,7 +1192,7 @@ recvmsgFunc(SyscallDesc *desc, ThreadContext *tc,
      */
     Addr msg_name_phold = 0;
     Addr msg_iov_phold = 0;
-    Addr iovec_base_phold[msgHdr->msg_iovlen];
+    auto iovec_base_phold = std::make_unique<Addr[]>(msgHdr->msg_iovlen);
     Addr msg_control_phold = 0;
 
     /**
@@ -1212,7 +1212,7 @@ recvmsgFunc(SyscallDesc *desc, ThreadContext *tc,
      * their pointers with buffer pointers.
      */
     BufferArg *iovBuf = NULL;
-    BufferArg *iovecBuf[msgHdr->msg_iovlen];
+    auto iovecBuf = std::make_unique<BufferArg *[]>(msgHdr->msg_iovlen);
     for (int i = 0; i < msgHdr->msg_iovlen; i++) {
         iovec_base_phold[i] = 0;
         iovecBuf[i] = NULL;
@@ -1224,14 +1224,13 @@ recvmsgFunc(SyscallDesc *desc, ThreadContext *tc,
                                     sizeof(struct iovec));
         /*3*/iovBuf->copyIn(proxy);
         for (int i = 0; i < msgHdr->msg_iovlen; i++) {
-            if (((struct iovec *)iovBuf->bufferPtr())[i].iov_base) {
-                /*1*/iovec_base_phold[i] =
-                     (Addr)((struct iovec *)iovBuf->bufferPtr())[i].iov_base;
-                /*2*/iovecBuf[i] = new BufferArg(iovec_base_phold[i],
-                     ((struct iovec *)iovBuf->bufferPtr())[i].iov_len);
+            auto iov = ((struct iovec *)iovBuf->bufferPtr())[i];
+            if (iov.iov_base) {
+                /*1*/iovec_base_phold[i] = (Addr)iov.iov_base;
+                /*2*/iovecBuf[i] = new BufferArg(
+                        iovec_base_phold[i], iov.iov_len);
                 /*3*/iovecBuf[i]->copyIn(proxy);
-                /*4*/((struct iovec *)iovBuf->bufferPtr())[i].iov_base =
-                     iovecBuf[i]->bufferPtr();
+                /*4*/iov.iov_base = iovecBuf[i]->bufferPtr();
             }
         }
         /*4*/msgHdr->msg_iov = (struct iovec *)iovBuf->bufferPtr();
@@ -1262,11 +1261,11 @@ recvmsgFunc(SyscallDesc *desc, ThreadContext *tc,
 
     if (msgHdr->msg_iov) {
         for (int i = 0; i< msgHdr->msg_iovlen; i++) {
-            if (((struct iovec *)iovBuf->bufferPtr())[i].iov_base) {
+            auto iov = ((struct iovec *)iovBuf->bufferPtr())[i];
+            if (iov.iov_base) {
                 iovecBuf[i]->copyOut(proxy);
                 delete iovecBuf[i];
-                ((struct iovec *)iovBuf->bufferPtr())[i].iov_base =
-                (void *)iovec_base_phold[i];
+                iov.iov_base = (void *)iovec_base_phold[i];
             }
         }
         iovBuf->copyOut(proxy);

--- a/src/systemc/utils/vcd.cc
+++ b/src/systemc/utils/vcd.cc
@@ -601,8 +601,8 @@ class VcdTraceValInt : public VcdTraceVal<T>
     output(std::ostream &os) override
     {
         const int w = this->width();
-        chart str[w+1];
-        str[w] = '\0';
+        std::string str;
+        str.reserve(w);
 
         const uint64_t val =
             static_cast<uint64_t>(this->value()) & gem5::mask(sizeof(T) * 8);

--- a/src/systemc/utils/vcd.cc
+++ b/src/systemc/utils/vcd.cc
@@ -601,7 +601,7 @@ class VcdTraceValInt : public VcdTraceVal<T>
     output(std::ostream &os) override
     {
         const int w = this->width();
-        char str[w + 1];
+        chart str[w+1];
         str[w] = '\0';
 
         const uint64_t val =


### PR DESCRIPTION
Variable Legnth Arrary(VLA) is not in C++ standard, clang18+ checks for VLA and generate compile error under -Werror.
This PR follows mainline fixing all VLAs.
Other various compile fixes are also picked to allow compile under GCC14, Clang18, Clang19.