### PR TITLE
Alternative phr

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -380,6 +380,8 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.tage.TTagBitSizes = [13] * 14
             cpu.branchPred.tage.TTagPcShifts = [1] * 14
             cpu.branchPred.tage.histLengths = [4, 7, 12, 16, 21, 29, 38, 51, 68, 90, 120, 160, 283, 499]
+            cpu.branchPred.tage.phrbLengths = [6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+            cpu.branchPred.tage.phrtLengths = [6, 13, 20, 27, 34, 41, 48, 55, 62, 69, 76, 83, 90, 100]
 
         # ideal l1 caches
         if args.caches:

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -380,8 +380,8 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.tage.TTagBitSizes = [16] * 14
             cpu.branchPred.tage.TTagPcShifts = [1] * 14
             cpu.branchPred.tage.histLengths = [4, 7, 12, 16, 21, 29, 38, 51, 68, 90, 120, 160, 283, 499]
-            cpu.branchPred.tage.phrbLengths = [6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
-            cpu.branchPred.tage.phrtLengths = [6, 13, 20, 27, 34, 41, 48, 55, 62, 69, 76, 83, 90, 100]
+            cpu.branchPred.tage.phrbLengths = [6, 13, 20, 27, 34, 41, 48, 55, 62, 69, 76, 83, 90, 100]
+            cpu.branchPred.tage.phrtLengths = [4, 7, 12, 16, 21, 29, 38, 51, 68, 90, 120, 160, 283, 499]
 
         # ideal l1 caches
         if args.caches:

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -377,7 +377,7 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.ftq_size = 256
             cpu.branchPred.fsq_size = 256
             cpu.branchPred.tage.numPredictors = 14
-            cpu.branchPred.tage.TTagBitSizes = [13] * 14
+            cpu.branchPred.tage.TTagBitSizes = [16] * 14
             cpu.branchPred.tage.TTagPcShifts = [1] * 14
             cpu.branchPred.tage.histLengths = [4, 7, 12, 16, 21, 29, 38, 51, 68, 90, 120, 160, 283, 499]
             cpu.branchPred.tage.phrbLengths = [6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1142,10 +1142,10 @@ class DecoupledBPUWithBTB(BranchPredictor):
     fsq_size = Param.Unsigned(64, "Fetch stream queue size")
     maxHistLen = Param.Unsigned(970, "The length of history")
 
-    phrbMaxLen = Param.Unsigned(28, "phrb max length")
+    phrbMaxLen = Param.Unsigned(100, "phrb max length")
     phrbXorLen = Param.Unsigned(4, "phrt xor length")
 
-    phrtMaxLen = Param.Unsigned(100, "phrt max length")
+    phrtMaxLen = Param.Unsigned(499, "phrt max length")
     phrtXorLen = Param.Unsigned(30, "phrb xor length")
 
     predictWidth = Param.Unsigned(64, "Maximum range in bytes that a single prediction can cover")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1032,8 +1032,13 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([4096]*4, "the ITTAGE T0~Tn length")
-    TTagBitSizes = VectorParam.Unsigned([8]*4, "the T0~Tn entry's tag bit size")
+    TTagBitSizes = VectorParam.Unsigned([12] * 4, "the T0~Tn entry's tag bit size")
     TTagPcShifts = VectorParam.Unsigned([1] * 4, "when the T0~Tn entry's tag generating, PC right shift")
+
+    usePhr = Param.Bool(True, "use phr")
+
+    phrbLengths = VectorParam.Unsigned([6, 11, 17, 28], "the BTB TAGE T0~Tn history length")
+    phrtLengths = VectorParam.Unsigned([6, 13, 57, 100], "the BTB TAGE T0~Tn history length")
 
     histLengths = VectorParam.Unsigned([8, 13, 32, 119], "the FTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
@@ -1136,6 +1141,12 @@ class DecoupledBPUWithBTB(BranchPredictor):
     ftq_size = Param.Unsigned(128, "Fetch target queue size")
     fsq_size = Param.Unsigned(64, "Fetch stream queue size")
     maxHistLen = Param.Unsigned(970, "The length of history")
+
+    phrbMaxLen = Param.Unsigned(28, "phrb max length")
+    phrbXorLen = Param.Unsigned(4, "phrt xor length")
+
+    phrtMaxLen = Param.Unsigned(100, "phrt max length")
+    phrtXorLen = Param.Unsigned(30, "phrb xor length")
 
     predictWidth = Param.Unsigned(64, "Maximum range in bytes that a single prediction can cover")
     numStages = Param.Unsigned(4, "Maximum number of stages in the pipeline")

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -176,7 +176,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
         Addr tag = 0;
         if (usePhr) {
             index = getTageIndexUsePhr(startPC, i, phrb, phrt);
-            tag = getTageTagUsePhr(startPC, i, phrb, phrt);
+            tag = getTageTagUsePhr(btb_entry.pc, i, phrb, phrt);
         } else {
             index = getTageIndex(startPC, i);
             tag = getTageTag(startPC, i); // use for tag comparison
@@ -602,7 +602,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
         Addr newTag = 0;
         if (usePhr) {
             newIndex = getTageIndexUsePhr(startPC,ti, commitPhrb, commitPhrt);
-            newTag = getTageTagUsePhr(startPC,ti, commitPhrb, commitPhrt);
+            newTag = getTageTagUsePhr(entry.pc,ti, commitPhrb, commitPhrt);
         } else {
             newIndex = getTageIndex(startPC, ti, updateIndexFoldedHist[ti].get());
             newTag = getTageTag(startPC, ti, updateTagFoldedHist[ti].get(), updateAltTagFoldedHist[ti].get());

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -10,6 +10,10 @@
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/TAGE.hh"
 
+#define GET_MASK(len) ((1ULL << (len)) - 1)
+#define GET_SELECTED_BITS(bits, highIdx, lowIdx) ((bits >> (lowIdx)) & GET_MASK((highIdx) - (lowIdx) + 1))
+#define GET_ONE_BIT(bits, idx) ((bits >> (idx)) & 0x1)
+
 namespace gem5 {
 
 namespace branch_prediction {
@@ -24,6 +28,9 @@ tableSizes(p.tableSizes),
 tableTagBits(p.TTagBitSizes),
 tablePcShifts(p.TTagPcShifts),
 histLengths(p.histLengths),
+phrbLengths(p.phrbLengths),
+phrtLengths(p.phrtLengths),
+usePhr(p.usePhr),
 maxHistLen(p.maxHistLen),
 numWays(p.numWays),
 numTablesToAlloc(p.numTablesToAlloc),
@@ -124,7 +131,12 @@ BTBTAGE::recordUsefulMask(const Addr &startPC) {
 
     // Look up entries in all TAGE tables
     for (int i = 0; i < numPredictors; ++i) {
-        Addr index = getTageIndex(startPC, i);
+        Addr index = 0;
+        if (usePhr) {
+            index = getTageIndexUsePhr(startPC, i, phrb, phrt);
+        } else {
+            index = getTageIndex(startPC, i);
+        }
         for (unsigned way = 0; way < numWays; way++) {
             auto &entry = tageTable[i][index][way];
             // Save useful bit to metadata
@@ -160,8 +172,15 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
 
     // Search from highest to lowest table for matches
     for (int i = numPredictors - 1; i >= 0; --i) {
-        Addr index = getTageIndex(startPC, i);
-        Addr tag = getTageTag(startPC, i); // use for tag comparison
+        Addr index = 0;
+        Addr tag = 0;
+        if (usePhr) {
+            index = getTageIndexUsePhr(startPC, i, phrb, phrt);
+            tag = getTageTagUsePhr(startPC, i, phrb, phrt);
+        } else {
+            index = getTageIndex(startPC, i);
+            tag = getTageTag(startPC, i); // use for tag comparison
+        }
         bool match = false; // for each table, only one way can be matched
         TageEntry matching_entry;
         unsigned matching_way = 0;
@@ -267,6 +286,14 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
         }
     }
     return cond_takens;
+}
+
+void
+BTBTAGE::putPhr(const boost::dynamic_bitset<> &s0phrb, const boost::dynamic_bitset<> &s0phrt) {
+    phrb = s0phrb;
+    phrt = s0phrt;
+
+    // DPRINTF(TAGE, "put s0phrb: %#lx\n", s0phrb.to_ulong());
 }
 
 /**
@@ -527,6 +554,8 @@ BTBTAGE::generateAllocationMask(const bitset &useful_mask,
  */
 bool
 BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
+                                 const boost::dynamic_bitset<> &commitPhrb,
+                                 const boost::dynamic_bitset<> &commitPhrt,
                                  const BTBEntry &entry,
                                  bool actual_taken,
                                  const std::vector<bitset> &useful_mask,
@@ -569,9 +598,15 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
         auto &updateAltTagFoldedHist = meta->altTagFoldedHist;
         auto &updateIndexFoldedHist = meta->indexFoldedHist;
 
-        // Compute index and tag for the new entry
-        Addr newIndex = getTageIndex(startPC, ti, updateIndexFoldedHist[ti].get());
-        Addr newTag = getTageTag(startPC, ti, updateTagFoldedHist[ti].get(), updateAltTagFoldedHist[ti].get());
+        Addr newIndex = 0;
+        Addr newTag = 0;
+        if (usePhr) {
+            newIndex = getTageIndexUsePhr(startPC,ti, commitPhrb, commitPhrt);
+            newTag = getTageTagUsePhr(startPC,ti, commitPhrb, commitPhrt);
+        } else {
+            newIndex = getTageIndex(startPC, ti, updateIndexFoldedHist[ti].get());
+            newTag = getTageTag(startPC, ti, updateTagFoldedHist[ti].get(), updateAltTagFoldedHist[ti].get());
+        }
 
         // Find a way to allocate (invalid entry or LRU victim)
         unsigned way = getLRUVictim(ti, newIndex);
@@ -639,7 +674,7 @@ BTBTAGE::update(const FetchStream &stream) {
             if (main_info.found) {
                 start_table = main_info.table + 1; // start from the table after the main prediction table
             }
-            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
+            alloc_success = handleNewEntryAllocation(startAddr, stream.phrb, stream.phrt, btb_entry, actual_taken,
                                    meta->usefulMask,
                                    start_table, meta);
         }
@@ -699,6 +734,76 @@ BTBTAGE::getTageTag(Addr pc, int t)
     return getTageTag(pc, t, tagFoldedHist[t].get(), altTagFoldedHist[t].get());
 }
 
+void reverse_dynamic_bitset(boost::dynamic_bitset<>& bits) {
+    size_t left = 0;
+    size_t right = bits.size() - 1;
+
+    while (left < right) {
+        bool temp = bits[left];
+        bits[left++] = bits[right];
+        bits[right--] = temp;
+    }
+}
+
+/**
+ * Folds a bitset by dividing it into segments of specified length and XORing them together.
+ * @param input The bitset to be folded
+ * @param foldLen The length of each segment (must divide evenly into input size)
+ * @return A new bitset containing the XOR result of all segments
+ */
+ boost::dynamic_bitset<> foldBits(const boost::dynamic_bitset<>& input, unsigned foldLen) {
+    assert(input.size() % foldLen == 0 && "Input size must be a multiple of fold length");
+
+    boost::dynamic_bitset<> result(foldLen);
+    unsigned numSegments = input.size() / foldLen;
+
+    for (unsigned seg = 0; seg < numSegments; ++seg) {
+        for (unsigned bit = 0; bit < foldLen; ++bit) {
+            if (input.test(seg * foldLen + bit)) {
+                result.flip(bit);  // XOR operation via flip
+            }
+        }
+    }
+
+    return result;
+}
+
+Addr
+BTBTAGE::getTageTagUsePhr(Addr pc, int table,
+    const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt)
+{
+    unsigned phrbLen = phrbLengths[table];
+    unsigned phrtLen = phrtLengths[table];
+    unsigned tagLen = tableIndexBits[table];
+
+    unsigned foldLen = tagLen;
+    unsigned paddedLen = ((phrbLen + phrtLen + foldLen - 1) / foldLen) * foldLen;
+
+    boost::dynamic_bitset<> phrbTemp = phrb;
+    phrbTemp.resize(phrbLen);
+    phrbTemp.resize(paddedLen);
+
+    boost::dynamic_bitset<> phrtTemp = phrt;
+    phrtTemp.resize(phrtLen);
+    phrtTemp.resize(paddedLen);
+
+    // DPRINTF(TAGE, "TAG: phrb: %#lx\n", phrb.to_ulong());
+    // DPRINTF(TAGE, "TAG: phrbTemp: %#lx\n", phrbTemp.to_ulong());
+
+    phrbTemp <<= phrtLen;
+    phrbTemp |= phrtTemp;
+
+    uint64_t pcXorBits = GET_SELECTED_BITS(pc, 5 + foldLen - 1, 5);
+    uint64_t tag = pcXorBits ^ foldBits(phrbTemp, foldLen).to_ulong();
+    // tag = (tag << 4) | GET_SELECTED_BITS(pc, 8, 5);
+
+    // DPRINTF(TAGE, "TAG: pc: %#lx\n", pc);
+    // DPRINTF(TAGE, "TAG: pcXorBits: %#lx\n", pcXorBits);
+    // DPRINTF(TAGE, "TAG: tag: %#lx\n", tag);
+
+    return tag;
+}
+
 Addr
 BTBTAGE::getTageIndex(Addr pc, int t, bitset &foldedHist)
 {
@@ -716,6 +821,41 @@ Addr
 BTBTAGE::getTageIndex(Addr pc, int t)
 {
     return getTageIndex(pc, t, indexFoldedHist[t].get());
+}
+
+Addr
+BTBTAGE::getTageIndexUsePhr(Addr pc, int table,
+    const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt)
+{
+    unsigned phrbLen = phrbLengths[table];
+    unsigned phrtLen = phrtLengths[table];
+    unsigned indexLen = tableIndexBits[table];
+
+    unsigned foldLen = indexLen - 1;
+    unsigned paddedLen = ((phrbLen + phrtLen + foldLen - 1) / foldLen) * foldLen;
+
+    boost::dynamic_bitset<> phrbTemp = phrb;
+    phrbTemp.resize(phrbLen);
+    phrbTemp.resize(paddedLen);
+
+    boost::dynamic_bitset<> phrtTemp = phrt;
+    phrtTemp.resize(phrtLen);
+    phrtTemp.resize(paddedLen);
+
+    // DPRINTF(TAGE, "INDEX: phrb: %#lx\n", phrb.to_ulong());
+    // DPRINTF(TAGE, "INDEX: phrbTemp: %#lx\n", phrbTemp.to_ulong());
+
+    phrbTemp <<= phrtLen;
+    phrbTemp |= phrtTemp;
+
+    uint64_t pcXorBits = GET_SELECTED_BITS(pc, 5 + foldLen - 1, 5);
+    uint64_t index = pcXorBits ^ foldBits(phrbTemp, foldLen).to_ulong();
+
+    index = (index << 1) | GET_ONE_BIT(pc, 5);
+
+    // DPRINTF(TAGE, "INDEX: index: %#lx\n", index);
+
+    return index;
 }
 
 bool

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -768,40 +768,235 @@ void reverse_dynamic_bitset(boost::dynamic_bitset<>& bits) {
     return result;
 }
 
+/**
+ * @brief Generate XOR pattern for PHRT bits based on the Paper-style regular stride
+ *
+ * @param phrt The path history register (target)
+ * @param phrtLen Length of PHRT to use
+ * @param bitIdx The tag bit index being computed
+ * @param tagLen Total tag length for stride calculation
+ * @return XORed value of selected PHRT bits
+ */
+uint64_t
+BTBTAGE::getPhrtXorPattern(const boost::dynamic_bitset<> &phrt, unsigned phrtLen,
+                          unsigned bitIdx, unsigned tagLen) {
+    if (phrtLen == 0) return 0;
+
+    // Calculate stride based on available PHRT length and desired coverage
+    // the Paper uses stride 12 for 100-bit PHRT, we scale proportionally
+    unsigned baseStride = std::max(1u, phrtLen / std::max(1u, tagLen));
+    unsigned stride = std::max(1u, baseStride + (phrtLen > 32 ? phrtLen / 32 : 0));
+
+    uint64_t result = 0;
+    unsigned startBit = bitIdx % phrtLen;
+
+    // XOR bits at regular stride intervals, wrapping around
+    for (unsigned offset = 0; offset < phrtLen; offset += stride) {
+        unsigned bitPos = (startBit + offset) % phrtLen;
+        if (bitPos < phrt.size() && phrt[bitPos]) {
+            result ^= 1;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @brief Generate XOR pattern for PHRB bits based on the Paper-style irregular pattern
+ *
+ * @param phrb The path history register (branch)
+ * @param phrbLen Length of PHRB to use
+ * @param bitIdx The tag bit index being computed
+ * @param tagLen Total tag length for pattern calculation
+ * @return XORed value of selected PHRB bits
+ */
+uint64_t
+BTBTAGE::getPhrbXorPattern(const boost::dynamic_bitset<> &phrb, unsigned phrbLen,
+                          unsigned bitIdx, unsigned tagLen) {
+    if (phrbLen == 0) return 0;
+
+    uint64_t result = 0;
+
+    // Create irregular pattern inspired by the Paper's PHRB usage
+    // Use different access patterns for different tag bits
+    unsigned pattern = bitIdx % 4;
+
+    switch (pattern) {
+        case 0: {
+            // Pattern like PHRB[8,21]: sparse, distant bits
+            unsigned spacing = std::max(2u, phrbLen / 8);
+            for (unsigned i = bitIdx % spacing; i < phrbLen; i += spacing * 2) {
+                if (i < phrb.size() && phrb[i]) result ^= 1;
+            }
+            break;
+        }
+        case 1: {
+            // Pattern like PHRB[0,13,26]: regular stride with offset
+            unsigned stride = std::max(3u, phrbLen / std::max(1u, tagLen / 2));
+            unsigned start = bitIdx % stride;
+            for (unsigned i = start; i < phrbLen; i += stride) {
+                if (i < phrb.size() && phrb[i]) result ^= 1;
+            }
+            break;
+        }
+        case 2: {
+            // Pattern like PHRB[11,12,24,25]: clustered pairs
+            unsigned clusterSize = 2;
+            unsigned clusterSpacing = std::max(4u, phrbLen / std::max(1u, tagLen / 3));
+            unsigned basePos = (bitIdx * clusterSpacing / 2) % phrbLen;
+            for (unsigned j = 0; j < clusterSize && basePos + j < phrbLen; j++) {
+                if (basePos + j < phrb.size() && phrb[basePos + j]) result ^= 1;
+            }
+            break;
+        }
+        case 3: {
+            // Pattern like PHRB[2,15]: two specific distant bits
+            unsigned pos1 = (bitIdx * 3) % phrbLen;
+            unsigned pos2 = (pos1 + phrbLen / 2) % phrbLen;
+            if (pos1 < phrb.size() && phrb[pos1]) result ^= 1;
+            if (pos2 < phrb.size() && phrb[pos2]) result ^= 1;
+            break;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @brief Generate XOR pattern for PHRT bits in index computation (the Paper-style)
+ *
+ * @param phrt The path history register (target)
+ * @param phrtLen Length of PHRT to use
+ * @param bitIdx The index bit position being computed
+ * @param indexLen Total index length for pattern calculation
+ * @return XORed value of selected PHRT bits
+ */
+uint64_t
+BTBTAGE::getIndexPhrtPattern(const boost::dynamic_bitset<> &phrt, unsigned phrtLen,
+                             unsigned bitIdx, unsigned indexLen) {
+    if (phrtLen == 0) return 0;
+
+    uint64_t result = 0;
+
+    // the Paper uses specific PHRT stride patterns for index computation
+    // Most bits use 2-3 PHRT bits with regular stride patterns
+
+    // Calculate adaptive stride based on available PHRT length
+    // the Paper uses stride ~41-50 for 100-bit PHRT, scale accordingly
+    unsigned baseStride = std::max(5u, phrtLen / std::max(1u, indexLen / 2));
+
+    // Pattern varies by bit position to create diversity
+    unsigned pattern = bitIdx % 3;
+
+    switch (pattern) {
+        case 0: {
+            // Pattern like PHRT[2]⊕PHRT[43]⊕PHRT[93]: start + 2 strides
+            unsigned start = (bitIdx * 5) % phrtLen;
+            unsigned pos1 = start;
+            unsigned pos2 = (start + baseStride) % phrtLen;
+            unsigned pos3 = (start + 2 * baseStride) % phrtLen;
+
+            if (pos1 < phrt.size() && phrt[pos1]) result ^= 1;
+            if (pos2 < phrt.size() && phrt[pos2]) result ^= 1;
+            if (pos3 < phrt.size() && phrt[pos3]) result ^= 1;
+            break;
+        }
+        case 1: {
+            // Pattern like PHRT[38]⊕PHRT[88]: two distant bits
+            unsigned start = (bitIdx * 7 + phrtLen / 3) % phrtLen;
+            unsigned pos1 = start;
+            unsigned pos2 = (start + phrtLen / 2) % phrtLen;
+
+            if (pos1 < phrt.size() && phrt[pos1]) result ^= 1;
+            if (pos2 < phrt.size() && phrt[pos2]) result ^= 1;
+            break;
+        }
+        case 2: {
+            // Pattern like PHRT[53]⊕PHRT[58]: close bits
+            unsigned start = (bitIdx * 11 + phrtLen / 2) % phrtLen;
+            unsigned pos1 = start;
+            unsigned pos2 = (start + std::max(5u, phrtLen / 20)) % phrtLen;
+
+            if (pos1 < phrt.size() && phrt[pos1]) result ^= 1;
+            if (pos2 < phrt.size() && phrt[pos2]) result ^= 1;
+            break;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @brief Generate XOR pattern for PHRB bits in index computation (the Paper-style)
+ *
+ * @param phrb The path history register (branch)
+ * @param phrbLen Length of PHRB to use
+ * @param bitIdx The index bit position being computed
+ * @param indexLen Total index length for pattern calculation
+ * @return XORed value of selected PHRB bits
+ */
+uint64_t
+BTBTAGE::getIndexPhrbPattern(const boost::dynamic_bitset<> &phrb, unsigned phrbLen,
+                             unsigned bitIdx, unsigned indexLen) {
+    if (phrbLen == 0) return 0;
+
+    uint64_t result = 0;
+
+    // the Paper uses single PHRB bits for index computation
+    // Pattern like PHRB[5], PHRB[10], PHRB[15], etc.
+
+    // Calculate position with stride pattern
+    unsigned stride = std::max(1u, phrbLen / std::max(1u, indexLen));
+    unsigned pos = (bitIdx * stride) % phrbLen;
+
+    if (pos < phrb.size() && phrb[pos]) {
+        result = 1;
+    }
+
+    return result;
+}
+
 Addr
 BTBTAGE::getTageTagUsePhr(Addr pc, int table,
     const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt)
 {
     unsigned phrbLen = phrbLengths[table];
     unsigned phrtLen = phrtLengths[table];
-    unsigned tagLen = tableIndexBits[table];
+    unsigned tagLen = tableTagBits[table];  // Use tableTagBits instead of tableIndexBits
 
-    unsigned foldLen = tagLen;
-    unsigned paddedLen = ((phrbLen + phrtLen + foldLen - 1) / foldLen) * foldLen;
 
-    boost::dynamic_bitset<> phrbTemp = phrb;
-    phrbTemp.resize(phrbLen);
-    phrbTemp.resize(paddedLen);
+    uint64_t tag = 0;
 
-    boost::dynamic_bitset<> phrtTemp = phrt;
-    phrtTemp.resize(phrtLen);
-    phrtTemp.resize(paddedLen);
+    // Calculate how many bits to use for XOR groups vs direct PC bits
+    // the Paper uses 12 XOR bits + 4 direct PC bits for 16-bit tag
+    unsigned xorBits = std::min(tagLen, (tagLen * 3) / 4);  // 75% for XOR groups
+    unsigned directPcBits = tagLen - xorBits;  // Remaining for direct PC bits
 
-    // DPRINTF(TAGE, "TAG: phrb: %#lx\n", phrb.to_ulong());
-    // DPRINTF(TAGE, "TAG: phrbTemp: %#lx\n", phrbTemp.to_ulong());
+    DPRINTF(TAGE, "TAG: tagLen=%u, xorBits=%u, directPcBits=%u\n", tagLen, xorBits, directPcBits);
 
-    phrbTemp <<= phrtLen;
-    phrbTemp |= phrtTemp;
+    // Generate XOR groups for each tag bit (the Paper-style)
+    for (unsigned i = 0; i < xorBits; i++) {
+        uint64_t pcBit = GET_ONE_BIT(pc, 7 + i);  // Start from PC[7] like the Paper
+        uint64_t phrtXor = getPhrtXorPattern(phrt, phrtLen, i, tagLen);
+        uint64_t phrbXor = getPhrbXorPattern(phrb, phrbLen, i, tagLen);
 
-    uint64_t pcXorBits = GET_SELECTED_BITS(pc, 5 + foldLen - 1, 5);
-    uint64_t tag = pcXorBits ^ foldBits(phrbTemp, foldLen).to_ulong();
-    // tag = (tag << 4) | GET_SELECTED_BITS(pc, 8, 5);
+        uint64_t tagBit = pcBit ^ phrtXor ^ phrbXor;
+        tag |= (tagBit & 1) << i;
+    }
 
-    // DPRINTF(TAGE, "TAG: pc: %#lx\n", pc);
-    // DPRINTF(TAGE, "TAG: pcXorBits: %#lx\n", pcXorBits);
-    // DPRINTF(TAGE, "TAG: tag: %#lx\n", tag);
+    // Add direct PC bits (like the Paper's PC[5:2])
+    if (directPcBits > 0) {
+        // Use PC bits that are meaningful for instruction alignment
+        // For 2-byte ISA: use PC[5:2], for 4-byte ISA: use PC[5:2]
+        unsigned directPcStart = 2;  // Skip alignment bits
+        uint64_t directPc = GET_SELECTED_BITS(pc, directPcStart + directPcBits - 1, directPcStart);
+        tag |= (directPc & GET_MASK(directPcBits)) << xorBits;
+    }
 
-    return tag;
+    DPRINTF(TAGE, "TAG: pc=%#lx, phrbLen=%u, phrtLen=%u, final_tag=%#lx\n",
+            pc, phrbLen, phrtLen, tag);
+
+    return tag & GET_MASK(tagLen);  // Ensure tag fits in allocated bits
 }
 
 Addr
@@ -831,31 +1026,66 @@ BTBTAGE::getTageIndexUsePhr(Addr pc, int table,
     unsigned phrtLen = phrtLengths[table];
     unsigned indexLen = tableIndexBits[table];
 
-    unsigned foldLen = indexLen - 1;
-    unsigned paddedLen = ((phrbLen + phrtLen + foldLen - 1) / foldLen) * foldLen;
+    // Ensure we don't exceed index length
+    if (indexLen == 0) {
+        return GET_SELECTED_BITS(pc, 7, 2);  // Fallback to simple PC bits
+    }
 
-    boost::dynamic_bitset<> phrbTemp = phrb;
-    phrbTemp.resize(phrbLen);
-    phrbTemp.resize(paddedLen);
+    uint64_t index = 0;
 
-    boost::dynamic_bitset<> phrtTemp = phrt;
-    phrtTemp.resize(phrtLen);
-    phrtTemp.resize(paddedLen);
+    // Calculate bit distribution based on the Paper patterns:
+    // - 20% PHRT-only patterns (bits 1-2 of 10)
+    // - 50% PHRT+PHRB patterns (bits 3-7, 9 of 10)
+    // - 10% PHRT+PC patterns (bit 8 of 10)
+    // - 20% direct PC patterns (bit 10 of 10)
 
-    // DPRINTF(TAGE, "INDEX: phrb: %#lx\n", phrb.to_ulong());
-    // DPRINTF(TAGE, "INDEX: phrbTemp: %#lx\n", phrbTemp.to_ulong());
+    unsigned phrtOnlyBits = std::max(1u, indexLen / 5);  // 20%
+    unsigned phrtPhrbBits = std::max(1u, indexLen / 2);   // 50%
+    unsigned phrtPcBits = std::max(1u, indexLen / 10);    // 10%
+    unsigned directPcBits = indexLen - phrtOnlyBits - phrtPhrbBits - phrtPcBits;  // Remaining
 
-    phrbTemp <<= phrtLen;
-    phrbTemp |= phrtTemp;
+    DPRINTF(TAGE, "INDEX: indexLen=%u, phrtOnly=%u, phrtPhrb=%u, phrtPc=%u, directPc=%u\n",
+            indexLen, phrtOnlyBits, phrtPhrbBits, phrtPcBits, directPcBits);
 
-    uint64_t pcXorBits = GET_SELECTED_BITS(pc, 5 + foldLen - 1, 5);
-    uint64_t index = pcXorBits ^ foldBits(phrbTemp, foldLen).to_ulong();
+    unsigned bitPos = 0;
 
-    index = (index << 1) | GET_ONE_BIT(pc, 5);
+    // PHRT-only patterns (like PHRT[2]⊕PHRT[43]⊕PHRT[93])
+    for (unsigned i = 0; i < phrtOnlyBits && bitPos < indexLen; i++, bitPos++) {
+        uint64_t phrtXor = getIndexPhrtPattern(phrt, phrtLen, i, indexLen);
+        index |= (phrtXor & 1) << bitPos;
+    }
 
-    // DPRINTF(TAGE, "INDEX: index: %#lx\n", index);
+    // PHRT+PHRB patterns (like PHRT[12]⊕PHRT[63]⊕PHRB[5])
+    for (unsigned i = 0; i < phrtPhrbBits && bitPos < indexLen; i++, bitPos++) {
+        uint64_t phrtXor = getIndexPhrtPattern(phrt, phrtLen, i + phrtOnlyBits, indexLen);
+        uint64_t phrbXor = getIndexPhrbPattern(phrb, phrbLen, i, indexLen);
 
-    return index;
+        uint64_t indexBit = phrtXor ^ phrbXor;
+        index |= (indexBit & 1) << bitPos;
+    }
+
+    // PHRT+PC patterns (like PHRT[38]⊕PHRT[88]⊕PC[9])
+    for (unsigned i = 0; i < phrtPcBits && bitPos < indexLen; i++, bitPos++) {
+        uint64_t phrtXor = getIndexPhrtPattern(phrt, phrtLen, i + phrtOnlyBits + phrtPhrbBits, indexLen);
+        uint64_t pcBit = GET_ONE_BIT(pc, 9 + i);  // Start from PC[9] like the Paper
+
+        uint64_t indexBit = phrtXor ^ pcBit;
+        index |= (indexBit & 1) << bitPos;
+    }
+
+    // Direct PC bits (like PC[6])
+    if (directPcBits > 0 && bitPos < indexLen) {
+        // Use PC bits that are meaningful for instruction alignment
+        // Start from PC[6] like the Paper
+        unsigned directPcStart = 6;
+        uint64_t directPc = GET_SELECTED_BITS(pc, directPcStart + directPcBits - 1, directPcStart);
+        index |= (directPc & GET_MASK(std::min(directPcBits, indexLen - bitPos))) << bitPos;
+    }
+
+    DPRINTF(TAGE, "INDEX: pc=%#lx, phrbLen=%u, phrtLen=%u, final_index=%#lx\n",
+            pc, phrbLen, phrtLen, index);
+
+    return index & GET_MASK(indexLen);  // Ensure index fits in allocated bits
 }
 
 bool

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -105,6 +105,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     void tickStart() override;
 
     void tick() override;
+
+    void putPhr(const boost::dynamic_bitset<> &s0phrb, const boost::dynamic_bitset<> &s0phrt);
+
     // Make predictions for a stream of instructions and record in stage preds
     void putPCHistory(Addr startAddr,
                       const boost::dynamic_bitset<> &history,
@@ -141,11 +144,19 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Calculate TAGE index with folded history
     Addr getTageIndex(Addr pc, int table, bitset &foldedHist);
 
+    // Calculate TAGE index with pc and phr
+    Addr getTageIndexUsePhr(Addr pc, int table,
+        const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt);
+
     // Calculate TAGE tag for a given PC and table
     Addr getTageTag(Addr pc, int table);
 
     // Calculate TAGE tag with folded history
     Addr getTageTag(Addr pc, int table, bitset &foldedHist, bitset &altFoldedHist);
+
+    // Calculate TAGE tag with pc and phr
+    Addr getTageTagUsePhr(Addr pc, int table,
+        const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt);
 
     // Get offset within a block for a given PC
     Addr getOffset(Addr pc) {
@@ -178,6 +189,17 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // History lengths for each table
     std::vector<unsigned> histLengths;
+
+    // History lengths for each table
+    std::vector<unsigned> phrbLengths;
+
+    // History lengths for each table
+    std::vector<unsigned> phrtLengths;
+
+    bool usePhr = true;
+
+    boost::dynamic_bitset<> phrb;
+    boost::dynamic_bitset<> phrt;
 
     // Folded history for tag calculation
     std::vector<FoldedHist> tagFoldedHist;
@@ -342,6 +364,8 @@ private:
 
     // Helper method to handle new entry allocation
     bool handleNewEntryAllocation(const Addr &startPC,
+                                 const boost::dynamic_bitset<> &commitPhrb,
+                                 const boost::dynamic_bitset<> &commitPhrt,
                                  const BTBEntry &entry,
                                  bool actual_taken,
                                  const std::vector<bitset> &useful_mask,

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -158,6 +158,18 @@ class BTBTAGE : public TimedBaseBTBPredictor
     Addr getTageTagUsePhr(Addr pc, int table,
         const boost::dynamic_bitset<> &phrb, const boost::dynamic_bitset<> &phrt);
 
+    // Helper functions for the Paper-style tag computation
+    uint64_t getPhrtXorPattern(const boost::dynamic_bitset<> &phrt, unsigned phrtLen,
+                               unsigned bitIdx, unsigned tagLen);
+    uint64_t getPhrbXorPattern(const boost::dynamic_bitset<> &phrb, unsigned phrbLen,
+                               unsigned bitIdx, unsigned tagLen);
+
+    // Helper functions for the Paper-style index computation
+    uint64_t getIndexPhrtPattern(const boost::dynamic_bitset<> &phrt, unsigned phrtLen,
+                                 unsigned bitIdx, unsigned indexLen);
+    uint64_t getIndexPhrbPattern(const boost::dynamic_bitset<> &phrb, unsigned phrbLen,
+                                 unsigned bitIdx, unsigned indexLen);
+
     // Get offset within a block for a given PC
     Addr getOffset(Addr pc) {
         return (pc & (blockSize - 1)) >> 1;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1987,7 +1987,7 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     std::tie(shamt, taken) = finalPred.getHistInfo();
 
     if (taken) {
-        updatePhr(s0PC, finalPred.getTarget(predictWidth));
+        updatePhr(finalPred.controlAddr(), finalPred.getTarget(predictWidth));
     }
 
     // Update global history
@@ -2055,7 +2055,7 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     // update phr, this isn't supposed to be triggered by trap squash and non-control squash
     // this is guaranteed by the fact that actually_taken is always false during these squashs. 
     if (actually_taken) {
-        updatePhr(stream.startPC, redirect_pc);
+        updatePhr(stream.getControlPC(), redirect_pc);
     }
 
     // Get actual history shift information

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -30,6 +30,10 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       predictWidth(p.predictWidth),
       maxInstsNum(p.predictWidth / 2),
       historyBits(p.maxHistLen),
+      phrbMaxLen(p.phrbMaxLen),
+      phrbXorLen(p.phrbXorLen),
+      phrtMaxLen(p.phrtMaxLen),
+      phrtXorLen(p.phrtXorLen),
       ubtb(p.ubtb),
       abtb(p.abtb),
       btb(p.btb),
@@ -96,6 +100,8 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
     for (unsigned int i = 0; i < mgsc->getNumEntriesFirstLocalHistories(); ++i) {
         s0LHistory[i].resize(historyBits, 0);
     }
+    s0phrb.resize(phrbMaxLen, 0);
+    s0phrt.resize(phrtMaxLen, 0);
     fetchTargetQueue.setName(name());
 
     commitHistory.resize(historyBits, 0);
@@ -618,7 +624,7 @@ DecoupledBPUWithBTB::requestNewPrediction()
         for (int i = 0; i < numStages; i++) {
             predsOfEachStage[i].bbStart = s0PC;
         }
-
+        tage->putPhr(s0phrb, s0phrt);
         // Query each predictor component with current PC and history
         for (int i = 0; i < numComponents; i++) {
             components[i]->putPCHistory(s0PC, s0History, predsOfEachStage);  //s0History not used
@@ -928,6 +934,7 @@ DecoupledBPUWithBTB::handleSquash(unsigned target_id,
     // Update PC and stream ID
     s0PC = redirect_pc;
     fsqId = stream_id + 1;
+    
 
     // Squash fetch target queue and redirect to new PC
     fetchTargetQueue.squash(target_id + 1, fsqId, redirect_pc);
@@ -989,6 +996,7 @@ DecoupledBPUWithBTB::controlSquash(unsigned target_id, unsigned stream_id,
     // Call shared squash handling logic
     handleSquash(target_id, stream_id, SQUASH_CTRL, control_pc,
                 real_target, is_conditional, actually_taken, static_inst, control_inst_size);
+
 }
 
 void
@@ -1004,6 +1012,7 @@ DecoupledBPUWithBTB::nonControlSquash(unsigned target_id, unsigned stream_id,
 
     // Call shared squash handling logic
     handleSquash(target_id, stream_id, SQUASH_OTHER, inst_pc, inst_pc.instAddr());
+
 }
 
 void
@@ -1018,6 +1027,7 @@ DecoupledBPUWithBTB::trapSquash(unsigned target_id, unsigned stream_id,
 
     // Call shared squash handling logic
     handleSquash(target_id, stream_id, SQUASH_TRAP, inst_pc, inst_pc.instAddr());
+
 }
 
 void DecoupledBPUWithBTB::update(unsigned stream_id, ThreadID tid)
@@ -1792,6 +1802,7 @@ DecoupledBPUWithBTB::createFetchStreamEntry()
     if (taken) {
         entry.predBranchInfo = finalPred.getTakenEntry().getBranchInfo();
         entry.predBranchInfo.target = nextPC; // Use final target (may not be from BTB)
+
     }
 
     // Record current history and prediction metadata
@@ -1800,9 +1811,13 @@ DecoupledBPUWithBTB::createFetchStreamEntry()
     entry.bwhistory = s0BwHistory;
     entry.ihistory = s0IHistory;
     entry.lhistory = s0LHistory;
+    entry.phrb = s0phrb;
+    entry.phrt = s0phrt;
     entry.predTick = finalPred.predTick;
     entry.predSource = finalPred.predSource;
     entry.overrideReason = finalPred.overrideReason;
+
+
 
     // Save predictors' metadata
     for (int i = 0; i < numComponents; i++) {
@@ -1971,6 +1986,10 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     bool taken;
     std::tie(shamt, taken) = finalPred.getHistInfo();
 
+    if (taken) {
+        updatePhr(s0PC, finalPred.getTarget(predictWidth));
+    }
+
     // Update global history
     histShiftIn(shamt, taken, s0History);
 
@@ -2030,6 +2049,14 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0BwHistory = stream.bwhistory;
     s0IHistory = stream.ihistory;
     s0LHistory = stream.lhistory;
+    s0phrb = stream.phrb;
+    s0phrt = stream.phrt;
+
+    // update phr, this isn't supposed to be triggered by trap squash and non-control squash
+    // this is guaranteed by the fact that actually_taken is always false during these squashs. 
+    if (actually_taken) {
+        updatePhr(stream.startPC, redirect_pc);
+    }
 
     // Get actual history shift information
     int real_shamt;

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -293,9 +293,9 @@ class DecoupledBPUWithBTB : public BPredUnit
         DPRINTF(DecoupleBP, "returnTarget %#lx\n", pred.returnTarget);
     }
 
-    void updatePhr(Addr start, Addr target) {
+    void updatePhr(Addr branchPc, Addr target) {
         s0phrb <<= 1;
-        boost::dynamic_bitset<> startXorBits(s0phrb.size(), GET_SELECTED_BITS(start, 8, 5));
+        boost::dynamic_bitset<> startXorBits(s0phrb.size(), GET_SELECTED_BITS(branchPc, 4, 1));
         s0phrb ^= startXorBits;
 
         s0phrt <<= 1;

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -41,6 +41,9 @@
 #include "debug/LoopPredictorVerbose.hh"
 #include "params/DecoupledBPUWithBTB.hh"
 
+#define GET_MASK(len) ((1ULL << (len)) - 1)
+#define GET_SELECTED_BITS(bits, highIdx, lowIdx) ((bits >> (lowIdx)) & GET_MASK((highIdx) - (lowIdx) + 1))
+
 namespace gem5
 {
 
@@ -94,6 +97,11 @@ class DecoupledBPUWithBTB : public BPredUnit
     unsigned maxInstsNum;
 
     const unsigned historyBits{488};
+
+    unsigned phrbMaxLen;
+    unsigned phrbXorLen;
+    unsigned phrtMaxLen;
+    unsigned phrtXorLen;
 
     const Addr MaxAddr{~(0ULL)};
 
@@ -150,6 +158,9 @@ class DecoupledBPUWithBTB : public BPredUnit
     boost::dynamic_bitset<> s0IHistory;  ///< IMLI History bits
     std::vector<boost::dynamic_bitset<>> s0LHistory;  ///< local History bits
     FullBTBPrediction finalPred;      ///< Final prediction
+
+    boost::dynamic_bitset<> s0phrb;
+    boost::dynamic_bitset<> s0phrt;
 
     boost::dynamic_bitset<> commitHistory;
 
@@ -280,6 +291,16 @@ class DecoupledBPUWithBTB : public BPredUnit
             pair.first, pair.second);
         }
         DPRINTF(DecoupleBP, "returnTarget %#lx\n", pred.returnTarget);
+    }
+
+    void updatePhr(Addr start, Addr target) {
+        s0phrb <<= 1;
+        boost::dynamic_bitset<> startXorBits(s0phrb.size(), GET_SELECTED_BITS(start, 8, 5));
+        s0phrb ^= startXorBits;
+
+        s0phrt <<= 1;
+        boost::dynamic_bitset<> targetXorBits(s0phrt.size(), GET_SELECTED_BITS(target, 30, 1));
+        s0phrt ^= targetXorBits;
     }
 
     /**
@@ -788,7 +809,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         bool is_conditional,
         bool actually_taken,
         SquashType squash_type,
-        Addr redirect_pc);
+        Addr redirect_pc // the target of the squashed Fetch Block, used to update PHR);
 
     // Common logic for squash handling
     void handleSquash(unsigned target_id,

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -809,7 +809,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         bool is_conditional,
         bool actually_taken,
         SquashType squash_type,
-        Addr redirect_pc // the target of the squashed Fetch Block, used to update PHR);
+        Addr redirect_pc); // the target of the squashed Fetch Block, used to update PHR
 
     // Common logic for squash handling
     void handleSquash(unsigned target_id,

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -294,6 +294,9 @@ typedef struct FetchStream
     std::vector<boost::dynamic_bitset<>> lhistory; // record LHR/s0History
     std::queue<Addr> previousPCs; // previous PCs, used by ahead BTB
 
+    boost::dynamic_bitset<> phrb;
+    boost::dynamic_bitset<> phrt;
+
     // for profiling
     int fetchInstNum;
     int commitInstNum;
@@ -320,6 +323,8 @@ typedef struct FetchStream
          bwhistory(),
          ihistory(),
          lhistory(),
+         phrb(),
+         phrt(),
          fetchInstNum(0),
          commitInstNum(0)
    {


### PR DESCRIPTION
this branch explored the possibility of another PHR policy. It features 2 separate PHR: PHRB and PHRT. While the former stores the path history of taken branch's pc, the latter stores the path history of taken branch's target. the new set of PHR has unique update policy and is adopted on TAGE. Needless to say, the tag and index functions are also unique.