### PR TITLE
mem: move writeallocator from cache to sb

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -44,6 +44,7 @@ from m5.objects.BaseCPU import BaseCPU
 from m5.objects.FUPool import *
 #from m5.objects.O3Checker import O3Checker
 from m5.objects.BranchPredictor import *
+from m5.objects.Cache import WriteAllocator
 from m5.SimObject import *
 
 class SMTFetchPolicy(ScopedEnum):
@@ -178,6 +179,7 @@ class BaseO3CPU(BaseCPU):
     SbufferEntries = Param.Unsigned(16, "Number of store buffer entries")
     SbufferEvictThreshold = Param.Unsigned(7, "store buffer eviction threshold")
     storeBufferInactiveThreshold = Param.Unsigned(800, "store buffer writeback timeout threshold")
+    write_allocator = Param.WriteAllocator(WriteAllocator(), "Write allocator")
 
     StoreWbStage = Param.Unsigned(4, "Which PipeLine Stage store instruction writeback, 4 means S4")
 

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -140,7 +140,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         thread.emplace_back(maxLQEntries, maxSQEntries, params.SbufferEntries,
             params.SbufferEvictThreshold, params.storeBufferInactiveThreshold,
-            params.LdPipeStages, params.StPipeStages);
+            params.LdPipeStages, params.StPipeStages, params.write_allocator);
         thread[tid].init(cpu, iew_ptr, params, this, tid);
         thread[tid].setDcachePort(&dcachePort);
     }
@@ -1626,6 +1626,14 @@ LSQ::SbufferRequest::buildPackets()
         pkt->senderState = this;
         _packets.push_back(pkt);
     }
+}
+
+void
+LSQ::SbufferRequest::buildPackets(bool writeNotAllocate)
+{
+    buildPackets();
+    assert(_packets.size() == 1);
+    _packets.back()->writeNotAllocateOpt = writeNotAllocate;
 }
 
 void

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -760,6 +760,7 @@ class LSQ
         void recvFunctionalCustomSignal(PacketPtr pkt) override;
         bool sendPacketToCache() override;
         void buildPackets() override;
+        void buildPackets(bool writeNotAllocate);
         Cycles handleLocalAccess(
                 gem5::ThreadContext *thread, PacketPtr pkt) override { return Cycles(0);};
         bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask) override { return false;};

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -41,6 +41,7 @@
 
 #include "cpu/o3/lsq_unit.hh"
 
+#include <algorithm>
 #include <cassert>
 
 #include "arch/generic/debugfaults.hh"
@@ -70,6 +71,7 @@
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
 #include "mem/request.hh"
+#include "params/WriteAllocator.hh"
 #include "sim/cur_tick.hh"
 
 namespace gem5
@@ -214,13 +216,20 @@ StoreBuffer::update(int index)
 }
 
 StoreBufferEntry *
-StoreBuffer::getEvict()
+StoreBuffer::getVictim()
 {
     assert(lru_index.size() > 0);
     uint64_t index = lru_index.back();
-    lru_index.pop_back();
     assert(data_vld[index]);
     return data_vec[index];
+}
+
+StoreBufferEntry *
+StoreBuffer::getAndEvict()
+{
+    StoreBufferEntry* res = getVictim();
+    lru_index.pop_back();
+    return res;
 }
 
 StoreBufferEntry *
@@ -459,11 +468,13 @@ LSQUnit::completeDataAccess(PacketPtr pkt)
 }
 
 LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries, uint32_t sbufferEvictThreshold,
-    uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages)
+    uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages,
+    WriteAllocator* writeAllocator)
     : sbufferEvictThreshold(sbufferEvictThreshold),
       sbufferEntries(sbufferEntries),
       storeBufferWritebackInactive(0),
       storeBufferInactiveThreshold(storeBufferInactiveThreshold),
+      writeAllocator(writeAllocator),
       lsqID(-1),
       storeQueue(sqEntries),
       loadQueue(lqEntries),
