### PR TITLE
cpu-o3: Add RAR and RAW blocking mechanisms with optimizations

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -349,6 +349,13 @@ def setKmhV3IdealParams(args, system):
         cpu.SQEntries = 64
         cpu.SbufferEntries = 24
         cpu.SbufferEvictThreshold = 16
+        # RAR/RAW replay queue thresholds
+        cpu.RARQEntries = 96 # set 72 in the RTL model.
+        cpu.RAWQEntries = 56 # set 32 in the RTL model.
+        cpu.LoadCompletionWidth = 8
+        cpu.StoreCompletionWidth = 4
+        cpu.RARDequeuePerCycle = 4
+        cpu.RAWDequeuePerCycle = 4
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
         cpu.RobCompressPolicy = 'kmhv3'

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -178,6 +178,13 @@ class BaseO3CPU(BaseCPU):
     LdPipeStages = Param.Unsigned(4, "Number of load pipeline stages")
     StPipeStages = Param.Unsigned(5, "Number of store pipeline stages")
 
+    RARQEntries = Param.Unsigned(72, "Number of RAR queue entries")
+    RAWQEntries = Param.Unsigned(32, "Number of RAW queue entries")
+    RARDequeuePerCycle = Param.Unsigned(4, "Maximum number of instructions to dequeue from RAR queue per cycle")
+    RAWDequeuePerCycle = Param.Unsigned(4, "Maximum number of instructions to dequeue from RAW queue per cycle")
+    LoadCompletionWidth = Param.Unsigned(8, "Number of loads to complete per cycle")
+    StoreCompletionWidth = Param.Unsigned(4, "Number of stores to complete per cycle")
+
     SbufferEntries = Param.Unsigned(16, "Number of store buffer entries")
     SbufferEvictThreshold = Param.Unsigned(7, "store buffer eviction threshold")
     storeBufferInactiveThreshold = Param.Unsigned(800, "store buffer writeback timeout threshold")

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -145,7 +145,9 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         thread.emplace_back(maxLQEntries, maxSQEntries, params.SbufferEntries,
             params.SbufferEvictThreshold, params.storeBufferInactiveThreshold,
-            params.LdPipeStages, params.StPipeStages);
+            params.LdPipeStages, params.StPipeStages, params.RARQEntries, params.RAWQEntries,
+            params.RARDequeuePerCycle, params.RAWDequeuePerCycle, params.LoadCompletionWidth,
+            params.StoreCompletionWidth);
         thread[tid].init(cpu, iew_ptr, params, this, tid);
         thread[tid].setDcachePort(&dcachePort);
     }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -552,7 +552,9 @@ LSQUnit::completeDataAccess(PacketPtr pkt)
 }
 
 LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries, uint32_t sbufferEvictThreshold,
-    uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages)
+    uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages,
+    uint32_t maxRARQEntries, uint32_t maxRAWQEntries, unsigned rarDequeuePerCycle,
+    unsigned rawDequeuePerCycle, unsigned loadCompletionWidth, unsigned storeCompletionWidth)
     : sbufferEvictThreshold(sbufferEvictThreshold),
       sbufferEntries(sbufferEntries),
       storeBufferWritebackInactive(0),
@@ -560,6 +562,8 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
       lsqID(-1),
       storeQueue(sqEntries),
       loadQueue(lqEntries),
+      loadCompletedIdx(loadQueue.head()),
+      storeCompletedIdx(storeQueue.head()),
       loadPipe(ldPipeStages - 1, 0),
       storePipe(stPipeStages - 1, 0),
       storesToWB(0),
@@ -573,6 +577,12 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
       storeInFlight(false),
       lastClockSQPopEntries(0),
       lastClockLQPopEntries(0),
