### PR TITLE
riscv-vector: Fix vset by aligning to NEMU

### DIFF
--- a/src/arch/riscv/isa/vector/simple/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_conf.isa
@@ -115,7 +115,7 @@ def template VConfExecute {{
             uint32_t new_vill =
                 !(vflmul >= 0.125 && vflmul <= 8) ||
                 sew > std::min(vflmul, 1.0f) * ELEN ||
-                bits(requested_vtype, 30, 8) != 0;
+                (requested_vtype >> 8) != 0;
 
             if (new_vill) {
                 vlmax = 0;


### PR DESCRIPTION
Align to OpenXiangShan/NEMU:
src/isa/riscv64/instr/rvv/vcommon.c, line 47:
```
  int vill = !(vflmul >= 0.125 && vflmul <= 8)
           || vsew > min_vflmul * 64
           || (vtype_req >> 8) != 0
           || vsew > 64;
```
and rvv doc, chapter 6.1.1 :

https://github.com/riscvarchive/riscv-v-spec/blob/master/v-spec.adoc

> If the vtype value is not supported by the implementation, then the vill bit is set in vtype, the remaining bits in vtype are set to zero, and the vl register is also set to zero.