### PR TITLE
mem: Align D-Cache MSHR and LSQ behavior with RTL model

### DIFF
--- a/configs/common/Caches.py
+++ b/configs/common/Caches.py
@@ -91,6 +91,10 @@ class L1_DCache(L1Cache):
 
     demand_mshr_reserve = 6
 
+    # Per-cycle MSHR arbitration for L1 DCache.
+    # -1 means unlimited (disabled); set to 1/2/... to enable.
+    mshr_alloc_per_cycle = 1
+
 class L2Cache(Cache):
     mshrs = 64
     tgts_per_mshr = 20

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdio>
 #include <deque>
 #include <list>
 #include <optional>
@@ -51,6 +52,7 @@
 
 #include "base/refcnt.hh"
 #include "base/trace.hh"
+#include "base/types.hh"
 #include "config/the_isa.hh"
 #include "cpu/checker/cpu.hh"
 #include "cpu/exec_context.hh"
@@ -69,7 +71,9 @@
 #include "debug/CommitTrace.hh"
 #include "debug/DecoupleBP.hh"
 #include "debug/HtmCpu.hh"
+#include "debug/LoadPipeline.hh"
 #include "debug/RiscvMisc.hh"
+#include "sim/cur_tick.hh"
 
 namespace gem5
 {
@@ -987,6 +991,10 @@ class DynInst : public ExecContext, public RefCounted
     void setBankConflicyReplay() { setReplay(LdStReplayType::BankConflictReplay); }
     bool needBankConflicyReplay() const { return getReplayType() == LdStReplayType::BankConflictReplay; }
 
+    // MSHR Replay
+    void setMshrArbFailReplay() { setReplay(LdStReplayType::MshrArbFailReplay); }
+    bool needMshrArbFailReplay() const { return getReplayType() == LdStReplayType::MshrArbFailReplay; }
+
     void setRARReplay() { setReplay(LdStReplayType::RARReplay); }
     bool needRARReplay() const { return getReplayType() == LdStReplayType::RARReplay; }
 
@@ -994,6 +1002,11 @@ class DynInst : public ExecContext, public RefCounted
     bool needRAWReplay() const { return getReplayType() == LdStReplayType::RAWReplay; }
 
     void clearNeedReplay() { status.reset(NeedReplay); }
+    void setMshrAliasFailReplay() { setReplay(LdStReplayType::MshrAliasFailReplay); }
+    bool needMshrAliasFailReplay() const { return getReplayType() == LdStReplayType::MshrAliasFailReplay; }
+
+    void setHitInWriteBufferReplay() { setReplay(LdStReplayType::HitInWriteBufferReplay); }
+    bool needHitInWriteBufferReplay() const { return getReplayType() == LdStReplayType::HitInWriteBufferReplay; }
 
     void setFullForward() { status.set(FullForward); }
     bool fullForward() const { return status[FullForward]; }

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1901,6 +1901,8 @@ IEW::tick()
     for (int i = 0;i < dispatchStalls.size();i++) {
         iewStats.dispatchStallReason[dispatchStalls[i]]++;
     }
+    ldstQueue.writebackStoreBuffer();
+
 
     if (exeStatus != Squashing) {
         instQueue.scheduleReadyInsts();
@@ -1922,7 +1924,6 @@ IEW::tick()
     }
 
     // Writeback any stores using any leftover bandwidth.
-    ldstQueue.writebackStoreBuffer();
 
     // Check the committed load/store signals to see if there's a load
     // or store to commit.  Also check if it's being told to execute a

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -45,6 +45,7 @@
 #include <cassert>
 #include <csignal>
 #include <cstdint>
+#include <cstdio>
 #include <list>
 #include <string>
 
@@ -1818,7 +1819,11 @@ LSQ::SingleDataRequest::sendPacketToCache()
     assert(_numOutstandingPackets == 0);
     bool bank_conflict = false;
     bool tag_read_fail = false;
-    bool success = lsqUnit()->trySendPacket(isLoad(), _packets.at(0), bank_conflict, tag_read_fail);
+    bool mshr_used = false;
+    bool mshr_alias_fail = false;
+    bool hit_in_write_buffer = false;
+    bool success = lsqUnit()->trySendPacket(isLoad(), _packets.at(0), bank_conflict,
+                                            tag_read_fail, mshr_used, mshr_alias_fail, hit_in_write_buffer);
     if (success) {
         if (isLoad()) {
             assert(lsqUnit()->inflightLoads.size() < lsqUnit()->numLoads() + 4);
@@ -1838,6 +1843,21 @@ LSQ::SingleDataRequest::sendPacketToCache()
         DPRINTF(LoadPipeline, "Load [sn:%ld] setBankConflicyReplay\n",
                 _inst->seqNum);
     }
+    if (mshr_used) {
+        instruction()->setMshrArbFailReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setMshrArbFailReplay\n",
+                _inst->seqNum);
+    }
+    if (mshr_alias_fail) {
+        instruction()->setMshrAliasFailReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setMshrAliasReplay\n",
+                _inst->seqNum);
+    }
+    if (hit_in_write_buffer) {
+        instruction()->setHitInWriteBufferReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setHitInWriteBufferReplay\n",
+                _inst->seqNum);
+    }
     if (tag_read_fail) {
         DPRINTF(TagReadFail, "sendPacketToCache fails addr: %lx\n", _packets.at(0)->getAddr());
         lsqUnit()->tagReadFailReplaySchedule();
@@ -1851,9 +1871,13 @@ LSQ::SplitDataRequest::sendPacketToCache()
     /* Try to send the packets. */
     bool bank_conflict = false;
     bool tag_read_fail = false;
+    bool mshr_used = false;
+    bool mshr_alias_fail = false;
+    bool hit_in_write_buffer = false;
     while (numReceivedPackets + _numOutstandingPackets < _packets.size()) {
         bool success = lsqUnit()->trySendPacket(isLoad(), _packets.at(numReceivedPackets + _numOutstandingPackets),
-                                                bank_conflict, tag_read_fail);
+                                                bank_conflict, tag_read_fail, mshr_used,
+                                                mshr_alias_fail, hit_in_write_buffer);
         if (success) {
             _numOutstandingPackets++;
         } else {
@@ -1866,7 +1890,21 @@ LSQ::SplitDataRequest::sendPacketToCache()
     if (tag_read_fail) {
         lsqUnit()->tagReadFailReplaySchedule();
     }
-
+    if (mshr_used) {
+        instruction()->setMshrArbFailReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setMshrArbFailReplay\n",
+                _inst->seqNum);
+    }
+    if (mshr_alias_fail){
+        instruction()->setMshrAliasFailReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setMshrAliasFailReplay\n",
+                _inst->seqNum);
+    }
+    if (hit_in_write_buffer) {
+        instruction()->setHitInWriteBufferReplay();
+        DPRINTF(LoadPipeline, "Load [sn:%ld] setHitInWriteBufferReplay\n",
+                _inst->seqNum);
+    }
     if (_numOutstandingPackets == _packets.size()) {
         LSQRequest::_inst->hasPendingCacheReq(true);
         LSQRequest::_inst->pendingCacheReq = this;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1509,6 +1509,9 @@ LSQUnit::executeLoadPipeSx()
                 stats.loadReplayEvents[*inst->getReplayType()]++;
 
                 if (inst->needBankConflicyReplay()) inst->issueQue->retryMem(inst);
+                else if (inst->needMshrArbFailReplay()) inst->issueQue->retryMem(inst);
+                else if (inst->needMshrAliasFailReplay()) inst->issueQue->retryMem(inst);
+                else if (inst->needHitInWriteBufferReplay()) inst->issueQue->retryMem(inst);
                 else if (inst->needCacheMissReplay()) iewStage->cacheMissLdReplay(inst);
                 else if (inst->needNukeReplay()) {
                     if (inst->cacheHit()) {
@@ -2648,11 +2651,11 @@ LSQUnit::completeStore(typename StoreQueue::iterator store_idx, bool from_sbuffe
 }
 
 bool
-LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, bool &tag_read_fail)
+LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, bool &tag_read_fail,
+                        bool &mshr_used, bool &mshr_alias_fail, bool &hit_in_write_buffer)
 {
     bool ret = true;
     bool cache_got_blocked = false;
-
     LSQRequest *request = dynamic_cast<LSQRequest *>(data_pkt->senderState);
     if (isLoad) {
         bank_conflict = lsq->loadBankConflictedCheck(data_pkt->req->getVaddr());
@@ -2662,6 +2665,10 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
     data_pkt->sendTick = curTick();
     PacketPtr pkt = data_pkt;
 
+    auto inst = dynamic_cast<LSQRequest *>(data_pkt->senderState)->instruction();
+
+    DPRINTF(LSQUnit, "Attempting to send packet for inst [sn:%llu], addr: %#x\n",
+            inst->seqNum, data_pkt->getAddr());
     if (!lsq->cacheBlocked() && lsq->cachePortAvailable(isLoad)) {
         if (bank_conflict) {
             ++stats.bankConflictTimes;
@@ -2675,12 +2682,17 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
         }
         if (!bank_conflict && !dcachePort->sendTimingReq(data_pkt)) {
             ret = false;
+            mshr_used = data_pkt->mshrArbFailed();
+            mshr_alias_fail = data_pkt->mshrAliasFailed();
+            hit_in_write_buffer = data_pkt->isHitInWriteBuffer();
             tag_read_fail = data_pkt->tagReadFail;
-            if (!tag_read_fail) {
+
+            if (!tag_read_fail && !mshr_used && !mshr_alias_fail && !hit_in_write_buffer) {
                 cache_got_blocked = true;
             }
         }
-    } else {
+    }
+    else {
         ret = false;
     }
 
@@ -2717,9 +2729,10 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
     }
     DPRINTF(LSQUnit,
             "Memory request (pkt: %s) from inst [sn:%llu] was"
-            " %ssent (cache is blocked: %d, cache_got_blocked: %d, bank conflict: %d, tag_read_fail: %d)\n",
+            " %ssent (cache is blocked: %d, cache_got_blocked: %d, bank conflict: %d, tag_read_fail: %d,"
+            " mshr_used: %d, mshr_alias_fail: %d, hit_in_write_buffer: %d)\n",
             data_pkt->print(), request->instruction()->seqNum, ret ? "" : "not ", lsq->cacheBlocked(),
-            cache_got_blocked, bank_conflict, tag_read_fail);
+            cache_got_blocked, bank_conflict, tag_read_fail, mshr_used, mshr_alias_fail, hit_in_write_buffer);
     return ret;
 }
 
@@ -3315,7 +3328,8 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         request->buildPackets();
         // if the cache is not blocked, do cache access
         request->sendPacketToCache();
-        if (!request->isSent() && !load_inst->needBankConflicyReplay()) {
+        if (!request->isSent() && !load_inst->needBankConflicyReplay() && !load_inst->needMshrArbFailReplay() &&
+            !load_inst->needMshrAliasFailReplay() &&!load_inst->needHitInWriteBufferReplay()) {
             iewStage->blockMemInst(load_inst);
             load_inst->setCacheBlockedReplay();
             DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheBlockedReplay\n", load_inst->seqNum);

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -558,13 +558,14 @@ class LSQUnit
 
     void tagReadFailReplaySchedule();
 
-    bool trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, bool &tag_read_fail);
+    bool trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, bool &tag_read_fail,
+                       bool &mshr_used, bool &mshr_alias_fail, bool &hit_in_write_buffer);
 
     bool sbufferSendPacket(PacketPtr data_pkt);
 
-    bool forwardFromStoreBuffer(const DynInstPtr& inst);
+    bool forwardFromStoreBuffer(const DynInstPtr &inst);
 
-    bool forwardFromStoreQueue(const DynInstPtr& inst);
+    bool forwardFromStoreQueue(const DynInstPtr &inst);
 
     /** Debugging function to dump instructions in the LSQ. */
     void dumpInsts() const;

--- a/src/cpu/o3/replay_events.hh
+++ b/src/cpu/o3/replay_events.hh
@@ -17,6 +17,9 @@ enum LdStReplayType
     BankConflictReplay,
     RARReplay,
     RAWReplay,
+    MshrAliasFailReplay,
+    HitInWriteBufferReplay,
+    MshrArbFailReplay,
     LdStReplayTypeCount
 };
 
