### PR TITLE
fix VCompress_micro

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -827,7 +827,7 @@ class VCompressMicroInst : public VectorArithMicroInst
                 uint32_t ei = vd_has_compressed + vdrs + compressed;
                 uint32_t vdElemIdx = vdrs + compressed;
                 uint32_t vs2ElemIdx = vs2rs + i;
-                if ((ei < rVl) && elem_mask(vm.as<uint8_t>(), ei)) {
+                if ((ei < rVl) && elem_mask(vm.as<uint8_t>(), vs2ElemIdx)) {
                     vd.as<Type>()[vdElemIdx] = vs.as<Type>()[i];
                     compressed++;
                 }


### PR DESCRIPTION
In VCompress, the index of vmask should correspond to vsrc. The index of vdest was mistakenly used here. This commit fixes that.