### PR TITLE
Fix address check bug

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -355,8 +355,8 @@ def setKmhV3IdealParams(args, system):
         cpu.scheduler = KMHV3Scheduler()
 
         cpu.BankConflictCheck = True   # real bank conflict 0.2 score
-        cpu.EnableLdMissReplay = False
-        cpu.EnablePipeNukeCheck = False
+        # cpu.EnableLdMissReplay = False
+        # cpu.EnablePipeNukeCheck = False
         cpu.StoreWbStage = 4 # store writeback at s4
 
         # ideal decoupled frontend

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -82,6 +82,8 @@ if env['CONF']['TARGET_ISA'] != 'null':
     DebugFlag('Counters')
     DebugFlag('Schedule')
     DebugFlag('Dispatch')
+    DebugFlag('LoadPipeline')
+    DebugFlag('StorePipeline')
 
     CompoundFlag('O3CPUAll', [ 'Fetch', 'Decode', 'Rename', 'IEW', 'Commit',
         'IQ', 'ROB', 'FreeList', 'LSQ', 'LSQUnit', 'StoreSet', 'MemDepUnit',

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -168,6 +168,8 @@ class DynInst : public ExecContext, public RefCounted
         LsqEntry,                /// Instruction is in the LSQ
         Completed,               /// Instruction has completed
         ResultReady,             /// Instruction has its result
+
+        // scheduler state begin
         CanIssue,                /// Instruction can issue and execute
         MemDepSolved,            /// Memory dependencies are solved
         InReadyQue,              /// Instruction is in the ready queue
@@ -175,6 +177,26 @@ class DynInst : public ExecContext, public RefCounted
         Scheduled,               /// Instruction is scheduled
         ArbFailed,
         Issued,                  /// Instruction has issued
+        // scheduler state end
+
+        // load/store pipe state begin
+        InPipe,
+        CacheHit,
+        WakeUpEarly,
+        FullForward,
+        LocalAccess,
+        NeedReplay,
+        TLBMissReplay,
+        CacheMissReplay,
+        RescheduleReplay,
+        STLFReplay,
+        NukeReplay,
+        CacheBlockedReplay,
+        BankConflicyReplay,
+        SkipFollowingPipe,
+
+        // load/store pipe state end
+
         Executed,                /// Instruction has executed
         CanCommit,               /// Instruction can commit
         AtCommit,                /// Instruction has reached commit
@@ -263,8 +285,6 @@ class DynInst : public ExecContext, public RefCounted
 
     // Whether or not the source register is ready, one bit per register.
     uint8_t *_readySrcIdx;
-
-    std::vector<bool> srcRegCanceled;
 
     uint64_t amoOldGoldenValue;
 
@@ -476,22 +496,6 @@ class DynInst : public ExecContext, public RefCounted
     }
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
 
-    /** True if inst is waiting for Dcache refill. */
-    bool
-    waitingCacheRefill() const
-    {
-        return instFlags[WaitingCacheRefill];
-    }
-    void waitingCacheRefill(bool f) { instFlags[WaitingCacheRefill] = f; }
-
-    /** True if inst is has pending cache request. */
-    bool
-    hasPendingCacheReq() const
-    {
-        return instFlags[HasPendingCacheReq];
-    }
-    void hasPendingCacheReq(bool f) { instFlags[HasPendingCacheReq] = f; }
-
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming
      * snoop invalidate modifies the line, in which case we need to squash.
@@ -576,6 +580,8 @@ class DynInst : public ExecContext, public RefCounted
     /** TODO: This I added for the LSQRequest side to be able to modify the
      * fault. There should be a better mechanism in place. */
     Fault& getFault() { return fault; }
+
+    bool faulted() const { return fault != NoFault; }
 
     /** Checks whether or not this instruction has had its branch target
      *  calculated yet.  For now it is not utilized and is hacked to be
@@ -891,6 +897,86 @@ class DynInst : public ExecContext, public RefCounted
     bool isIssued() const { return status[Issued]; }
 
     /** Scheduler state end */
+
+
+    /** load/store pipe state begin */
+
+    void beginPipelining() {
+                status &= ~(
+                    (1 << CacheHit) |
+                    (1 << WakeUpEarly) |
+                    (1 << FullForward) |
+                    (1 << LocalAccess) |
+                    (1 << NeedReplay) |
+                    (1 << TLBMissReplay) |
+                    (1 << CacheMissReplay) |
+                    (1 << RescheduleReplay) |
+                    (1 << STLFReplay) |
+                    (1 << NukeReplay) |
+                    (1 << CacheBlockedReplay) |
+                    (1 << BankConflicyReplay) |
+                    (1 << SkipFollowingPipe));
+        status.set(InPipe);
+    }
+
+    void endPipelining() {
+        status.reset(InPipe);
+    }
+
+    bool inPipe() const { return status[InPipe]; }
+
+    void setCacheHit() { status.set(CacheHit); }
+    bool cacheHit() const { return status[CacheHit]; }
+
+    // only can be set once!!!
+    void setNeedReplay() {
+        assert(!status[NeedReplay]);
+        status.set(NeedReplay);
+    }
+    bool needReplay() const { return status[NeedReplay]; }
+
+    void setTLBMissReplay() { setNeedReplay(); status.set(TLBMissReplay); }
+    bool needTLBMissReplay() const { return status[TLBMissReplay]; }
+
+    void setCacheMissReplay() { setNeedReplay(); status.set(CacheMissReplay); }
+    bool needCacheMissReplay() const { return status[CacheMissReplay]; }
+
+    void setRescheduleReplay() { setNeedReplay(); status.set(RescheduleReplay); }
+    bool needRescheduleReplay() const { return status[RescheduleReplay]; }
+
+    void setSTLFReplay() { setNeedReplay(); status.set(STLFReplay); }
+    bool needSTLFReplay() const { return status[STLFReplay]; }
+
+    void setNukeReplay() { setNeedReplay(); status.set(NukeReplay); }
+    bool needNukeReplay() const { return status[NukeReplay]; }
+
+    void setCacheBlockedReplay() { setNeedReplay(); status.set(CacheBlockedReplay); }
+    bool needCacheBlockedReplay() const { return status[CacheBlockedReplay]; }
+
+    void setBankConflicyReplay() { setNeedReplay(); status.set(BankConflicyReplay); }
+    bool needBankConflicyReplay() const { return status[BankConflicyReplay]; }
+
+    void setFullForward() { status.set(FullForward); }
+    bool fullForward() const { return status[FullForward]; }
+
+    void setWakeUpEarly() { status.set(WakeUpEarly); }
+    bool wakeUpEarly() const { return status[WakeUpEarly]; }
+
+    void setSkipFollowingPipe() { status.set(SkipFollowingPipe); }
+    bool replayOrSkipFollowingPipe() const { return status[SkipFollowingPipe] || status[NeedReplay]; }
+
+    /** True if inst is waiting for Dcache refill. */
+    bool waitingCacheRefill() const { return instFlags[WaitingCacheRefill]; }
+    void setWaitingCacheRefill() { instFlags.set(WaitingCacheRefill); }
+    void clearWaitingCacheRefill() { instFlags.reset(WaitingCacheRefill); }
+
+    void waitingCacheRefill(bool f) { instFlags[WaitingCacheRefill] = f; }
+
+    /** True if inst is has pending cache request. */
+    bool hasPendingCacheReq() const { return instFlags[HasPendingCacheReq]; }
+    void hasPendingCacheReq(bool f) { instFlags[HasPendingCacheReq] = f; }
+
+    /** load/store pipe state end */
 
     /** Sets this instruction as executed. */
     void setExecuted() { status.set(Executed); }

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -223,6 +223,7 @@ class DynInst : public ExecContext, public RefCounted
         NotAnInst,
         TranslationStarted,
         TranslationCompleted,
+        NormalLd,
         WaitingCacheRefill,
         HasPendingCacheReq,
         PossibleLoadViolation,
@@ -495,6 +496,14 @@ class DynInst : public ExecContext, public RefCounted
         return instFlags[TranslationCompleted];
     }
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
+
+
+    void setNormalLd() { instFlags.set(NormalLd); }
+
+    bool isNormalLd() const
+    {
+        return instFlags[NormalLd];
+    }
 
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -498,7 +498,7 @@ class DynInst : public ExecContext, public RefCounted
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
 
 
-    void setNormalLd() { instFlags.set(NormalLd); }
+    void setNormalLd(bool t) { instFlags[NormalLd] = t; }
 
     bool isNormalLd() const
     {

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -697,7 +697,7 @@ IEW::cacheUnblocked()
 }
 
 void
-IEW::instToCommit(const DynInstPtr& inst)
+IEW::readyToFinish(const DynInstPtr& inst)
 {
     // This function should not be called after writebackInsts in a
     // single cycle.  That will cause problems with an instruction
@@ -1736,13 +1736,13 @@ IEW::executeInsts()
 
             if (!inst->isSplitStoreData()) {
                 inst->setExecuted();
-                instToCommit(inst);
+                readyToFinish(inst);
             } else {
                 DPRINTF(IEW, "Execute: Split store data, [sn:%lli]\n", inst->seqNum);
                 // STD is ready, wake up corresponding load if any
                 instQueue.resolveSTLFFailInst(inst->seqNum);
                 if (inst->sqIt->splitStoreFinish()) {
-                    instToCommit(inst->sqIt->instruction());
+                    readyToFinish(inst->sqIt->instruction());
                 }
             }
         }
@@ -2097,7 +2097,7 @@ IEW::checkLoadStoreInst(DynInstPtr inst)
     int depth=-1;
     if (inFlight) {
         assert(inst->pendingCacheReq);
-        depth = inst->pendingCacheReq->mainReq()->depth;
+        depth = 0;// inst->pendingCacheReq->mainReq()->depth;
     }
     assert(depth < 5);
     bool in_l1 = depth == 0;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -216,8 +216,8 @@ class IEW
     /** Notifies that the cache has become unblocked */
     void cacheUnblocked();
 
-    /** Sends an instruction to commit through the time buffer. */
-    void instToCommit(const DynInstPtr &inst);
+    /** inst is ready to finish (The last cycle in FU) */
+    void readyToFinish(const DynInstPtr &inst);
 
     /** Inserts unused instructions of a thread into the skid buffer. */
     void skidInsert(ThreadID tid);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -641,8 +641,6 @@ LSQ::recvFunctionalCustomSignal(PacketPtr pkt, int sig)
                 request->instruction()->seqNum,
                 sig == DcacheRespType::Miss,
                 sig == DcacheRespType::Block_Not_Ready);
-        // cancel subsequent dependent insts of this load
-        iewStage->loadCancel(request->instruction());
     } else if (sig == DcacheRespType::Hint) {
         // get cache miss load replay hint
         request->recvFunctionalCustomSignal(pkt);
@@ -659,7 +657,7 @@ LSQ::recvFunctionalCustomSignal(PacketPtr pkt, int sig)
                 DPRINTF(LSQ, " erased bus: [sn:%ld] addr: %#lx\n", seqNum, addr);
             } else {
                 it++;
-            }
+            } 
         }
         panic_if(bus.size() > getLQEntries(), "elements on bus should never be greater than LQ size");
     } else {
@@ -1452,6 +1450,7 @@ LSQ::LSQRequest::~LSQRequest()
     }
     assert(!isAnyOutstandingRequest());
     if (_inst && _inst->savedRequest == this) {
+        DPRINTF(LSQ, "inst [sn:%llu] Deleting LSQRequest, savedRequest\n", _inst->seqNum);
          _inst->savedRequest = nullptr;
     }
 