@@ -31,6 +34,9 @@ static const char *load_store_replay_event_str[LdStReplayTypeCount] =
     "BankConflictReplay",
     "RARReplay",
     "RAWReplay",
+    "MshrAliasFailReplay",
+    "HitInWriteBufferReplay",
+    "MshrArbFailReplay",
 };
 
 } // namespace o3

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -93,6 +93,11 @@ class BaseCache(ClockedObject):
     mshrs = Param.Unsigned("Number of MSHRs (max outstanding requests)")
     demand_mshr_reserve = Param.Unsigned(1, "MSHRs reserved for demand access")
     tgts_per_mshr = Param.Unsigned("Max number of accesses per MSHR")
+    # Per-cycle limit for MSHR arbitration (allocations or target merges).
+    # -1 means unlimited (no arbitration limit). Set per cache instance in
+    # python configs, e.g. only enable for DCache.
+    mshr_alloc_per_cycle = Param.Int(-1,
+        "Max number of MSHR allocations/merges allowed per cycle; -1 = unlimited")
     write_buffers = Param.Unsigned(8, "Number of write buffers")
     do_fast_writeline = Param.Bool(True, "Write whole line do not read")
 
@@ -187,4 +192,3 @@ class NoncoherentCache(BaseCache):
     # This is typically a last level cache and any clean
     # writebacks would be unnecessary traffic to the main memory.
     writeback_clean = False