@@ -632,6 +643,8 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
                 "first time a load is issued and its completion"),
       ADD_STAT(loadTranslationLat, "Distribution of cycle latency between the "
                 "first time a load is issued and its translation completion"),
+      ADD_STAT(writeAllocatorState, "Distribution of state cycles where "
+                "writeAllocator is in"),
       ADD_STAT(forwardSTDNotReady, "Number of load forward but store data not ready"),
       ADD_STAT(STAReadyFirst, "Number of store addr ready first"),
       ADD_STAT(STDReadyFirst, "Number of store data ready first"),
@@ -644,6 +657,9 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
         .flags(statistics::nozero);
     loadTranslationLat
         .init(0, 299, 10)
+        .flags(statistics::nozero);
+    writeAllocatorState
+        .init(0, 2, 1)
         .flags(statistics::nozero);
 }
 
@@ -2020,12 +2036,18 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
         StoreBuffer,
         "insert %#x to entry[%#x] successed, sbuffer size: %d unsentsize: %d\n",
         paddr, blockPaddr, storeBuffer.size(), storeBuffer.unsentSize());
+
+    // detect store stream
+    if (writeAllocator) {
+        writeAllocator->updateMode(vaddr, size, blockVaddr);
+    }
     return true;
 }
 
 void
 LSQUnit::storeBufferEvictToCache()
 {
+    stats.writeAllocatorState.sample(writeAllocator->allocate());
     if (storeBufferFlushing && storeBuffer.size() == 0) [[unlikely]] {
         assert(storeBuffer.unsentSize() == 0);
         storeBufferFlushing = false;
@@ -2069,7 +2091,27 @@ LSQUnit::storeBufferEvictToCache()
         }
 
         // evict entry to cache
-        auto entry = storeBuffer.getEvict();
+        bool writeNotAllocToDcache = false;
+        if (writeAllocator && writeAllocator->coalesce()) {
+            auto entry= storeBuffer.getVictim();
+            if (std::all_of(entry->validMask.begin(), entry->validMask.end(), [](bool x) { return x;})) {
+                writeAllocator->resetDelay(entry->blockVaddr);
+                // This is a full overwrite entry, if writeAllocator is in not allocate mode,
+                // the data does not need to occupy dcache space
+                writeNotAllocToDcache = !writeAllocator->allocate();
+            } else {
+                // If writeAllocator is in coalesce mode, it will delay the eviction of the entry
+                // and wait more stores to be merged into it unless waiting for too long
+                if (writeAllocator->delay(entry->blockVaddr)) {
+                    // nothing will be evict this cycle
+                    cpu->activityThisCycle();
+                    return;
+                } else {
+                    writeAllocator->reset();
+                }
+            }
+        }
+        auto entry = storeBuffer.getAndEvict();
         DPRINTF(StoreBuffer, "Evicting sbuffer entry[%#x]\n",
                 entry->blockPaddr);
 
@@ -2086,7 +2128,7 @@ LSQUnit::storeBufferEvictToCache()
 
         entry->request = new LSQ::SbufferRequest(cpu, this, entry->blockPaddr, entry->blockDatas.data());
         entry->request->addReq(entry->blockVaddr, entry->blockPaddr, entry->validMask);
-        entry->request->buildPackets();
+        entry->request->buildPackets(writeNotAllocToDcache);
         entry->request->sbuffer_entry = entry;
         bool success = entry->request->sendPacketToCache();
         if (!success) {

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -68,6 +68,7 @@
 #include "cpu/timebuf.hh"
 #include "debug/HtmCpu.hh"
 #include "debug/LSQUnit.hh"
+#include "mem/cache/base.hh"
 #include "mem/packet.hh"
 #include "mem/port.hh"
 
@@ -140,7 +141,8 @@ public:
     void insert(int index, uint64_t addr);
     StoreBufferEntry* get(uint64_t addr);
     void update(int index);
-    StoreBufferEntry* getEvict();
+    StoreBufferEntry* getVictim();
+    StoreBufferEntry* getAndEvict();
     StoreBufferEntry* createVice(StoreBufferEntry* entry);
     void release(StoreBufferEntry* entry);
 };
@@ -316,11 +318,13 @@ class LSQUnit
 
     std::vector<LSQRequest*> inflightLoads;
 
+    WriteAllocator * writeAllocator;
+
   public:
     /** Constructs an LSQ unit. init() must be called prior to use. */
     LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries,
       uint32_t sbufferEvictThreshold, uint64_t storeBufferInactiveThreshold,
-      uint32_t ldPipeStages, uint32_t stPipeStages);
+      uint32_t ldPipeStages, uint32_t stPipeStages, WriteAllocator *writeAllocator);
 
     /** We cannot copy LSQUnit because it has stats for which copy
      * contructor is deleted explicitly. However, STL vector requires
@@ -846,6 +850,7 @@ class LSQUnit
          * is issued and its completion */
         statistics::Distribution loadToUse;
         statistics::Distribution loadTranslationLat;
