### PR TITLE
arch-riscv: fix default mcounteren value

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -332,7 +332,7 @@ void ISA::clear()
         miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET) |
                                     (1ULL << FS_OFFSET);
     }
-    miscRegFile[MISCREG_MCOUNTEREN] = 0x7;
+    miscRegFile[MISCREG_MCOUNTEREN] = 0;
     miscRegFile[MISCREG_SCOUNTEREN] = 0;
     // don't set it to zero; software may try to determine the supported
     // triggers, starting at zero. simply set a different value here.


### PR DESCRIPTION
**Description:**
difftest encountered the following error when running linux.bin.
![Screenshot 2025-07-01 at 5 22 32 PM](https://github.com/user-attachments/assets/be7fd12f-50d4-44e6-a40a-7f4cd96812b1)

**Command:**
`${GEM5_HOME}/build/RISCV/gem5.opt ./configs/example/xiangshan.py --difftest-ref-so=${NEMU_HOME}/build/riscv64-nemu-interpreter-so --num-cpus=1 --raw-cpt --generic-rv-cpt=${NOOP_HOME}/ready-to-run/linux.bin`

**Cause:**
mcounteren is initialized to 0x7 in gem5, but to 0x0 in NEMU (firmware will turn the enable bit on afterwards). 

**Fix:**
Initialize mcounteren in gem5 to 0x0.