### PR TITLE
cpu: fix btb block address mask

### DIFF
--- a/src/cpu/pred/btb/btb.cc
+++ b/src/cpu/pred/btb/btb.cc
@@ -398,7 +398,7 @@ DefaultBTB::lookupSingleBlock(Addr block_pc)
                 " skipping tag compare, assigning miss\n", aheadReadBtbEntries.size());
         }
     }
-    DPRINTF(BTB, "BTB: Doing tag comparison for index %d tag %#lx\n",
+    DPRINTF(BTB, "BTB: Doing tag comparison for index 0x%lx tag %#lx\n",
         current_idx, current_tag);
     for (auto &way : current_set) {
         if (way.valid && way.tag == current_tag) {

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -136,7 +136,7 @@ protected:
     void SetUp() override {
         // Create a BTB with 16 entries, 8-bit tags, and 4-way set associative
         mbtb_small = new DefaultBTB(16, 8, 4, 1, true); // mbtb (L1 BTB)
-        mbtb = new DefaultBTB (1024, 20, 8, 1, true);
+        mbtb = new DefaultBTB (16384, 20, 8, 1, true);
     }
     
     
@@ -181,6 +181,19 @@ TEST_F(BTBTest, PredictionAfterUpdate) {
     // Execute prediction-update cycle
     std::vector<FullBTBPrediction> stagePreds =
         predictUpdateCycle(mbtb, 0x1000, branch, true);
+
+    // Verify predictions
+    verifyPrediction(stagePreds, mbtb->getDelay(), {branch});
+}
+
+// Test large virtual addr
+TEST_F(BTBTest, PredictionAfterUpdateLargeAddr) {
+    // Create branch info
+    BranchInfo branch = createBranchInfo(0xffffffff8027ac64, 0xffffffff80261dee, true);
+
+    // Execute prediction-update cycle
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0xffffffff8027ac60, branch, true);
 
     // Verify predictions
     verifyPrediction(stagePreds, mbtb->getDelay(), {branch});

--- a/src/cpu/pred/btb/test/mockbtb.hh
+++ b/src/cpu/pred/btb/test/mockbtb.hh
@@ -333,7 +333,7 @@ class DefaultBTB : public TimedBaseBTBPredictor
     std::queue<std::tuple<Addr, Addr, BTBSet>> aheadReadBtbEntries;
 
     /** BTB configuration parameters */
-    unsigned blockSize{32};  // max size in byte of a Fetch Block
+    uint64_t blockSize{32};  // max size in byte of a Fetch Block
     unsigned numEntries;    // Total number of entries
     unsigned numWays;       // Number of ways per set
     unsigned numSets;       // Number of sets (numEntries/numWays)

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -52,7 +52,7 @@ class TimedBaseBTBPredictor: public SimObject
     int getComponentIdx() { return componentIdx; }
     void setComponentIdx(int idx) { componentIdx = idx; }
 
-    unsigned blockSize;
+    uint64_t blockSize;
     unsigned predictWidth;
 
     bool hasDB {false};


### PR DESCRIPTION
Previous code causing mBTB miss forever when PC is larger then 32bit space.
This PR fixes the mask by using uint64_t instead of 32b unsigned type.
Also added a unit test.