-

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -46,14 +46,17 @@
 #include "mem/cache/base.hh"
 
 #include <algorithm>
+#include <cstdio>
 
 #include "base/compiler.hh"
 #include "base/logging.hh"
+#include "base/named.hh"
 #include "base/output.hh"
 #include "base/statistics.hh"
 #include "base/stats/group.hh"
 #include "base/trace.hh"
 #include "base/types.hh"
+#include "cpu/inst_seq.hh"
 #include "debug/ArchDB.hh"
 #include "debug/Cache.hh"
 #include "debug/CacheComp.hh"
@@ -61,6 +64,7 @@
 #include "debug/CacheRepl.hh"
 #include "debug/CacheVerbose.hh"
 #include "debug/HWPrefetch.hh"
+#include "debug/MSHR.hh"
 #include "debug/TagReadFail.hh"
 #include "mem/cache/compressors/base.hh"
 #include "mem/cache/mshr.hh"
@@ -139,6 +143,8 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       sliceNum(p.slice_num),
       freeTagLoadReadPorts(p.tag_load_read_ports),
       lastTagAccessCheckCycle(0),
+      lastMSHRAllocCycle(0),
+      mshrAllocPerCycle(p.mshr_alloc_per_cycle),
       compressor(p.compressor),
       prefetcher(p.prefetcher),
       writeAllocator(p.write_allocator),
