### PR TITLE
mem-cache: fix sendEvent schedule time bugs.

### DIFF
--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1341,7 +1341,7 @@ class BaseCache : public ClockedObject, CacheAccessor
             setBlocked((BlockedCause)MSHRQueue_MSHRs);
         }
 
-        if (sched_send && !memSidePort.hasSchedSendEvent()) {
+        if (sched_send) {
             // schedule the send
             DPRINTF(Cache, "Scheduling a send for addr %llx after alloc MSHR\n", pkt->getAddr());
             schedMemSideSendEvent(time);

--- a/src/mem/packet_queue.cc
+++ b/src/mem/packet_queue.cc
@@ -162,12 +162,13 @@ PacketQueue::schedSendEvent(Tick when)
     // if we are waiting on a retry just hold off
     if (waitingOnRetry) {
         DPRINTF(PacketQueue, "Not scheduling send as waiting for retry\n");
+        assert(!sendEvent.scheduled());
         return;
     }
-    if (sendEvent.scheduled()) {
-        DPRINTF(PacketQueue, "Not scheduling send as already scheduled\n");
-        return;
-    }
+    // if (sendEvent.scheduled()) {
+    //     DPRINTF(PacketQueue, "Not scheduling send as already scheduled\n");
+    //     return;
+    // }
 
     if (when != MaxTick) {
         // we cannot go back in time, and to be consistent we stick to

--- a/src/mem/packet_queue.cc
+++ b/src/mem/packet_queue.cc
@@ -165,10 +165,6 @@ PacketQueue::schedSendEvent(Tick when)
         assert(!sendEvent.scheduled());
         return;
     }
-    // if (sendEvent.scheduled()) {
-    //     DPRINTF(PacketQueue, "Not scheduling send as already scheduled\n");
-    //     return;
-    // }
 
     if (when != MaxTick) {
         // we cannot go back in time, and to be consistent we stick to


### PR DESCRIPTION
The "sendEvent" has been wrongly set as "If it is scheduled and has not been executed yet, it cannot be rescheduled." This results in the inability to update the sendEvent time in a timely manner when more urgent events need to be scheduled.

we put a panic here to check. For test we try checkpoint "/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/astar_biglakes/562/_562_0.202736_.zstd", and panic happend.
<img width="1109" height="1170" alt="image" src="https://github.com/user-attachments/assets/543b60b2-5061-467f-bf9e-89f9f1645348" />

the breakpoint environment
<img width="2040" height="174" alt="image" src="https://github.com/user-attachments/assets/dfe0cb2b-89b3-4bae-aee0-fa4b4ad761c3" />

this is a early prefetch should be shedule before it.

Change-Id: Id8f470ee02ad111fc6b9f90908dc47835b2be38d