@@ -1550,6 +1549,7 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
         } else {
             // this load is either missed and waken up early or hit.
             if (pkt->cacheSatisfied) {
+                DPRINTF(LSQ, "[sn:%ld] cache hit\n", _inst->seqNum);
                 // cache hit
                 instruction()->setCacheHit();
             } else {

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -82,6 +82,11 @@ LSQ::DcachePort::DcachePort(LSQ *_lsq, CPU *_cpu) :
     RequestPort(_cpu->name() + ".dcache_port", _cpu), lsq(_lsq), cpu(_cpu)
 {}
 
+uint64_t LSQ::LSQRequest::numSBufferRequest = 0;
+uint64_t LSQ::LSQRequest::numSingleRequest = 0;
+uint64_t LSQ::LSQRequest::numSplitRequest = 0;
+std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;
+
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     : cpu(cpu_ptr), iewStage(iew_ptr),
       _cacheBlocked(false),
@@ -538,13 +543,6 @@ LSQ::recvReqRetry()
     }
 }
 
-void
-LSQ::completeDataAccess(PacketPtr pkt)
-{
-    LSQRequest *request = dynamic_cast<LSQRequest*>(pkt->senderState);
-    thread[cpu->contextToThread(request->contextId())]
-        .completeDataAccess(pkt);
-}
 
 bool
 LSQ::recvTimingResp(PacketPtr pkt)
@@ -578,7 +576,13 @@ LSQ::recvTimingResp(PacketPtr pkt)
             thread[tid].checkSnoop(pkt);
         }
     }
-    // Update the LSQRequest state (this may delete the request)
+
+    if (!request->isSplit() && !request->mainPacket()->cacheSatisfied) {
+        // if cache miss, the packet must be delete
+        assert(request->isReleased());
+        assert(request->_numOutstandingPackets == 1);
+    }
+
     request->packetReplied();
 
     if (waitingForStaleTranslation) {
@@ -1065,20 +1069,23 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
         request->initiateTranslation();
     }
 
+    if (!isLoad && !inst->isVector() && size > 1 && addr % size != 0) {
+        warn( "Store misaligned: size: %u, Addr: %#lx, code: %d\n", size,
+            addr, RiscvISA::ExceptionCode::STORE_ADDR_MISALIGNED);
+        return std::make_shared<RiscvISA::AddressFault>(request->mainReq()->getVaddr(),
+            request->mainReq()->getgPaddr(),
+            RiscvISA::ExceptionCode::STORE_ADDR_MISALIGNED);
+    }
+
     if (!isLoad && !isAtomic) {
         // store inst temporally saves its data in memData
         inst->memData = new uint8_t[size];
         memcpy(inst->memData, data, size);
     }
 
-    inst->effSize = size;
-
     /* This is the place were instructions get the effAddr. */
     /* Only atomic types can attempt to send requests to the cache at this stage.*/