@@ -325,6 +331,36 @@ BaseCache::inRange(Addr addr) const
     return false;
 }
 
+bool
+BaseCache::checkAndAllocateMSHRCycle(PacketPtr pkt)
+{
+    // No arbitration limit when set to -1.
+    if (mshrAllocPerCycle < 0)
+        return true;
+
+    uint64_t curCycle = ticksToCycles(curTick());
+
+    // New cycle: reset counter and grant.
+    if (lastMSHRAllocCycle != curCycle) {
+        accessCounter = 1;
+        lastMSHRAllocCycle = curCycle;
+        return true;
+    }
+
+    // Same cycle: allow up to mshrAllocPerCycle grants.
+    if (accessCounter < mshrAllocPerCycle) {
+        accessCounter++;
+        return true;
+    }
+
+    // Exceeded per-cycle limit: fail and account.
+    stats.MSHRArbFails++;
+    pkt->setMshrArbFailed();
+    pkt->req->decAccessDepth();
+    stats.cmdStats(pkt).misses[pkt->req->requestorId()]--;
+    return false;
+}
+
 void
 BaseCache::handleTimingReqHit(PacketPtr pkt, CacheBlk *blk, Tick request_time, bool first_acc_after_pf)
 {
@@ -481,6 +517,11 @@ BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
                 DPRINTF(Cache, "%s: miss on late pref: %i, pref source: %i, coalescing cpu requests: %i\n", __func__,
                         pkt->missOnLatePf, pkt->pfSource, pkt->coalescingMSHR);
 
+                // MSHR arbiter: per-cycle grant limit is configurable via
+                // mshr_alloc_per_cycle (-1 = unlimited)
+                if (!checkAndAllocateMSHRCycle(pkt)) {
+                    return;
+                }
                 // We use forward_time here because it is the same
                 // considering new targets. We have multiple
                 // requests for the same address here. It
@@ -533,10 +574,16 @@ BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
                     pkt->req->isCacheMaintenance());
                 blk->clearCoherenceBits(CacheBlk::ReadableBit);
             }
