### PR TITLE
cpu: avoid using bitset in foldedhist

### DIFF
--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -358,15 +358,19 @@ BTBITTAGE::updateCounter(bool taken, unsigned width, short &counter) {
 }
 
 Addr
-BTBITTAGE::getTageTag(Addr pc, int t, bitset &foldedHist, bitset &altFoldedHist)
+BTBITTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHist)
 {
-    bitset buf(tableTagBits[t], pc >> floorLog2(blockSize));  // lower bits of PC
-    bitset altTagBuf(altFoldedHist);
-    altTagBuf.resize(tableTagBits[t]);
-    altTagBuf <<= 1;
-    buf ^= foldedHist;
-    buf ^= altTagBuf;
-    return buf.to_ulong();
+    // Create mask for tableTagBits[t]
+    uint64_t mask = ((1ULL << tableTagBits[t]) - 1);
+
+    // Extract lower bits of PC
+    uint64_t pcBits = (pc >> floorLog2(blockSize));
+
+    // Prepare alt tag: shift left by 1 and mask
+    uint64_t altTagBits = (altFoldedHist << 1);
+
+    // XOR all components
+    return (pcBits ^ foldedHist ^ altTagBits) & mask;
 }
 
 Addr
@@ -376,11 +380,14 @@ BTBITTAGE::getTageTag(Addr pc, int t)
 }
 
 Addr
-BTBITTAGE::getTageIndex(Addr pc, int t, bitset &foldedHist)
+BTBITTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
 {
-    bitset buf(tableIndexBits[t], pc >> floorLog2(blockSize));  // lower bits of PC
-    buf ^= foldedHist;
-    return buf.to_ulong();
+    // Create mask for tableIndexBits[t]
+    uint64_t mask = ((1ULL << tableIndexBits[t]) - 1);
+
+    // Extract lower bits of PC and XOR with folded history
+    uint64_t pcBits = (pc >> floorLog2(blockSize));
+    return (pcBits ^ foldedHist) & mask;
 }
 
 Addr

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -119,14 +119,14 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // use blockPC
     Addr getTageIndex(Addr pc, int table);
 
-    // use blockPC
-    Addr getTageIndex(Addr pc, int table, bitset &foldedHist);
+    // use blockPC (uint64_t version for performance)
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist);
 
     // use blockPC
     Addr getTageTag(Addr pc, int table);
 
-    // use blockPC
-    Addr getTageTag(Addr pc, int table, bitset &foldedHist, bitset &altFoldedHist);
+    // use blockPC (uint64_t version for performance)
+    Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist);
 
     Addr getOffset(Addr pc) {
         return (pc & (blockSize - 1)) >> 1;

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -109,7 +109,7 @@ mgscStats(this)
         for (unsigned int j = 0; j < (std::pow(2,logPnb)); ++j) {
             pTable[i][j].resize(numWays);
         }
-        indexPFoldedHist.push_back(FoldedHist(pm[i], logPnb, 16, HistoryType::PATH));
+        indexPFoldedHist.push_back(FoldedHist(pm[i], logPnb, 2, HistoryType::PATH));
     }
     pIndex.resize(pnb);
 
@@ -836,14 +836,14 @@ BTBMGSC::updateCounter(bool taken, unsigned width, unsigned &counter) {
 
 
 Addr
-BTBMGSC::getHistIndex(Addr pc, unsigned tableIndexBits, bitset &foldedHist)
+BTBMGSC::getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist)
 {
     // Create mask to limit result size to tableIndexBits
     Addr mask = (1ULL << tableIndexBits) - 1;
 
     // Extract lower bits of PC and XOR with folded history directly
     Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
-    Addr foldedBits = foldedHist.to_ulong() & mask;
+    Addr foldedBits = foldedHist & mask;
 
     return pcBits ^ foldedBits;
 }

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -251,7 +251,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
                                       const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results);
 
     // Calculate MGSC history index with folded history
-    Addr getHistIndex(Addr pc, unsigned tableIndexBits, bitset &foldedHist);
+    Addr getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist);
 
     // Calculate MGSC bias index
     Addr getBiasIndex(Addr pc, unsigned tableIndexBits, bool lowbit0, bool lowbit1);

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -674,22 +674,22 @@ BTBTAGE::updateCounter(bool taken, unsigned width, short &counter) {
 
 // Calculate TAGE tag with folded history - optimized version using bitwise operations
 Addr
-BTBTAGE::getTageTag(Addr pc, int t, bitset &foldedHist, bitset &altFoldedHist)
+BTBTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHist)
 {
     // Create mask for tableTagBits[t] to limit result size
     Addr mask = (1ULL << tableTagBits[t]) - 1;
 
-    // Extract lower bits of PC directly without bitset
+    // Extract lower bits of PC directly
     Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
 
     // Extract and prepare folded history bits
-    Addr foldedBits = foldedHist.to_ulong() & mask;
+    Addr foldedBits = foldedHist & mask;
 
-    // Extract and shift alt folded history bits
-    Addr altBits = (altFoldedHist.to_ulong() << 1) & mask;
+    // Extract alt tag bits and shift left by 1
+    Addr altTagBits = (altFoldedHist << 1) & mask;
 
-    // Combine all bits using XOR
-    return pcBits ^ foldedBits ^ altBits;
+    // XOR all components together
+    return pcBits ^ foldedBits ^ altTagBits;
 }
 
 Addr
