### PR TITLE
cpu-o3: Add new cache request status  while maintain backward-compati…

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -309,7 +309,6 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             {Blocked, "Blocked"},
             {Fetching, "Fetching"},
             {TrapPending, "TrapPending"},
-            {QuiescePending, "QuiescePending"},
             {ItlbWait, "ItlbWait"},
             {IcacheWaitResponse, "IcacheWaitResponse"},
             {IcacheWaitRetry, "IcacheWaitRetry"},
@@ -577,6 +576,7 @@ Fetch::processCacheCompletion(PacketPtr pkt)
         return;
     }
 
+    // Check state consistency between old and new systems
     if (fetchStatus[tid] != IcacheWaitResponse && fetchStatus[tid] != ItlbWait) {
         DPRINTF(Fetch, "[tid:%i] Invalid fetch state or request\n", tid);
         ++fetchStats.icacheSquashes;
@@ -626,12 +626,25 @@ Fetch::processCacheCompletion(PacketPtr pkt)
 
     switchToActive();
 
+    // Update cache request status to reflect completion
+    if (cacheReq[tid].allReady()) {
+        // All cache requests are complete, mark overall status as complete
+        for (size_t i = 0; i < cacheReq[tid].requestStatus.size(); ++i) {
+            if (cacheReq[tid].requestStatus[i] == CacheWaitResponse) {
+                cacheReq[tid].updateRequestStatus(i, AccessComplete);
+            }
+        }
+    }
+
     // Only switch to IcacheAccessComplete if we're not stalled as well.
     if (checkStall(tid)) {
         fetchStatus[tid] = Blocked;
     } else {
         fetchStatus[tid] = IcacheAccessComplete;
     }
+
+    // Ensure state consistency between new and old systems
+    updateLegacyFetchStatus(tid);
 }
 
 void
