### PR TITLE
cpu: fix LSQRequest num control bugs by moving into LSQUnit

### DIFF
--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -254,10 +254,6 @@ class LSQ
         void markDelayed() override { flags.set(Flag::Delayed); }
         bool isDelayed() { return flags.isSet(Flag::Delayed); }
 
-        static uint64_t numSBufferRequest;
-        static uint64_t numSingleRequest;
-        static uint64_t numSplitRequest;
-
       public:
         LSQUnit& _port;
         const DynInstPtr _inst;
@@ -624,19 +620,9 @@ class LSQ
         SingleDataRequest(LSQUnit* port, const DynInstPtr& inst,
                 bool isLoad, const Addr& addr, const uint32_t& size,
                 const Request::Flags& flags_, PacketDataPtr data=nullptr,
-                uint64_t* res=nullptr, AtomicOpFunctorPtr amo_op=nullptr) :
-            LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
-                       std::move(amo_op)) {
-            numSingleRequest++;
-            singleList.push_back(this);
-            assert(numSingleRequest <= 400);
-        }
+                uint64_t* res=nullptr, AtomicOpFunctorPtr amo_op=nullptr);
 
-        virtual ~SingleDataRequest() {
-            assert(numSingleRequest > 0);
-            numSingleRequest--;
-            singleList.remove(this);
-        }
+        virtual ~SingleDataRequest();
         virtual void markAsStaleTranslation();
         virtual void initiateTranslation();
         virtual void finish(const Fault &fault, const RequestPtr &req,
@@ -685,30 +671,8 @@ class LSQ
         SplitDataRequest(LSQUnit* port, const DynInstPtr& inst,
                 bool isLoad, const Addr& addr, const uint32_t& size,
                 const Request::Flags & flags_, PacketDataPtr data=nullptr,
-                uint64_t* res=nullptr) :
-            LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
-                       nullptr),
-            numFragments(0),
-            numReceivedPackets(0),
-            _mainReq(nullptr),
-            _mainPacket(nullptr)
-        {
-            numSplitRequest++;
-            assert(numSplitRequest <= 400);
-            flags.set(Flag::IsSplit);
-        }
-        virtual ~SplitDataRequest()
-        {
-            assert(numSplitRequest > 0);
-            numSplitRequest--;
-            if (_mainReq) {
-                _mainReq = nullptr;
-            }
-            if (_mainPacket) {
-                delete _mainPacket;
-                _mainPacket = nullptr;
-            }
-        }
+                uint64_t* res=nullptr);
+        virtual ~SplitDataRequest();
         virtual void markAsStaleTranslation();
         virtual void finish(const Fault &fault, const RequestPtr &req,
                 gem5::ThreadContext* tc, BaseMMU::Mode mode);
@@ -734,10 +698,7 @@ class LSQ
       public:
         StoreBufferEntry* sbuffer_entry=nullptr;
         SbufferRequest(CPU* cpu, LSQUnit* port, Addr blockpaddr, uint8_t* data);
-        virtual ~SbufferRequest() {
-            assert(numSBufferRequest > 0);
-            numSBufferRequest--;
-        }
+        virtual ~SbufferRequest();
 
         void addReq(Addr blockVaddr, Addr blockPaddr, const std::vector<bool> byteEnable);
 

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -555,6 +555,9 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
     uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages)
     : sbufferEvictThreshold(sbufferEvictThreshold),
       sbufferEntries(sbufferEntries),
+      numSBufferRequest(0),
+      numSingleRequest(0),
+      numSplitRequest(0),
       storeBufferWritebackInactive(0),
       storeBufferInactiveThreshold(storeBufferInactiveThreshold),
       lsqID(-1),

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -303,6 +303,11 @@ class LSQUnit
     bool sqWillFull = false;
     const uint32_t sbufferEvictThreshold = 0;
     const uint32_t sbufferEntries = 0;
+
+    uint64_t numSBufferRequest = 0;
+    uint64_t numSingleRequest = 0;
+    uint64_t numSplitRequest = 0;
+
     StoreBuffer storeBuffer;
     // Store Buffer Writeback Timeout
     uint64_t storeBufferWritebackInactive;


### PR DESCRIPTION
During multi-core operation, we observed a situation where the number of `numSBufferRequests` exceeded the upper limit of `port->sbufferEntries`. This is because `numSBufferRequest` was wrongly defined as a `static` variable, which resulted in different lsqUnits sharing the same numSBufferRequest. As a result, the numSBufferRequest in each lsqUnit did not exceed its respective sbufferEntries, but the total exceeded the limit. Therefore, it is modified to a `non-static` variable and `moved inside the LSQUnit`. Each lsqUnit maintains its own set of values, and numSingleRequest and numSplitRequest follow the same pattern.

Change-Id: I42e41a69333ce85d3145cae13441eda0ab3cc158