+      maxRARQEntries(maxRARQEntries),
+      maxRAWQEntries(maxRAWQEntries),
+      rarDequeuePerCycle(rarDequeuePerCycle),
+      rawDequeuePerCycle(rawDequeuePerCycle),
+      loadCompletionWidth(loadCompletionWidth),
+      storeCompletionWidth(storeCompletionWidth),
       stats(nullptr)
 {
     // reserve space, we want if sq will be full, sbuffer will start evicting
@@ -619,6 +629,12 @@ LSQUnit::init(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params,
     depCheckShift = params.LSQDepCheckShift;
     checkLoads = params.LSQCheckLoads;
     needsTSO = params.needsTSO;
+
+    // Clear RAR/RAW queues
+    RARQueue.clear();
+    RAWQueue.clear();
+    RARReplayQueue.clear();
+    RAWReplayQueue.clear();
 
     enableStorePrefetchTrain = params.store_prefetch_train;
     std::vector<StoreBufferEntry*> sbufer;
@@ -667,10 +683,20 @@ LSQUnit::resetState()
 
     storeWBIt = storeQueue.begin();
 
+    // Reset completed iterators
+    loadCompletedIdx = loadQueue.head();
+    storeCompletedIdx = storeQueue.head();
+
     retryPkt = NULL;
     memDepViolator = NULL;
 
     stalled = false;
+
+    // Clear RAR/RAW queues
+    RARQueue.clear();
+    RAWQueue.clear();
+    RARReplayQueue.clear();
+    RAWReplayQueue.clear();
 
     cacheBlockMask = ~(((uint64_t)cpu->cacheLineSize()) - 1);
 }
@@ -730,13 +756,27 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(STDReadyFirst, "Number of store data ready first"),
       ADD_STAT(nonUnitStrideCross16Byte, "Number of vector non unitStride cross 16-byte boundary"),
       ADD_STAT(unitStrideCross16Byte, "Number of vector unitStride cross 16-byte boundary"),
-      ADD_STAT(unitStrideAligned, "Number of vector unitStride 16-byte aligned")
+      ADD_STAT(unitStrideAligned, "Number of vector unitStride 16-byte aligned"),
+      ADD_STAT(RARQueueFull, "Number of times RAR queue was full"),
+      ADD_STAT(RARQueueReplay, "Number of instructions replayed from RAR queue"),
+      ADD_STAT(RARQueueLatency, statistics::units::Cycle::get(), "RAR queue latency distribution"),
+      ADD_STAT(RAWQueueFull, "Number of times RAW queue was full"),
+      ADD_STAT(RAWQueueReplay, "Number of instructions replayed from RAW queue"),
+      ADD_STAT(RAWQueueLatency, statistics::units::Cycle::get(), "RAW queue latency distribution")
 {
     loadToUse
         .init(0, 299, 10)
         .flags(statistics::nozero);
     loadTranslationLat
         .init(0, 299, 10)
+        .flags(statistics::nozero);
+
+    RARQueueLatency
+        .init(0, 500, 20)
+        .flags(statistics::nozero);
+
+    RAWQueueLatency
+        .init(0, 500, 20)
         .flags(statistics::nozero);
 }
 
@@ -1321,6 +1361,44 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
         }
     }
 
+    if (loadCompletedIdx != loadQueue.tail() && inst->isNormalLd()) {
+        if (inst->lqIt.idx() > loadCompletedIdx + 1) {
+            if (RARQueue.size() >= maxRARQEntries) {
+                DPRINTF(LSQUnit, "RARQueue full, reschedule [sn:%llu], LoadCompletedItIdx: %d, inst->lqItIdx: %d\n",
+                        inst->seqNum, loadCompletedIdx, inst->lqIt._idx);
+                stats.RARQueueFull++;
+                loadSetReplay(inst, request, true);
+                addToRARReplayQueue(inst);
+                inst->setRARReplay();
+                return fault;
+            } else {
+                auto existingIt = std::find(RARQueue.begin(), RARQueue.end(), inst);
+                if (existingIt == RARQueue.end()) {
+                    RARQueue.push_back(inst);
+                }
+            }
+        }
+    }
+
+    if (storeCompletedIdx != storeQueue.tail() && inst->isNormalLd()) {
+        if (inst->sqIt.idx() > storeCompletedIdx + 1) {
+            if (RAWQueue.size() >= maxRAWQEntries) {
+                DPRINTF(LSQUnit, "RAWQueue full, reschedule [sn:%lli], StoreCompletedItIdx: %d, inst->sqItIdx: %d\n",
+                        inst->seqNum, storeCompletedIdx, inst->sqIt.idx());
+                stats.RAWQueueFull++;
+                loadSetReplay(inst, request, true);
+                addToRAWReplayQueue(inst);
+                inst->setRAWReplay();
+                return fault;
+            } else {
+                auto existingIt = std::find(RAWQueue.begin(), RAWQueue.end(), inst);
+                if (existingIt == RAWQueue.end()) {
+                    RAWQueue.push_back(inst);
+                }
+            }
+        }
+    }
+
     // No nuke happens, prepare the inst data
     // assert(request->isNormalLd() ? !request->isAnyOutstandingRequest() : true);
     request = inst->savedRequest;