+        statistics::Distribution writeAllocatorState;
 
 
         statistics::Scalar forwardSTDNotReady;

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -207,6 +207,7 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
     if (compressor)
         compressor->setCache(this);
 
+    fatal_if(writeAllocator, "WriteAllocator should not be used in the cache");
     if (sliceNum > 0) {
         sliceReadyTick.resize(sliceNum, 0);
         assert(popCount(sliceNum) == 1);
@@ -436,12 +437,6 @@ void
 BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
                                Tick forward_time, Tick request_time)
 {
-    if (writeAllocator &&
-        pkt && pkt->isWrite() && !pkt->req->isUncacheable()) {
-        writeAllocator->updateMode(pkt->getAddr(), pkt->getSize(),
-                                   pkt->getBlockAddr(blkSize));
-    }
-
     if (mshr) {
         /// MSHR hit
         /// @note writebacks will be checked in getNextMSHR()
@@ -490,7 +485,7 @@ BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
                 // port and also takes into account the additional
                 // delay of the xbar.
                 mshr->allocateTarget(pkt, forward_time, order++,
-                                     allocOnFill(pkt->cmd));
+                                     allocOnFill(pkt->cmd), pkt->writeNotAllocateOpt);
                 if (mshr->getNumTargets() >= numTarget) {
                     noTargetMSHR = mshr;
                     setBlocked(Blocked_NoTargets);
@@ -902,8 +897,9 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         DPRINTF(Cache, "Block for addr %#llx being updated in Cache\n",
                 pkt->getAddr());
 
-        const bool allocate = (writeAllocator && mshr->wasWholeLineWrite) ?
-            writeAllocator->allocate() : mshr->allocOnFill();
+        const bool allocate = (mshr->notAllocOpt() && mshr->wasWholeLineWrite) ?
+            false : mshr->allocOnFill();
+
         blk = handleFill(pkt, blk, writebacks, allocate);
         assert(blk != nullptr);
         ppFill->notify(pkt);
@@ -2044,6 +2040,12 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
         // with the temporary storage
         blk = allocate ? allocateBlock(pkt, writebacks) : nullptr;
 
+        if (allocate) {
+            stats.doRealRefill++;
+        } else {
+            stats.useTempBlock++;
+        }
+
         if (!blk) {
             // No replaceable block or a mostly exclusive
             // cache... just use temporary storage to complete the
@@ -2423,29 +2425,6 @@ BaseCache::sendMSHRQueuePacket(MSHR* mshr)
     PacketPtr tgt_pkt = mshr->getTarget()->pkt;
 
     DPRINTF(Cache, "%s: MSHR %s\n", __func__, tgt_pkt->print());
-
-    // if the cache is in write coalescing mode or (additionally) in
-    // no allocation mode, and we have a write packet with an MSHR
-    // that is not a whole-line write (due to incompatible flags etc),
-    // then reset the write mode
-    if (writeAllocator && writeAllocator->coalesce() && tgt_pkt->isWrite()) {
-        if (!mshr->isWholeLineWrite()) {
-            // if we are currently write coalescing, hold on the
-            // MSHR as many cycles extra as we need to completely
-            // write a cache line
-            if (writeAllocator->delay(mshr->blkAddr)) {
-                Tick delay = blkSize / tgt_pkt->getSize() * clockPeriod();
-                DPRINTF(CacheVerbose, "Delaying pkt %s %llu ticks to allow "
-                        "for write coalescing\n", tgt_pkt->print(), delay);
-                mshrQueue.delay(mshr, delay);
-                return false;
-            } else {
-                writeAllocator->reset();
-            }
-        } else {
-            writeAllocator->resetDelay(mshr->blkAddr);
-        }
-    }
 
     CacheBlk *blk = tags->findBlock(mshr->blkAddr, mshr->isSecure);
 
@@ -2857,6 +2836,10 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
              "number of squashed inst block demand hits"),
     ADD_STAT(loadTagReadFails, statistics::units::Count::get(),
              "number of load Tag read fail because of prefetcher"),
+    ADD_STAT(useTempBlock, statistics::units::Count::get(),
+             "number of times using temp block"),
+    ADD_STAT(doRealRefill, statistics::units::Count::get(),
+             "number of times doing real refill to cache"),
     ADD_STAT(prefetchTagReadFails, statistics::units::Count::get(),
              "number of prefetch req Tag read fail because of load"),
     ADD_STAT(dataExpansions, statistics::units::Count::get(),

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1296,6 +1296,9 @@ class BaseCache : public ClockedObject, CacheAccessor
         /** Number of load Tag read fail because of prefetcher. */
         statistics::Scalar loadTagReadFails;
 
+        statistics::Scalar useTempBlock;
+        statistics::Scalar doRealRefill;
+
         /** Number of prefetch req Tag read fail because of load. */
         mutable statistics::Scalar prefetchTagReadFails;
 
@@ -1348,7 +1351,7 @@ class BaseCache : public ClockedObject, CacheAccessor
     {
         MSHR *mshr = mshrQueue.allocate(pkt->getBlockAddr(blkSize), blkSize,
                                         pkt, time, order++,
-                                        allocOnFill(pkt->cmd));
+                                        allocOnFill(pkt->cmd), pkt->writeNotAllocateOpt);
 
         if (mshrQueue.isFull()) {
             setBlocked((BlockedCause)MSHRQueue_MSHRs);

--- a/src/mem/cache/mshr.cc
+++ b/src/mem/cache/mshr.cc
@@ -73,7 +73,7 @@ MSHR::MSHR(const std::string &name)
 MSHR::TargetList::TargetList(const std::string &name)
     :   Named(name),
         needsWritable(false), hasUpgrade(false),
-        allocOnFill(false), hasFromCache(false),
+        allocOnFill(false), notAllocOpt(false), hasFromCache(false),
         hasFromPref(false), hasFromCPU(false),
         pfSource(PF_NONE), pfDepth(0),
         blkAddr(0), blkSize(0),
@@ -83,7 +83,7 @@ MSHR::TargetList::TargetList(const std::string &name)
 
 void
 MSHR::TargetList::updateFlags(PacketPtr pkt, Target::Source source,
-                              bool alloc_on_fill)
+                              bool alloc_on_fill, bool not_alloc_opt)
 {
     if (source != Target::FromSnoop) {
         if (pkt->needsWritable()) {
@@ -100,6 +100,7 @@ MSHR::TargetList::updateFlags(PacketPtr pkt, Target::Source source,
         // potentially re-evaluate whether we should allocate on a fill or
         // not
         allocOnFill = allocOnFill || alloc_on_fill;
+        notAllocOpt = notAllocOpt || not_alloc_opt;
 
         if (source != Target::FromPrefetcher) {
             hasFromCache = hasFromCache || pkt->fromCache();
@@ -126,7 +127,7 @@ MSHR::TargetList::populateFlags()
 {
     resetFlags();
     for (auto& t: *this) {
-        updateFlags(t.pkt, t.source, t.allocOnFill);
+        updateFlags(t.pkt, t.source, t.allocOnFill, t.notAllocOpt);
     }
 }
 
@@ -186,9 +187,9 @@ MSHR::TargetList::updateWriteFlags(PacketPtr pkt)
 inline void
 MSHR::TargetList::add(PacketPtr pkt, Tick readyTime,
                       Counter order, Target::Source source, bool markPending,
-                      bool alloc_on_fill)
+                      bool alloc_on_fill, bool write_not_alloc_opt)
 {
-    updateFlags(pkt, source, alloc_on_fill);
+    updateFlags(pkt, source, alloc_on_fill, write_not_alloc_opt);
     if (markPending) {
         // Iterate over the SenderState stack and see if we find
         // an MSHR entry. If we do, set the downstreamPending
@@ -203,7 +204,7 @@ MSHR::TargetList::add(PacketPtr pkt, Tick readyTime,
         }
     }
 
-    emplace_back(pkt, readyTime, order, source, markPending, alloc_on_fill);
+    emplace_back(pkt, readyTime, order, source, markPending, alloc_on_fill, write_not_alloc_opt);
 
     DPRINTF(MSHR, "New target allocated: %s\n", pkt->print());
 }
@@ -325,7 +326,7 @@ MSHR::TargetList::print(std::ostream &os, int verbosity,
 
 void
 MSHR::allocate(Addr blk_addr, unsigned blk_size, PacketPtr target,
-               Tick when_ready, Counter _order, bool alloc_on_fill)
+               Tick when_ready, Counter _order, bool alloc_on_fill, bool not_alloc_opt)
 {
     blkAddr = blk_addr;
     blkSize = blk_size;
@@ -347,7 +348,7 @@ MSHR::allocate(Addr blk_addr, unsigned blk_size, PacketPtr target,
     Target::Source source = (target->cmd == MemCmd::HardPFReq) ?
         Target::FromPrefetcher : Target::FromCPU;
     DPRINTF(MSHR, "New MSHR allocated: %s, from cpu: %i\n", target->print(), Target::FromCPU);
-    targets.add(target, when_ready, _order, source, true, alloc_on_fill);
+    targets.add(target, when_ready, _order, source, true, alloc_on_fill, not_alloc_opt);
 
     // All targets must refer to the same block
     assert(target->matchBlockAddr(targets.front().pkt, blkSize));
@@ -399,7 +400,7 @@ MSHR::deallocate()
  */
 void
 MSHR::allocateTarget(PacketPtr pkt, Tick whenReady, Counter _order,
-                     bool alloc_on_fill)
+                     bool alloc_on_fill, bool write_not_alloc_opt)
 {
     // assume we'd never issue a prefetch when we've got an
     // outstanding miss
@@ -431,14 +432,14 @@ MSHR::allocateTarget(PacketPtr pkt, Tick whenReady, Counter _order,
         if (inService && hasPostInvalidate())
             replaceUpgrade(pkt);
         deferredTargets.add(pkt, whenReady, _order, Target::FromCPU, true,
-                            alloc_on_fill);
+                            alloc_on_fill, write_not_alloc_opt);
     } else {
         // No request outstanding, or still OK to append to
         // outstanding request: append to regular target list.  Only
         // mark pending if current request hasn't been issued yet
         // (isn't in service).
         targets.add(pkt, whenReady, _order, Target::FromCPU, !inService,
-                    alloc_on_fill);
+                    alloc_on_fill, write_not_alloc_opt);
     }
 
     DPRINTF(MSHR, "After target allocation: %s", print());
@@ -557,7 +558,7 @@ MSHR::handleSnoop(PacketPtr pkt, Counter _order)
         }
 
         targets.add(cp_pkt, curTick(), _order, Target::FromSnoop,
-                    downstreamPending && targets.needsWritable, false);
+                    downstreamPending && targets.needsWritable, false, false);
 
         if (pkt->needsWritable() || pkt->isInvalidate()) {
             // This transaction will take away our pending copy
@@ -832,6 +833,7 @@ MSHR::print(std::ostream &os, int verbosity, const std::string &prefix) const
              isSecure ? "s" : "ns",
              isForward ? "Forward" : "",
              allocOnFill() ? "AllocOnFill" : "",
+             notAllocOpt() ? "notAllocOpt" : "",
              needsWritable() ? "Wrtbl" : "",
              _isUncacheable ? "Unc" : "",
              inService ? "InSvc" : "",

--- a/src/mem/cache/mshr.hh
+++ b/src/mem/cache/mshr.hh
@@ -159,10 +159,12 @@ class MSHR : public QueueEntry, public Printable
         const bool allocOnFill;   //!< Should the response servicing this
                                   //!< target list allocate in the cache?
 
+        const bool notAllocOpt;
+
         Target(PacketPtr _pkt, Tick _readyTime, Counter _order,
-               Source _source, bool _markedPending, bool alloc_on_fill)
+               Source _source, bool _markedPending, bool alloc_on_fill, bool not_alloc_opt)
             : QueueEntry::Target(_pkt, _readyTime, _order), source(_source),
-              markedPending(_markedPending), allocOnFill(alloc_on_fill)
+              markedPending(_markedPending), allocOnFill(alloc_on_fill), notAllocOpt(not_alloc_opt)
         {}
     };
 
@@ -174,6 +176,7 @@ class MSHR : public QueueEntry, public Printable
         bool hasUpgrade;
         /** Set when the response should allocate on fill */
         bool allocOnFill;
+        bool notAllocOpt;
         /**
          * Determine whether there was at least one non-snooping
          * target coming from another cache.
@@ -197,9 +200,11 @@ class MSHR : public QueueEntry, public Printable
          * @param pkt Packet considered for the flag update
          * @param source Indicates the source of the packet
          * @param alloc_on_fill Whether the pkt would allocate on a fill
+         * @param not_alloc_opt Whether the pkt would prefer not to allocate in cache
+         *        not_alloc_opt has higher priority than alloc_on_fill
          */
         void updateFlags(PacketPtr pkt, Target::Source source,
-                         bool alloc_on_fill);
+                         bool alloc_on_fill, bool not_alloc_opt);
 
         /**
          * Reset state
@@ -222,6 +227,7 @@ class MSHR : public QueueEntry, public Printable
             needsWritable = false;
             hasUpgrade = false;
             allocOnFill = false;
+            notAllocOpt = false;
             hasFromCache = false;
             hasFromPref = false;
             hasFromCPU = false;
@@ -254,7 +260,7 @@ class MSHR : public QueueEntry, public Printable
          * @return True if the TargetList are reset, false otherwise.
          */
         bool isReset() const {
-            return !needsWritable && !hasUpgrade && !allocOnFill &&
+            return !needsWritable && !hasUpgrade && !allocOnFill && !notAllocOpt &&
                 !hasFromCache && canMergeWrites;
         }
 
@@ -269,9 +275,11 @@ class MSHR : public QueueEntry, public Printable
          * @param source Indicates the source agent of the packet
          * @param markPending Set for deferred targets or pending MSHRs
          * @param alloc_on_fill Whether it should allocate on a fill
+         * @param write_not_alloc_opt Whether it prefer not to allocate in cache
+         *        write_not_alloc_opt has higher priority than alloc_on_fill
          */
         void add(PacketPtr pkt, Tick readyTime, Counter order,
-                 Target::Source source, bool markPending, bool alloc_on_fill);
+                 Target::Source source, bool markPending, bool alloc_on_fill, bool write_not_alloc_opt);
 
         /**
          * Convert upgrades to the equivalent request if the cache line they
@@ -352,6 +360,10 @@ class MSHR : public QueueEntry, public Printable
 
     bool allocOnFill() const {
         return targets.allocOnFill;
+    }
+
+    bool notAllocOpt() const {
+        return targets.notAllocOpt;
     }
 
     /**
@@ -445,9 +457,11 @@ class MSHR : public QueueEntry, public Printable
      * @param when_ready When should the MSHR be ready to act upon.
      * @param _order The logical order of this MSHR
      * @param alloc_on_fill Should the cache allocate a block on fill
+     * @param not_alloc_opt Prefer not to allocate a cache block
+     *        not_alloc_opt has higher priority than alloc_on_fill
      */
     void allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
-                  Tick when_ready, Counter _order, bool alloc_on_fill);
+                  Tick when_ready, Counter _order, bool alloc_on_fill, bool not_alloc_opt);
 
     void markInService(bool pending_modified_resp);
 