+            // MSHR arbiter: per-cycle grant limit is configurable via
+            // mshr_alloc_per_cycle (-1 = unlimited)
+            if (!checkAndAllocateMSHRCycle(pkt)) {
+                return;
+            }
             // Here we are using forward_time, modelling the latency of
             // a miss (outbound) just as forwardLatency, neglecting the
             // lookupLatency component.
             allocateMissBuffer(pkt, forward_time);
+
         }
     }
 }
@@ -2830,6 +2877,12 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
              "number of squashed inst block demand hits"),
     ADD_STAT(loadTagReadFails, statistics::units::Count::get(),
              "number of load Tag read fail because of prefetcher"),
+    ADD_STAT(MSHRArbFails,statistics::units::Count::get(),
+             "number of MSHR arbitration fails (one miss per cycle)"),
+    ADD_STAT(MSHRAliasFails, statistics::units::Count::get(),
+             "number of MSHR Alias fails (VA diff)"),
+    ADD_STAT(FindHitInWriteBuffer, statistics::units::Count::get(),
+             "number of hits in write buffer when missing in cache"),
     ADD_STAT(prefetchTagReadFails, statistics::units::Count::get(),
              "number of prefetch req Tag read fail because of load"),
     ADD_STAT(dataExpansions, statistics::units::Count::get(),
@@ -3143,6 +3196,7 @@ BaseCache::CpuSidePort::tryTiming(PacketPtr pkt)
     }
     mustSendRetry = false;
     return true;
+
 }
 
 bool
@@ -3157,7 +3211,23 @@ BaseCache::CpuSidePort::recvTimingReq(PacketPtr pkt)
         assert(success);
         return true;
     } else if (tryTiming(pkt)) {
+        pkt->clearMshrArbFailed();
+        pkt->clearMshrAliasFailed();
+        pkt->clearHitInWriteBuffer();
         cache->recvTimingReq(pkt);
+        if (pkt->mshrArbFailed() || pkt->mshrAliasFailed() ||
+            pkt->isHitInWriteBuffer()) {
+            // If the MSHR arbitration failed, we need to retry later.
+            // We will schedule a retry event to try again.
+            if (sendRetryEvent.scheduled()) {
+                owner.reschedule(sendRetryEvent, cache->nextCycle());
+            } else {
+                owner.schedule(sendRetryEvent, cache->nextCycle());
+            }
+            DPRINTF(Cache, "MSHR arbitration failed for pkt %s, retrying later\n",
+                    pkt->print());
+            return false;
+        }
         return true;
     }
     return false;

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -46,6 +46,8 @@
 #ifndef __MEM_CACHE_BASE_HH__
 #define __MEM_CACHE_BASE_HH__
 