-    if (inst->isAtomic() && request->isTranslationComplete()) {
-        if (isMisaligned(inst, request)) {
-            return inst->getFault();
-        }
+    if (request->isTranslationComplete()) {
         if (request->isMemAccessRequired()) {
             inst->effAddr = request->getVaddr();
             inst->effSize = size;
@@ -1087,17 +1094,20 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
             if (cpu->checker) {
                 inst->reqToVerify = std::make_shared<Request>(*request->req());
             }
-            Fault fault;
-            if (isLoad)
-                fault = read(request, inst->lqIdx);
-            else
-                fault = write(request, data, inst->sqIdx);
-            // inst->getFault() may have the first-fault of a
-            // multi-access split request at this point.
-            // Overwrite that only if we got another type of fault
-            // (e.g. re-exec).
-            if (fault != NoFault)
-                inst->getFault() = fault;
+
+            if (inst->isAtomic()) {
+                Fault fault;
+                if (isLoad)
+                    fault = read(request, inst->lqIdx);
+                else
+                    fault = write(request, data, inst->sqIdx);
+                // inst->getFault() may have the first-fault of a
+                // multi-access split request at this point.
+                // Overwrite that only if we got another type of fault
+                // (e.g. re-exec).
+                if (fault != NoFault)
+                    inst->getFault() = fault;
+            }
         } else if (isLoad) {
             inst->setMemAccPredicate(false);
             // Commit will have to clean up whatever happened.  Set this
@@ -1307,7 +1317,10 @@ LSQ::SplitDataRequest::initiateTranslation()
 LSQ::SbufferRequest::SbufferRequest(CPU* cpu, LSQUnit* port, Addr blockpaddr, uint8_t* data)
     : LSQRequest(port, nullptr, false, 0, port->cacheLineSize(), 0, data,
                  nullptr, nullptr, false),
-      cpu(cpu) {}
+      cpu(cpu) {
+    numSBufferRequest++;
+    assert(numSBufferRequest <= port->sbufferEntries);
+}
 
 void
 LSQ::SbufferRequest::addReq(Addr blockVaddr, Addr blockPaddr, const std::vector<bool> byteEnable)
@@ -1329,6 +1342,7 @@ LSQ::LSQRequest::LSQRequest(
     _numOutstandingPackets(0), _amo_op(nullptr),
     _sbufferBypass(false)
 {
+
     flags.set(Flag::IsLoad, isLoad);
     if (_inst) {
         flags.set(Flag::WriteBackToRegister,
@@ -1355,6 +1369,7 @@ LSQ::LSQRequest::LSQRequest(
     _hasStaleTranslation(stale_translation),
     _sbufferBypass(false)
 {
+
     flags.set(Flag::IsLoad, isLoad);
     if (_inst) {
         flags.set(Flag::WriteBackToRegister,
@@ -1415,11 +1430,15 @@ LSQ::LSQRequest::addReq(Addr addr, unsigned size,
 void
 LSQ::LSQRequest::forward()
 {
-    if (!isLoad() || !needWBToRegister() || forwardPackets.empty()) return;
-    DPRINTF(StoreBuffer, "sbuffer forward data\n");
+    if (!isLoad() || !needWBToRegister()) return;
+    DPRINTF(StoreBuffer, "sbuffer/storeQue forward data\n");
     _sbufferBypass = true;
-    for (auto& p : forwardPackets)
+    for (auto& p : SBforwardPackets)
     {
+        _inst->memData[p.idx] = p.byte;
+    }
+
+    for (auto& p : SQforwardPackets) {
         _inst->memData[p.idx] = p.byte;
     }
 }
@@ -1432,7 +1451,7 @@ LSQ::LSQRequest::~LSQRequest()
         std::raise(SIGINT);
     }
     assert(!isAnyOutstandingRequest());
-    if (_inst->savedRequest == this) {
+    if (_inst && _inst->savedRequest == this) {
          _inst->savedRequest = nullptr;
     }
 
@@ -1498,6 +1517,7 @@ LSQ::SbufferRequest::recvTimingResp(PacketPtr pkt)
     flags.set(Flag::Complete);
     assert(pkt == _packets.front());
     _port.completeSbufferEvict(pkt);
+    discard();
     return true;
 }
 
@@ -1509,9 +1529,10 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
     bool enableLdMissReplay = lsq->enableLdMissReplay();
     // Dump inst num, request addr, and packet addr
     DPRINTF(LSQ, "Single Req::recvTimingResp: inst: %llu, pkt: %#lx, isLoad: %d, "
-                "isLLSC: %d, isUncache: %d, isCacheSatisfied: %d, data: %d\n",
+                "isLLSC: %d, isUncache: %d, isCachehit: %d, data: %d\n",
                 pkt->req->getReqInstSeqNum(), pkt->getAddr(), isLoad(), mainReq()->isLLSC(),
                 mainReq()->isUncacheable(), pkt->cacheSatisfied, *(pkt->getPtr<uint64_t*>()));
+
     if (isLoad()) {
         auto it = std::find(lsqUnit()->inflightLoads.begin(), lsqUnit()->inflightLoads.end(), this);
         if (it != lsqUnit()->inflightLoads.end()) {
@@ -1530,9 +1551,9 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
             // this load is either missed and waken up early or hit.
             if (pkt->cacheSatisfied) {
                 // cache hit
-                _port.setFlagInPipeLine(_inst, LdStFlags::CacheHit);
+                instruction()->setCacheHit();
             } else {
-                DPRINTF(LSQ, "[sn:%ld] addToBus\n", pkt->req->getReqInstSeqNum());
+                DPRINTF(LSQ, "[sn:%ld] addToBus\n", _inst->seqNum);
                 // cache miss refill, make data stable on data bus
                 lsq->bus[_inst->seqNum] = pkt->getAddr();
                 _port.getStats()->busAppendTimes++;
@@ -1748,17 +1769,21 @@ LSQ::SingleDataRequest::sendPacketToCache()
     if (success) {
         if (isLoad()) {
             assert(lsqUnit()->inflightLoads.size() < lsqUnit()->numLoads() + 4);
-            lsqUnit()->inflightLoads.emplace_back(this);
+            //lsqUnit()->inflightLoads.emplace_back(this);
         }
 
         if (!bank_conflict) {
             _numOutstandingPackets = 1;
             LSQRequest::_inst->hasPendingCacheReq(true);
             LSQRequest::_inst->pendingCacheReq = this;
+            DPRINTF(LSQ, "sendPacketToCache success [sn:%llu], pkt: %#lx\n",
+                    _inst->seqNum, _packets[0]->getAddr());
         }
     }
     if (bank_conflict) {
-        lsqUnit()->bankConflictReplaySchedule();
+        instruction()->setBankConflicyReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setBankConflicyReplay\n",
+                _inst->seqNum);
     }
     if (tag_read_fail) {
         DPRINTF(TagReadFail, "sendPacketToCache fails addr: %lx\n", _packets.at(0)->getAddr());

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1427,13 +1427,14 @@ LSQ::LSQRequest::forward()
 {
     if (!isLoad() || !needWBToRegister()) return;
     DPRINTF(StoreBuffer, "sbuffer/storeQue forward data\n");
-    _sbufferBypass = true;
     for (auto& p : SBforwardPackets)
     {
+        _sbufferBypass = true;
         _inst->memData[p.idx] = p.byte;
     }
 
     for (auto& p : SQforwardPackets) {
+        _sbufferBypass = true;
         _inst->memData[p.idx] = p.byte;
     }
 }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1067,13 +1067,6 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
         request->initiateTranslation();
     }
 
-    if (!isLoad && !inst->isVector() && size > 1 && addr % size != 0) {
-        warn( "Store misaligned: size: %u, Addr: %#lx, code: %d\n", size,
-            addr, RiscvISA::ExceptionCode::STORE_ADDR_MISALIGNED);
-        return std::make_shared<RiscvISA::AddressFault>(request->mainReq()->getVaddr(),
-            request->mainReq()->getgPaddr(),
-            RiscvISA::ExceptionCode::STORE_ADDR_MISALIGNED);
-    }
 
     if (!isLoad && !isAtomic) {
         // store inst temporally saves its data in memData
@@ -1111,6 +1104,10 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
             // Commit will have to clean up whatever happened.  Set this
             // instruction as executed.
             inst->setExecuted();
+        }
+        if (isMisaligned(inst, request)) {
+            // inst->getFault() is set in isMisaligned()
+            return inst->getFault();
         }
     }
 

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -577,7 +577,7 @@ LSQ::recvTimingResp(PacketPtr pkt)
         }
     }
 
-    if (!request->isSplit() && !request->mainPacket()->cacheSatisfied) {
+    if (request->isNormalLd() && !request->mainPacket()->cacheSatisfied) {
         // if cache miss, the packet must be delete
         assert(request->isReleased());
         assert(request->_numOutstandingPackets == 1);

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -611,7 +611,7 @@ class LSQ
         bool
         isNormalLd()
         {
-            return isLoad() && !isSplit() && !mainReq()->isLLSC() && !mainReq()->isUncacheable();
+            return isLoad() && !isSplit() && !mainReq()->isLLSC() && !mainReq()->isStrictlyOrdered() && !mainReq()->isUncacheable();
         }
 
         virtual std::string name() const { return "LSQRequest"; }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1149,6 +1149,9 @@ LSQUnit::loadDoSendRequest(const DynInstPtr &inst)
             inst->setExecuted();
         }
         inst->setSkipFollowingPipe();
+        if (inst->needReplay()) {
+            iewStage->readyToFinish(inst);
+        }
         return load_fault;
     }
 
@@ -2258,7 +2261,7 @@ LSQUnit::writebackReg(const DynInstPtr &inst, PacketPtr pkt)
         }
     }
 
-    if (inst->isStoreConditional()) {
+    if (!inst->savedRequest->isNormalLd()) {
         // Need to insert instruction into queue to commit
         iewStage->readyToFinish(inst);
         iewStage->activityThisCycle();

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1348,8 +1348,7 @@ LSQUnit::executeLoadPipeSx()
                 //     assert(false);
                 //     DPRINTF(LoadPipeline, "Load [sn:%llu] no savedRequest\n", inst->seqNum);
                 // }
-
-                if (inst->isNormalLd()) iewStage->readyToFinish(inst);
+                if (inst->isNormalLd() || !inst->readMemAccPredicate()) iewStage->readyToFinish(inst);
                 iewStage->activityThisCycle();
                 inst->endPipelining();
                 DPRINTF(LoadPipeline, "Load [sn:%llu] ready to finish\n",

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1074,8 +1074,8 @@ LSQUnit::loadDoTranslate(const DynInstPtr &inst)
         DPRINTF(LoadPipeline, "Load [sn:%llu] setTLBMissReplay\n", inst->seqNum);
     }
 
-    if (inst->savedRequest && inst->savedRequest->isTranslationComplete() && inst->savedRequest->isNormalLd()) {
-        inst->setNormalLd();
+    if (inst->savedRequest && inst->savedRequest->isTranslationComplete()) {
+        inst->setNormalLd(inst->savedRequest->isNormalLd());
     }
 
     return load_fault;
@@ -1153,9 +1153,9 @@ LSQUnit::loadDoSendRequest(const DynInstPtr &inst)
             inst->setExecuted();
         }
         inst->setSkipFollowingPipe();
-        if (inst->needReplay()) {
-            iewStage->readyToFinish(inst);
-        }
+        // if (inst->strictlyOrdered() && !inst->isExecuted()) {
+        //     iewStage->readyToFinish(inst);
+        // }
         return load_fault;
     }
 
@@ -1215,7 +1215,7 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
         inst->setWaitingCacheRefill();
         DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
         return fault;
-    } else if (!request) {
+    } else if (inst->isNormalLd() && !request) {
         loadSetReplay(inst, request, false);
         inst->setBankConflicyReplay();// fast replay
         DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -857,10 +857,10 @@ LSQUnit::checkSnoop(PacketPtr pkt)
 
     DynInstPtr ld_inst = iter->instruction();
     assert(ld_inst);
-    LSQRequest *request = iter->request();
+    LSQRequest *request = ld_inst->savedRequest; //iter->request();
 
     // Check that this snoop didn't just invalidate our lock flag
-    if (ld_inst->effAddrValid() &&
+    if (ld_inst->effAddrValid() && request &&
         request->isCacheBlockHit(invalidate_addr, cacheBlockMask)
         && ld_inst->memReqFlags & Request::LLSC) {
         ld_inst->tcBase()->getIsaPtr()->handleLockedSnoopHit(ld_inst.get());
@@ -871,7 +871,7 @@ LSQUnit::checkSnoop(PacketPtr pkt)
     while (++iter != loadQueue.end()) {
         ld_inst = iter->instruction();
         assert(ld_inst);
-        request = iter->request();
+        request = ld_inst->savedRequest;// iter->request();
         if (!ld_inst->effAddrValid() || ld_inst->strictlyOrdered())
             continue;
 
@@ -879,7 +879,7 @@ LSQUnit::checkSnoop(PacketPtr pkt)
                     ld_inst->seqNum, invalidate_addr);
 
         if (force_squash ||
-            request->isCacheBlockHit(invalidate_addr, cacheBlockMask)) {
+            (request && request->isCacheBlockHit(invalidate_addr, cacheBlockMask))) {
             if (needsTSO) {
                 // If we have a TSO system, as all loads must be ordered with
                 // all other loads, this load as well as *all* subsequent loads
@@ -1074,6 +1074,10 @@ LSQUnit::loadDoTranslate(const DynInstPtr &inst)
         DPRINTF(LoadPipeline, "Load [sn:%llu] setTLBMissReplay\n", inst->seqNum);
     }
 
+    if (inst->savedRequest && inst->savedRequest->isTranslationComplete() && inst->savedRequest->isNormalLd()) {
+        inst->setNormalLd();
+    }
+
     return load_fault;
 }
 
@@ -1211,6 +1215,11 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
         inst->setWaitingCacheRefill();
         DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
         return fault;
+    } else if (!request) {
+        loadSetReplay(inst, request, false);
+        inst->setBankConflicyReplay();// fast replay
+        DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
+        return fault;
     }
 
     for (int i = 0; i < storePipeSx[1]->size; i++) {
@@ -1223,9 +1232,10 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
     }
 
     // no nuke happens, prepare the inst data
-    assert(request->isNormalLd() ? !request->isAnyOutstandingRequest() : true);
+    // assert(request->isNormalLd() ? !request->isAnyOutstandingRequest() : true);
     request = inst->savedRequest;
     if (inst->fullForward()) {
+        DPRINTF(LoadPipeline, "Load [sn:%llu] fullForward\n", inst->seqNum);
         assert(request);
         // forwarding
         request->forward();
@@ -1237,6 +1247,7 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
     } else {
         if (lsq->enableLdMissReplay() && request && request->isNormalLd()) {
             // assemble cache & sbuffer forwarded data and completeDataAcess
+            DPRINTFR(LoadPipeline, "Load [sn:%llu] assemble packet\n", inst->seqNum);
             request->assemblePackets();
         }
     }
@@ -1333,7 +1344,12 @@ LSQUnit::executeLoadPipeSx()
             }
 
             if (i == loadPipeStages - 1 && !inst->needReplay()) {
-                if (inst->savedRequest->isNormalLd()) iewStage->readyToFinish(inst);
+                // if (!inst->savedRequest && inst->seqNum == 1683) {
+                //     assert(false);
+                //     DPRINTF(LoadPipeline, "Load [sn:%llu] no savedRequest\n", inst->seqNum);
+                // }
+
+                if (inst->isNormalLd()) iewStage->readyToFinish(inst);
                 iewStage->activityThisCycle();
                 inst->endPipelining();
                 DPRINTF(LoadPipeline, "Load [sn:%llu] ready to finish\n",

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -67,6 +67,7 @@
 #include "debug/LSQUnit.hh"
 #include "debug/O3PipeView.hh"
 #include "debug/StoreBuffer.hh"
+#include "debug/StorePipeline.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
 #include "mem/request.hh"
@@ -118,10 +119,10 @@ StoreBufferEntry::recordForward(RequestPtr req, LSQ::LSQRequest *lsqreq)
         if (vice && vice->validMask[offset + i]) {
             // vice is newer
             assert(vice->blockVaddr == blockVaddr);
-            lsqreq->forwardPackets.push_back(
+            lsqreq->SBforwardPackets.push_back(
                 LSQ::LSQRequest::FWDPacket{.idx = goffset + i, .byte = vice->blockDatas[offset + i]});
         } else if (validMask[offset + i]) {
-            lsqreq->forwardPackets.push_back(
+            lsqreq->SBforwardPackets.push_back(
                 LSQ::LSQRequest::FWDPacket{.idx = goffset + i, .byte = blockDatas[offset + i]});
         } else {
             full_forward = false;
@@ -262,7 +263,7 @@ LSQUnit::SQEntry::setStatus(SplitStoreStatus status)
     }
 }
 
-LSQUnit::WritebackEvent::WritebackEvent(const DynInstPtr &_inst,
+LSQUnit::WritebackRegEvent::WritebackRegEvent(const DynInstPtr &_inst,
         PacketPtr _pkt, LSQUnit *lsq_ptr)
     : Event(Default_Pri, AutoDelete),
       inst(_inst), pkt(_pkt), lsqPtr(lsq_ptr)
@@ -272,11 +273,11 @@ LSQUnit::WritebackEvent::WritebackEvent(const DynInstPtr &_inst,
 }
 
 void
-LSQUnit::WritebackEvent::process()
+LSQUnit::WritebackRegEvent::process()
 {
     assert(!lsqPtr->cpu->switchedOut());
 
-    lsqPtr->writeback(inst, pkt);
+    lsqPtr->writebackReg(inst, pkt);
 
     assert(inst->savedRequest);
     inst->savedRequest->writebackDone();
@@ -284,9 +285,9 @@ LSQUnit::WritebackEvent::process()
 }
 
 const char *
-LSQUnit::WritebackEvent::description() const
+LSQUnit::WritebackRegEvent::description() const
 {
-    return "Store writeback";
+    return "writeback to reg";
 }
 
 LSQUnit::bankConflictReplayEvent::bankConflictReplayEvent(LSQUnit *lsq_ptr)
@@ -339,7 +340,13 @@ LSQUnit::recvTimingResp(PacketPtr pkt)
     /* Check that the request is still alive before any further action. */
     if (!request->isReleased()) {
         ret = request->recvTimingResp(pkt);
+    } else if (request->instruction()) {
+        DPRINTF(LoadPipeline, "LSQUnit::recvTimingResp [sn:%lu] pkt: %s - ignored\n",
+                request->instruction()->seqNum, pkt->print());
+        request->instruction()->hasPendingCacheReq(false);
+        request->instruction()->pendingCacheReq = nullptr;
     }
+
     return ret;
 }
 
@@ -438,7 +445,7 @@ LSQUnit::completeDataAccess(PacketPtr pkt)
                     pkt->getHtmTransactionFailedInCacheRC() );
             }
 
-            writeback(inst, request->mainPacket());
+            writebackReg(inst, request->mainPacket());
             if (inst->isStore() || inst->isAtomic()) {
                 request->writebackDone();
                 completeStore(request->instruction()->sqIt);
@@ -908,25 +915,6 @@ LSQUnit::checkSnoop(PacketPtr pkt)
     return;
 }
 
-bool
-LSQUnit::skipNukeReplay(const DynInstPtr& load_inst)
-{
-    // if the load_inst has been marked as `Nuke`
-    // load will be replayed, so no Raw violation happens.
-    if (lsq->enablePipeNukeCheck()) {
-        for (int i = 1; i <= 2; i++) {
-            // check loadPipe s1 & s2
-            auto& stage = loadPipeSx[i];
-            for (int j = 0; j < stage->size; j++) {
-                if (load_inst == stage->insts[j] && stage->flags[j][LdStFlags::Nuke]) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 Fault
 LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
         const DynInstPtr& inst)
@@ -992,7 +980,7 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                 // if this load has been marked as Nuke, the load will then be replayed
                 // So next time this load replaying to pipeline will forward from store correctly
                 // And no RAW violation happens
-                if (skipNukeReplay(ld_inst)) {
+                if (ld_inst->needNukeReplay()) {
                     ++loadIt;
                     continue;
                 }
@@ -1022,28 +1010,15 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
 }
 
 void
-LSQUnit::loadReplayHelper(DynInstPtr inst, LSQRequest* request, bool cacheMiss, bool fastReplay, bool dropReqNow)
+LSQUnit::loadSetReplay(DynInstPtr inst, LSQRequest* request, bool dropReqNow)
 {
     // clear state in this instruction
     inst->effAddrValid(false);
     // Reset DTB translation state
     inst->translationStarted(false);
     inst->translationCompleted(false);
-    if (cacheMiss) {
-        // set it as waiting for dcache refill
-        inst->waitingCacheRefill(true);
-        // insert to missed load replay queue
-        iewStage->cacheMissLdReplay(inst);
-    } else if (fastReplay) {
-        // insert to replayQ directly, replay at next cycle
-        inst->issueQue->retryMem(inst);
-    }
     // clear request in loadQueue
     loadQueue[inst->lqIdx].setRequest(nullptr);
-    // set replayed flag in pipeline
-    setFlagInPipeLine(inst, LdStFlags::Replayed);
-    // cancel subsequent dependent insts of this load
-    iewStage->loadCancel(inst);
     if (dropReqNow) {
         // discard this request
         request->discard();
@@ -1051,40 +1026,7 @@ LSQUnit::loadReplayHelper(DynInstPtr inst, LSQRequest* request, bool cacheMiss, 
         inst->savedRequest = nullptr;
     }
 
-    DPRINTF(LSQUnit, "[sn:%ld]Load Replayed Because of %s, dropReqNow: %d\n", inst->seqNum,
-            cacheMiss  ? "Cache Miss" :
-            fastReplay ? "Nuke Fast Replay": "Other Reason", dropReqNow);
-}
-
-void
-LSQUnit::setFlagInPipeLine(DynInstPtr inst, LdStFlags f)
-{
-    bool found = false;
-    if (inst->isLoad()) {
-        for (int i = (loadPipeSx.size() - 1); i >= 0; i--) {
-            for (int j = 0; j < loadPipeSx[i]->size; j++) {
-                if (inst == loadPipeSx[i]->insts[j]) {
-                    found = true;
-                    (loadPipeSx[i]->flags[j])[f] = true;
-                    break;
-                }
-            }
-        }
-    } else {
-        for (int i = (storePipeSx.size() - 1); i >= 0; i--) {
-            for (int j = 0; j < storePipeSx[i]->size; j++) {
-                if (inst == storePipeSx[i]->insts[j]) {
-                    found = true;
-                    (storePipeSx[i]->flags[j])[f] = true;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (!found) {
-        panic("[sn:%ld] Can not found corresponding inst in PipeLine, isLoad: %d\n", inst->seqNum, inst->isLoad());
-    }
+    DPRINTF(LoadPipeline, "Load [sn:%ld] set replay, dropReqNow: %d\n", inst->seqNum, dropReqNow);
 }
 
 void
@@ -1092,14 +1034,14 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
 {
     // push to loadPipeS0
     assert(loadPipeSx[0]->size < MaxWidth);
-    int idx = loadPipeSx[0]->size;
+    panic_if(inst->inPipe(), "load [sn:%llu] is already in pipeline", inst->seqNum);
+    inst->beginPipelining();
 
+    int idx = loadPipeSx[0]->size;
     loadPipeSx[0]->insts[idx] = inst;
-    loadPipeSx[0]->flags[idx][LdStFlags::Valid] = true;
     loadPipeSx[0]->size++;
 
-    DPRINTF(LSQUnit, "issueToLoadPipe: [sn:%lli]\n", inst->seqNum);
-    dumpLoadPipe();
+    DPRINTF(LoadPipeline, "issueToLoadPipe: [sn:%llu]\n", inst->seqNum);
 }
 
 void
@@ -1107,46 +1049,56 @@ LSQUnit::issueToStorePipe(const DynInstPtr &inst)
 {
     // push to storePipeS0
     assert(storePipeSx[0]->size < MaxWidth);
-    int idx = storePipeSx[0]->size;
+    panic_if(inst->inPipe(), "load [sn:%llu] is already in pipeline", inst->seqNum);
+    inst->beginPipelining();
 
+    int idx = storePipeSx[0]->size;
     storePipeSx[0]->insts[idx] = inst;
-    storePipeSx[0]->flags[idx][LdStFlags::Valid] = true;
     storePipeSx[0]->size++;
 
     DPRINTF(LSQUnit, "issueToStorePipe: [sn:%lli]\n", inst->seqNum);
-    dumpStorePipe();
 }
 
 Fault
-LSQUnit::loadPipeS0(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::loadDoTranslate(const DynInstPtr &inst)
 {
-    DPRINTF(LSQUnit, "LoadPipeS0: Executing load PC %s, [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(LoadPipeline, "loadDoTranslate: load [sn:%llu]\n", inst->seqNum);
     assert(!inst->isSquashed());
 
     Fault load_fault = NoFault;
     // Now initiateAcc only does TLB access
     load_fault = inst->initiateAcc();
 
+    if (inst->isTranslationDelayed() && load_fault == NoFault) {
+        inst->setTLBMissReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%llu] setTLBMissReplay\n", inst->seqNum);
+    }
+
     return load_fault;
 }
 
 Fault
-LSQUnit::loadPipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::loadDoSendRequest(const DynInstPtr &inst)
 {
-    DPRINTF(LSQUnit, "LoadPipeS1: Executing load PC %s, [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(LoadPipeline, "loadDoSendRequest: load [sn:%lli]\n", inst->seqNum);
     assert(!inst->isSquashed());
-
     Fault load_fault = inst->getFault();
     LSQRequest* request = inst->savedRequest;
+
+    if (inst->effAddrValid()) {
+        for (int i = 0; i < storePipeSx[1]->size; i++) {
+            auto& store_inst = storePipeSx[1]->insts[i];
+            if (pipeLineNukeCheck(inst, store_inst)) {
+                DPRINTF(LoadPipeline, "Load [sn:%llu] Nuke need replay\n", inst->seqNum);
+                inst->setNukeReplay();
+                return NoFault;
+            }
+        }
+    }
 
     // normal inst cache access
     if (request && request->isTranslationComplete()) {
         if (request->isMemAccessRequired()) {
-            inst->effAddr = request->getVaddr();
-            inst->effAddrValid(true);
-
             Fault fault;
             fault = read(request, inst->lqIdx);
             // inst->getFault() may have the first-fault of a
@@ -1165,21 +1117,14 @@ LSQUnit::loadPipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
         }
     }
 
-    if (!inst->translationCompleted()) {
-        // TLB miss
-        iewStage->loadCancel(inst);
-    } else {
-        DPRINTF(LSQUnit, "LoadPipeS1: load tlb hit [sn:%lli]\n",
-                inst->seqNum);
-    }
-
     if (load_fault == NoFault && !inst->readMemAccPredicate()) {
-        flag[LdStFlags::readMemAccNotPredicate] = true;
+        assert(inst->readPredicate());
+        inst->setExecuted();
+        inst->completeAcc(nullptr);
+        inst->setSkipFollowingPipe();
+        DPRINTF(LoadPipeline, "Load [sn:%lli] not executed from readMemAccPredicate\n",
+                inst->seqNum);
         return NoFault;
-    }
-
-    if (inst->isTranslationDelayed() && load_fault == NoFault) {
-        return load_fault;
     }
 
     if (load_fault != NoFault && inst->translationCompleted() &&
@@ -1190,150 +1135,106 @@ LSQUnit::loadPipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
         // then the cache must have been blocked. This load will be re-executed
         // when the cache gets unblocked. We will handle the fault when the
         // mem access is complete.
+        // not replay or cancel
         return NoFault;
     }
 
     if (load_fault != NoFault || !inst->readPredicate()) {
-        flag[LdStFlags::HasFault] = load_fault != NoFault;
-        flag[LdStFlags::readNotPredicate] = !inst->readPredicate();
-    } else {
-        if (inst->effAddrValid()) {
-            // raw violation check (nuke replay)
-            for (int i = 0; i < storePipeSx[1]->size; i++) {
-                auto& store_inst = storePipeSx[1]->insts[i];
-                if (pipeLineNukeCheck(inst, store_inst)) {
-                    DPRINTF(LSQUnit, "LoadPipeS1: Nuke replay at s1, [sn:%lli]\n", inst->seqNum);
-                    flag[LdStFlags::Nuke] = true;
-                    break;
-                }
-            }
-            // rar violation check
-            auto it = inst->lqIt;
-            ++it;
+        if (!inst->readPredicate())
+            inst->forwardOldRegs();
 
-            if (checkLoads)
-                load_fault = checkViolations(it, inst);
+        DPRINTF(LoadPipeline, "Load [sn:%llu] not executed from %s\n",
+                inst->seqNum, (load_fault != NoFault ? "fault" : "readPredicate"));
+        if (!(inst->hasRequest() && inst->strictlyOrdered()) || inst->isAtCommit()) {
+            inst->setExecuted();
         }
+        inst->setSkipFollowingPipe();
+        return load_fault;
+    }
+
+    if (inst->needReplay()) { return NoFault; }
+
+    if (inst->effAddrValid()) {
+        // rar violation check
+        auto it = inst->lqIt;
+        ++it;
+        if (checkLoads)
+            load_fault = checkViolations(it, inst);
     }
 
     return load_fault;
 }
 
 Fault
-LSQUnit::loadPipeS2(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::loadDoRecvData(const DynInstPtr &inst)
 {
     Fault fault = inst->getFault();
-    DPRINTF(LSQUnit, "LoadPipeS2: Executing load PC %s, [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(LoadPipeline, "loadDoRecvData: load [sn:%lli]\n", inst->seqNum);
+
     assert(!inst->isSquashed());
     LSQRequest* request = inst->savedRequest;
 
-    if (flag[LdStFlags::readMemAccNotPredicate]) {
-        assert(inst->readPredicate() && fault == NoFault);
-        inst->setExecuted();
-        inst->completeAcc(nullptr);
-        iewStage->instToCommit(inst);
-        iewStage->activityThisCycle();
-        return NoFault;
-    }
-
-    // If the instruction faulted or predicated false, then we need to send it
-    // along to commit without the instruction completing.
-    if (flag[LdStFlags::HasFault] || flag[LdStFlags::readNotPredicate]) {
-        // Send this instruction to commit, also make sure iew stage
-        // realizes there is activity.  Mark it as executed unless it
-        // is a strictly ordered load that needs to hit the head of
-        // commit.
-        if (flag[LdStFlags::readNotPredicate])
-            inst->forwardOldRegs();
-        DPRINTF(LSQUnit, "LoadPipeS2: Load [sn:%lli] not executed from %s\n",
-                inst->seqNum, (fault != NoFault ? "fault" : "predication"));
-        if (!(inst->hasRequest() && inst->strictlyOrdered()) || inst->isAtCommit()) {
-            inst->setExecuted();
-        }
-        iewStage->instToCommit(inst);
-        iewStage->activityThisCycle();
-        return fault;
-    }
-
-    if (flag[LdStFlags::WakeUpEarly]) {
+    if (inst->wakeUpEarly()) {
         auto& bus = getLsq()->bus;
         bool busFwdSuccess = bus.find(inst->seqNum) != bus.end();
         if (inst->hasPendingCacheReq() || !busFwdSuccess) {
             // Load has been waken up too early, even no TimingResp at load s2
             // Or load received TimingResp any time at [s1, s2], but can not find data on bus
             // replay this load
-            // warn("Tick:%ld Hint & TimingResp not Match, "
-            //     "plz check the timing relationship between Hint & TimingResp, sn:%ld\n", curTick(), inst->seqNum);
-            loadReplayHelper(
-                inst, request,
-                true,  // cache miss
-                false, // Dont fast replay
-                true   // call request->discard() now
-            );
+
+            DPRINTF(LoadPipeline, "Load [sn:%ld]: Early wakeup, no data on bus\n",
+                    inst->seqNum);
+
+            loadSetReplay(inst, request,true);
+            inst->setCacheMissReplay();
+            inst->setWaitingCacheRefill();
             stats.cacheMissReplayEarly++;
+            return fault;
         } else {
             // Load received TimingResp any time at [s1, s2], forward from data bus
-            DPRINTF(LSQUnit, "[sn:%ld]: Forward from bus at load s2, data: %lx\n",
+            DPRINTF(LoadPipeline, "Load [sn:%ld]: Forward from bus at load s2, data: %lx\n",
                     inst->seqNum, *((uint64_t*)(inst->memData)));
             panic_if(bus.size() > lsq->getLQEntries(), "packets on bus should never be greater than LQ size");
-            forwardFrmBus(inst, request);
-        }
-    }
-
-    if (flag[LdStFlags::Replayed] || flag[LdStFlags::LocalAccess]) {
-        return fault;
-    }
-
-    // raw violation check (nuke replay)
-    for (int i = 0; i < storePipeSx[1]->size; i++) {
-        auto& store_inst = storePipeSx[1]->insts[i];
-        if (pipeLineNukeCheck(inst, store_inst)) {
-            DPRINTF(LSQUnit, "LoadPipeS2: Nuke replay at s2, [sn:%lli]\n", inst->seqNum);
-            flag[LdStFlags::Nuke] = true;
-            break;
+            forwardFromBus(inst, request);
         }
     }
 
     // check if cache hit & get cache response?
     // NOTE: cache miss replay has higher priority than nuke replay!
-    if (lsq->enableLdMissReplay() &&
-        request && request->isNormalLd() && !flag[LdStFlags::FullForward] && !flag[LdStFlags::CacheHit]) {
+    if (lsq->enableLdMissReplay() && request && request->isNormalLd() && !inst->fullForward() && !inst->cacheHit()) {
         // cannot get cache data at load s2, replay this load
-        loadReplayHelper(
-            inst, request,
-            true,  // cache miss
-            false, // Dont fast replay
-            false  // call request->discard() later when TimingResp comes
-        );
+        loadSetReplay(inst, request, false);
+        inst->setCacheMissReplay();
+        inst->setWaitingCacheRefill();
+        DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
         return fault;
     }
 
-    if (flag[LdStFlags::Nuke]) {
-        assert(lsq->enablePipeNukeCheck());
-        // replay load if nuke happens
-        loadReplayHelper(
-            inst, request,
-            false, // cache hit
-            true,  // fast replay
-            true   // call request->discard() now
-        );
-        stats.pipeRawNukeReplay++;
+    for (int i = 0; i < storePipeSx[1]->size; i++) {
+        auto& store_inst = storePipeSx[1]->insts[i];
+        if (pipeLineNukeCheck(inst, store_inst)) {
+            DPRINTF(LoadPipeline, "Load [sn:%llu] Nuke need replay\n", inst->seqNum);
+            inst->setNukeReplay();
+            return fault;
+        }
+    }
+
+    // no nuke happens, prepare the inst data
+    assert(request->isNormalLd() ? !request->isAnyOutstandingRequest() : true);
+    request = inst->savedRequest;
+    if (inst->fullForward()) {
+        assert(request);
+        // forwarding
+        request->forward();
+        PacketPtr pkt = makeFullFwdPkt(inst, request);
+        // this load gets full data from sq or sbuffer
+        writebackReg(inst, pkt);
+        request->writebackDone();
+        delete pkt;
     } else {
-        // no nuke happens, prepare the inst data
-        request = inst->savedRequest;
-        if (flag[LdStFlags::FullForward]) {
-            assert(request);
-            PacketPtr pkt = makeFullFwdPkt(inst, request);
-            // this load gets full data from sq or sbuffer
-            writeback(inst, pkt);
-            request->writebackDone();
-            delete pkt;
-        } else {
-            if (lsq->enableLdMissReplay() && request && request->isNormalLd()) {
-                // assemble cache & sbuffer forwarded data and completeDataAcess
-                request->assemblePackets();
-            }
+        if (lsq->enableLdMissReplay() && request && request->isNormalLd()) {
+            // assemble cache & sbuffer forwarded data and completeDataAcess
+            request->assemblePackets();
         }
     }
 
@@ -1341,13 +1242,10 @@ LSQUnit::loadPipeS2(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
 }
 
 Fault
-LSQUnit::loadPipeS3(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::loadDoWriteback(const DynInstPtr &inst)
 {
-    Fault fault = inst->getFault();
-    DPRINTF(LSQUnit, "LoadPipeS3: Executing load PC %s, [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
-    assert(!inst->isSquashed());
-    return fault;
+    DPRINTF(LoadPipeline, "loadDoWriteback: load [sn:%lli]\n", inst->seqNum);
+    return NoFault;
 }
 
 void
@@ -1359,71 +1257,110 @@ LSQUnit::executeLoadPipeSx()
         auto& stage = loadPipeSx[i];
         for (int j = 0; j < stage->size; j++) {
             auto& inst = stage->insts[j];
-            auto& flag = stage->flags[j];
-            if (!inst->isSquashed()) {
+            if (!inst) {
+                continue;
+            }
+            if (inst->isSquashed()) {
+                DPRINTF(LoadPipeline, "Instruction was squashed. PC: %s, [tid:%i]"
+                    " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
+                    inst->seqNum);
+                inst->setExecuted();
+                inst->setCanCommit();
+                inst = nullptr;
+                continue;
+            }
+            if (!inst->replayOrSkipFollowingPipe()) {
                 switch (i) {
                     case 0:
-                        fault = loadPipeS0(inst, flag);
+                        fault = loadDoTranslate(inst);
                         break;
                     case 1:
                         iewStage->getScheduler()->specWakeUpFromLoadPipe(inst);
                         // Loads will mark themselves as executed, and their writeback
                         // event adds the instruction to the queue to commit
-                        fault = loadPipeS1(inst, flag);
-
-                        if (inst->isTranslationDelayed() && fault == NoFault) {
-                            // A hw page table walk is currently going on; the
-                            // instruction must be deferred.
-                            DPRINTF(LSQUnit, "Execute: Delayed translation, deferring "
-                            "load.\n");
-                            iewStage->deferMemInst(inst);
-                            flag[LdStFlags::Replayed] = true;
-                        }
+                        fault = loadDoSendRequest(inst);
                         iewStage->SquashCheckAfterExe(inst);
                         break;
                     case 2:
-                        fault = loadPipeS2(inst, flag);
+                        fault = loadDoRecvData(inst);
 
                         if (inst->isDataPrefetch() || inst->isInstPrefetch()) {
                             inst->fault = NoFault;
                         }
                         break;
                     case 3:
-                        fault = loadPipeS3(inst, flag);
+                        fault = loadDoWriteback(inst);
                         break;
                     default:
                         panic("unsupported loadpipe length");
                 }
-            } else {
-                DPRINTF(LSQUnit, "Execute: Instruction was squashed. PC: %s, [tid:%i]"
-                                " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
-                                inst->seqNum);
-                inst->setExecuted();
-                inst->setCanCommit();
-                flag[LdStFlags::Squashed] = true;
+            }
+
+            // if inst was replyed, must clear inst in pipeline
+            if (inst->needSTLFReplay() || inst->needCacheBlockedReplay() || inst->needRescheduleReplay()) {
+                DPRINTF(LoadPipeline, "Load [sn:%llu] replayed\n", inst->seqNum);
+                iewStage->loadCancel(inst);
+                inst->endPipelining();
+                inst = nullptr;
+                continue;
+            }
+
+            if (i == loadWhenToReplay && inst->needReplay()) [[unlikely]] {
+                DPRINTF(LoadPipeline, "Load [sn:%llu] replayed\n", inst->seqNum);
+
+                if (inst->needBankConflicyReplay()) inst->issueQue->retryMem(inst);
+                else if (inst->needCacheMissReplay()) iewStage->cacheMissLdReplay(inst);
+                else if (inst->needNukeReplay()) {
+                    if (inst->cacheHit()) {
+                        loadSetReplay(inst, inst->savedRequest, true);
+                    } else if (inst->hasPendingCacheReq()) {
+                        loadSetReplay(inst, inst->savedRequest, false);
+                    }
+                    inst->issueQue->retryMem(inst);
+                }
+                else if (inst->needTLBMissReplay()) iewStage->deferMemInst(inst);
+                // else if (inst->needRescheduleReplay()) iewStage->rescheduleMemInst(inst);
+                // if (inst->needSTLFReplay()) iewStage->stlfFailLdReplay //do not here called
+                // if (inst->needCacheBlockedReplay()) iewStage->blockMemInst //do not here called
+
+                iewStage->loadCancel(inst);
+                inst->endPipelining();
+                inst = nullptr;
+                continue;
+            }
+
+            if (i == loadPipeStages - 1 && !inst->needReplay()) {
+                iewStage->readyToFinish(inst);
+                iewStage->activityThisCycle();
+                inst->endPipelining();
+                DPRINTF(LoadPipeline, "Load [sn:%llu] ready to finish\n",
+                        inst->seqNum);
             }
         }
     }
 }
 
 Fault
-LSQUnit::storePipeS0(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::storeDoTranslate(const DynInstPtr &inst)
 {
     // Make sure that a store exists.
     assert(storeQueue.size() != 0);
     assert(!inst->isSquashed());
 
-    DPRINTF(LSQUnit, "StorePipeS0: Executing store PC %s [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(StorePipeline, "storeDoTranslate: Store [sn:%llu]\n", inst->seqNum);
 
     // Now initiateAcc only does TLB access
     Fault store_fault = inst->initiateAcc();
+
+    if (inst->isTranslationDelayed() && store_fault == NoFault) {
+        inst->setTLBMissReplay();
+    }
 
     return store_fault;
 }
 
 Fault
-LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
+LSQUnit::storeDoWriteSQ(const DynInstPtr &inst)
 {
     // Make sure that a store exists.
     assert(storeQueue.size() != 0);
@@ -1431,8 +1368,7 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
     ssize_t store_idx = inst->sqIdx;
     LSQRequest* request = inst->savedRequest;
 
-    DPRINTF(LSQUnit, "StorePipeS1: Executing store PC %s [sn:%lli] flags: %s\n",
-            inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(StorePipeline, "storeDoWriteSQ: Store [sn:%lli]\n", inst->seqNum);
 
     // Check the recently completed loads to see if any match this store's
     // address.  If so, then we have a memory ordering violation.
@@ -1440,10 +1376,7 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
 
     /* This is the place were instructions get the effAddr. */
     if (request && request->isTranslationComplete()) {
-        lsq->isMisaligned(inst, request);
         if (request->isMemAccessRequired() && (inst->getFault() == NoFault)) {
-            inst->effAddr = request->getVaddr();
-            inst->effAddrValid(true);
 
             if (cpu->checker) {
                 inst->reqToVerify = std::make_shared<Request>(*request->req());
@@ -1461,15 +1394,10 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
 
     Fault store_fault = inst->getFault();
 
-    if (inst->isTranslationDelayed() &&
-        store_fault == NoFault)
-        return store_fault;
-
     if (!inst->readPredicate()) {
-        DPRINTF(LSQUnit, "StorePipeS1: Store [sn:%lli] not executed from predication\n",
+        DPRINTF(StorePipeline, "Store [sn:%lli] not executed from readPredicate\n",
                 inst->seqNum);
         inst->forwardOldRegs();
-        flag[LdStFlags::readNotPredicate] = true;
         return store_fault;
     }
 
@@ -1485,9 +1413,8 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
     }
 
     if (storeQueue[store_idx].size() == 0) {
-        DPRINTF(LSQUnit, "StorePipeS1: Fault on Store PC %s, [sn:%lli], Size = 0\n",
-                inst->pcState(), inst->seqNum);
-        flag[LdStFlags::HasFault] = true;
+        DPRINTF(StorePipeline, "Store [sn:%lli] not executed from storeQueue\n",
+                inst->seqNum);
         return store_fault;
     }
 
@@ -1509,14 +1436,13 @@ LSQUnit::storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag)
 }
 
 Fault
-LSQUnit::emptyStorePipeSx(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag, uint64_t stage)
+LSQUnit::emptyStorePipeSx(const DynInstPtr &inst, uint64_t stage)
 {
     // empty store pipe stage, Does not perform any operation
     Fault fault = inst->getFault();
     assert(!inst->isSquashed());
 
-    DPRINTF(LSQUnit, "StorePipeS%d: Executing store PC %s [sn:%lli] flags: %s\n",
-            stage, inst->pcState(), inst->seqNum, getLdStFlagStr(flag));
+    DPRINTF(StorePipeline, "emptyStorePipeSx: Store [sn:%lli]\n", inst->seqNum);
     return fault;
 }
 
@@ -1529,23 +1455,27 @@ LSQUnit::executeStorePipeSx()
         auto& stage = storePipeSx[i];
         for (int j = 0; j < stage->size; j++) {
             auto& inst = stage->insts[j];
-            auto& flag = stage->flags[j];
-            if (!inst->isSquashed()) {
+            if (!inst) {
+                continue;
+            }
+
+            if (inst->isSquashed()) {
+                DPRINTF(StorePipeline, "Execute: Instruction was squashed. PC: %s, [tid:%i]"
+                    " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
+                    inst->seqNum);
+                inst->setExecuted();
+                inst->setCanCommit();
+                inst = nullptr;
+                continue;
+            }
+
+            if (!inst->replayOrSkipFollowingPipe()) {
                 switch (i) {
                     case 0:
-                        fault = storePipeS0(inst, flag);
+                        fault = storeDoTranslate(inst);
                         break;
                     case 1:
-                        fault = storePipeS1(inst, flag);
-                        if (inst->isTranslationDelayed() && fault == NoFault) {
-                            // A hw page table walk is currently going on; the
-                            // instruction must be deferred.
-                            DPRINTF(LSQUnit, "Execute: Delayed translation, deferring "
-                                    "store.\n");
-                            iewStage->deferMemInst(inst);
-                            flag[LdStFlags::Replayed] = true;
-                            continue;
-                        }
+                        fault = storeDoWriteSQ(inst);
 
                         iewStage->notifyExecuted(inst);
                         iewStage->SquashCheckAfterExe(inst);
@@ -1553,40 +1483,45 @@ LSQUnit::executeStorePipeSx()
                     case 2:
                     case 3:
                     case 4:
-                        fault = emptyStorePipeSx(inst, flag, i);
+                        fault = emptyStorePipeSx(inst, i);
                         break;
                     default:
                         panic("unsupported storepipe length");
                 }
-                if (i == (lsq->storeWbStage() - 1)) {
-                    // If the store had a fault then it may not have a mem req
-                    if (inst->fault != NoFault || !inst->readPredicate() || !inst->isStoreConditional()) {
-                        // If the instruction faulted, then we need to send it
-                        // along to commit without the instruction completing.
-                        // Send this instruction to commit, also make sure iew
-                        // stage realizes there is activity.
-                        if (!flag[LdStFlags::Replayed]) {
-                            inst->sqIt->setStatus(SplitStoreStatus::StaPipeFinish);
-                            if (!inst->isSplitStoreAddr()) {
-                                inst->sqIt->setStatus(SplitStoreStatus::StdPipeFinish);
-                            }
-                            if (inst->fault != NoFault) {
-                                inst->setExecuted();
-                                iewStage->instToCommit(inst);
-                            } else if (inst->sqIt->splitStoreFinish()) {
-                                iewStage->instToCommit(inst);
-                            }
-                            iewStage->activityThisCycle();
+            }
+
+
+            if (i == storeWhenToReplay && inst->needReplay()) [[unlikely]] {
+                if (inst->needTLBMissReplay()) iewStage->deferMemInst(inst);
+                inst->endPipelining();
+                inst = nullptr;
+                continue;
+            }
+
+            if (i == (lsq->storeWbStage() - 1)) {
+                // If the store had a fault then it may not have a mem req
+                if (inst->fault != NoFault || !inst->readPredicate() || !inst->isStoreConditional()) {
+                    // If the instruction faulted, then we need to send it
+                    // along to commit without the instruction completing.
+                    // Send this instruction to commit, also make sure iew
+                    // stage realizes there is activity.
+                    if (!inst->needReplay()) {
+                        inst->sqIt->setStatus(SplitStoreStatus::StaPipeFinish);
+                        if (!inst->isSplitStoreAddr()) {
+                            inst->sqIt->setStatus(SplitStoreStatus::StdPipeFinish);
                         }
+                        DPRINTF(StorePipeline, "Store [sn:%llu] ready to finish\n",
+                                inst->seqNum);
+                        if (inst->fault != NoFault) {
+                            inst->setExecuted();
+                            iewStage->readyToFinish(inst);
+                        } else if (inst->sqIt->splitStoreFinish()) {
+                            iewStage->readyToFinish(inst);
+                        }
+                        iewStage->activityThisCycle();
                     }
                 }
-            } else {
-                DPRINTF(LSQUnit, "Execute: Instruction was squashed. PC: %s, [tid:%i]"
-                                " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
-                                inst->seqNum);
-                inst->setExecuted();
-                inst->setCanCommit();
-                flag[LdStFlags::Squashed] = true;
+                inst->endPipelining();
             }
         }
     }
@@ -1661,7 +1596,7 @@ LSQUnit::executeAmo(const DynInstPtr &amo_inst)
             amo_inst->isAtCommit()) {
             amo_inst->setExecuted();
         }
-        iewStage->instToCommit(amo_inst);
+        iewStage->readyToFinish(amo_inst);
         iewStage->activityThisCycle();
 
         return amo_fault;
@@ -1814,7 +1749,7 @@ LSQUnit::directStoreToCache()
                     "Instantly completing it.\n",
                     inst->seqNum);
             PacketPtr new_pkt = new Packet(*request->packet());
-            WritebackEvent *wb = new WritebackEvent(inst, new_pkt, this);
+            WritebackRegEvent *wb = new WritebackRegEvent(inst, new_pkt, this);
             cpu->schedule(wb, curTick() + 1);
             completeStore(storeWBIt);
             if (!storeQueue.empty())
@@ -2268,7 +2203,7 @@ LSQUnit::storePostSend()
 }
 
 void
-LSQUnit::writeback(const DynInstPtr &inst, PacketPtr pkt)
+LSQUnit::writebackReg(const DynInstPtr &inst, PacketPtr pkt)
 {
     assert(!inst->isSplitStoreAddr());
     iewStage->wakeCPU();
@@ -2278,6 +2213,9 @@ LSQUnit::writeback(const DynInstPtr &inst, PacketPtr pkt)
         ++stats.ignoredResponses;
         return;
     }
+
+    DPRINTF(LoadPipeline, "WritebackReg: %s [sn:%lli] data: %#lx\n", enums::OpClassStrings[inst->opClass()], inst->seqNum,
+        inst->memData ? *((uint64_t *)inst->memData) : 0);
 
     if (!inst->isExecuted()) {
         inst->setExecuted();
@@ -2320,11 +2258,11 @@ LSQUnit::writeback(const DynInstPtr &inst, PacketPtr pkt)
         }
     }
 
-    // Need to insert instruction into queue to commit
-    iewStage->instToCommit(inst);
-
-    iewStage->activityThisCycle();
-
+    if (inst->isStoreConditional()) {
+        // Need to insert instruction into queue to commit
+        iewStage->readyToFinish(inst);
+        iewStage->activityThisCycle();
+    }
     // see if this load changed the PC
     iewStage->checkMisprediction(inst);
 }
@@ -2499,7 +2437,7 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
                 if (entry->recordForward(pkt->req, request)) {
                     assert(request->isSplit()); // here must be split request
                     stats.sbufferFullForward++;
-                } else if (!request->forwardPackets.empty()) {
+                } else if (!request->SBforwardPackets.empty()) {
                     stats.sbufferPartiForward++;
                 }
             }
@@ -2599,44 +2537,6 @@ LSQUnit::recvRetry()
 }
 
 void
-LSQUnit::dumpLoadPipe()
-{
-    if (GEM5_UNLIKELY(::gem5::debug::LSQUnit)) {
-        DPRINTFN("Dumping LoadPipe:\n");
-        for (int i = 0; i < loadPipeSx.size(); i++) {
-            DPRINTFN("Load S%d:, size: %d\n", i, loadPipeSx[i]->size);
-            for (int j = 0; j < loadPipeSx[i]->size; j++) {
-                DPRINTFN("  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
-                        loadPipeSx[i]->insts[j]->pcState(),
-                        loadPipeSx[i]->insts[j]->threadNumber,
-                        loadPipeSx[i]->insts[j]->seqNum,
-                        getLdStFlagStr(loadPipeSx[i]->flags[j])
-                );
-            }
-        }
-    }
-}
-
-void
-LSQUnit::dumpStorePipe()
-{
-    if (GEM5_UNLIKELY(::gem5::debug::LSQUnit)) {
-        DPRINTFN("Dumping StorePipe:\n");
-        for (int i = 0; i < storePipeSx.size(); i++) {
-            DPRINTFN("Store S%d:, size: %d\n", i, storePipeSx[i]->size);
-            for (int j = 0; j < storePipeSx[i]->size; j++) {
-                DPRINTFN("  PC: %s, [tid:%i] [sn:%lli] flags: %s\n",
-                        storePipeSx[i]->insts[j]->pcState(),
-                        storePipeSx[i]->insts[j]->threadNumber,
-                        storePipeSx[i]->insts[j]->seqNum,
-                        getLdStFlagStr(storePipeSx[i]->flags[j])
-                );
-            }
-        }
-    }
-}
-
-void
 LSQUnit::dumpInsts() const
 {
     cprintf("Load store queue: Dumping instructions.\n");
@@ -2720,25 +2620,12 @@ LSQUnit::makeFullFwdPkt(DynInstPtr load_inst, LSQRequest *request)
 }
 
 void
-LSQUnit::forwardFrmBus(DynInstPtr inst, LSQRequest *request)
+LSQUnit::forwardFromBus(DynInstPtr inst, LSQRequest *request)
 {
     // load can get it's data from data bus, actually saved in `inst->memData`
     // So there is no need to access Dcache
 
-    // forward sbuffer again
-    auto entry = storeBuffer.get(request->mainReq()->getPaddr() & cacheBlockMask);
-    if (entry) {
-        if (entry->recordForward(request->mainReq(), request)) {
-            assert(request->isSplit()); // here must be split request
-            stats.sbufferFullForward++;
-        } else {
-            stats.sbufferPartiForward++;
-        }
-    }
-    // merge forward result
-    request->forward();
-    // set as FullForwarded, writeback at load s2
-    setFlagInPipeLine(inst, LdStFlags::FullForward);
+    inst->setFullForward();
     stats.busForwardSuccess++;
 }
 
@@ -2748,7 +2635,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
     LQEntry& load_entry = loadQueue[load_idx];
     const DynInstPtr& load_inst = load_entry.instruction();
 
-    DPRINTF(LSQUnit, "request: size: %u, Addr: %#lx\n",
+    DPRINTF(LoadPipeline, "request: size: %u, Addr: %#lx\n",
             request->mainReq()->getSize(), request->mainReq()->getVaddr());
 
     Addr addr = request->mainReq()->getVaddr();
@@ -2767,10 +2654,6 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         }
     }
 
-    if (lsq->isMisaligned(load_inst, request)) {
-        return load_inst->getFault();
-    }
-
     load_entry.setRequest(request);
     assert(load_inst);
 
@@ -2785,11 +2668,12 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         // should not enter this
         // Tell IQ/mem dep unit that this instruction will need to be
         // rescheduled eventually
-        iewStage->rescheduleMemInst(load_inst);
         load_inst->effAddrValid(false);
-        setFlagInPipeLine(load_inst, LdStFlags::Replayed);
+        load_inst->setSkipFollowingPipe();
+        load_inst->setRescheduleReplay();
+        iewStage->rescheduleMemInst(load_inst);
         ++stats.rescheduledLoads;
-        DPRINTF(LSQUnit, "Strictly ordered load [sn:%lli] PC %s\n",
+        DPRINTF(LoadPipeline, "Strictly ordered load [sn:%lli] PC %s\n",
                 load_inst->seqNum, load_inst->pcState());
 
         // Must delete request now that it wasn't handed off to
@@ -2802,7 +2686,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
             load_inst->pcState());
     }
 
-    DPRINTF(LSQUnit, "Read called, load idx: %i, store idx: %i, "
+    DPRINTF(LoadPipeline, "Read called, load idx: %i, store idx: %i, "
             "storeHead: %i addr: %#x%s\n",
             load_idx - 1, load_inst->sqIt._idx, storeQueue.head() - 1,
             request->mainReq()->getPaddr(), request->isSplit() ? " split" :
@@ -2834,9 +2718,11 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
 
         Cycles delay = request->mainReq()->localAccessor(thread, main_pkt);
 
-        WritebackEvent *wb = new WritebackEvent(load_inst, main_pkt, this);
+        WritebackRegEvent *wb = new WritebackRegEvent(load_inst, main_pkt, this);
         cpu->schedule(wb, cpu->clockEdge(delay));
-        setFlagInPipeLine(load_inst, LdStFlags::LocalAccess);
+        load_inst->setSkipFollowingPipe();
+        DPRINTF(LoadPipeline, "Load [sn:%llu] local access, setSkipFollowingPipe",
+                load_inst->seqNum);
         return NoFault;
     }
 
@@ -2871,9 +2757,9 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
             bool lower_load_has_store_part = req_s < st_e;
             bool upper_load_has_store_part = req_e > st_s;
 
-            DPRINTF(LSQUnit, "req_s:%x,req_e:%x,st_s:%x,st_e:%x\n", req_s,
+            DPRINTF(LoadPipeline, "req_s:%x,req_e:%x,st_s:%x,st_e:%x\n", req_s,
                     req_e, st_s, st_e);
-            DPRINTF(LSQUnit, "store_size:%x,store_pc:%s,req_size:%x,req_pc:%s\n",
+            DPRINTF(LoadPipeline, "store_size:%x,store_pc:%s,req_size:%x,req_pc:%s\n",
                     store_size, store_it->instruction()->pcState(),
                     request->mainReq()->getSize(),
                     request->instruction()->pcState());
@@ -2894,7 +2780,9 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                     stats.forwardSTDNotReady++;
                     // insert load inst into replayQ and wait for store data to be ready
                     iewStage->stlfFailLdReplay(load_inst, store_it->instruction()->seqNum);
-                    loadReplayHelper(load_inst, request, false, false, true);
+                    loadSetReplay(load_inst, request, true);
+                    load_inst->setSTLFReplay();
+                    DPRINTF(LoadPipeline, "Load [sn:%llu] setSTLFReplay\n", load_inst->seqNum);
                     return NoFault;
                 } else {
                     coverage = store_req->isMasked()
@@ -2942,22 +2830,26 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                     load_inst->memData =
                         new uint8_t[request->mainReq()->getSize()];
                 }
-                if (store_it->isAllZeros())
-                    memset(load_inst->memData, 0,
-                            request->mainReq()->getSize());
-                else{
-                    memcpy(load_inst->memData,
-                        store_it->data() + shift_amt,
-                        request->mainReq()->getSize());
-
+                if (store_it->isAllZeros()) {
+                    for (int i=0;i<request->mainReq()->getSize();i++) {
+                        request->SQforwardPackets.push_back(
+                            LSQRequest::FWDPacket{i, 0}
+                        );
+                    }
+                }
+                else {
+                    for (int i=0;i<request->mainReq()->getSize();i++) {
+                        request->SQforwardPackets.push_back(
+                            LSQRequest::FWDPacket{i, *(uint8_t*)(store_it->data() + shift_amt + i)}
+                        );
+                    }
                 }
 
-                DPRINTF(LSQUnit, "Forwarding from store idx %i to load to "
-                        "addr %#x\n", store_it._idx,
-                        request->mainReq()->getVaddr());
+                DPRINTF(LoadPipeline, "Forwarding from store [sn:%llu] to load [sn:%llu] "
+                        "addr %#x, data: %#lx\n", store_it->instruction()->seqNum, load_inst->seqNum,
+                        request->mainReq()->getPaddr(), *((uint64_t*)load_inst->memData));
 
-                // set FullForward flag, then this load will be written back at s2
-                setFlagInPipeLine(load_inst, LdStFlags::FullForward);
+                load_inst->setFullForward();
 
                 // Don't need to do anything special for split loads.
                 ++stats.forwLoads;
@@ -2985,14 +2877,14 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
 
                 // Tell IQ/mem dep unit that this instruction will need to be
                 // rescheduled eventually
-                iewStage->rescheduleMemInst(load_inst);
                 load_inst->effAddrValid(false);
-                setFlagInPipeLine(load_inst, LdStFlags::Replayed);
+                load_inst->setRescheduleReplay();
+                iewStage->rescheduleMemInst(load_inst);
                 ++stats.rescheduledLoads;
 
                 // Do not generate a writeback event as this instruction is not
                 // complete.
-                DPRINTF(LSQUnit, "Load-store forwarding mis-match. "
+                DPRINTF(LoadPipeline, "Load-store forwarding mis-match. "
                         "Store idx %i to load addr %#x\n",
                         store_it._idx, request->mainReq()->getVaddr());
 
@@ -3018,22 +2910,14 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                     load_inst->memData = new uint8_t[request->mainReq()->getSize()];
                 }
 
-                request->forward();
-
-                // set FullForward flag, then this load will be written back at s2
-                setFlagInPipeLine(load_inst, LdStFlags::FullForward);
+                load_inst->setFullForward();
+                DPRINTF(LoadPipeline, "Load [sn:%llu] forward from sbuffer, data: %lx\n",
+                        load_inst->seqNum, *((uint64_t*)load_inst->memData));
 
                 return NoFault;
             }
-            // if not fully forward, need to clear buffer
-            request->forwardPackets.clear();
         }
     }
-
-
-    // If there's no forwarding case, then go access memory
-    DPRINTF(LSQUnit, "Doing memory access for inst [sn:%lli] PC %s\n",
-            load_inst->seqNum, load_inst->pcState());
 
     // Allocate memory if this is the first time a load is issued.
     if (!load_inst->memData) {
@@ -3061,26 +2945,27 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         // Load has been waken up too early, TimingResp is not present now
         // try waiting TimingResp and forward bus again at load s2
         assert(request->isLoad());
-        setFlagInPipeLine(load_inst, LdStFlags::WakeUpEarly);
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setWakeUpEarly\n", load_inst->seqNum);
+        load_inst->setWakeUpEarly();
     } else if (busFwdSuccess) {
-        DPRINTF(LSQUnit, "[sn:%ld]: Forward from bus at load s1, data: %lx\n",
-                load_inst->seqNum, *((uint64_t*)(load_inst->memData)));
+        DPRINTF(LoadPipeline, "Load [sn:%ld]: Forward from bus, data: %lx\n",
+                load_inst->seqNum, *((uint64_t*)load_inst->memData));
         panic_if(bus.size() > lsq->getLQEntries(), "packets on bus should never be greater than LQ size");
         for (auto ele : bus) {
             DPRINTF(LSQUnit, " bus:[sn:%ld], paddr:%lx\n", ele.first, ele.second);
         }
         // this load can forward data from bus
-        forwardFrmBus(load_inst, request);
+        forwardFromBus(load_inst, request);
     } else {
+        DPRINTF(LoadPipeline, "Load [sn:%llu] sendPacketToCache\n", load_inst->seqNum);
         // if cannot forward from bus, do real cache access
         request->buildPackets();
         // if the cache is not blocked, do cache access
-        if (!request->sendPacketToCache()) {
-            iewStage->loadCancel(load_inst);
-        }
-        if (!request->isSent()) {
+        request->sendPacketToCache();
+        if (!request->isSent() && !load_inst->needBankConflicyReplay()) {
             iewStage->blockMemInst(load_inst);
-            setFlagInPipeLine(load_inst, LdStFlags::Replayed);
+            load_inst->setCacheBlockedReplay();
+            DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheBlockedReplay\n", load_inst->seqNum);
         }
     }
 
@@ -3093,7 +2978,7 @@ LSQUnit::write(LSQRequest *request, uint8_t *data, ssize_t store_idx)
     auto &entry = storeQueue[store_idx];
     assert(entry.valid());
 
-    DPRINTF(LSQUnit, "Doing write to store idx %i, addr %#x | storeHead:%i, size: %d"
+    DPRINTF(StorePipeline, "Doing write to store idx %i, addr %#x | storeHead:%i, size: %d"
             "[sn:%llu]\n",
             store_idx - 1, request->req()->getPaddr(), storeQueue.head() - 1, request->_size,
             entry.instruction()->seqNum);
@@ -3111,7 +2996,6 @@ LSQUnit::write(LSQRequest *request, uint8_t *data, ssize_t store_idx)
         !request->req()->isAtomic() && !entry.instruction()->isSplitStoreAddr()) {
         memcpy(entry.data(), data, size);
     }
-
 
     // This function only writes the data to the store queue, so no fault
     // can happen here.

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1333,7 +1333,7 @@ LSQUnit::executeLoadPipeSx()
             }
 
             if (i == loadPipeStages - 1 && !inst->needReplay()) {
-                iewStage->readyToFinish(inst);
+                if (inst->savedRequest->isNormalLd()) iewStage->readyToFinish(inst);
                 iewStage->activityThisCycle();
                 inst->endPipelining();
                 DPRINTF(LoadPipeline, "Load [sn:%llu] ready to finish\n",

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2673,6 +2673,14 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         }
     }
 
+    if (load_inst->getFault() != NoFault) {
+        // If the instruction has an outstanding fault, we cannot complete
+        // the access as this discards the current fault.
+        DPRINTF(LoadPipeline, "Not completing instruction [sn:%lli] access "
+                "due to pending fault.\n", load_inst->seqNum);
+        return load_inst->getFault();
+    }
+
     load_entry.setRequest(request);
     assert(load_inst);
 

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2688,6 +2688,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         // Tell IQ/mem dep unit that this instruction will need to be
         // rescheduled eventually
         load_inst->effAddrValid(false);
+        load_inst->setCanCommit();
         load_inst->setSkipFollowingPipe();
         load_inst->setRescheduleReplay();
         iewStage->rescheduleMemInst(load_inst);

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -68,6 +68,7 @@
 #include "cpu/timebuf.hh"
 #include "debug/HtmCpu.hh"
 #include "debug/LSQUnit.hh"
+#include "debug/LoadPipeline.hh"
 #include "mem/packet.hh"
 #include "mem/port.hh"
 
@@ -288,6 +289,13 @@ class LSQUnit
     const int maxSQoffload = 2;
     const int sqFullBufferSize = 4;
 
+    // loadpipe
+    const int loadPipeStages = 4;
+    const int loadWhenToReplay = 3;
+    // stapipe
+    const int storePipeStages = 4;
+    const int storeWhenToReplay = 2;
+
     int sqFullUpperLimit = 0;
     int sqFullLowerLimit = 0;
     bool storeBufferFlushing = false;
@@ -369,8 +377,7 @@ class LSQUnit
      * @param fastReplay insert to replayQ
      * @param dropReqNow call request->discard() now
      */
-    void loadReplayHelper(DynInstPtr inst, LSQRequest* request, bool cacheMiss,
-            bool fastReplay, bool dropReqNow);
+    void loadSetReplay(DynInstPtr inst, LSQRequest* request, bool dropReqNow);
 
     /** Check if an incoming invalidate hits in the lsq on a load
      * that might have issued out of order wrt another load beacuse
@@ -426,9 +433,6 @@ class LSQUnit
 
     /** Returns the memory ordering violator. */
     DynInstPtr getMemDepViolator();
-
-    /** Check if store should skip this raw violation because of nuke replay. */
-    bool skipNukeReplay(const DynInstPtr& load_inst);
 
     /** Check if there exists raw nuke between load and store. */
     bool pipeLineNukeCheck(const DynInstPtr &load_inst, const DynInstPtr &store_inst);
@@ -494,19 +498,6 @@ class LSQUnit
     /** Returns the number of stores to writeback. */
     int numStoresToSbuffer() { return storesToWB; }
 
-    /** get description string from load/store pipeLine flag. */
-    std::string getLdStFlagStr(const std::bitset<LdStFlagNum>& flag)
-    {
-        std::string res{};
-        for (int i = 0; i < LdStFlagNum; i++) {
-            if (flag.test(i)) {
-                res += LdStFlagName[i] + ": [1] ";
-            } else {
-                res += LdStFlagName[i] + ": [0] ";
-            }
-        }
-        return res;
-    }
 
     LSQ* getLsq() { return lsq; }
 
@@ -533,7 +524,7 @@ class LSQUnit
     void resetState();
 
     /** Writes back the instruction, sending it to IEW. */
-    void writeback(const DynInstPtr &inst, PacketPtr pkt);
+    void writebackReg(const DynInstPtr &inst, PacketPtr pkt);
 
     /** Try to finish a previously blocked write back attempt */
     void writebackBlockedStore();
@@ -557,11 +548,9 @@ class LSQUnit
 
     bool sbufferSendPacket(PacketPtr data_pkt);
 
-    /** Debugging function to dump instructions in the LoadPipe. */
-    void dumpLoadPipe();
+    bool forwardFromStoreBuffer(const DynInstPtr& inst);
 
-    /** Debugging function to dump instructions in the storePipe. */
-    void dumpStorePipe();
+    bool forwardFromStoreQueue(const DynInstPtr& inst);
 
     /** Debugging function to dump instructions in the LSQ. */
     void dumpInsts() const;
@@ -580,10 +569,10 @@ class LSQUnit
      * - stage2: Analyze the flag and try to send the inst to commit.
      * - stage3: now just return fault and do nothing.
      */
-    Fault loadPipeS0(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault loadPipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault loadPipeS2(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault loadPipeS3(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
+    Fault loadDoTranslate(const DynInstPtr &inst);
+    Fault loadDoSendRequest(const DynInstPtr &inst);
+    Fault loadDoRecvData(const DynInstPtr &inst);
+    Fault loadDoWriteback(const DynInstPtr &inst);
 
     /** Process instructions in each store pipeline stages. */
     void executeStorePipeSx();
@@ -592,9 +581,9 @@ class LSQUnit
      * - stage0: access TLB
      * - stage1: save data to store queue, check load violations, set memDepViolator
      */
-    Fault storePipeS0(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault storePipeS1(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag);
-    Fault emptyStorePipeSx(const DynInstPtr &inst, std::bitset<LdStFlagNum> &flag, uint64_t stage);
+    Fault storeDoTranslate(const DynInstPtr &inst);
+    Fault storeDoWriteSQ(const DynInstPtr &inst);
+    Fault emptyStorePipeSx(const DynInstPtr &inst, uint64_t stage);
 
     /** Wrap function. */
     void executePipeSx();
@@ -620,11 +609,11 @@ class LSQUnit
     RequestPort *dcachePort;
 
     /** Writeback event, specifically for when stores forward data to loads. */
-    class WritebackEvent : public Event
+    class WritebackRegEvent : public Event
     {
       public:
         /** Constructs a writeback event. */
-        WritebackEvent(const DynInstPtr &_inst, PacketPtr pkt,
+        WritebackRegEvent(const DynInstPtr &_inst, PacketPtr pkt,
                 LSQUnit *lsq_ptr);
 
         /** Processes the writeback event. */
@@ -695,34 +684,33 @@ class LSQUnit
     /** The load queue. */
     LoadQueue loadQueue;
 
+    const static int MaxPipeWidth = 4;
+
     /** Struct that defines the information passed through Load Pipeline. */
     struct LoadPipeStruct
     {
         int size;
 
-        DynInstPtr insts[MaxWidth];
-        std::bitset<LdStFlagNum> flags[MaxWidth];
+        DynInstPtr insts[MaxPipeWidth];
     };
-    /** The load pipeline TimeBuffer. */
-    TimeBuffer<LoadPipeStruct> loadPipe;
-    /** Each stage in load pipeline. loadPipeSx[0] means load pipe S0 */
-    std::vector<TimeBuffer<LoadPipeStruct>::wire> loadPipeSx;
-
     /** Struct that defines the information passed through Store Pipeline. */
     struct StorePipeStruct
     {
         int size;
 
-        DynInstPtr insts[MaxWidth];
-        std::bitset<LdStFlagNum> flags[MaxWidth];
+        DynInstPtr insts[MaxPipeWidth];
     };
+
+
+    /** The load pipeline TimeBuffer. */
+    TimeBuffer<LoadPipeStruct> loadPipe;
+    /** Each stage in load pipeline. loadPipeSx[0] means load pipe S0 */
+    std::vector<TimeBuffer<LoadPipeStruct>::wire> loadPipeSx;
+
     /** The store pipeline TimeBuffer. */
     TimeBuffer<StorePipeStruct> storePipe;
     /** Each stage in store pipeline. storePipeSx[0] means store pipe S0 */
     std::vector<TimeBuffer<StorePipeStruct>::wire> storePipeSx;
-
-    /** Find inst in Load/Store Pipeline, set corresponding flag to true */
-    void setFlagInPipeLine(DynInstPtr inst, LdStFlags f);
 
   private:
     /** The number of places to shift addresses in the LSQ before checking
@@ -864,7 +852,7 @@ class LSQUnit
 
   public:
     /** Load Forwards data from Data bus. */
-    void forwardFrmBus(DynInstPtr inst, LSQRequest *request);
+    void forwardFromBus(DynInstPtr inst, LSQRequest *request);
 
     /** Executes the load at the given index. */
     Fault read(LSQRequest *request, ssize_t load_idx);

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -79,7 +79,7 @@ namespace gem5
 {
 
 BaseCache::SendTimingRespEvent::SendTimingRespEvent(BaseCache* cache, PacketPtr pkt)
-    : Event(Stat_Event_Pri, AutoDelete),
+    : Event(Delayed_Writeback_Pri, AutoDelete),
       cache(cache),
       pkt(pkt) {}
 
@@ -411,7 +411,7 @@ BaseCache::handleTimingReqHit(PacketPtr pkt, CacheBlk *blk, Tick request_time, b
         DPRINTF(Cache, "In handle timing hit, pkt has data: %i\n", pkt->hasData());
         if (cacheLevel == 1) {
             // load pipe shoud have fixed delay
-            this->schedule(new SendTimingRespEvent(this, pkt), request_time - 1);
+            this->schedule(new SendTimingRespEvent(this, pkt), request_time);
         }
         else {
             cpuSidePort.schedTimingResp(pkt, request_time);
@@ -700,8 +700,6 @@ BaseCache::recvTimingReq(PacketPtr pkt)
 
         handleTimingReqHit(pkt, blk, request_time, first_acc_after_pf);
         if (cacheLevel == 1 && pkt->isResponse() && pkt->isRead() && !pkt->isWrite() && lat > 1) {
-            // cache block not ready, send cancel signal
-            cpuSidePort.sendCustomSignal(pkt, DcacheRespType::Block_Not_Ready);
             pkt->cacheSatisfied = false;
         }
     } else {
@@ -709,8 +707,6 @@ BaseCache::recvTimingReq(PacketPtr pkt)
             calculateSliceBusy(pkt);
         }
         if (cacheLevel == 1 && pkt->needsResponse() && pkt->isRead() && !pkt->isWrite()) {
-            // send cache miss signal
-            cpuSidePort.sendCustomSignal(pkt, DcacheRespType::Miss);
             pkt->cacheSatisfied = false;
         }
 


### PR DESCRIPTION
When a translation request enters the PTW, it checks whether the corresponding address is valid. If the address cannot be translated, an appropriate exception is returned directly without allocating a walker state in the PTW.
@jensen-yan @Ergou-ren This PR might fix the bug you're currently encountering. You can try cherry-picking it to see if it helps.