### PR TITLE
arch-riscv: fix fredosum by setting softfloat_roundingMode to 0

### DIFF
--- a/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
@@ -1389,6 +1389,7 @@ Fault
 %(class_name)s<ElemType>::execute(ExecContext* xc,
                                   Trace::InstRecord* traceData) const
 {
+    softfloat_roundingMode = 0;
     %(type_def)s;
     if (machInst.vill) {
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);


### PR DESCRIPTION
Change-Id: Ib53dc82d260adf4d1e2ad360c1f245e0e5f08b07