### PR TITLE
cpu-o3: split fetchStatus into fetch and cache status

### DIFF
--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -777,17 +777,6 @@ class Fetch
             return true;
         }
 
-        /** Check if there are any active requests (NEW) */
-        bool hasActiveRequests() const {
-            for (const auto& status : requestStatus) {
-                if (status != CacheIdle && status != AccessComplete &&
-                    status != AccessFailed && status != Cancelled) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         /** Get overall status of the cache request group (NEW) */
         CacheRequestStatus getOverallStatus() const {
             if (requestStatus.empty()) return CacheIdle;
@@ -984,19 +973,7 @@ class Fetch
      */
     bool hasPendingCacheRequests(ThreadID tid) const;
 
-    /**
-     * Check if the thread is waiting for cache response
-     * @param tid Thread ID
-     * @return true if waiting for cache
-     */
-    bool isWaitingForCache(ThreadID tid) const;
 
-    /**
-     * Check if the thread is in a runnable state (not blocked/squashing)
-     * @param tid Thread ID
-     * @return true if thread is in running state
-     */
-    bool isThreadRunning(ThreadID tid) const;
 
     /**
      * State setting interfaces for new state system
@@ -1006,9 +983,8 @@ class Fetch
      * Set the thread status with unified interface
      * @param tid Thread ID
      * @param status New thread status
-     * @param reason Optional reason for status change (for debugging)
      */
-    void setThreadStatus(ThreadID tid, ThreadStatus status, const std::string& reason = "");
+    void setThreadStatus(ThreadID tid, ThreadStatus status);
 
     /**
      * Update cache request status for specific request
@@ -1018,6 +994,15 @@ class Fetch
      */
     void updateCacheRequestStatus(ThreadID tid, size_t reqIndex, CacheRequestStatus status);
 
+    /**
+     * Helper function to update cache request status by RequestPtr
+     * Combines findRequestIndex + updateCacheRequestStatus + warn pattern
+     * @param tid Thread ID
+     * @param req Request pointer to find and update
+     * @param status New cache request status
+     */
+    void updateCacheRequestStatusByRequest(ThreadID tid, const RequestPtr& req,
+                                          CacheRequestStatus status);
 
     /**
      * Cancel all cache requests for thread (used in squash)

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -181,6 +181,7 @@ class Fetch
         Squashing,
         Blocked,
         TrapPending,
+        WaitingCache,
         NumFetchStatus
     };
 
@@ -189,7 +190,8 @@ class Fetch
         {Idle, "Idle"},
         {Squashing, "Squashing"},
         {Blocked, "Blocked"},
-        {TrapPending, "TrapPending"}
+        {TrapPending, "TrapPending"},
+        {WaitingCache, "WaitingCache"}
     };
 
     /** Cache request status for new state management system.

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -457,6 +457,16 @@ class Fetch
      */
     bool checkSignalsAndUpdate(ThreadID tid);
 
+    /** Handles commit signals including squash and update operations.
+     *  @return: Returns true if squash occurred and immediate return needed.
+     */
+    bool handleCommitSignals(ThreadID tid);
+
+    /** Handles decode squash signals.
+     *  @return: Returns true if squash occurred and immediate return needed.
+     */
+    bool handleDecodeSquash(ThreadID tid);
+
     /** Does the actual fetching of instructions and passing them on to the
      * next stage.
      * @param status_change fetch() sets this variable if there was a status


### PR DESCRIPTION
Key changes:
- Add CacheRequestStatus enum with 7 states (CacheIdle, TlbWait, etc.)
- Extend CacheRequest struct with requestStatus field and management methods
- Implement status mapping functions between new and legacy systems
- Add status query interfaces (canFetchInstructions, hasPendingCacheRequests)
- Modify finishTranslation, processCacheCompletion, and doSquash functions

Change-Id: I3fb954252c7e4ce8196ddd2ac6def0771c44e83c