### PR TITLE
arch-riscv: Fix SV48_debug implementation

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -108,6 +108,7 @@ def build_test_system(np, args):
             uncacheable=[AddrRange(0, size=0x80000000)])
         cpu.mmu.functional = args.functional_tlb
         cpu.mmu.enable_sv48 = args.open_sv48
+        cpu.enable_sv48     = args.open_sv48
 
     # configure BP
     args.enable_loop_predictor = True

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -511,6 +511,7 @@ Walker::WalkerState::startWalk(Addr ppn, int f_level, bool from_l2tlb,
             setupWalk(ppn, mainReq->getForwardPreVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
                       from_forward_req, from_back_req);
         } else {
+
             setupWalk(ppn, mainReq->getVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
                       from_forward_req, from_back_req);
         }
@@ -1051,8 +1052,6 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
     uint64_t vaddr_choose;
     PTE pte;
     PTE l2pte;
-
-
     vaddr_choose = (entry.vaddr >> (level * LEVEL_BITS + PageShift)) & VADDR_CHOOSE_MASK;
     pte = read->getLE_l2tlb<uint64_t>(vaddr_choose);
     PTESv39 pte39 = read->getLE_l2tlb<uint64_t>(vaddr_choose);
@@ -1062,7 +1061,6 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
     bool doTLBInsert = false;
     bool doEndWalk = false;
     int l2_i =0;
-
     int l2_level;
 
     DPRINTF(PageTableWalker3,
@@ -1070,6 +1068,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
             "next_vaddr %#x pre %d\n",
             level, pte, pte.ppn, vaddr_choose, entry.vaddr, nextline,
             nextlineEntry.vaddr, entry.fromForwardPreReq);
+
     // step 2:
     // Performing PMA/PMP checks on physical address of PTE
 
@@ -1164,6 +1163,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                                 "%d pre %d\n",
                                 entry.paddr, entry.vaddr, entry.pte, level,
                                 entry.fromForwardPreReq);
+
                     }
                 }
             } else {
@@ -1232,6 +1232,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                             "%#x,nextread %#x\n",
                             pte.ppn, idx, sizeof(pte), nextRead);
                     DPRINTF(PageTableWalker, "tlb_ppn %#x vaddr %#x\n", tlbppn, entry.vaddr);
+
                 }
             }
         }