+#include <sys/types.h>
+
 #include <cassert>
 #include <cstdint>
 #include <queue>
@@ -401,6 +403,20 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
     Cycles lastTagAccessCheckCycle;
 
+    /**
+     * Arbitration state for per-cycle MSHR allocations/merges.
+     * lastMSHRAllocCycle records the last cycle when an allocation/merge
+     * was granted; accessCounter counts grants within the same cycle.
+     */
+    uint64_t lastMSHRAllocCycle;
+    int accessCounter = 0;
+
+    /** Max number of MSHR allocations/merges allowed per cycle.
+     * -1 means unlimited (no arbitration limit). Configured per cache via
+     * the Python SimObject parameter mshr_alloc_per_cycle.
+     */
+    const int mshrAllocPerCycle;
+
     /** Compression method being used. */
     compression::Base* compressor;
 
@@ -556,6 +572,21 @@ class BaseCache : public ClockedObject, public CacheAccessor
      */
     virtual bool access(PacketPtr pkt, CacheBlk *&blk, Cycles &lat,
                         PacketList &writebacks);
+
+    /**
+     * @brief Checks MSHR arbiter and allocates a slot for the current cycle.
+     *
+     * This function implements the one-miss-per-cycle arbitration logic.
+     * It checks if an MSHR slot has already been used in the current cycle.
+     * If not, it allocates the slot by updating lastMSHRAllocCycle and
+     * returns true. If the slot is already in use, it sets the MSHR
+     * arbitration failure flag on the packet, corrects statistics, and
+     * returns false.
+     *
+     * @param pkt The memory request packet that requires an MSHR.
+     * @return True if arbitration succeeds, false otherwise.
+     */
+    bool checkAndAllocateMSHRCycle(PacketPtr pkt);
 
     /*
      * Handle a timing request that hit in the cache
@@ -1282,6 +1313,17 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
         /** Number of load Tag read fail because of prefetcher. */
         statistics::Scalar loadTagReadFails;
+
+        /**
+         * Number of times MSHR arbitration failed due to the
+         * one-miss-per-cycle limit.
+         */
+        statistics::Scalar MSHRArbFails;
+
+        /** Number of MSHR Alias fails (VA diff) . */
+        statistics::Scalar MSHRAliasFails;
+
+        statistics::Scalar FindHitInWriteBuffer;
 
         /** Number of prefetch req Tag read fail because of load. */
         mutable statistics::Scalar prefetchTagReadFails;

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -47,6 +47,7 @@
 #include "mem/cache/cache.hh"
 
 #include <cassert>
+#include <cstdio>
 
 #include "base/compiler.hh"
 #include "base/logging.hh"
@@ -404,6 +405,48 @@ Cache::handleTimingReqMiss(PacketPtr pkt, CacheBlk *blk, Tick forward_time,
         // MSHR) this is set to null
         pkt = pf;
     }
+
+    WriteQueueEntry *wb_entry = writeBuffer.findMatch(pkt->getAddr(),
+                                                     pkt->isSecure());
+
+    if (wb_entry != nullptr && level() == 1 && !isReadOnly) {
+        DPRINTF(Cache, "Cache miss for %s, but hit in Write Buffer, triggering replay\n", pkt->print());
+        assert(wb_entry->getNumTargets() == 1);
+        pkt->setHitInWriteBuffer();
+        pkt->req->decAccessDepth();
+        stats.FindHitInWriteBuffer++;
+        return; // don't allocate an MSHR, just replay
+    }
+
+    // When PA is the same, we will check VA index to decide if a alias
+    // happens. If so, we simply send it to replay.
+    else if (mshr && level() == 1 && !isReadOnly) {
+        PacketPtr mshr_pkt = mshr->getTarget()->pkt;
+
+        bool va_mismatch = false;
+
+        if (pkt->req->hasVaddr() && mshr_pkt->req->hasVaddr()) {
+            DPRINTF(Cache,"VA index Set: pkt index %d, MSHR index %d\n",
+                    tags->getIndexingPolicy()->extractSet(pkt->req->getVaddr()),
+                    tags->getIndexingPolicy()->extractSet(mshr_pkt->req->getVaddr()));
+
+            if (tags->getIndexingPolicy()->extractSet(pkt->req->getVaddr()) !=
+                tags->getIndexingPolicy()->extractSet(mshr_pkt->req->getVaddr()) ) {
+                va_mismatch = true;
+            }
+        }
+
+        if (va_mismatch) {
+            DPRINTF(Cache, "MSHR PA Hit but VA Mismatch (aliasing) for %s, triggering replay\n",
+                    pkt->print());
+            pkt->setMshrAliasFailed();
+            stats.MSHRAliasFails++;
+            pkt->req->decAccessDepth();
+            return;
+        }
+    }
+
+
 
     BaseCache::handleTimingReqMiss(pkt, mshr, blk, forward_time, request_time);
 }