@@ -1398,6 +1476,11 @@ LSQUnit::executeLoadPipeSx()
                     default:
                         panic("unsupported loadpipe length");
                 }
+            }
+
+            // Clear forward packets when replayed
+            if (inst->needReplay()) {
+                inst->clearForwardPackets();
             }
 
             // If inst was replyed, must clear inst in pipeline
@@ -1633,6 +1716,7 @@ LSQUnit::executePipeSx()
 {
     executeLoadPipeSx();
     executeStorePipeSx();
+    updateCompletedIdx();
 }
 
 bool
@@ -2186,6 +2270,17 @@ LSQUnit::squash(const InstSeqNum &squashed_num)
         ++stats.squashedLoads;
     }
 
+    auto loadCompletedIt = loadQueue.getIterator(loadCompletedIdx);
+    if (loadCompletedIt->valid() && loadCompletedIt->instruction() &&
+        loadCompletedIt->instruction()->seqNum > squashed_num) {
+        for (auto it = loadQueue.end(); it != loadQueue.begin(); it--) {
+            if (it->instruction()->seqNum < squashed_num) {
+                loadCompletedIdx = it.idx();
+                break;
+            }
+        }
+    }
+
     for (auto it = inflightLoads.begin(); it != inflightLoads.end();) {
         if ((*it)->instruction()->isSquashed()) {
             it = inflightLoads.erase(it);
@@ -2264,6 +2359,58 @@ LSQUnit::squash(const InstSeqNum &squashed_num)
         storeQueue.pop_back();
         lastClockSQPopEntries++;
         ++stats.squashedStores;
+    }
+
+    auto storeCompletedIt = storeQueue.getIterator(storeCompletedIdx);
+    if (storeCompletedIt->valid() && storeCompletedIt->instruction() &&
+        storeCompletedIt->instruction()->seqNum > squashed_num) {
+        for (auto it = storeQueue.end(); it != storeQueue.begin(); it--) {
+            if (it->instruction()->seqNum < squashed_num) {
+                storeCompletedIdx = it.idx();
+                break;
+            }
+        }
+    }
+
+    auto RARIt = RARQueue.begin();
+    while (RARIt != RARQueue.end()) {
+        if ((*RARIt)->seqNum > squashed_num) {
+            RARIt = RARQueue.erase(RARIt);
+        } else {
+            ++RARIt;
+        }
+    }
+
+    // Clean up replay queues - remove squashed instructions
+    while (!RARReplayQueue.empty()) {
+        auto inst = RARReplayQueue.front();
+        if (inst->seqNum > squashed_num) {
+            DPRINTF(LSQUnit, "Removing squashed inst [sn:%llu] from RARReplayQueue\n",
+                    inst->seqNum);
+            RARReplayQueue.pop_front();
+        } else {
+            break;
+        }
+    }
+
+    auto RAWIt = RAWQueue.begin();
+    while (RAWIt != RAWQueue.end()) {
+        if ((*RAWIt)->seqNum > squashed_num) {
+            RAWIt = RAWQueue.erase(RAWIt);
+        } else {
+            ++RAWIt;
+        }
+    }
+
+    while (!RAWReplayQueue.empty()) {
+        auto inst = RAWReplayQueue.front();
+        if (inst->seqNum > squashed_num) {
+            DPRINTF(LSQUnit, "Removing squashed inst [sn:%llu] from RAWReplayQueue\n",
+                    inst->seqNum);
+            RAWReplayQueue.pop_front();
+        } else {
+            break;
+        }
     }
 }
 
@@ -2633,6 +2780,65 @@ LSQUnit::checkStaleTranslations() const
 }
 
 void