@@ -885,6 +898,14 @@ Fetch::handleSuccessfulTranslation(ThreadID tid, const RequestPtr &mem_req, Addr
     if (!cpu->system->isMemAddr(mem_req->getPaddr())) {
         DPRINTF(Fetch, "Address %#x is outside of physical memory, stopping fetch, %lu\n",
                 mem_req->getPaddr(), curTick());
+
+        // Update new cache request status system
+        size_t reqIndex = cacheReq[tid].findRequestIndex(mem_req);
+        if (reqIndex != SIZE_MAX) {
+            cacheReq[tid].markRequestFailed(reqIndex);
+        }
+
+        // Update legacy status for backward compatibility
         fetchStatus[tid] = NoGoodAddr;
         setAllFetchStalls(StallReason::OtherFetchStall);
         cacheReq[tid].reset();
@@ -906,10 +927,19 @@ Fetch::handleSuccessfulTranslation(ThreadID tid, const RequestPtr &mem_req, Addr
 
     fetchStats.cacheLines++;
 
+    // Find the cache request index for status tracking
+    size_t reqIndex = cacheReq[tid].findRequestIndex(mem_req);
+
     // Access the cache.
     if (!icachePort.sendTimingReq(data_pkt)) {
         DPRINTF(Fetch, "[tid:%i] Out of MSHRs!\n", tid);
 
+        // Update new cache request status system
+        if (reqIndex != SIZE_MAX) {
+            cacheReq[tid].updateRequestStatus(reqIndex, CacheWaitRetry);
+        }
+
+        // Update legacy status for backward compatibility
         fetchStatus[tid] = IcacheWaitRetry;
         data_pkt->setRetriedPkt();
         DPRINTF(Fetch, "[tid:%i] mem_req.addr=%#lx needs retry.\n", tid,
@@ -922,6 +952,13 @@ Fetch::handleSuccessfulTranslation(ThreadID tid, const RequestPtr &mem_req, Addr
         DPRINTF(Fetch, "[tid:%i] Doing Icache access.\n", tid);
         DPRINTF(Activity, "[tid:%i] Activity: Waiting on I-cache response.\n", tid);
         lastIcacheStall[tid] = curTick();
+
+        // Update new cache request status system
+        if (reqIndex != SIZE_MAX) {
+            cacheReq[tid].updateRequestStatus(reqIndex, CacheWaitResponse);
+        }
+
+        // Update legacy status for backward compatibility
         fetchStatus[tid] = IcacheWaitResponse;
         setAllFetchStalls(StallReason::IcacheStall);
         // Notify Fetch Request probe when a packet containing a fetch request is successfully sent
@@ -950,6 +987,12 @@ Fetch::handleTranslationFault(ThreadID tid, const RequestPtr &mem_req, const Fau
 
     DPRINTF(Fetch, "[tid:%i] Got back req with addr %#x but expected base addr %#x\n",
             tid, mem_req->getVaddr(), cacheReq[tid].baseAddr);
+
+    // Update new cache request status system
+    size_t reqIndex = cacheReq[tid].findRequestIndex(mem_req);
+    if (reqIndex != SIZE_MAX) {
+        cacheReq[tid].markRequestFailed(reqIndex);
+    }
 
     // Translation faulted, icache request won't be sent.
     cacheReq[tid].reset();
@@ -1014,6 +1057,9 @@ Fetch::finishTranslation(const Fault &fault, const RequestPtr &mem_req)
         handleTranslationFault(tid, mem_req, fault);
     }
 
+    // Update legacy fetch status based on new cache request state
+    updateLegacyFetchStatus(tid);
+
     _status = updateFetchStatus();
 }
 
@@ -1058,6 +1104,13 @@ Fetch::doSquash(PCStateBase &new_pc, const DynInstPtr squashInst, const InstSeqN
 
     // Clear the icache miss if it's outstanding.
     DPRINTF(Fetch, "[tid:%i] Squash: clear cacheReq, current fetchStatus[tid]=%d\n", tid, fetchStatus[tid]);
+
+    // Cancel all active cache requests in new status system
+    cacheReq[tid].cancelAllRequests();
+    DPRINTF(Fetch, "[tid:%i] Squash: cancelled all cache requests, status: %s\n",
+            tid, cacheReq[tid].getStatusSummary().c_str());
+
+    // Reset the cache request after cancelling
     cacheReq[tid].reset();
 
     // Get rid of the retrying packet if it was from this thread.
@@ -1635,8 +1688,7 @@ Fetch::checkSignalsAndUpdate(ThreadID tid)
     if (checkStall(tid) &&
         fetchStatus[tid] != IcacheWaitResponse &&
         fetchStatus[tid] != IcacheWaitRetry &&
-        fetchStatus[tid] != ItlbWait &&
-        fetchStatus[tid] != QuiescePending) {
+        fetchStatus[tid] != ItlbWait) {
         DPRINTF(Fetch, "[tid:%i] Setting to blocked\n",tid);
 
         fetchStatus[tid] = Blocked;
@@ -2360,10 +2412,6 @@ Fetch::profileStall(ThreadID tid)
         ++fetchStats.pendingTrapStallCycles;
         DPRINTF(Fetch, "[tid:%i] Fetch is waiting for a pending trap!\n",
                 tid);
-    } else if (fetchStatus[tid] == QuiescePending) {
-        ++fetchStats.pendingQuiesceStallCycles;
-        DPRINTF(Fetch, "[tid:%i] Fetch is waiting for a pending quiesce "
-                "instruction!\n", tid);
     } else if (fetchStatus[tid] == IcacheWaitRetry) {
         ++fetchStats.icacheWaitRetryStallCycles;
         DPRINTF(Fetch, "[tid:%i] Fetch is waiting for an I-cache retry!\n",
@@ -2431,6 +2479,143 @@ void
 Fetch::IcachePort::recvReqRetry()
 {
     fetch->recvReqRetry();
+}
+
+Fetch::ThreadStatus
+Fetch::mapCacheStatusToThreadStatus(const CacheRequest& req)
+{
+    // Map the new cache request status to legacy thread status
+    CacheRequestStatus overallStatus = req.getOverallStatus();
+
+    switch (overallStatus) {
+        case CacheIdle:
+            return Running;  // No cache activity, can continue fetch
+
+        case TlbWait:
+            return ItlbWait;  // Waiting for TLB translation
+
+        case CacheWaitResponse:
+            return IcacheWaitResponse;  // Waiting for cache response
+
+        case CacheWaitRetry:
+            return IcacheWaitRetry;  // Waiting for cache retry
+
+        case AccessComplete:
+            return IcacheAccessComplete;  // Cache access completed
+
+        case AccessFailed:
+            return NoGoodAddr;  // Access failed, invalid address
+
+        case Cancelled:
+            return Running;  // Cancelled requests allow normal operation
+
+        default:
+            DPRINTF(Fetch, "Unknown cache request status: %d\n", overallStatus);
+            return Running;  // Default to Running for unknown states
+    }
+}
+
+void
+Fetch::updateLegacyFetchStatus(ThreadID tid)
+{
+    // Update legacy fetchStatus based on new cache request state
+    Fetch::ThreadStatus cacheStatus = mapCacheStatusToThreadStatus(cacheReq[tid]);
+
+    // Only update if we're not in a higher priority state like Squashing or Blocked
+    if (fetchStatus[tid] != Squashing && fetchStatus[tid] != Blocked &&
+        fetchStatus[tid] != TrapPending) {
+
+        // Update to cache-derived status
+        fetchStatus[tid] = cacheStatus;
+
+        DPRINTF(Fetch, "[tid:%i] updateLegacyFetchStatus: Updated from cache state to %d (%s)\n",
+                tid, fetchStatus[tid],
+                cacheStatus == Running ? "Running" :
+                cacheStatus == ItlbWait ? "ItlbWait" :
+                cacheStatus == IcacheWaitResponse ? "IcacheWaitResponse" :
+                cacheStatus == IcacheWaitRetry ? "IcacheWaitRetry" :
+                cacheStatus == IcacheAccessComplete ? "IcacheAccessComplete" :
+                cacheStatus == NoGoodAddr ? "NoGoodAddr" : "Unknown");
+    } else {
+        DPRINTF(Fetch, "[tid:%i] updateLegacyFetchStatus: Keeping priority status %d\n",
+                tid, fetchStatus[tid]);
+    }
+}
+
+Fetch::ThreadStatus
+Fetch::getEffectiveThreadStatus(ThreadID tid)
+{
+    // Get the effective thread status considering both systems
+
+    // High priority states from legacy system take precedence
+    if (fetchStatus[tid] == Squashing || fetchStatus[tid] == Blocked ||
+        fetchStatus[tid] == TrapPending) {
+        return fetchStatus[tid];
+    }
+
+    // For normal operation, consider cache request state
+    if (cacheReq[tid].hasActiveRequests()) {
+        return mapCacheStatusToThreadStatus(cacheReq[tid]);
+    }
+
+    // Default to current legacy status
+    return fetchStatus[tid];
+}
+
+bool
+Fetch::canFetchInstructions(ThreadID tid) const
+{
+    // Check if the thread can fetch instructions based on comprehensive state
+
+    // Cannot fetch if in high priority blocking states
+    if (fetchStatus[tid] == Squashing || fetchStatus[tid] == Blocked ||
+        fetchStatus[tid] == TrapPending) {
+        return false;
+    }
+
+    // Cannot fetch if thread is idle or not in active threads list
+    if (fetchStatus[tid] == Idle) {
+        return false;
+    }
+
+    // Check cache-related constraints
+    if (cacheReq[tid].anyFailed()) {
+        return false;  // Cannot fetch if cache requests failed
+    }
+
+    // Can fetch if no active cache requests or if cache access is complete
+    if (!cacheReq[tid].hasActiveRequests() || cacheReq[tid].allReady()) {
+        return true;
+    }
+
+    // Cannot fetch if actively waiting for cache
+    return false;
+}
+
+bool
+Fetch::hasPendingCacheRequests(ThreadID tid) const
+{
+    return cacheReq[tid].hasActiveRequests();
+}
+
+bool
+Fetch::isWaitingForCache(ThreadID tid) const
+{
+    // Check if waiting for cache based on new state system
+    CacheRequestStatus overallStatus = cacheReq[tid].getOverallStatus();
+
+    return (overallStatus == TlbWait ||
+            overallStatus == CacheWaitResponse ||
+            overallStatus == CacheWaitRetry);
+}
+
+bool
+Fetch::isThreadRunning(ThreadID tid) const
+{
+    // Check if thread is in running state (not blocked by high priority conditions)
+    return (fetchStatus[tid] == Running || fetchStatus[tid] == Fetching ||
+            fetchStatus[tid] == IcacheAccessComplete) &&
+           !checkStall(tid);
 }
 
 } // namespace o3

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -182,13 +182,27 @@ class Fetch
         Blocked,
         Fetching,
         TrapPending,
-        QuiescePending,
         ItlbWait,
         IcacheWaitResponse,
         IcacheWaitRetry,
         IcacheAccessComplete,
         NoGoodAddr,
         NumFetchStatus
+    };
+
+    /** Cache request status for new state management system.
+     * Manages the lifecycle of individual cache access requests.
+     */
+    enum CacheRequestStatus
+    {
+        CacheIdle,              // No active request
+        TlbWait,               // Waiting for TLB translation completion
+        CacheWaitResponse,     // Waiting for cache data return
+        CacheWaitRetry,        // Waiting for cache retry opportunity
+        AccessComplete,        // Access completed, data available
+        AccessFailed,          // Access failed (invalid address etc.)
+        Cancelled,             // Request cancelled (squash etc.)
+        NumCacheRequestStatus
     };
 
   private:
@@ -724,6 +738,9 @@ class Fetch
         /** Vector of corresponding request pointers */
         std::vector<RequestPtr> requests;
 
+        /** Vector of status for each cache request (NEW) */
+        std::vector<CacheRequestStatus> requestStatus;
+
         /** Base address of the fetch request */
         Addr baseAddr;
 
@@ -741,10 +758,71 @@ class Fetch
             return completedPackets >= packets.size() && packets.size() > 0;
         }
 
+        /** Check if any request has failed (NEW) */
+        bool anyFailed() const {
+            for (const auto& status : requestStatus) {
+                if (status == AccessFailed) return true;
+            }
+            return false;
+        }
+
+        /** Check if all requests are ready for processing (NEW) */
+        bool allReady() const {
+            if (requestStatus.empty()) return false;
+            for (const auto& status : requestStatus) {
+                if (status != AccessComplete) return false;
+            }
+            return true;
+        }
+
+        /** Check if there are any active requests (NEW) */
+        bool hasActiveRequests() const {
+            for (const auto& status : requestStatus) {
+                if (status != CacheIdle && status != AccessComplete &&
+                    status != AccessFailed && status != Cancelled) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /** Get overall status of the cache request group (NEW) */
+        CacheRequestStatus getOverallStatus() const {
+            if (requestStatus.empty()) return CacheIdle;
+
+            bool hasActive = false;
+            bool hasCompleted = false;
+            bool hasFailed = false;
+
+            for (const auto& status : requestStatus) {
+                switch (status) {
+                    case TlbWait:
+                    case CacheWaitResponse:
+                    case CacheWaitRetry:
+                        hasActive = true;
+                        break;
+                    case AccessComplete:
+                        hasCompleted = true;
+                        break;
+                    case AccessFailed:
+                        hasFailed = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (hasFailed) return AccessFailed;
+            if (hasActive) return CacheWaitResponse;  // Simplified active state
+            if (hasCompleted && allReady()) return AccessComplete;
+            return CacheIdle;
+        }
+
         /** Reset the cache request state */
         void reset() {
             packets.clear();
             requests.clear();
+            requestStatus.clear();
             baseAddr = 0;
             totalSize = 0;
             completedPackets = 0;
@@ -754,6 +832,73 @@ class Fetch
         void addRequest(RequestPtr req) {
             requests.push_back(req);
             packets.push_back(nullptr);  // Initialize with null packet
+            requestStatus.push_back(CacheIdle);  // Initialize status
+        }
+
+        /** Mark a specific request as completed by index (NEW) */
+        void markRequestCompleted(size_t index, PacketPtr pkt) {
+            if (index < packets.size()) {
+                if (packets[index] == nullptr) {
+                    packets[index] = pkt;
+                    completedPackets++;
+                }
+                if (index < requestStatus.size()) {
+                    requestStatus[index] = AccessComplete;
+                }
+            }
+        }
+
+        /** Mark a specific request as failed (NEW) */
+        void markRequestFailed(size_t index) {
+            if (index < requestStatus.size()) {
+                requestStatus[index] = AccessFailed;
+            }
+        }
+
+        /** Cancel all active requests (NEW) */
+        void cancelAllRequests() {
+            for (auto& status : requestStatus) {
+                if (status != AccessComplete && status != AccessFailed) {
+                    status = Cancelled;
+                }
+            }
+        }
+
+        /** Update status for a specific request by index (NEW) */
+        void updateRequestStatus(size_t index, CacheRequestStatus status) {
+            if (index < requestStatus.size()) {
+                requestStatus[index] = status;
+            }
+        }
+
+        /** Find request index by RequestPtr (NEW) */
+        size_t findRequestIndex(const RequestPtr& req) const {
+            for (size_t i = 0; i < requests.size(); ++i) {
+                if (requests[i] == req) {
+                    return i;
+                }
+            }
+            return SIZE_MAX;  // Not found
+        }
+
+        /** Get status summary string for debugging (NEW) */
+        std::string getStatusSummary() const {
+            std::string summary = "CacheRequest[";
+            for (size_t i = 0; i < requestStatus.size(); ++i) {
+                if (i > 0) summary += ",";
+                switch (requestStatus[i]) {
+                    case CacheIdle: summary += "Idle"; break;
+                    case TlbWait: summary += "TlbWait"; break;
+                    case CacheWaitResponse: summary += "CacheWait"; break;
+                    case CacheWaitRetry: summary += "Retry"; break;
+                    case AccessComplete: summary += "Complete"; break;
+                    case AccessFailed: summary += "Failed"; break;
+                    case Cancelled: summary += "Cancelled"; break;
+                    default: summary += "Unknown"; break;
+                }
+            }
+            summary += "]";
+            return summary;
         }
 
         /** Mark a packet as completed by matching request */
@@ -768,6 +913,10 @@ class Fetch
                         packets[i] = pkt;  // Store the packet
                         completedPackets++;
                         found_packet = true;
+                        // Update status to AccessComplete
+                        if (i < requestStatus.size()) {
+                            requestStatus[i] = AccessComplete;
+                        }
                     }
                 }
             }
@@ -845,6 +994,62 @@ class Fetch
 
     /** Get the start PC of the next FTQ entry and update fetchBufferPC */
     Addr getNextFTQStartPC(ThreadID tid);
+
+    /**
+     * State management functions for new/legacy system compatibility
+     */
+
+    /**
+     * Map cache request status to legacy thread status for backward compatibility
+     * @param req The cache request to analyze
+     * @return Equivalent ThreadStatus based on cache request state
+     */
+    ThreadStatus mapCacheStatusToThreadStatus(const CacheRequest& req);
+
+    /**
+     * Update legacy fetchStatus to maintain existing behavior
+     * @param tid Thread ID
+     */
+    void updateLegacyFetchStatus(ThreadID tid);
+
+    /**
+     * Get effective thread status considering both legacy and new state systems
+     * @param tid Thread ID
+     * @return The effective thread status
+     */
+    ThreadStatus getEffectiveThreadStatus(ThreadID tid);
+
+    /**
+     * High-level status query interfaces for new state system
+     */
+
+    /**
+     * Check if the thread can fetch instructions
+     * @param tid Thread ID
+     * @return true if thread can fetch instructions
+     */
+    bool canFetchInstructions(ThreadID tid) const;
+
+    /**
+     * Check if there are pending cache requests for this thread
+     * @param tid Thread ID
+     * @return true if there are active cache requests
+     */
+    bool hasPendingCacheRequests(ThreadID tid) const;
+
+    /**
+     * Check if the thread is waiting for cache response
+     * @param tid Thread ID
+     * @return true if waiting for cache
+     */
+    bool isWaitingForCache(ThreadID tid) const;
+
+    /**
+     * Check if the thread is in a runnable state (not blocked/squashing)
+     * @param tid Thread ID
+     * @return true if thread is in running state
+     */
+    bool isThreadRunning(ThreadID tid) const;
 
   protected:
     struct FetchStatGroup : public statistics::Group


### PR DESCRIPTION
…bility

Key changes:
- Add CacheRequestStatus enum with 7 states (CacheIdle, TlbWait, etc.)
- Extend CacheRequest struct with requestStatus field and management methods
- Implement status mapping functions between new and legacy systems
- Add status query interfaces (canFetchInstructions, hasPendingCacheRequests)
- Modify finishTranslation, processCacheCompletion, and doSquash functions
- Ensure dual status system synchronization during state transitions

This is Stage 1 of fetchStatus refactoring to separate thread management   from cache access lifecycle tracking. Tested with dummy workload showing identical performance metrics