### PR TITLE
cpu-o3: add RTC device and connect to CLINT

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -683,6 +683,12 @@ def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=
     self.lint.pio_addr = 0x38000000
     self.lint.num_threads = np
 
+    # add RTC device and connect to CLINT
+    from m5.objects.RTC import RiscvRTC
+    from m5.params import Frequency
+    self.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+    self.lint.int_pin = self.rtc.int_pin
+
     self.mmcs = NemuMMC()
     self.mmcs.pio = self.iobus.mem_side_ports
 


### PR DESCRIPTION
This commit adds a RTC (Real-Time Clock) device to the Xiangshan system and connects it to the CLINT (Core Local Interruptor). The RTC device helps maintain system time and generates periodic interrupts through the CLINT to update time-related registers.

The frequency is temporarily set to 100MHz, but needs to be aligned with the RTL implementation. This parameter may need adjustment after verification with RTL timing.

Change-Id: Id73e407dc36eaa95308cb0744a40446cc0ee791f