@@ -1261,10 +1262,13 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         }
 
         if (doTLBInsert) {
+
             if (!functional) {
                 if (((!entry.fromForwardPreReq) && (!entry.fromBackPreReq)) || (preHitInPtw)) {
-                    if (!walker->openSv48)
-                        walker->tlb->insert(entry.vaddr, entry, false, direct);
+                    walker->tlb->insert(entry.vaddr, entry, false, direct);
+                }
+                if (walker->openSv48 ){
+                     walker->tlb->insert(entry.vaddr, entry, false, direct);
                 }
                 finishDefaultTranslate = true;
 
@@ -1275,10 +1279,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                 DPRINTF(PageTableWalker3, "final l1tlb vaddr %#x pre %d\n", entry.vaddr, entry.fromForwardPreReq);
 
                 for (l2_i = 0; l2_i < l2tlbLineSize; l2_i++) {
-                    inl2Entry.vaddr = ((entry.vaddr >> ((l2_level * LEVEL_BITS + PageShift + L2TLB_BLK_OFFSET))
-                                                           << L2TLB_BLK_OFFSET) +
-                                       l2_i)
-                                      << ((l2_level * LEVEL_BITS + PageShift));
+                    inl2Entry.vaddr = ((entry.vaddr >> (l2_level * LEVEL_BITS + PageShift + L2TLB_BLK_OFFSET)
+                    << L2TLB_BLK_OFFSET) + l2_i) << ((l2_level * LEVEL_BITS + PageShift));
                     l2pte = read->getLE_l2tlb<uint64_t>(l2_i);
                     DPRINTF(PageTableWalker3, "final insert vaddr %#x ppn %#x pte %#x pre %d\n", inl2Entry.vaddr,
                             l2pte.ppn, l2pte, entry.fromForwardPreReq);
@@ -1359,7 +1361,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                 }
 
                 }
-             else {
+            else {
                 DPRINTF(PageTableWalker, "Translated %#x -> %#x\n",
                         entry.vaddr, entry.paddr << PageShift |
                         (entry.vaddr & mask(entry.logBytes)));
@@ -1526,22 +1528,31 @@ Fault
 Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tlb, bool open_nextline,
                                bool auto_open_nextline, bool from_forward_pre_req, bool from_back_pre_req)
 {
+
     Addr topAddr;
     int vaddr_bits = 39;
     // support SV48
     if (walker->openSv48 && satp.mode == AddrXlateMode::SV48) {
         level = 3;
         vaddr_bits = 48;
+
     } else {
         level = 2;
         vaddr_bits = 39;
+
     }
     if (from_l2tlb) {
         level = f_level;
+
     } else {
-        if (mainReq && mainReq->get_level() != (walker->openSv48 ? 3 : 2))
-            level = mainReq->get_level();
+        if (!walker->openSv48){
+            if (mainReq && (mainReq->get_level() != (walker->openSv48 ? 3 : 2))){
+                level= mainReq->get_level();
+            }
+        }
+
         if (isVsatp0Mode)
+
             level = 0;
     }
     Addr shift = PageShift + LEVEL_BITS * level;
@@ -1602,6 +1613,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
 
         finishGVA = mainReq->get_finish_gva();
         level = mainReq->get_level();
+
         twoStageLevel = mainReq->get_two_stage_level();
         inGstage = mainReq->get_h_gstage();
         if (finishGVA){
@@ -1622,6 +1634,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
             return fault;
         }
     } else {
+
         //vaddr = Addr(sext<VADDR_BITS>(vaddr));
         twoStageLevel = 0;
 
@@ -1638,6 +1651,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
             nextlineRead = topAddr;
             nextlineLevel = level;
         } else {
+
             topAddr = (satp.ppn << PageShift) + (idx * sizeof(PTESv39));
             nextlineLevelMask = LEVEL_MASK;
             nextlineShift = shift;
@@ -1664,7 +1678,6 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
         entry.fromForwardPreReq = from_forward_pre_req;
         entry.fromBackPreReq = from_back_pre_req;
         entry.preSign = false;
-
 
         nextlineEntry.vaddr = vaddr;
         nextlineEntry.asid = satp.asid;

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1104,6 +1104,7 @@ TLB::translateWithTLB(Addr vaddr, uint16_t asid, BaseMMU::Mode mode, uint8_t tra
 {
     TlbEntry *e = lookup(vaddr, asid, mode, false, false, translateMode);
     DPRINTF(TLB, "translateWithTLB vaddr %#x \n", vaddr);
+
     assert(e != nullptr);
     DPRINTF(TLBGPre, "translateWithTLB vaddr %#x paddr %#x\n", vaddr,
             e->paddr << PageShift | (vaddr & mask(e->logBytes)));
@@ -1324,11 +1325,8 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
     } else {
         Addr pgBase = vsatp.ppn << PageShift;
         Addr gPaddr = 0;
-
         Addr paddrBase = 0;
         Addr pg_mask = 0;
-
-
         e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage);
         if (e[0]){
             req->setPte(e[0]->pte);
@@ -1370,7 +1368,6 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 if (fault != NoFault) {
                     return std::make_pair(hit_type, fault);
                 }
-
 
                 walker->doL2TLBHitSchedule(req, tc, translation, mode, gPaddr, e_l2tlb, e_l2tlbVsstage, e_l2tlbGstage,
                                            3);
@@ -1578,7 +1575,6 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     return std::make_pair(hit_type, NoFault);
                 }
             }
-
         } else {
             hit_type = H_L1miss;
             req->setTwoPtwWalk(false, level, twoStageLevel, 0, hitInSp);
@@ -1758,7 +1754,17 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *pre_back = l2tlb->lookupBackPre(back_pre_block, satp.asid, true);
     backPrePrecision = checkPrePrecision(l2tlb->removeNoUseBackPre, l2tlb->usedBackPre);
     forwardPrePrecision = checkPrePrecision(l2tlb->removeNoUseForwardPre, l2tlb->forwardUsedPre);
+
     if (walker->openSv48) {
+        TlbEntry *e_sv48entry= lookup(vaddr, satp.asid, mode, false, true, direct);
+        if (e_sv48entry!= nullptr){
+            fault= NoFault;
+            paddr = e[0]->paddr << PageShift | (vaddr & mask(e[0]->logBytes));
+            req->setPaddr(paddr);
+            return fault;
+        }
+
+
         fault = walker->start(0, tc, translation, req, mode, false, false, 3, false, 0);
 
         if (translation != nullptr || fault != NoFault) {
@@ -1985,6 +1991,7 @@ TLB::misalignDataAddrCheck(const RequestPtr &req, BaseMMU::Mode mode)
 MMUMode
 TLB::isaMMUCheck(ThreadContext *tc, Addr vaddr, BaseMMU::Mode mode)
 {
+
     STATUS status = tc->readMiscReg(MISCREG_STATUS);
     PrivilegeMode pp = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
     SATP satp = tc->readMiscReg(MISCREG_SATP);
@@ -2025,12 +2032,13 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
         bool two_stage_translation = false;
         STATUS status = tc->readMiscReg(MISCREG_STATUS);
 
-        if ((pmode == PrivilegeMode::PRV_M || satp.mode == AddrXlateMode::BARE))
+        if ((pmode == PrivilegeMode::PRV_M || satp.mode == AddrXlateMode::BARE)){
             req->setFlags(Request::PHYSICAL);
-
+        }
         Fault fault;
 
         if (req->getFlags() & Request::PHYSICAL) {
+
             req->setTwoStageState(false, 0, 0);
             /**
              * we simply set the virtual address to physical address
@@ -2038,6 +2046,7 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
 
             if ((hgatp.mode == 8 || vsatp.mode == 8) && (pmode < PrivilegeMode::PRV_M)) {
                 fault = doTwoStageTranslate(req, tc, translation, mode, delayed);
+
             } else {
                 req->setPaddr(req->getVaddr());
                 fault = NoFault;
@@ -2081,7 +2090,6 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
 
         if (!delayed && fault == NoFault) {
             pma->check(req);
-
             // do pmp check if any checking condition is met.
             // mainFault will be NoFault if pmp checks are
             // passed, otherwise an address fault will be returned.
@@ -2100,13 +2108,10 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
         assert(req->getSize() > 0);
         if (req->getVaddr() + req->getSize() - 1 < req->getVaddr())
             return std::make_shared<GenericPageTableFault>(req->getVaddr());
-
         Process * p = tc->getProcessPtr();
-
         Fault fault = p->pTable->translate(req);
         if (fault != NoFault)
             return fault;
-
         return NoFault;
     }
 }


### PR DESCRIPTION
    Fix the `ideal_sv48` implementation. Currently, SV48 is only supported through PTW, and the feature is disabled by default but can be enabled via an option.

Change-Id: I309db51d221243418ac26531ef22d140a50843bc