+LSQUnit::updateCompletedIdx()
+{
+    // Ensure completed indices are within valid range
+    if (loadCompletedIdx < loadQueue.head() - 1 || loadCompletedIdx > loadQueue.tail())
+        loadCompletedIdx = loadQueue.head();
+    if (storeCompletedIdx < storeQueue.head() - 1 || storeCompletedIdx > storeQueue.tail())
+        storeCompletedIdx = storeQueue.head();
+
+    // Advance load completed index (controls RAR queue dequeue rate)
+    for (unsigned i = 0; i < loadCompletionWidth; i++) {
+        const int currentIdx = loadCompletedIdx;
+        auto loadIt = loadQueue.getIterator(loadCompletedIdx + 1);
+        if (loadIt->valid() && loadIt->instruction() && loadIt->instruction()->isExecuted()) {
+            loadCompletedIdx++;
+            DPRINTF(LSQUnit, "loadCompletedIdx [%d]->[%d]\n", currentIdx, loadCompletedIdx);
+        } else {
+            break;
+        }
+    }
+
+    // Advance store completed index (controls RAW queue dequeue rate)
+    for (unsigned i = 0; i < storeCompletionWidth; i++) {
+        const int currentIdx = storeCompletedIdx;
+        auto storeIt = storeQueue.getIterator(storeCompletedIdx + 1);
+        if (storeIt->addrReady() || storeIt->canWB()) {
+            storeCompletedIdx++;
+            DPRINTF(LSQUnit, "storeCompletedIdx [%d]->[%d]\n", currentIdx, storeCompletedIdx);
+        } else {
+            break;
+        }
+    }
+
+    // Remove completed instructions from RAR and RAW queues
+    auto RARIt = RARQueue.begin();
+    int RARDequeueCount = 0;
+    while (RARIt != RARQueue.end() && RARDequeueCount < rarDequeuePerCycle) {
+        if ((*RARIt)->lqIt.idx() <= loadCompletedIdx + 1) {
+            RARIt = RARQueue.erase(RARIt);
+            RARDequeueCount++;
+        } else {
+            ++RARIt;
+        }
+    }
+
+    auto RAWIt = RAWQueue.begin();
+    int RAWDequeueCount = 0;
+    while (RAWIt != RAWQueue.end() && RAWDequeueCount < rawDequeuePerCycle) {
+        if ((*RAWIt)->sqIt.idx() <= storeCompletedIdx + 1) {
+            RAWIt = RAWQueue.erase(RAWIt);
+            RAWDequeueCount++;
+        } else {
+            ++RAWIt;
+        }
+    }
+
+    processReplayQueues();
+}
+
+void
 LSQUnit::recvRetry()
 {
     if (isStoreBlocked) {
@@ -2648,18 +2854,24 @@ LSQUnit::dumpInsts() const
     cprintf("Load queue size: %i\n", loadQueue.size());
     cprintf("Load queue: ");
 
-    for (const auto& e: loadQueue) {
-        const DynInstPtr &inst(e.instruction());
-        cprintf("%s.[sn:%llu] ", inst->pcState(), inst->seqNum);
+    for (auto it = loadQueue.begin(); it != loadQueue.end(); ++it) {
+        if (it->valid()) {
+            const DynInstPtr &inst(it->instruction());
+            cprintf("idx:%d %s.[sn:%llu] %s\n", it.idx(), inst->pcState(), inst->seqNum,
+                    inst->isExecuted() ? "Executed" : "Not Executed");
+        }
     }
     cprintf("\n");
 
     cprintf("Store queue size: %i\n", storeQueue.size());
     cprintf("Store queue: ");
 
-    for (const auto& e: storeQueue) {
-        const DynInstPtr &inst(e.instruction());
-        cprintf("%s.[sn:%llu] ", inst->pcState(), inst->seqNum);
+    for (auto it = storeQueue.begin(); it != storeQueue.end(); ++it) {
+        if (it->valid()) {
+            const DynInstPtr &inst(it->instruction());
+            cprintf("idx:%d %s.[sn:%llu] %s\n", it.idx(), inst->pcState(), inst->seqNum,
+                    it->addrReady() ? "AddrReady" : "Not AddrReady");
+        }
     }
 
     cprintf("\n");
@@ -3149,6 +3361,115 @@ LSQUnit::getStoreHeadSeqNum()
         return storeQueue.front().instruction()->seqNum;
     else
         return 0;
+}
+
+void
+LSQUnit::addToRARReplayQueue(const DynInstPtr &inst)
+{
+    DPRINTF(LSQUnit, "Adding inst [sn:%llu] to RARReplayQueue\n", inst->seqNum);
+    // Record entry time for latency calculation
+    inst->RARQueueEntryTick = curTick();
+
+    // Insert in sorted order by seqNum (ascending)
+    auto it = std::lower_bound(RARReplayQueue.begin(), RARReplayQueue.end(), inst,
+                               [](const DynInstPtr &a, const DynInstPtr &b) { return a->seqNum < b->seqNum; });
+    RARReplayQueue.insert(it, inst);
+}
+
+void
+LSQUnit::addToRAWReplayQueue(const DynInstPtr &inst)
+{
+    DPRINTF(LSQUnit, "Adding inst [sn:%llu] to RAWReplayQueue\n", inst->seqNum);
+    // Record entry time for latency calculation
+    inst->RAWQueueEntryTick = curTick();
+
+    // Insert in sorted order by seqNum (ascending)
+    auto it = std::lower_bound(RAWReplayQueue.begin(), RAWReplayQueue.end(), inst,
+                               [](const DynInstPtr &a, const DynInstPtr &b) { return a->seqNum < b->seqNum; });
+    RAWReplayQueue.insert(it, inst);
+}
+
+void
+LSQUnit::processReplayQueues()
+{
+    std::vector<DynInstPtr> instsToReplay;
+
+    // Collect remaining RAR instructions that can be completed immediately
+    auto RARReplayIt = RARReplayQueue.begin();
+    int RARReplayCount = 0;
+    while (RARReplayIt != RARReplayQueue.end() && RARReplayCount < rarDequeuePerCycle) {
+        if ((*RARReplayIt)->lqIt.idx() <= loadCompletedIdx + 1) {
+            DynInstPtr inst = *RARReplayIt;
+            instsToReplay.push_back(inst);
+            RARReplayIt = RARReplayQueue.erase(RARReplayIt);
+            RARReplayCount++;
+        } else {
+            ++RARReplayIt;
+        }
+    }
+
+    // Collect remaining RAW instructions that can be completed immediately
+    auto RAWReplayIt = RAWReplayQueue.begin();
+    int RAWReplayCount = 0;
+    while (RAWReplayIt != RAWReplayQueue.end() && RAWReplayCount < rawDequeuePerCycle) {
+        if ((*RAWReplayIt)->sqIt.idx() <= storeCompletedIdx + 1) {
+            DynInstPtr inst = *RAWReplayIt;
+            instsToReplay.push_back(inst);
+            RAWReplayIt = RAWReplayQueue.erase(RAWReplayIt);
+            RAWReplayCount++;
+        } else {
+            ++RAWReplayIt;
+        }
+    }
+
+    // Collect instructions from RAR replay queue when space available
+    assert(RARQueue.size() <= maxRARQEntries);
+    const int freeRARSize = maxRARQEntries - RARQueue.size();
+    const int maxRARCollect = std::min(freeRARSize, (int)rarDequeuePerCycle - RARReplayCount);
+    for (int i = 0; i < maxRARCollect && !RARReplayQueue.empty(); ++i) {
+        DynInstPtr inst = RARReplayQueue.front();
+        RARReplayQueue.pop_front();
+        instsToReplay.push_back(inst);
+    }
+
+    // Collect instructions from RAW replay queue when space available
+    assert(RAWQueue.size() <= maxRAWQEntries);
+    const int freeRAWSize = maxRAWQEntries - RAWQueue.size();
+    const int maxRAWCollect = std::min(freeRAWSize, (int)rawDequeuePerCycle - RAWReplayCount);
+    for (int i = 0; i < maxRAWCollect && !RAWReplayQueue.empty(); ++i) {
+        DynInstPtr inst = RAWReplayQueue.front();
+        RAWReplayQueue.pop_front();
+        instsToReplay.push_back(inst);
+    }
+
+    // Process all collected instructions
+    for (const auto& inst : instsToReplay) {
+        if (inst->isSquashed()) {
+            DPRINTF(LSQUnit, "Removing squashed inst [sn:%llu] from ReplayQueue\n",
+                    inst->seqNum);
+            continue;
+        }
+
+        // Record latency statistics
+        bool isRAR = inst->needRARReplay();
+        const Tick entryTick = isRAR ? inst->RARQueueEntryTick : inst->RAWQueueEntryTick;
+        if (entryTick != (Tick)-1) {
+            const Tick latency = curTick() - entryTick;
+            const Cycles cycleLatency = cpu->ticksToCycles(latency);
+            if (isRAR) {
+                stats.RARQueueLatency.sample(cycleLatency);
+                stats.RARQueueReplay++;
+                inst->clearRARReplay();
+            } else {
+                stats.RAWQueueLatency.sample(cycleLatency);
+                stats.RAWQueueReplay++;
+                inst->clearRAWReplay();
+            }
+        }
+
+        inst->clearNeedReplay();
+        inst->issueQue->retryMem(inst);
+    }
 }
 
 } // namespace o3

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -328,13 +329,17 @@ class LSQUnit
     /** Constructs an LSQ unit. init() must be called prior to use. */
     LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries,
       uint32_t sbufferEvictThreshold, uint64_t storeBufferInactiveThreshold,
-      uint32_t ldPipeStages, uint32_t stPipeStages);
+      uint32_t ldPipeStages, uint32_t stPipeStages, uint32_t maxRARQEntries, uint32_t maxRAWQEntries,
+      unsigned rarDequeuePerCycle, unsigned rawDequeuePerCycle,
+      unsigned loadCompletionWidth, unsigned storeCompletionWidth);
 
     /** We cannot copy LSQUnit because it has stats for which copy
      * contructor is deleted explicitly. However, STL vector requires
      * a valid copy constructor for the base type at compile time.
      */
