### PR TITLE
misc: using gem5.fast mode to run CI performance test.

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -61,7 +61,7 @@ jobs:
           cmake ..
           make -j 48
           cd $GEM5_HOME
-      - name: Build GEM5 opt
+      - name: Build GEM5 fast
         run: |
           # use pgo profile to build gem5
           export GEM5_HOME=$(pwd)
@@ -74,6 +74,7 @@ jobs:
           export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
           export GCB_RESTORER=""
           export GEM5_HOME=$(pwd)
+          export GEM5_BUILD_TYPE=fast
           mkdir -p $GEM5_HOME/util/xs_scripts/test
           cd $GEM5_HOME/util/xs_scripts/test
           bash ../parallel_sim.sh `realpath ${{ inputs.script_path }}` \

--- a/util/pgo/basic_pgo_new.sh
+++ b/util/pgo/basic_pgo_new.sh
@@ -33,7 +33,7 @@ export GEM5_PGO_CPT=/nfs/home/share/gem5_ci/checkpoints/coremark-riscv64-xs.bin
 checkForVariable GEM5_PGO_CPT
 
 # build gem5 with pgo instrumentation
-CC=clang CXX=clang++ scons build/RISCV/gem5.opt -j $build_threads --gold-linker --pgo-prof
+CC=clang CXX=clang++ scons build/RISCV/gem5.fast -j $build_threads --gold-linker --pgo-prof
 check $?
 
 # run gem5 with pgo instrumentation
@@ -43,7 +43,7 @@ cd llvm-pgo
 # run gem5 and let it to generate profile here
 export LLVM_PROFILE_FILE=$(pwd)/default.profraw
 
-$gem5_home/build/RISCV/gem5.opt \
+$gem5_home/build/RISCV/gem5.fast \
      $gem5_home/configs/example/xiangshan.py \
      --ideal-kmhv3 --raw-cpt \
      --generic-rv-cpt=$GEM5_PGO_CPT
@@ -56,7 +56,7 @@ check $?
 cd ..
 
 # build gem5 with pgo instrumentation
-CC=clang CXX=clang++ scons build/RISCV/gem5.opt -j $build_threads --gold-linker --pgo-use=llvm-pgo/gem5_single.profdata
+CC=clang CXX=clang++ scons build/RISCV/gem5.fast -j $build_threads --gold-linker --pgo-use=llvm-pgo/gem5_single.profdata
 check $?
 
 printf "PGO build is done!\n"

--- a/util/xs_scripts/common.sh
+++ b/util/xs_scripts/common.sh
@@ -1,7 +1,13 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 
 export gem5_home=$(dirname $(dirname $script_dir ))
-export gem5=$(realpath $gem5_home/build/RISCV/gem5.opt) # GEM5 executable
+
+# Support configurable GEM5 build type via environment variable
+# Default to gem5.opt for backward compatibility
+export GEM5_BUILD_TYPE=${GEM5_BUILD_TYPE:-opt}
+export gem5=$(realpath $gem5_home/build/RISCV/gem5.$GEM5_BUILD_TYPE) # GEM5 executable
+
+echo "Using gem5 binary: $gem5"
 
 function checkForVariable() {
     local env_var=


### PR DESCRIPTION
- Changed build target from 'gem5.opt' to 'gem5.fast' in multiple scripts to enable faster builds.
- Introduced an environment variable 'GEM5_BUILD_TYPE' to allow users to specify the build type, defaulting to 'opt' for backward compatibility.
- use GEM5_BUILD_TYPE=fast bash util/xs_scripts/kmh_v3_ideal.sh xxx to use fast mode.
- fast mode runs 20% faster than opt mode.

Change-Id: Ibe1530ec95de5f816ba3f42d51bb771b6c78d5cb