### PR TITLE
arch-riscv: CSR_TIME can be accessed now

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -366,13 +366,6 @@ def template CSRExecute {{
             }
             break;
           }
-          case CSR_TIME: {
-                std::string error = csprintf(
-                    "force accessing to time CSR generate fault\n");
-                olddata = 0;
-                return std::make_shared<IllegalInstFault>(error, machInst);
-                break;
-          }
           default:
             break;
         }


### PR DESCRIPTION
NEMU can access CSR_TIME in configs/riscv64-gem5-ref_defconfig: https://github.com/OpenXiangShan/NEMU/blob/caa9c8aa82d90ea5e6095383140a355ea08e52cc/configs/riscv64-gem5-ref_defconfig#L38

So GEM5 should not report illegal Instruction fault now

Change-Id: Ic1d5d4390b4cde14811dbb0cdd897a449d8d96b8