-    LSQUnit(const LSQUnit &l) : stats(nullptr)
+    LSQUnit(const LSQUnit &l) : maxRARQEntries(0), maxRAWQEntries(0),
+        rarDequeuePerCycle(0), rawDequeuePerCycle(0), loadCompletionWidth(0),
+        storeCompletionWidth(0), stats(nullptr)
     {
         panic("LSQUnit is not copy-able");
     }
@@ -499,6 +504,8 @@ class LSQUnit
     /** Returns the number of stores to writeback. */
     int numStoresToSbuffer() { return storesToWB; }
 
+    /** Update loadCompletedIdx and storeCompletedIdx */
+    void updateCompletedIdx();
 
     LSQ* getLsq() { return lsq; }
 
@@ -685,6 +692,12 @@ class LSQUnit
     /** The load queue. */
     LoadQueue loadQueue;
 
+    /** Points to the last position of continuously completed instructions from the beginning in loadQueue */
+    size_t loadCompletedIdx;
+
+    /** Points to the last position of continuously completed instructions from the beginning in storeQueue */
+    size_t storeCompletedIdx;
+
     const static int MaxPipeWidth = 4;
 
     /** Struct that defines the information passed through Load Pipeline. */
@@ -773,6 +786,40 @@ class LSQUnit
 
     unsigned lastClockSQPopEntries;
     unsigned lastClockLQPopEntries;