--- a/src/mem/cache/tags/base.hh
+++ b/src/mem/cache/tags/base.hh
@@ -228,6 +228,15 @@ class BaseTags : public ClockedObject
     }
 
     /**
+     * Get a pointer to the indexing policy object.
+     * @return A const pointer to the BaseIndexingPolicy object.
+     */
+    const BaseIndexingPolicy* getIndexingPolicy() const
+    {
+        return indexingPolicy;
+    }
+
+    /**
      * Limit the allocation for the cache ways.
      * @param ways The maximum number of ways available for replacement.
      */

--- a/src/mem/cache/tags/indexing_policies/base.hh
+++ b/src/mem/cache/tags/indexing_policies/base.hh
@@ -49,6 +49,7 @@
 
 #include <vector>
 
+#include "base/logging.hh"
 #include "params/BaseIndexingPolicy.hh"
 #include "sim/sim_object.hh"
 
@@ -137,6 +138,18 @@ class BaseIndexingPolicy : public SimObject
      * @return The tag of the address.
      */
     virtual Addr extractTag(const Addr addr) const;
+
+    /**
+     * Apply a hash function to calculate address set.
+     *
+     * @param addr The address to calculate the set for.
+     * @return The set index for given combination of address and way.
+     */
+    virtual uint32_t extractSet(const Addr addr) const
+    {
+        panic("extractSet() not implemented in %s", name());
+        return 0;
+    }
 
     /**
      * Find all possible entries for insertion and replacement of an address.

--- a/src/mem/cache/tags/indexing_policies/set_associative.hh
+++ b/src/mem/cache/tags/indexing_policies/set_associative.hh
@@ -81,16 +81,17 @@ class ReplaceableEntry;
  */
 class SetAssociative : public BaseIndexingPolicy
 {
-  protected:
+
+  public:
+
     /**
      * Apply a hash function to calculate address set.
      *
      * @param addr The address to calculate the set for.
      * @return The set index for given combination of address and way.
      */
-    virtual uint32_t extractSet(const Addr addr) const;
+    virtual uint32_t extractSet(const Addr addr) const override;
 
-  public:
     /**
      * Convenience typedef.
      */

--- a/src/mem/cache/tags/indexing_policies/skewed_associative.cc
+++ b/src/mem/cache/tags/indexing_policies/skewed_associative.cc
@@ -192,7 +192,7 @@ SkewedAssociative::deskew(const Addr addr, const uint32_t way) const
 }
 
 uint32_t
-SkewedAssociative::extractSet(const Addr addr, const uint32_t way) const
+SkewedAssociative::getSet(const Addr addr, const uint32_t way) const
 {
     return skew(addr >> setShift, way) & setMask;
 }
@@ -214,7 +214,7 @@ SkewedAssociative::getPossibleEntries(const Addr addr) const
     // Parse all ways
     for (uint32_t way = 0; way < assoc; ++way) {
         // Apply hash to get set, and get way entry in it
-        entries.push_back(sets[extractSet(addr, way)][way]);
+        entries.push_back(sets[getSet(addr, way)][way]);
     }
 
     return entries;