@@ -463,7 +477,7 @@ class MSHR : public QueueEntry, public Printable
      * @param target The target.
      */
     void allocateTarget(PacketPtr target, Tick when, Counter order,
-                        bool alloc_on_fill);
+                        bool alloc_on_fill, bool write_not_alloc_opt);
     bool handleSnoop(PacketPtr target, Counter order);
 
     /** A simple constructor. */

--- a/src/mem/cache/mshr_queue.cc
+++ b/src/mem/cache/mshr_queue.cc
@@ -61,7 +61,7 @@ MSHRQueue::MSHRQueue(const std::string &_label,
 
 MSHR *
 MSHRQueue::allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
-                    Tick when_ready, Counter order, bool alloc_on_fill)
+                    Tick when_ready, Counter order, bool alloc_on_fill, bool not_alloc_opt)
 {
     assert(!freeList.empty());
     MSHR *mshr = freeList.front();
@@ -71,7 +71,7 @@ MSHRQueue::allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
     DPRINTF(MSHR, "Allocating new MSHR. Number in use will be %lu/%lu\n",
             allocatedList.size() + 1, numEntries);
 
-    mshr->allocate(blk_addr, blk_size, pkt, when_ready, order, alloc_on_fill);
+    mshr->allocate(blk_addr, blk_size, pkt, when_ready, order, alloc_on_fill, not_alloc_opt);
     mshr->allocIter = allocatedList.insert(allocatedList.end(), mshr);
     mshr->readyIter = addToReadyList(mshr);
 

--- a/src/mem/cache/mshr_queue.hh
+++ b/src/mem/cache/mshr_queue.hh
@@ -91,13 +91,15 @@ class MSHRQueue : public Queue<MSHR>
      * @param when_ready When should the MSHR be ready to act upon.
      * @param order The logical order of this MSHR
      * @param alloc_on_fill Should the cache allocate a block on fill
+     * @param not_alloc_opt Prefer not to allocate a block in cache
+     *        not_alloc_opt has higher priority than alloc_on_fill
      *
      * @return The a pointer to the MSHR allocated.
      *
      * @pre There are free entries.
      */
     MSHR *allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
-                   Tick when_ready, Counter order, bool alloc_on_fill);
+                   Tick when_ready, Counter order, bool alloc_on_fill, bool not_alloc_opt);
 
     /**
      * Deallocate a MSHR and its targets

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -1601,6 +1601,9 @@ class Packet : public Printable
 
     bool cacheSatisfied = true;
 
+    // If true, the packet will not allocate in Dcache
+    bool writeNotAllocateOpt = false;
+
     bool fromBOP() const { return pfSource == PrefetchSourceType::HWP_BOP; }
     
     PrefetchSourceType getPFSource() const { return static_cast<PrefetchSourceType>(pfSource); }


### PR DESCRIPTION
Since we have implemented storebuffer, the logic of writeAllocator in cache is no longer applicable and needs to be moved to storebuffer.

What writeAllocator is doing now:
1. Detect memset
2. If memset is detected, force storebuffer to wait for merging a whole block data
3. If memset is detected, Allow full overwrite (from storebuffer to dcache) to not occupy dcache space

set `write_allocator = Param.WriteAllocator(NULL, "Write allocator")` in `src/cpu/o3/BaseO3CPU.py` to disable it

Change-Id: I6a63ec490a3251006ed2e0dc5fe4547d71b3b23a