+    /** Store requests for potential RAR violations */
+    std::list<DynInstPtr> RARQueue;
+    const int maxRARQEntries;
+
+    /** Store requests for potential RAW violations */
+    std::list<DynInstPtr> RAWQueue;
+    const int maxRAWQEntries;
+
+    /** Maximum number of instructions to dequeue from RAR queue per cycle */
+    const unsigned rarDequeuePerCycle;
+
+    /** Maximum number of instructions to dequeue from RAW queue per cycle */
+    const unsigned rawDequeuePerCycle;
+
+    /** Number of loads to complete per cycle */
+    const unsigned loadCompletionWidth;
+
+    /** Number of stores to complete per cycle */
+    const unsigned storeCompletionWidth;
+
+    /** RARReplayQueue for instructions waiting due to RAR dependency */
+    std::list<DynInstPtr> RARReplayQueue;
+
+    /** RAWReplayQueue for instructions waiting due to RAW dependency */
+    std::list<DynInstPtr> RAWReplayQueue;
+
+    /** Process instructions in RARReplayQueue and RAWReplayQueue */
+    void processReplayQueues();
+
+    /** Add instruction to RARReplayQueue */
+    void addToRARReplayQueue(const DynInstPtr &inst);
+
+    /** Add instruction to RAWReplayQueue */
+    void addToRAWReplayQueue(const DynInstPtr &inst);
 
   protected:
     // Will also need how many read/write ports the Dcache has.  Or keep track
@@ -843,6 +890,16 @@ class LSQUnit
         statistics::Scalar nonUnitStrideCross16Byte;
         statistics::Scalar unitStrideCross16Byte;
         statistics::Scalar unitStrideAligned;
+
+        /** RAR replay queue related stats */
+        statistics::Scalar RARQueueFull;
+        statistics::Scalar RARQueueReplay;
+        statistics::Distribution RARQueueLatency;
+
+        /** RAW replay queue related stats */
+        statistics::Scalar RAWQueueFull;
+        statistics::Scalar RAWQueueReplay;
+        statistics::Distribution RAWQueueLatency;
     } stats;
 
     void bankConflictReplay();


### PR DESCRIPTION
1. Add blocking logic for RARQueue and RAWQueue.
2. Modify RAR and RAW to appropriate sizes.
Change-Id: I3e474f82641439cf9cd9ff47d5ef877c7a34e33d