--- a/src/mem/cache/tags/indexing_policies/skewed_associative.hh
+++ b/src/mem/cache/tags/indexing_policies/skewed_associative.hh
@@ -136,7 +136,7 @@ class SkewedAssociative : public BaseIndexingPolicy
      * @param way The way to get the set from.
      * @return The set index for given combination of address and way.
      */
-    uint32_t extractSet(const Addr addr, const uint32_t way) const;
+    uint32_t getSet(const Addr addr, const uint32_t way) const;
 
   public:
     /** Convenience typedef. */

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -360,7 +360,17 @@ class Packet : public Printable
 
         // Signal block present to squash prefetch and cache evict packets
         // through express snoop flag
-        BLOCK_CACHED          = 0x00010000
+        BLOCK_CACHED          = 0x00010000,
+
+        // To check if the MSHR arbiter has failed to allocate an MSHR
+        // for this packet.
+        MSHR_ARB_FAILED       = 0x00020000,
+
+        // Signal that the packet has an aliasing failure.
+        MSHR_ALIAS_FAIL       = 0x00040000,
+
+        // Signal that the packet hit in the write buffer.
+        HIT_IN_WRITE_BUFFER   = 0x00080000
     };
 
     Flags flags;
@@ -779,6 +789,21 @@ class Packet : public Printable
     void setBlockCached()          { flags.set(BLOCK_CACHED); }
     bool isBlockCached() const     { return flags.isSet(BLOCK_CACHED); }
     void clearBlockCached()        { flags.clear(BLOCK_CACHED); }
+
+    //MSHR arbiter failure flag handle
+    void setMshrArbFailed() { flags.set(MSHR_ARB_FAILED); }
+    bool mshrArbFailed() const { return flags.isSet(MSHR_ARB_FAILED); }
+    void clearMshrArbFailed() { flags.clear(MSHR_ARB_FAILED); }
+
+    //MSHR alias failure flag handle
+    void setMshrAliasFailed() { flags.set(MSHR_ALIAS_FAIL); }
+    bool mshrAliasFailed() const { return flags.isSet(MSHR_ALIAS_FAIL); }
+    void clearMshrAliasFailed() { flags.clear(MSHR_ALIAS_FAIL); }
+
+    // Hit in write buffer flag handle
+    void setHitInWriteBuffer() { flags.set(HIT_IN_WRITE_BUFFER); }
+    bool isHitInWriteBuffer() const { return flags.isSet(HIT_IN_WRITE_BUFFER); }
+    void clearHitInWriteBuffer() { flags.clear(HIT_IN_WRITE_BUFFER); }
 
     /**
      * QoS Value getter

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -1150,6 +1150,8 @@ class Request
      */
     void incAccessDepth() const { depth++; }
     int getAccessDepth() const { return depth; }
+    void decAccessDepth() const { assert(depth > -1); if (depth > 0) depth--; }
+
 
     /**
      * Set/Get the time taken for this request to be successfully translated.


### PR DESCRIPTION
Align the MSHR behavior in Dcache with current RTL model.

Basically, four features have been added to the D-Cache and LSQ interaction:

****1. Per-Cycle MSHR Arbitration**:** Implemented a "one-miss-per-cycle" arbitration limit for the D-Cache MSHR. This applies to both new MSHR allocations (on a primary miss) and merges into existing MSHRs (on a secondary miss).

****2. MSHR Arbitration**:**  Requests originating from the  StoreBuffer (MainPipe) are now executed before new requests from the LSU pipelines (executePipeSx), giving them higher priority when competing for the D-Cache port and MSHR resources.

**3. MSHR Alias Conflict Detection & Replay:** Added a mechanism to detect memory aliasing conflicts. If the request hit the MSHR (has same PA) but has different Virtual Addresses (VA), the request is now rejected and triggers a replay, instead of being merged into the existing MSHR.

****4. Write-Back Queue (WBQ) Hit on Miss & Replay**:** If a request misses in the cache but hits in the writeBuffer (WBQ), it is now rejected and triggers an instruction replay, instead of allocating a new MSHR.