### PR TITLE
cpu-o3: fix pc nullptr for storeDataUop

### DIFF
--- a/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
@@ -423,6 +423,8 @@ def template VlWholeConstructor {{
 %(class_name)s::%(class_name)s(ExtMachInst _machInst)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
 {
+    %(set_reg_idx_arr)s;
+
     size_t NFIELDS = machInst.nf + 1;
     eew = 8;
     StaticInstPtr microop;


### PR DESCRIPTION
Description:
gem5 encounters segmentation fault when specifying`--debug-flags=IEW`

Command:
`${GEM5_HOME}/build/RISCV/gem5.opt --debug-flags=IEW ./configs/example/xiangshan.py --difftest-ref-so=${NEMU_HOME}/build/riscv64-nemu-interpreter-so --num-cpus=1 --raw-cpt --generic-rv-cpt=${NOOP_HOME}/ready-to-run/linux.bin`

Cause:
When creating storeDataUop, the `pc` and `next_pc` arguments are not passed to the `DynInst` constructor, causing them to be nullptrs.

Fix:
Initialize `pc` and `next_pc` with those from the storeAddrUop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced register initialization for vector memory instruction processing to ensure proper register index setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->