### PR TITLE
cpu-o3: add bypass BPU fetch after squash

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -375,6 +375,7 @@ def setKmhV3IdealParams(args, system):
                 cpu.branchPred.tage.tableSizes = [2048] * 14
             else:
                 cpu.branchPred.predictWidth = 64              # max width of a fetch block
+                cpu.branchPred.enableBypassBpuFetch = True  # enable bypass bpu fetch
                 cpu.branchPred.btb.numEntries = 16384
                 # TODO: BTB TAGE do not bave base table, do not support SC
                 cpu.branchPred.tage.tableSizes = [2048] * 14  # 2ways, 2048 sets

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1154,3 +1154,4 @@ class DecoupledBPUWithBTB(BranchPredictor):
     enableLoopBuffer = Param.Bool(False, "Enable loop buffer to supply inst for loops")
     enableLoopPredictor = Param.Bool(False, "Use loop predictor to predict loop exit")
     enableJumpAheadPredictor = Param.Bool(False, "Use jump ahead predictor to skip no-need-to-predict blocks")
+    enableBypassBpuFetch = Param.Bool(True, "enable bypass BPU fetch after squash")

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -25,6 +25,7 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       enableLoopBuffer(p.enableLoopBuffer),
       enableLoopPredictor(p.enableLoopPredictor),
       enableJumpAheadPredictor(p.enableJumpAheadPredictor),
+      enableBypassBpuFetch(p.enableBypassBpuFetch),
       fetchTargetQueue(p.ftq_size),
       fetchStreamQueueSize(p.fsq_size),
       predictWidth(p.predictWidth),
@@ -556,9 +557,13 @@ void
 DecoupledBPUWithBTB::tick()
 {
     // 2. Handle pending prediction if available
-    if (!receivedPred && numOverrideBubbles == 0 && sentPCHist) {
+    if (!receivedPred && prevNumOverrideBubbles == 0 && sentPCHist) {
         DPRINTF(Override, "Generating final prediction for PC %#lx\n", s0PC);
         generateFinalPredAndCreateBubbles();
+    }
+    if(enableBypassBpuFetch && squashing){
+        numOverrideBubbles = 0;
+        prevNumOverrideBubbles = 0;
     }
 
     // 3. Process enqueue operations and bubble counter
@@ -584,18 +589,23 @@ DecoupledBPUWithBTB::processEnqueueAndBubbles()
     // Try to enqueue new predictions if not squashing
     if (!squashing) {
         DPRINTF(Override, "DecoupledBPUWithBTB::tick()\n");
-        tryEnqFetchTarget();
-        tryEnqFetchStream();
+        if(enableBypassBpuFetch){
+            tryEnqFetchStream();
+            tryEnqFetchTarget();
+        }else{
+            tryEnqFetchTarget();
+            tryEnqFetchStream();
+        }
     } else {
         receivedPred = false;
         DPRINTF(Override, "Squashing, skip this cycle, receivedPred is %d.\n", receivedPred);
     }
 
     // Decrement override bubbles counter
-    if (numOverrideBubbles > 0) {
-        numOverrideBubbles--;
+    if (prevNumOverrideBubbles > 0) {
+        prevNumOverrideBubbles--;
         dbpBtbStats.overrideBubbleNum++;
-        DPRINTF(Override, "Consuming override bubble, %d remaining\n", numOverrideBubbles);
+        DPRINTF(Override, "Consuming override bubble, %d remaining\n", prevNumOverrideBubbles);
     }
 
     sentPCHist = false;
@@ -703,7 +713,11 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
     }
 
     // 4. Record override bubbles and update statistics
+    prevNumOverrideBubbles = numOverrideBubbles;
     numOverrideBubbles = first_hit_stage;
+    if(!enableBypassBpuFetch){
+        prevNumOverrideBubbles = numOverrideBubbles;
+    }
     if (numOverrideBubbles > 0) {
         dbpBtbStats.overrideCount++;
     }
@@ -1563,8 +1577,8 @@ DecoupledBPUWithBTB::validateFSQEnqueue()
 
     // 3. Check for override bubbles
     // When higher stages override lower stages, bubbles are needed for pipeline consistency
-    if (numOverrideBubbles > 0) {
-        DPRINTF(Override, "Waiting for %u override bubbles before enqueuing\n", numOverrideBubbles);
+    if (prevNumOverrideBubbles > 0) {
+        DPRINTF(Override, "Waiting for %u override bubbles before enqueuing\n", prevNumOverrideBubbles);
         return false;
     }
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -78,6 +78,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     JumpAheadPredictor jap;
     bool enableJumpAheadPredictor{false};
+    bool enableBypassBpuFetch{false};
 
   private:
     std::string _name;
@@ -158,6 +159,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     HistoryManager historyManager;
 
     unsigned numOverrideBubbles{0};
+    unsigned prevNumOverrideBubbles{0};
 
 
     using JAInfo = JumpAheadPredictor::JAInfo;


### PR DESCRIPTION
- Introduced a new parameter `enableBypassBpuFetch`
- Updated the `DecoupledBPUWithBTB` class to handle the new bypass logic in the tick and enqueue processes.
- Adjusted the handling of override bubbles to accommodate the new feature.