@@ -699,14 +699,14 @@ BTBTAGE::getTageTag(Addr pc, int t)
 }
 
 Addr
-BTBTAGE::getTageIndex(Addr pc, int t, bitset &foldedHist)
+BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
 {
     // Create mask for tableIndexBits[t] to limit result size
     Addr mask = (1ULL << tableIndexBits[t]) - 1;
 
     // Extract lower bits of PC and XOR with folded history directly
     Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
-    Addr foldedBits = foldedHist.to_ulong() & mask;
+    Addr foldedBits = foldedHist & mask;
 
     return pcBits ^ foldedBits;
 }

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -138,14 +138,14 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Calculate TAGE index for a given PC and table
     Addr getTageIndex(Addr pc, int table);
 
-    // Calculate TAGE index with folded history
-    Addr getTageIndex(Addr pc, int table, bitset &foldedHist);
+    // Calculate TAGE index with folded history (uint64_t version for performance)
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist);
 
     // Calculate TAGE tag for a given PC and table
     Addr getTageTag(Addr pc, int table);
 
-    // Calculate TAGE tag with folded history
-    Addr getTageTag(Addr pc, int table, bitset &foldedHist, bitset &altFoldedHist);
+    // Calculate TAGE tag with folded history (uint64_t version for performance)
+    Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist);
 
     // Get offset within a block for a given PC
     Addr getOffset(Addr pc) {

--- a/src/cpu/pred/btb/folded_hist.hh
+++ b/src/cpu/pred/btb/folded_hist.hh
@@ -1,18 +1,22 @@
 #ifndef __CPU_PRED_BTB_FOLDED_HIST_HH__
 #define __CPU_PRED_BTB_FOLDED_HIST_HH__
 
+#include <array>
+
 #include <boost/dynamic_bitset.hpp>
 
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/btb/stream_struct.hh"
-// #include "debug/FoldedHist.hh"
 
-namespace gem5 {
+namespace gem5
+{
 
-namespace branch_prediction {
+namespace branch_prediction
+{
 
-namespace btb_pred {
+namespace btb_pred
+{
 
 /**
  * FoldedHist implements a folded history mechanism for branch prediction.
@@ -20,61 +24,72 @@ namespace btb_pred {
  * into a smaller number of bits, which helps reduce storage while preserving
  * correlation information.
  */
-class FoldedHist {
-    private:
-        int histLen;     // Length of the original history
-        int foldedLen;   // Length of the folded (compressed) history
-        int maxShamt;    // Maximum shift amount for history updates
-        HistoryType type;
-        boost::dynamic_bitset<> folded;  // The folded history bits
-        
-        // Pre-calculated positions for efficient history updates
-        std::vector<int> posHighestBitsInGhr;           // Positions of highest bits in global history
-        std::vector<int> posHighestBitsInOldFoldedHist; // Positions in old folded history
+class FoldedHist
+{
+  private:
+    constexpr static int staticMaxShamtLimit = 16;
+    int histLen;    // Length of the original history
+    int foldedLen;  // Length of the folded (compressed) history
+    int maxShamt;   // Maximum shift amount for history updates
+    HistoryType type;
+    uint64_t folded;  // The folded history bits
 
-    public:
-        /**
-         * Constructor for FoldedHist
-         * @param histLen Length of the original branch history
-         * @param foldedLen Length of the folded (compressed) history
-         * @param maxShamt Maximum number of bits to shift during updates
-         */
-        FoldedHist(int histLen, int foldedLen, int maxShamt, HistoryType type=HistoryType::GLOBAL) :
-            histLen(histLen), foldedLen(foldedLen), maxShamt(maxShamt), type(type)
-            {
-                folded.resize(foldedLen);
-                for (int i = 0; i < maxShamt; i++) {
-                    posHighestBitsInGhr.push_back(histLen - 1 - i);
-                    posHighestBitsInOldFoldedHist.push_back((histLen - 1 - i) % foldedLen);
-                }
-            }
-    
-    public:
-        /**
-         * Get the current folded history
-         * @return Reference to the folded history bits
-         */
-        boost::dynamic_bitset<> &get() { return folded; }
+    // Pre-calculated positions for efficient history updates
+    // Use static sized type to avoid heap alloc
+    // This class is very frequently used in fetch/BP, so ensure it is a fixed-sized object
+    std::array<std::size_t, staticMaxShamtLimit> posHighestBitsInGhr;  // Positions of highest bits in global history
+    std::array<std::size_t, staticMaxShamtLimit> posHighestBitsInOldFoldedHist;  // Positions in old folded history
 
-        /**
-         * Update the folded history with a new branch outcome
-         * @param ghr Global history register
-         * @param shamt Number of bits to shift
-         * @param taken Whether the branch was taken
-         */
-        void update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc=0);
+  public:
+    /**
+     * Constructor for FoldedHist
+     * @param histLen Length of the original branch history
+     * @param foldedLen Length of the folded (compressed) history
+     * @param maxShamt Maximum number of bits to shift during updates
+     */
+    FoldedHist(int histLen, int foldedLen, int maxShamt, HistoryType type = HistoryType::GLOBAL)
+        : histLen(histLen), foldedLen(foldedLen), maxShamt(maxShamt), type(type), folded(0)
+    {
+        assert(maxShamt <= staticMaxShamtLimit);
+        assert(foldedLen + maxShamt < 64);  // Ensure folded history fits in uint64_t
+        for (int i = 0; i < maxShamt; i++) {
+            posHighestBitsInGhr[i] = histLen - 1 - i;
+            posHighestBitsInOldFoldedHist[i] = (histLen - 1 - i) % foldedLen;
+        }
+    }
 
-        /**
-         * Recover the folded history from another instance
-         * @param other The FoldedHist to recover from
-         */
-        void recover(FoldedHist &other);
+  public:
+    /**
+     * Get the current folded history as uint64_t
+     * @return The folded history bits
+     */
+    uint64_t get() const { return folded; }
 
-        /**
-         * Verify that the folded history is consistent with the global history
-         * @param ghr Global history register to check against
-         */
-        void check(const boost::dynamic_bitset<> &ghr);
+    /**
+     * Get the current folded history as bitset for compatibility
+     * @return The folded history as boost::dynamic_bitset
+     */
+    boost::dynamic_bitset<> getAsBitset() const { return boost::dynamic_bitset<>(foldedLen, folded); }
+
+    /**
+     * Update the folded history with a new branch outcome
+     * @param ghr Global history register
+     * @param shamt Number of bits to shift
+     * @param taken Whether the branch was taken
+     */
+    void update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc = 0);
+
+    /**
+     * Recover the folded history from another instance
+     * @param other The FoldedHist to recover from
+     */
+    void recover(FoldedHist &other);
+
+    /**
+     * Verify that the folded history is consistent with the global history
+     * @param ghr Global history register to check against
+     */
+    void check(const boost::dynamic_bitset<> &ghr);
 };
 
 }  // namespace btb_pred

--- a/src/cpu/pred/btb/test/btb_tage.hh
+++ b/src/cpu/pred/btb/test/btb_tage.hh
@@ -143,14 +143,14 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Calculate TAGE index for a given PC and table
     Addr getTageIndex(Addr pc, int table);
 
-    // Calculate TAGE index with folded history
-    Addr getTageIndex(Addr pc, int table, bitset &foldedHist);
+    // Calculate TAGE index with folded history (uint64_t version for performance)
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist);
 
     // Calculate TAGE tag for a given PC and table
     Addr getTageTag(Addr pc, int table);
 
-    // Calculate TAGE tag with folded history
-    Addr getTageTag(Addr pc, int table, bitset &foldedHist, bitset &altFoldedHist);
+    // Calculate TAGE tag with folded history (uint64_t version for performance)
+    Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist);
 
     // Get offset within a block for a given PC
     Addr getOffset(Addr pc) {


### PR DESCRIPTION
foldedhist is frequently allocated and deallocated, using boost::dynamic_bitset is expensive here

Also fix a bug in SC path history folding.

This PR alone reduce coremark simulation time from 30s to 24s

Baseline flame graph:

<img width="2558" alt="Screenshot 2025-06-04 at 17 49 01" src="https://github.com/user-attachments/assets/c77ba251-f14f-4999-b61e-34d59762f04c" />

This PR

<img width="2555" alt="Screenshot 2025-06-04 at 17 41 43" src="https://github.com/user-attachments/assets/b9bf9174-d981-4fa4-9f68-e9008b25c569" />

Conbimed with #416, coremark simluation time can be further reduced to 21s on 7950X3D machine, which is on-par with FTB KMHV2 version.

Flame graph combined with #416 

<img width="2557" alt="Screenshot 2025-06-04 at 17 46 29" src="https://github.com/user-attachments/assets/0af2533d-01d1-411e-a6f0-070c2e49a1df" />

