### PR TITLE
configs: update pht-pf-level default and enhance prefetcher configuration

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -299,7 +299,7 @@ def addCommonOptions(parser, configure_xiangshan=False):
     parser.add_argument("--short-stride-thres", action="store", default=0, type=int,
                         help="""
                         Ignore short strides when seen long strides for stride, 0 for turning off""")
-    parser.add_argument("--pht-pf-level", action="store", default=1,
+    parser.add_argument("--pht-pf-level", action="store", default=2,
                         help="""
                         Prefetching cache level for SMS'pht""")
 

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -31,6 +31,9 @@ def create_prefetcher(cpu, cache_level, options):
             prefetcher.enable_spp = True
         if options.l1d_enable_cplx:
             prefetcher.enable_cplx = True
+        
+        prefetcher.act_entries = "64"
+        prefetcher.pht_entries = "64"
         prefetcher.pht_pf_level = 2 if options.kmh_align else options.pht_pf_level
         prefetcher.short_stride_thres = options.short_stride_thres
         prefetcher.enable_temporal = not options.kmh_align


### PR DESCRIPTION
Using act_entries=64 and pht_pf_level=2 provide a hyper performance than act_entries=32 and pht_pf_level=1 in solo L1 sms prefetcher. New Params solve the problem of negative optimization on omnetpp.

![fca42381-449f-4859-ad56-7ed2cce8fd28](https://github.com/user-attachments/assets/d6d72076-12e8-4223-834c-97359cf66dca)

I also tried some other parameters, about (act_entries, pht_entries, pht_assoc, pht_pf_level). The results are as follows. From this, it can be observed that the common features of high-score configuration are a greater number of act entries and pht prefetching that spans multiple layers to the L2.
![image](https://github.com/user-attachments/assets/1465508c-8adb-467d-aefd-0cd1b12d445d)

