### PR TITLE
cpu-o3: docs: add midcore docs for GEM5 O3 CPU [skip ci]

### DIFF
--- a/docs/Gem5_Docs/frontend/fetch-cache.md
+++ b/docs/Gem5_Docs/frontend/fetch-cache.md
@@ -1,0 +1,373 @@
+# GEM5 XiangShan Fetch阶段访问I-Cache的时序分析
+
+## 1. I-Cache配置参数
+
+### 基本配置 (来自configs/common/Caches.py)
+```python
+class L1_ICache(L1Cache):
+    mshrs = 2                    # Miss Handling Status Registers
+    is_read_only = True          # 只读cache
+    writeback_clean = False      # 不回写clean lines
+    
+    tag_latency = 1              # Tag访问延迟：1拍
+    data_latency = 1             # Data array访问延迟：1拍  
+    sequential_access = False    # 并行访问tag和data
+    response_latency = 0         # 响应延迟：0拍
+    enable_wayprediction = False # 禁用way预测
+```
+
+### 时序关键参数
+- **主频**: 3GHz，即每拍333 ticks
+- **tag_latency**: 控制tag lookup的时间，影响cache hit/miss判断
+- **data_latency**: 控制data array访问时间，影响数据读取
+- **sequential_access = False**: 表示tag和data并行访问
+
+## 2. Fetch阶段访问I-Cache的完整流程
+
+### 2.1 fetchCacheLine()函数 - 发起访问
+
+```cpp
+// src/cpu/o3/fetch.cc:761-860
+bool Fetch::fetchCacheLine(Addr vaddr, ThreadID tid, Addr pc)
+{
+    // 1. 检查cache阻塞状态
+    if (cacheBlocked) {
+        setAllFetchStalls(StallReason::IcacheStall);
+        return false;
+    }
+    
+    // 2. 检查中断状态
+    if (checkInterrupt(pc) && !delayedCommit[tid]) {
+        setAllFetchStalls(StallReason::IntStall);
+        return false;
+    }
+    
+    // 3. 处理跨cache line的misaligned访问
+    if (fetchPC % 64 + fetchBufferSize > 64) {
+        fetchMisaligned[tid] = true;
+        // 需要两次访问：第一次获取当前cache line的剩余部分
+        // 第二次获取下一个cache line的开始部分
+    }
+    
+    // 4. 创建memory request
+    RequestPtr mem_req = std::make_shared<Request>(
+        fetchPC, fetchSize,
+        Request::INST_FETCH, cpu->instRequestorId(), pc,
+        cpu->thread[tid]->contextId());
+    
+    // 5. 启动地址翻译
+    fetchStatus[tid] = ItlbWait;
+    setAllFetchStalls(StallReason::ITlbStall);
+    FetchTranslation *trans = new FetchTranslation(this);
+    cpu->mmu->translateTiming(mem_req, cpu->thread[tid]->getTC(),
+                              trans, BaseMMU::Execute);
+    return true;
+}
+```
+
+### 2.2 地址翻译完成后的I-Cache访问
+
+```cpp
+// 地址翻译完成后，通过finishTranslation()发送到I-Cache
+void Fetch::finishTranslation(const Fault &fault, const RequestPtr &req, 
+                               ThreadContext *tc, BaseMMU::Mode mode)
+{
+    // 发送timing request到I-Cache
+    if (!icachePort.sendTimingReq(fetchPkt)) {
+        // 如果无法发送，设置retry状态
+        fetchStatus[tid] = IcacheWaitRetry;
+    } else {
+        // 成功发送，等待响应
+        fetchStatus[tid] = IcacheWaitResponse;
+    }
+}
+```
+
+## 3. I-Cache内部的时序处理
+
+### 3.1 Cache::access() - 核心访问逻辑
+
+```cpp
+// src/mem/cache/base.cc:1693
+bool BaseCache::access(PacketPtr pkt, CacheBlk *&blk, Cycles &lat,
+                       PacketList &writebacks)
+{
+    // 1. 访问tag array
+    Cycles tag_latency(0);
+    blk = tags->accessBlock(pkt, tag_latency);  // tag_latency = 1拍
+    
+    DPRINTF(Cache, "%s for %s %s, block access lat %lu\n", __func__, 
+            pkt->print(), blk ? "hit " + blk->print() : "miss", tag_latency);
+            
+    // 2. 根据hit/miss计算总延迟
+    if (blk && blk->isValid() && blk->isSet(CacheBlk::ReadableBit)) {
+        // Cache Hit路径
+        lat = calculateAccessLatency(blk, pkt->headerDelay, tag_latency);
+        return true;  // Hit
+    } else {
+        // Cache Miss路径
+        lat = calculateAccessLatency(blk, pkt->headerDelay, tag_latency);
+        return false; // Miss
+    }
+}
+```
+
+### 3.2 延迟计算函数
+
+```cpp
+// src/mem/cache/base.cc:1647
+Cycles BaseCache::calculateAccessLatency(const CacheBlk* blk, 
+                                        const uint32_t delay,
+                                        const Cycles lookup_lat) const
+{
+    Cycles lat(0);
+    
+    if (blk != nullptr) {  // Cache Hit
+        if (sequentialAccess) {
+            // 顺序访问：先tag，后data
+            lat = ticksToCycles(delay) + lookup_lat + dataLatency;
+        } else {
+            // 并行访问：取tag和data中的最大值
+            lat = ticksToCycles(delay) + std::max(lookup_lat, dataLatency);
+        }
+        
+        // 检查block是否ready（用于modeling bank conflict等）
+        const Tick tick = curTick() + delay;
+        const Tick when_ready = blk->getWhenReady();
+        if (when_ready > tick) {
+            lat += ticksToCycles(when_ready - tick);
+            DPRINTF(Cache, "block not ready, need %lu cycle\n", 
+                    ticksToCycles(when_ready - tick));
+        }
+    } else {  // Cache Miss
+        // Miss情况下只需要tag lookup延迟
+        lat = ticksToCycles(delay) + lookup_lat;
+    }
+    
+    return lat;
+}
+```
+
+### 3.3 Cache Hit的响应处理
+
+```cpp
+// src/mem/cache/base.cc:380-430
+void BaseCache::handleTimingReqHit(PacketPtr pkt, CacheBlk *blk, 
+                                   Tick request_time, bool first_acc_after_pf)
+{
+    if (pkt->needsResponse()) {
+        // 1. 生成response
+        pkt->makeTimingResponse();
+        
+        DPRINTF(Cache, "Making timing response for %s, schedule it at %llu\n",
+                pkt->print(), request_time);
+        
+        // 2. 调度响应 - 关键时序点
+        if (cacheLevel == 1) {
+            // L1 cache有固定的pipeline延迟
+            this->schedule(new SendTimingRespEvent(this, pkt), request_time - 1);
+        } else {
+            cpuSidePort.schedTimingResp(pkt, request_time);
+        }
+    }
+}
+```
+
+## 4. 具体时序分析（基于debug输出）
+
+### 4.1 Cache Miss场景分析
+
+```
+时刻999: access for ReadReq [80000000:8000003f] IF miss, block access lat 1
+```
+- **tick 999**: Fetch发起请求，tag lookup耗时1拍
+- tag_latency = 1，因为是miss所以只需要tag访问
+- 实际延迟计算：`lat = tag_latency = 1拍 = 333 ticks`
+
+```
+时刻1332: Sending pkt ReadReq [80000000:8000003f] IF  
+时刻1332: createMissPacket: created ReadCleanReq [80000000:8000003f] IF
+```
+- **tick 1332**: 向下级发送miss packet
+- 延迟：1332 - 999 = 333 ticks = 1拍，符合tag_latency
+
+```
+时刻60939: recvTimingResp: Handling response ReadResp [80000000:8000003f] IF
+时刻60939: Scheduling 0x80000000 to response to sender 0 at tick 60939
+```
+- **tick 60939**: 收到下级响应，立即调度给fetch
+- response_latency = 0，所以没有额外延迟
+
+### 4.2 Cache Hit场景分析
+
+```
+时刻61605: access for ReadReq [8000003e:8000003f] IF hit, block access lat 1
+时刻61605: final cache read lat 1
+时刻61605: Making timing response for ReadResp, schedule it at 61938
+```
+- **tick 61605**: 发起访问，hit延迟1拍
+- 由于sequential_access = False且tag_latency = data_latency = 1
+- 计算：`lat = max(tag_latency, data_latency) = max(1, 1) = 1拍`
+- 调度响应：61605 + 333 = 61938
+
+```
+时刻121545: access for ReadReq [8000007e:8000007f] IF hit, block access lat 1
+时刻121545: block not ready, need 1 cycle  
+时刻121545: final cache read lat 2
+时刻121545: Making timing response for ReadResp, schedule it at 122211
+```
+- **tick 121545**: Hit但block未ready，额外1拍延迟
+- 总延迟：1(tag/data) + 1(block not ready) = 2拍
+- 调度响应：121545 + 666 = 122211
+
+## 5. 关键时序参数的影响
+
+### 5.1 tag_latency的影响
+
+**作用**：
+- 控制tag lookup的时间
+- 影响hit/miss判断的延迟
+- Miss情况下决定最终访问延迟
+
+**时序计算**：
+- Cache Miss: `latency = tag_latency` 
+- Cache Hit并行访问: `latency = max(tag_latency, data_latency)`
+- Cache Hit顺序访问: `latency = tag_latency + data_latency`
+
+### 5.2 data_latency的影响
+
+**作用**：
+- 控制data array访问时间
+- 只在cache hit时影响总延迟
+- 在miss时被忽略（因为不需要读取数据）
+
+**时序计算**：
+- Cache Miss: data_latency不影响延迟
+- Cache Hit: 与tag_latency共同决定访问延迟
+
+### 5.3 sequential_access参数的影响
+
+**当前配置**: `sequential_access = False` (并行访问)
+
+**并行访问** (当前使用):
+```cpp
+lat = ticksToCycles(delay) + std::max(tag_latency, data_latency);
+// 对于L1_ICache: lat = max(1, 1) = 1拍
+```
+
+**顺序访问** (如果改为True):
+```cpp  
+lat = ticksToCycles(delay) + tag_latency + data_latency;
+// 对于L1_ICache: lat = 1 + 1 = 2拍
+```
+
+## 6. Fetch与I-Cache的接口时序
+
+### 6.1 Request路径时序
+```
+Fetch::fetchCacheLine() 
+    ↓ (地址翻译)
+IcachePort::sendTimingReq()
+    ↓ (bus延迟)  
+Cache::recvTimingReq()
+    ↓ (access延迟：tag_latency)
+Cache::handleTimingReqHit/Miss()
+```
+
+### 6.2 Response路径时序  
+```
+Cache::handleTimingReqHit()
+    ↓ (调度响应：request_time)
+IcachePort::recvTimingResp() 
+    ↓ (处理数据)
+Fetch::finishIcacheResponse()
+    ↓ (更新fetch buffer)
+继续fetch指令
+```
+
+### 6.3 Pipeline关键时序点
+
+1. **Tag Lookup**: tick + tag_latency * clockPeriod
+2. **Data Access**: 与tag并行或串行，取决于sequential_access
+3. **Response Generation**: request_time（包含上述所有延迟）
+4. **Response Delivery**: response_time（通常立即，response_latency=0）
+
+## 7. 性能优化建议
+
+### 7.1 减少Cache访问延迟
+- 降低tag_latency和data_latency可直接减少hit延迟
+- 但需要考虑实际硬件实现的限制
+
+### 7.2 Way Prediction优化
+- 当前禁用了way prediction
+- 启用后可以减少data array访问时间
+
+### 7.3 Bank Interleaving
+- 通过bank interleaving减少bank conflict
+- 避免"block not ready"导致的额外延迟
+
+这个分析展示了在3GHz主频下，tag_latency和data_latency如何精确控制I-Cache的访问时序，每1拍的延迟对应333 ticks的时间成本。
+
+## 8. 跨Cache Line取指 (Misaligned Fetch) 的处理
+
+根据 `src/cpu/o3/fetch.cc` 的实现，Fetch阶段在处理跨越Cache Line边界的取指请求时，有一套特殊的处理逻辑，以对齐某些RTL设计。默认情况下，对ICache的访问是针对一个Cache Line（通常是64字节）的。当一次取指请求跨越两个Cache Line时，GEM5会将其拆分为两次独立的ICache访问，并在收到响应后将数据合并。
+
+### 8.1 关键数据结构
+
+为了管理跨行取指的复杂状态，Fetch逻辑使用了几个关键的线程相关（`[tid]`）数据结构：
+
+-   `bool fetchMisaligned[tid]`: 状态标志。当一次取指被识别为跨行访问时，此标志被设为 `true`。它控制后续逻辑将请求拆分，并在响应返回时进行合并。
+-   `RequestPtr memReq[tid]`: 指向当前内存请求的智能指针。在跨行访问场景下，它在`fetchCacheLine`函数执行过程中，最终会指向**第二次**的Cache访问请求。
+-   `RequestPtr anotherMemReq[tid]`: 另一个请求指针。在跨行访问中，它被用来保存**第一次**的Cache访问请求。
+-   `uint8_t *firstPktData[tid]`: 用于临时存储第一个Cache Line返回的数据。当第二个包返回时，这两个包的数据会被合并到最终的 `fetchBuffer` 中。
+
+### 8.2 请求的拆分：`fetchCacheLine()` 逻辑详解
+
+当检测到跨行访问时 (`fetchPC % 64 + fetchBufferSize > 64`)，`fetchCacheLine` 会执行以下操作：
+
+1.  **标记为跨行访问**:
+    -   `fetchMisaligned[tid] = true;`
+
+2.  **创建并发送第一个请求** (访问当前Cache Line的尾部):
+    -   计算大小: `fetchSize = 64 - fetchPC % 64;`
+    -   创建请求: `RequestPtr mem_req = std::make_shared<Request>(...);`
+    -   **保存请求**: 此时，会将这个请求同时赋值给 `memReq[tid]` 和 `anotherMemReq[tid]`。
+    -   发起翻译: `cpu->mmu->translateTiming(mem_req, ...);`
+
+3.  **创建并发送第二个请求** (访问下一个Cache Line的头部):
+    -   这部分代码紧接着第一个请求的创建逻辑。
+    -   更新PC和大小: `fetchPC` 指向下一个Line的开头，`fetchSize` 为剩余大小。
+    -   创建请求: `RequestPtr mem_req = std::make_shared<Request>(...);`
+    -   **更新请求指针**: `memReq[tid]` 被更新为指向这个**新的（第二个）请求**。此时，`anotherMemReq[tid]` 仍然保留着第一个请求。
+    -   发起翻译: `cpu->mmu->translateTiming(mem_req, ...);`
+
+函数执行完毕后，两个独立的取指请求都已被发送出去进行地址翻译，并最终由 `finishTranslation` 发往ICache。
+
+### 8.3 响应的接收与合并：`processCacheCompletion()` 逻辑详解
+
+ICache的响应最终会触发 `processCacheCompletion()` 函数。该函数通过检查 `fetchMisaligned[tid]` 标志来决定如何处理返回的数据包 (`pkt`)。
+
+1.  **检查是否为跨行访问**:
+    -   `if (fetchMisaligned[tid]) { ... }`
+
+2.  **处理第一个返回包**:
+    -   通过比对返回包的地址和 `anotherMemReq[tid]` 中保存的第一个请求的地址，来判断这是否是第一个响应。
+    -   `if (pkt->getAddr() == anotherMemReq[tid]->getVaddr()) { ... }`
+    -   如果是第一个响应，将其数据临时存储在 `firstPktData[tid]` 中，然后直接 `return`，等待第二个包的到来。
+
+3.  **处理第二个返回包并合并数据**:
+    -   如果当前返回的包不是第一个包，那么它就是第二个包。
+    -   **数据合并**:
+        -   将第一个包的数据（来自`firstPktData`）和当前第二个包的数据，依次拷贝到连续的 `fetchBuffer` 中。
+        -   `memcpy(fetchBuffer[tid], firstPktData[tid], first_size);`
+        -   `memcpy(fetchBuffer[tid] + first_size, pkt_data, second_size);`
+    -   **清理状态**: 合并完成后，将 `fetchMisaligned[tid]` 设回 `false`，并释放临时资源。
+
+4.  **处理普通（非跨行）访问**:
+    -   如果 `fetchMisaligned[tid]` 为 `false`，则直接将返回的数据包内容拷贝到 `fetchBuffer`。
+
+### 8.4 总结
+
+-   **ICache的访问粒度**: ICache本身处理的是对齐的Cache Line请求。
+-   **Fetch的责任**: Fetch单元通过精巧的状态管理（`fetchMisaligned`标志和多个请求指针），将一个对用户透明的跨行访问分解为两个独立的、对齐的Cache访问，并在响应返回后将结果无缝合并。
+-   **与RTL对齐**: 这种"拆分请求、缓存结果、最终合并"的模式，是为了更精确地模拟某些高性能处理器RTL设计的行为，从而获得更准确的性能和时序模拟结果。

--- a/docs/Gem5_Docs/midcore/decode.md
+++ b/docs/Gem5_Docs/midcore/decode.md
@@ -1,0 +1,915 @@
+# GEM5 O3 CPU Decode Stage 详细解析文档
+
+## 概述
+
+Decode 阶段是 GEM5 O3 处理器模型中的第二个流水线阶段，位于 Fetch 和 Rename 之间。虽然指令的实际解码工作在 Fetch 阶段创建 StaticInst 时已经完成，但 Decode 阶段的主要职责是进行**分支预测验证（Branch Prediction Check）**，确保从 Fetch 阶段传来的分支预测信息是正确的。
+
+## 核心功能
+
+### 主要职责
+1. **分支预测验证**: 检查 Fetch 阶段的分支预测是否正确
+2. **指令流控制**: 在检测到错误预测时发送 squash 信号给 Fetch 阶段
+3. **流水线控制**: 处理来自后续阶段的阻塞和 squash 信号
+4. **指令传递**: 将经过验证的指令传递给 Rename 阶段
+5. **停顿传播**: 在流水线阶段间传播停顿原因
+
+### 核心验证机制（Precheck）
+Decode 阶段实现了四种关键的分支预测验证：
+
+1. **控制流预测验证**: 检查被预测为跳转的指令是否真的是控制指令
+2. **直接分支目标验证**: 对于直接分支，计算实际目标并与预测目标比较
+3. **未预测返回指令处理**: 处理被 BP 遗漏的返回指令
+4. **非推测指令修正**: 修正错误预测的非推测指令
+
+## 核心数据结构
+
+### 1. 流水线状态管理
+
+#### 整体状态
+```cpp
+enum DecodeStatus {
+    Active,      // 有线程在活跃处理
+    Inactive     // 所有线程都空闲
+} _status;
+```
+
+#### 线程级状态
+```cpp
+enum ThreadStatus {
+    Running,      // 正常运行，处理指令
+    Idle,         // 空闲，没有指令处理
+    StartSquash,  // 开始 squash 操作
+    Squashing,    // 正在进行 squash
+    Blocked,      // 被下游阶段阻塞
+    Unblocking    // 正在解除阻塞
+} decodeStatus[MaxThreads];
+```
+
+### 2. 时间缓冲接口系统
+
+#### 输入接口（接收信号）
+```cpp
+// 来自 Fetch 阶段的指令队列
+TimeBuffer<FetchStruct>::wire fromFetch;
+// 包含: insts[]数组、size、fetchStallReason[]
+
+// 来自 Rename 阶段的反向控制信号  
+TimeBuffer<TimeStruct>::wire fromRename;
+// 包含: renameBlock[]、renameUnblock[]、renameInfo.blockReason
+
+// 来自 IEW 阶段的信号
+TimeBuffer<TimeStruct>::wire fromIEW;
+
+// 来自 Commit 阶段的重要控制信号
+TimeBuffer<TimeStruct>::wire fromCommit;
+// 包含: commitInfo[].squash、squashVersion、squashInst等
+```
+
+#### 输出接口（发送信号）
+```cpp
+// 向 Fetch 阶段发送控制信息
+TimeBuffer<TimeStruct>::wire toFetch;
+// 包含: decodeInfo[].squash、branchMispredict、nextPC等
+
+// 向 Rename 阶段传递指令
+TimeBuffer<DecodeStruct>::wire toRename; 
+// 包含: insts[]数组、size、fetchStallReason、decodeStallReason
+```
+
+### 3. 指令缓冲和队列管理
+
+#### 指令队列
+```cpp
+// 每线程的指令队列：存储从 Fetch 来的新指令
+std::queue<DynInstPtr> insts[MaxThreads];
+
+// 滑动缓冲区：当阶段被阻塞时临时存储指令
+std::queue<DynInstPtr> skidBuffer[MaxThreads];
+unsigned skidBufferMax;  // 最大缓冲区大小
+
+// 当前周期向 Rename 发送的指令索引
+unsigned toRenameIndex;
+```
+
+### 4. 停顿和阻塞控制
+
+#### 停顿跟踪结构
+```cpp
+struct Stalls {
+    bool rename;  // 来自 Rename 阶段的停顿信号
+} stalls[MaxThreads];
+
+// 停顿原因向量：记录每个指令槽的停顿原因
+std::vector<StallReason> decodeStalls;  // 大小 = decodeWidth
+
+// 当前阻塞的原因
+StallReason blockReason;
+```
+
+#### 停顿原因类型
+```cpp
+enum StallReason {
+    NoStall,         // 无停顿
+    InstSquashed,    // 指令被 squash
+    InstMisPred,     // 分支误预测
+    SquashStall,     // 正在 squash 过程中
+    FetchFragStall,  // Fetch 阶段片段停顿
+    // ... 其他停顿类型
+};
+```
+
+### 5. 性能统计结构
+
+```cpp
+struct DecodeStats {
+    statistics::Scalar idleCycles;        // 空闲周期数
+    statistics::Scalar blockedCycles;     // 阻塞周期数  
+    statistics::Scalar runCycles;         // 运行周期数
+    statistics::Scalar unblockCycles;     // 解除阻塞周期数
+    statistics::Scalar squashCycles;      // Squash 周期数
+    
+    statistics::Scalar branchResolved;    // 分支解析次数
+    statistics::Scalar branchMispred;     // 分支误预测次数
+    statistics::Scalar controlMispred;    // 控制误预测次数
+    
+    statistics::Scalar decodedInsts;      // 解码指令总数
+    statistics::Scalar squashedInsts;     // 被 squash 的指令数
+    
+    statistics::Scalar mispredictedByPC;  // PC 误预测数量
+    statistics::Scalar mispredictedByNPC; // NPC 误预测数量
+} stats;
+```
+
+### 6. 版本控制和延迟处理
+
+```cpp
+// Squash 版本控制（用于乱序处理）
+SquashVersion localSquashVer;
+
+// MIPS 特有的延迟分支处理
+Addr bdelayDoneSeqNum[MaxThreads];           // 延迟槽完成序号
+DynInstPtr squashInst[MaxThreads];           // Squash 指令指针  
+bool squashAfterDelaySlot[MaxThreads];       // 延迟槽后 squash 标志
+// 之后可以删除了，目前只支持RISCV了
+```
+
+#### 版本控制机制详解
+
+Decode 阶段使用 **version-based squash strategy** 来处理多重 squash 冲突：
+
+```cpp
+// 在 sortInsts() 中进行版本检查
+void Decode::sortInsts() {
+    int insts_from_fetch = fromFetch->size;
+    for (int i = 0; i < insts_from_fetch; ++i) {
+        const DynInstPtr &inst = fromFetch->insts[i];
+        
+        // 检查指令版本是否过期
+        if (localSquashVer.largerThan(inst->getVersion())) {
+            inst->setSquashed();  // 标记过期指令
+        }
+        
+        insts[inst->threadNumber].push(inst);
+    }
+}
+
+// 在接收 Commit squash 时同步版本
+if (fromCommit->commitInfo[tid].squash) {
+    squash(tid);
+    
+    // 同步版本号，确保后续指令使用新版本
+    localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
+    DPRINTF(Decode, "Updating squash version to %u\n", localSquashVer.getVersion());
+    
+    return true;
+}
+```
+
+**版本控制的作用**：
+- **时期分离**: 区分不同 squash epoch 的指令
+- **精确清理**: 只处理属于过期版本的指令
+- **冲突解决**: 处理 Decode 和 Commit 同时发送 squash 的情况
+
+## 核心函数详细解析
+
+### 1. tick() - 主时钟周期函数
+
+```cpp
+void Decode::tick()
+```
+
+**功能**: 每个时钟周期的主处理函数，协调整个 Decode 阶段的工作流程。
+
+**执行流程**:
+
+#### 1.1 初始化阶段
+```cpp
+// 传递 Fetch 的停顿原因给 Rename
+toRename->fetchStallReason = fromFetch->fetchStallReason;
+
+// 重置周期状态
+wroteToTimeBuffer = false;
+bool status_change = false;
+toRenameIndex = 0;
+```
+
+#### 1.2 指令预处理
+```cpp
+sortInsts();  // 将 Fetch 来的指令按线程分类
+```
+
+#### 1.3 多线程处理循环
+```cpp
+while (threads != end) {
+    ThreadID tid = *threads++;
+    
+    // 检查并更新信号状态
+    status_change = checkSignalsAndUpdate(tid) || status_change;
+    
+    // 执行实际的解码处理
+    decode(status_change, tid);
+    
+    // 设置反馈给 Fetch 的阻塞原因
+    toFetch->decodeInfo[tid].blockReason = blockReason;
+}
+```
+
+#### 1.4 停顿原因传播逻辑
+```cpp
+if (stalls[tid].rename) {
+    // 有来自 Rename 的停顿 -> 传播 Rename 停顿
+    setAllStalls(fromRename->renameInfo[tid].blockReason);
+} else if (toRenameIndex == 0) {
+    // 本周期没有处理任何指令 -> 传播 Decode 自身的停顿
+    if (decodeStalls[0] != StallReason::NoStall) {
+        setAllStalls(decodeStalls[0]);
+    }
+} else {
+    // 处理了部分指令 -> 分别设置处理和未处理指令的停顿状态
+    for (int i = 0; i < decodeStalls.size(); i++) {
+        if (i < toRenameIndex) {
+            decodeStalls.at(i) = StallReason::NoStall;  // 已处理：无停顿
+        } else {
+            decodeStalls.at(i) = fromFetch->fetchStallReason.at(i);  // 未处理：传播 Fetch 停顿
+        }
+    }
+}
+
+// 将停顿原因传递给 Rename 阶段
+toRename->decodeStallReason = decodeStalls;
+```
+
+### 2. checkSignalsAndUpdate() - 信号检查和状态更新
+
+```cpp
+bool checkSignalsAndUpdate(ThreadID tid)
+```
+
+**功能**: 检查来自其他流水线阶段的控制信号，并相应更新 Decode 状态。
+
+**处理优先级**:
+
+#### 2.1 Commit 阶段 Squash 信号（最高优先级）
+```cpp
+if (fromCommit->commitInfo[tid].squash) {
+    DPRINTF(Decode, "[tid:%i] Squashing instructions due to squash from commit.\n", tid);
+    
+    squash(tid);  // 执行 squash 操作
+    
+    // 更新本地 squash 版本号
+    localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
+    
+    return true;
+}
+```
+
+#### 2.2 Rename 阶段停顿信号
+```cpp
+if (checkStall(tid)) {
+    blockReason = fromRename->renameInfo[tid].blockReason;
+    return block(tid);  // 阻塞当前线程
+}
+```
+
+#### 2.3 状态转换处理
+```cpp
+if (decodeStatus[tid] == Blocked) {
+    // 从阻塞状态转换到解除阻塞状态
+    decodeStatus[tid] = Unblocking;
+    unblock(tid);
+    return true;
+}
+
+if (decodeStatus[tid] == Squashing) {
+    // 从 Squash 状态转换到运行状态
+    decodeStatus[tid] = Running;
+    return false;
+}
+```
+
+### 3. decodeInsts() - 指令解码和分支验证核心函数
+
+```cpp
+void decodeInsts(ThreadID tid)
+```
+
+**功能**: 这是 Decode 阶段最核心的函数，负责处理指令并进行关键的分支预测验证。
+
+#### 3.1 初始化和状态检查
+
+```cpp
+// 确定指令来源：skidBuffer（解除阻塞时）或 insts（正常运行时）
+int insts_available = decodeStatus[tid] == Unblocking ? 
+    skidBuffer[tid].size() : insts[tid].size();
+
+std::queue<StallReason> decode_stalls;  // 记录停顿原因
+StallReason breakDecode = StallReason::NoStall;  // 破坏解码的原因
+
+// 无指令可处理的情况
+if (insts_available == 0) {
+    ++stats.idleCycles;
+    // 传播 Fetch 阶段的停顿原因
+    StallReason stall = StallReason::NoStall;
+    for (auto iter : fromFetch->fetchStallReason) {
+        if (iter != StallReason::NoStall) {
+            stall = iter;
+            break;
+        }
+    }
+    setAllStalls(stall);
+    return;
+}
+```
+
+#### 3.2 向量指令限制检查
+
+```cpp
+// 向量指令解码限制：如果第一条不是向量指令，则本周期不能处理向量指令
+bool vec_decode_limit = false;
+if (!insts_to_decode.front()->isVector()) {
+    vec_decode_limit = true;
+}
+```
+
+#### 3.3 主指令处理循环
+
+```cpp
+while (insts_available > 0 && toRenameIndex < decodeWidth) {
+    // 向量指令检查
+    if (vec_decode_limit && insts_to_decode.front()->isVector()) {
+        break;
+    }
+    
+    DynInstPtr inst = std::move(insts_to_decode.front());
+    insts_to_decode.pop();
+    
+    // 跳过已被 squash 的指令
+    if (inst->isSquashed()) {
+        ++stats.squashedInsts;
+        decode_stalls.push(StallReason::InstSquashed);
+        continue;
+    }
+    
+    // 无源寄存器的指令可以立即发射
+    if (inst->numSrcRegs() == 0) {
+        inst->setCanIssue();
+    }
+    
+    // 将指令添加到输出队列
+    toRename->insts[toRenameIndex] = inst;
+    ++(toRename->size);
+    ++toRenameIndex;
+    ++stats.decodedInsts;
+    --insts_available;
+```
+
+#### 3.4 分支预测验证机制（核心Precheck逻辑）
+
+##### **验证1: 控制流预测检查**
+```cpp
+// 确保被预测为跳转的指令真的是控制指令
+if (inst->readPredTaken() && !inst->isControl()) {
+    ++stats.controlMispred;
+    
+    // 发送 squash 信号给 Fetch
+    squash(inst, inst->threadNumber);
+    
+    decode_stalls.push(StallReason::InstMisPred);
+    breakDecode = StallReason::InstMisPred;
+    break;
+}
+```
+
+这个检查防止了**假阳性分支预测**：当分支预测器错误地将非控制指令预测为跳转指令时，Decode 阶段能够及时发现并纠正。
+
+##### **验证2: 直接分支目标验证**
+```cpp
+// 对于直接分支（无条件或预测为跳转的条件分支）
+if (inst->isDirectCtrl() && (inst->isUncondCtrl() || inst->readPredTaken())) {
+    ++stats.branchResolved;
+    
+    // 计算实际分支目标
+    std::unique_ptr<PCStateBase> target = inst->branchTarget();
+    auto &t = target->as<RiscvISA::PCState>();
+    auto &pred = inst->readPredTarg().as<RiscvISA::PCState>();
+    
+    // RISC-V 特有：处理 NPC 覆盖问题
+    if (t.start_equals(pred) && !t.equals(pred)) {
+        DPRINTF(DecoupleBP, "Override useless npc, from %#lx->%#lx to %#lx->%#lx\n",
+                pred.pc(), pred.npc(), t.pc(), t.npc());
+        inst->setPredTarg(t);
+    }
+    
+    // 比较实际目标与预测目标
+    if (*target != inst->readPredTarg()) {
+        ++stats.branchMispred;
+        
+        // 细分误预测类型统计
+        RiscvISA::PCState cpTarget = target->clone()->as<RiscvISA::PCState>();
+        RiscvISA::PCState cpPredTarget = inst->readPredTarg().clone()->as<RiscvISA::PCState>();
+        
+        if (cpTarget.instAddr() != cpPredTarget.instAddr() && cpTarget.npc() == cpPredTarget.npc()) {
+            ++stats.mispredictedByPC;   // PC 地址误预测
+        } else if (cpTarget.instAddr() == cpPredTarget.instAddr() && cpTarget.npc() != cpPredTarget.npc()) {
+            ++stats.mispredictedByNPC;  // NPC 地址误预测
+        }
+        
+        // 发送 squash 信号并更新预测目标
+        squash(inst, inst->threadNumber);
+        inst->setPredTarg(*target);
+        
+        decode_stalls.push(StallReason::InstMisPred);
+        breakDecode = StallReason::InstMisPred;
+        break;
+    }
+}
+```
+
+这个验证确保直接分支的目标地址是正确的，是**早期分支解析**的关键部分。
+
+##### **验证3: 未预测返回指令处理**
+```cpp
+// 处理分支预测器遗漏的返回指令
+if (inst->isReturn() && !inst->isNonSpeculative() && !inst->readPredTaken()) {
+    ++stats.branchMispred;
+    decode_stalls.push(StallReason::InstMisPred);
+    breakDecode = StallReason::InstMisPred;
+    
+    // 从 Fetch 阶段获取保存的返回地址
+    auto return_addr = fetch_ptr->getPreservedReturnAddr(inst);
+    auto target = std::make_unique<RiscvISA::PCState>(return_addr);
+    
+    DPRINTF(Decode, "[tid:%i] [sn:%llu] Updating predictions: "
+            "Return not identified by bp: predTaken %d, PredPC: %s Now PC %s\n",
+            tid, inst->seqNum, inst->readPredTaken(), inst->readPredTarg(), *target);
+    
+    // 更新预测信息
+    inst->setPredTaken(true);
+    inst->setPredTarg(*target);
+    
+    // 发送 squash 信号
+    squash(inst, inst->threadNumber);
+    break;
+}
+```
+
+这个机制处理了**返回地址栈（RAS）遗漏**的情况，确保所有返回指令都能正确预测。
+
+##### **验证4: 非推测指令修正**
+```cpp
+// 修正错误预测为跳转的非推测指令
+if (inst->isNonSpeculative() && inst->readPredTaken()) {
+    // 重定向到 fall-through 地址
+    std::unique_ptr<PCStateBase> npc(inst->pcState().clone());
+    npc->as<RiscvISA::PCState>().set(inst->pcState().getFallThruPC());
+    inst->setPredTaken(false);
+    inst->setPredTarg(*npc);
+}
+```
+
+这确保非推测指令（如系统调用、异常指令）不会被错误地预测为跳转。
+
+#### 3.5 停顿处理和阻塞检查
+
+```cpp
+// 设置停顿状态
+if (!decode_stalls.empty()) {
+    setAllStalls(decode_stalls.front());
+} else if (breakDecode != StallReason::NoStall) {
+    setAllStalls(breakDecode);
+}
+
+// 如果还有未处理的指令，则需要阻塞并将指令放入 skid buffer
+if (!insts_to_decode.empty()) {
+    blockReason = breakDecode;
+    block(tid);
+}
+
+// 记录时间缓冲写入活动
+if (toRenameIndex) {
+    wroteToTimeBuffer = true;
+}
+```
+
+### 4. squash() - Squash 信号发送函数
+
+```cpp
+void squash(const DynInstPtr &inst, ThreadID tid)
+```
+
+**功能**: 当检测到分支误预测时，向 Fetch 阶段发送 squash 信号以重新开始取指。
+
+#### 4.1 设置 squash 信号
+```cpp
+// 向 Fetch 发送误预测信息
+toFetch->decodeInfo[tid].branchMispredict = true;
+toFetch->decodeInfo[tid].predIncorrect = true;
+toFetch->decodeInfo[tid].mispredictInst = inst;
+toFetch->decodeInfo[tid].squash = true;
+toFetch->decodeInfo[tid].doneSeqNum = inst->seqNum;
+```
+
+#### 4.2 计算正确的跳转目标
+```cpp
+if (inst->isControl()) {
+    if (!inst->isReturn()) {
+        // 直接分支：使用计算出的分支目标
+        set(toFetch->decodeInfo[tid].nextPC, *inst->branchTarget());
+    } else {
+        // 返回指令：使用已设置的预测目标
+        std::unique_ptr<PCStateBase> tgt_ptr(inst->readPredTarg().clone());
+        set(toFetch->decodeInfo[tid].nextPC, *tgt_ptr);
+    }
+} else {
+    // 非控制指令：使用 fall-through 地址
+    std::unique_ptr<PCStateBase> npc_ptr(inst->pcState().clone());
+    npc_ptr->as<RiscvISA::PCState>().set(inst->pcState().getFallThruPC());
+    set(toFetch->decodeInfo[tid].nextPC, *npc_ptr);
+}
+```
+
+#### 4.3 设置分支状态信息
+```cpp
+// 设置分支跳转状态（考虑 BTB 别名问题）
+toFetch->decodeInfo[tid].branchTaken = inst->readPredTaken() || inst->isUncondCtrl();
+toFetch->decodeInfo[tid].squashInst = inst;
+```
+
+#### 4.4 清理流水线状态
+```cpp
+// 解除可能的阻塞状态
+if (decodeStatus[tid] == Blocked || decodeStatus[tid] == Unblocking) {
+    toFetch->decodeUnblock[tid] = 1;
+}
+
+// 设置状态为 Squashing
+decodeStatus[tid] = Squashing;
+
+// Squash 来自 Fetch 的后续指令
+for (int i = 0; i < fromFetch->size; i++) {
+    if (fromFetch->insts[i]->threadNumber == tid &&
+        fromFetch->insts[i]->seqNum > squash_seq_num) {
+        fromFetch->insts[i]->setSquashed();
+    }
+}
+
+// 清空指令队列和 skid buffer
+while (!insts[tid].empty()) { insts[tid].pop(); }
+while (!skidBuffer[tid].empty()) { skidBuffer[tid].pop(); }
+
+// 通知 CPU 移除错误路径上的指令
+cpu->removeInstsUntil(squash_seq_num, tid);
+```
+
+### 5. 其他重要支持函数
+
+#### 阻塞控制机制详解
+
+流水线阻塞控制是现代处理器中的关键机制，用于处理**流水线阶段间的速度不匹配**和**资源竞争**问题。
+
+##### 1. 为什么需要阻塞机制？
+
+**问题背景**：
+- **后端压力**: Rename/IEW/Commit 阶段可能因为寄存器重命名表满、指令队列满、ROB满等原因无法接收新指令
+- **速度不匹配**: 上游阶段（Fetch/Decode）可能产生指令的速度超过下游阶段的处理能力
+- **资源争用**: 多线程环境下不同线程争用有限的处理器资源
+
+**没有阻塞机制的后果**：
+- 指令丢失：无法处理的指令被直接丢弃
+- 数据不一致：流水线状态混乱
+- 性能下降：频繁的 squash 和重新执行
+
+##### 2. Skid Buffer 的设计目的
+
+**Skid Buffer（滑行缓冲区）**解决了**流水线惯性**问题：
+
+```cpp
+// Skid Buffer 大小计算
+skidBufferMax = (fetchToDecodeDelay + 1) * params.fetchWidth;
+```
+
+**设计理念**：
+- **惯性缓冲**: 当 Decode 被阻塞时，Fetch 阶段不能立即停止（就像汽车刹车需要滑行距离）
+- **延迟补偿**: 考虑到 Fetch 到 Decode 的传输延迟（`fetchToDecodeDelay`）
+- **宽度适配**: 适应 Fetch 阶段的取指宽度（`fetchWidth`）
+
+**Skid Buffer 的作用**：
+
+1. **暂存指令**: 阻塞期间存储来自 Fetch 的指令
+```cpp
+void Decode::skidInsert(ThreadID tid) {
+    while (!insts[tid].empty()) {
+        inst = insts[tid].front();
+        insts[tid].pop();
+        
+        skidBuffer[tid].push(inst);  // 移入 skid buffer
+        
+        DPRINTF(Decode, "Inserting [tid:%d][sn:%lli] PC: %s into decode "
+                "skidBuffer %i\n", inst->threadNumber, inst->seqNum,
+                inst->pcState(), skidBuffer[tid].size());
+    }
+}
+```
+
+2. **顺序恢复**: 解除阻塞时优先处理 skid buffer 中的指令
+```cpp
+// 在 decodeInsts() 中根据状态选择指令来源
+int insts_available = decodeStatus[tid] == Unblocking ?
+    skidBuffer[tid].size() : insts[tid].size();
+
+std::queue<DynInstPtr> &insts_to_decode = decodeStatus[tid] == Unblocking ?
+    skidBuffer[tid] : insts[tid];
+```
+
+##### 3. 状态转换机制
+
+```cpp
+enum ThreadStatus {
+    Running,      // 正常运行，处理来自 Fetch 的指令
+    Blocked,      // 被阻塞，指令存入 skid buffer
+    Unblocking    // 解除阻塞中，优先处理 skid buffer
+};
+```
+
+**状态转换流程**：
+
+```
+Running → Blocked → Unblocking → Running
+   ↑         ↓          ↓         ↑
+正常运行  →  阻塞    →  解除阻塞  →  恢复运行
+           (存储指令) (处理积压)  (正常处理)
+```
+
+**完整工作流程图**：
+
+```mermaid
+graph TD
+    A["Fetch 发送指令"] --> B["Decode 正常接收"]
+    B --> C["处理指令"]
+    C --> D{"Rename 是否<br/>可以接收？"}
+    
+    D -->|可以接收| E["向 Rename 发送指令"]
+    E --> F["继续 Running 状态"]
+    F --> A
+    
+    D -->|无法接收| G["触发 block()"]
+    G --> H["1.指令存入 skid buffer"]
+    H --> I["2.设置状态为 Blocked"]
+    I --> J["3.通知 Fetch 停止发送"]
+    J --> K["Blocked 状态等待"]
+    
+    K --> L{"Rename 是否<br/>恢复可接收？"}
+    L -->|仍无法接收| K
+    L -->|可以接收| M["转换为 Unblocking 状态"]
+    
+    M --> N["处理 skid buffer 中指令"]
+    N --> O{"skid buffer<br/>是否为空？"}
+    O -->|不为空| N
+    O -->|为空| P["调用 unblock()"]
+    P --> Q["转换为 Running 状态"]
+    Q --> R["通知 Fetch 恢复发送"]
+    R --> A
+    
+    style A fill:#e1f5fe
+    style G fill:#ffcdd2
+    style K fill:#fff3e0
+    style M fill:#f3e5f5
+    style Q fill:#e8f5e8
+```
+
+##### 4. 阻塞触发条件
+
+```cpp
+bool Decode::checkStall(ThreadID tid) const {
+    bool ret_val = false;
+    
+    if (stalls[tid].rename) {
+        DPRINTF(Decode,"[tid:%i] Stall from Rename stage detected.\n", tid);
+        ret_val = true;
+    }
+    
+    return ret_val;
+}
+```
+
+**阻塞触发场景**：
+- **Rename 阶段反压**: 寄存器重命名表满、空闲寄存器不足
+- **IEW 阶段反压**: 指令队列满、Load/Store队列满
+- **ROB 满**: Commit 阶段处理速度跟不上
+
+##### 5. block() - 阻塞处理函数
+
+```cpp
+bool Decode::block(ThreadID tid) {
+    DPRINTF(Decode, "[tid:%i] Blocking.\n", tid);
+    
+    // 1. 将当前周期的指令保存到 skid buffer
+    skidInsert(tid);
+    
+    // 2. 设置阻塞状态
+    if (decodeStatus[tid] != Blocked) {
+        decodeStatus[tid] = Blocked;
+        
+        // 3. 通知 Fetch 阶段停止发送指令
+        if (toFetch->decodeUnblock[tid]) {
+            toFetch->decodeUnblock[tid] = false;
+        } else {
+            toFetch->decodeBlock[tid] = true;
+            wroteToTimeBuffer = true;
+        }
+        
+        return true;
+    }
+    
+    return false;
+}
+```
+
+**阻塞处理步骤**：
+1. **指令保护**: 将正在处理的指令移入 skid buffer
+2. **状态更新**: 设置线程状态为 Blocked
+3. **上游通知**: 通知 Fetch 阶段停止发送指令
+4. **信号传播**: 向上游传播阻塞信号
+
+##### 6. unblock() - 解除阻塞函数
+
+```cpp
+bool Decode::unblock(ThreadID tid) {
+    // 只有当 skid buffer 完全清空时才能完全解除阻塞
+    if (skidBuffer[tid].empty()) {
+        DPRINTF(Decode, "[tid:%i] Done unblocking.\n", tid);
+        
+        // 通知 Fetch 可以继续发送指令
+        toFetch->decodeUnblock[tid] = true;
+        wroteToTimeBuffer = true;
+        
+        // 恢复正常运行状态
+        decodeStatus[tid] = Running;
+        return true;
+    }
+    
+    DPRINTF(Decode, "[tid:%i] Currently unblocking.\n", tid);
+    return false;
+}
+```
+
+**解除阻塞条件**：
+- **下游就绪**: Rename 阶段能够接收新指令（stalls[tid].rename = false）
+- **积压清空**: skid buffer 中的指令全部处理完毕
+
+##### 7. 解除阻塞的状态转换
+
+在 `checkSignalsAndUpdate()` 中处理状态转换：
+
+```cpp
+// 检查是否仍需要阻塞
+if (checkStall(tid)) {
+    blockReason = fromRename->renameInfo[tid].blockReason;
+    return block(tid);  // 继续阻塞
+}
+
+// 如果当前是阻塞状态且阻塞条件已解除
+if (decodeStatus[tid] == Blocked) {
+    DPRINTF(Decode, "[tid:%i] Done blocking, switching to unblocking.\n", tid);
+    
+    // 转换到解除阻塞状态
+    decodeStatus[tid] = Unblocking;
+    unblock(tid);
+    
+    return true;
+}
+```
+
+##### 8. Unblocking 状态的特殊处理
+
+```cpp
+if (decodeStatus[tid] == Unblocking) {
+    // 确保 skid buffer 不为空
+    assert(!skidsEmpty());
+    
+    // 优先处理 skid buffer 中的指令
+    decodeInsts(tid);
+    
+    // 如果还有新指令从 Fetch 来，也要保存到 skid buffer
+    if (fetchInstsValid()) {
+        skidInsert(tid);
+    }
+    
+    // 尝试完全解除阻塞
+    status_change = unblock(tid) || status_change;
+}
+```
+
+**Unblocking 状态的特点**：
+- **优先处理**: 优先处理 skid buffer 中的积压指令
+- **继续缓存**: 新来的指令仍然进入 skid buffer
+- **逐步清空**: 每周期处理部分积压指令
+- **条件完成**: 只有当 skid buffer 完全清空才转为 Running
+
+##### 9. 性能影响和优化
+
+**性能统计**：
+```cpp
+if (decodeStatus[tid] == Blocked) {
+    ++stats.blockedCycles;
+} else if (decodeStatus[tid] == Unblocking) {
+    ++stats.unblockCycles;
+}
+```
+
+**优化策略**：
+- **最小阻塞**: 只在必要时阻塞，尽快解除阻塞
+- **批量处理**: Unblocking 期间批量处理积压指令
+- **信号优化**: 减少阻塞/解除阻塞信号的延迟
+
+这种三态设计（Running→Blocked→Unblocking→Running）确保了：
+- **指令不丢失**: 所有指令都会被正确处理
+- **顺序保持**: 指令的原始顺序得到维护
+- **性能最优**: 最小化阻塞对流水线性能的影响
+
+##### 10. 实际应用场景举例
+
+**场景1: 寄存器重命名表满**
+```
+T0: Decode 正常处理指令，Rename 正常接收
+T1: Rename 阶段寄存器重命名表满员
+T2: Rename 发送 renameBlock[tid] = true
+T3: Decode 检测到阻塞信号，调用 block()
+    - 当前指令移入 skid buffer
+    - 设置状态为 Blocked
+    - 通知 Fetch 停止发送
+T4-T8: Decode 保持 Blocked 状态
+T9: Rename 阶段释放部分寄存器，发送 renameUnblock[tid] = true
+T10: Decode 检测到解除阻塞，转换为 Unblocking 状态
+T11-T13: 逐步处理 skid buffer 中的积压指令
+T14: skid buffer 清空，转换为 Running 状态
+T15: 通知 Fetch 恢复发送指令
+```
+
+**场景2: ROB 满导致的连锁反应**
+```
+Commit(ROB满) → IEW(阻塞) → Rename(阻塞) → Decode(阻塞) → Fetch(停止)
+```
+
+这种设计体现了现代流水线处理器的**优雅降级**特性，在遇到资源瓶颈时能够：
+- 保护指令完整性
+- 维持系统稳定性  
+- 提供最佳的恢复性能
+
+#### sortInsts() - 指令分类
+```cpp
+void sortInsts() {
+    int insts_from_fetch = fromFetch->size;
+    for (int i = 0; i < insts_from_fetch; ++i) {
+        const DynInstPtr &inst = fromFetch->insts[i];
+        
+        // 检查 squash 版本号
+        if (localSquashVer.largerThan(inst->getVersion())) {
+            inst->setSquashed();
+        }
+        
+        // 按线程 ID 分类指令
+        insts[inst->threadNumber].push(inst);
+    }
+}
+```
+
+## 分支预测验证总结
+
+Decode 阶段的分支预测验证是一个**多层次的安全检查机制**：
+
+### 检查层次
+1. **控制流正确性**: 预测跳转的指令必须是控制指令
+2. **目标地址正确性**: 直接分支的目标地址必须与计算结果一致  
+3. **预测完整性**: 不能遗漏返回指令等特殊控制指令
+4. **指令特性一致性**: 非推测指令不应被预测为跳转
+
+### Squash 机制工作流程
+1. **检测误预测** → **设置 squash 信号** → **计算正确目标** → **清理流水线** → **通知 Fetch 重新取指**
+
+### 性能影响
+- **早期检测**: 在 Decode 阶段而非 Execute 阶段检测分支误预测，减少了流水线惩罚
+- **精确恢复**: 提供准确的重定向地址，确保程序执行的正确性
+- **统计信息**: 详细的误预测统计有助于分支预测器的调优
+
+这种设计确保了 O3 处理器在高性能执行的同时保持程序执行的正确性，是现代超标量处理器不可或缺的关键组件。

--- a/docs/Gem5_Docs/midcore/iew.md
+++ b/docs/Gem5_Docs/midcore/iew.md
@@ -1,0 +1,1544 @@
+# GEM5 XS-GEM5：IEW阶段深度解析与分布式调度器架构
+
+## 1. 引言：IEW在乱序流水线中的核心作用
+
+IEW（Issue/Execute/Writeback）阶段是GEM5 XS-GEM5中乱序执行的心脏，位于**重命名(Rename)**阶段之后，**提交(Commit)**阶段之前。作为香山V3处理器的关键模拟组件，IEW不仅实现了传统的乱序执行逻辑，更引入了现代超标量处理器的**分布式调度器架构**。
+
+### 1.1 IEW的四大子阶段
+
+1. **分发 (Dispatch)**: 从重命名阶段接收指令，通过智能分类将其分发到多个专用队列中
+2. **发射 (Issue)**: 采用分布式调度器，并行监控多个指令队列，实现高效的指令选择和发射
+3. **执行 (Execute)**: 指令在功能单元中执行，支持推测执行和多级流水线
+4. **写回 (Writeback)**: 结果写回与依赖唤醒，支持推测性唤醒优化
+
+### 1.2 现代化的分布式设计特点
+
+- **多队列架构**: 根据指令类型分为整数、浮点、向量、内存等专用队列
+- **负载均衡**: 智能的指令分发策略避免队列拥塞
+- **跨队列协作**: 灵活的推测唤醒网络支持跨队列依赖处理
+- **资源仲裁**: 精确的寄存器文件端口管理和冲突仲裁
+
+---
+
+## 2. 核心数据结构与架构组件
+
+### 2.1 `IEW` 类：顶层协调者（src/cpu/o3/iew.hh, iew.cc）
+
+IEW类作为整个乱序执行阶段的总指挥，协调着分发、调度、执行等各个环节。
+
+#### 2.1.1 关键成员变量
+
+```cpp
+class IEW {
+    // 分布式调度器 - 现代化的核心组件
+    Scheduler* scheduler;                    // 分布式调度器指针
+    InstructionQueue instQueue;             // 指令队列管理器
+    LSQ ldstQueue;                          // 加载/存储队列
+    
+    // 分发队列 - 两阶段分发缓冲
+    std::deque<DynInstPtr> dispQue[3];      // 分发队列：[IntDQ, FVDQ, MemDQ]
+    std::vector<uint32_t> dqSize;           // 各分发队列容量
+    std::vector<uint32_t> dispWidth;        // 各队列分发带宽
+    
+    // 流水级间通信
+    TimeBuffer<TimeStruct> *timeBuffer;     // 主时间缓冲
+    TimeBuffer<RenameStruct> *renameQueue;  // 来自重命名阶段
+    TimeBuffer<IEWStruct> *iewQueue;        // 发送到提交阶段
+    TimeBuffer<IssueStruct> issueToExecQueue; // 内部发射到执行
+    
+    // 阻塞控制与缓冲
+    std::deque<DynInstPtr> skidBuffer[MaxThreads];  // 阻塞缓冲区
+    std::deque<DynInstPtr> insts[MaxThreads];       // 输入指令队列
+    
+    // 状态管理
+    Status _status;                         // 整体状态
+    StageStatus dispatchStatus[MaxThreads]; // 各线程分发状态
+    StageStatus exeStatus, wbStatus;        // 执行和写回状态
+};
+```
+
+#### 2.1.2 分发队列架构 (Dispatch Queue)
+
+XS-GEM5引入了**两阶段分发机制**，通过分发队列（dispQue）实现更灵活的指令缓冲：
+
+```cpp
+enum DQType {
+    IntDQ,   // 整数指令队列
+    FVDQ,    // 浮点/向量指令队列  
+    MemDQ,   // 内存指令队列
+    NumDQ
+};
+
+// 指令分类逻辑 (src/cpu/o3/iew.cc:2157)
+IEW::DQType IEW::getInstDQType(const DynInstPtr &inst) {
+    if (inst->isMemRef() || inst->isReadBarrier() || 
+        inst->isWriteBarrier() || inst->isNonSpeculative()) {
+        return MemDQ;  // 内存相关指令
+    }
+    if (inst->isFloating() || inst->isVector()) {
+        return FVDQ;   // 浮点/向量指令
+    }
+    return IntDQ;      // 整数指令
+}
+```
+
+### 2.2 分布式调度器架构 (`Scheduler` & `IssueQue`)
+
+#### 2.2.1 Scheduler：中央协调者
+
+```cpp
+class Scheduler {
+    // 发射队列集合
+    std::vector<IssueQue*> issueQues;
+    
+    // 推测唤醒网络
+    std::vector<SpecWakeupChannel> specWakeupNetwork;
+    std::map<DynInstPtr, std::vector<Event*>> specWakeEvents;
+    
+    // 寄存器文件端口管理
+    std::vector<std::pair<DynInstPtr, int>> rfPortOccupancy;
+    std::vector<DynInstPtr> arbFailedInsts;
+    
+    // 三级记分板系统
+    std::vector<bool> scoreboard;          // 正式记分板
+    std::vector<bool> bypassScoreboard;    // 旁路记分板  
+    std::vector<bool> earlyScoreboard;     // 早期记分板
+    
+    // 性能计数器
+    struct SchedulerStats {
+        statistics::Scalar arbFailed;      // 仲裁失败次数
+        statistics::Vector portissued;     // 端口发射统计
+        statistics::Vector portBusy;       // 端口占用统计
+    } schedulerStats;
+};
+```
+
+#### 2.2.2 IssueQue：分布式指令队列
+
+每个IssueQue是一个独立的小型调度器，专门处理特定类型的指令：
+
+```cpp
+class IssueQue {
+    // 指令存储与管理
+    std::list<DynInstPtr> instList;                    // 主指令链表
+    std::vector<std::queue<DynInstPtr>> readyQs;       // 就绪队列（按端口）
+    std::vector<DynInstPtr> selectQ;                   // 选择队列
+    std::queue<DynInstPtr> replayQ;                    // 重试队列
+    
+    // 依赖关系管理
+    std::vector<std::vector<std::pair<uint8_t, DynInstPtr>>> subDepGraph;
+    // subDepGraph[physRegId] = [(srcOpIdx, dependentInst), ...]
+    
+    // 流水线控制
+    std::vector<std::vector<DynInstPtr>> inflightIssues;  // 多级发射流水线
+    int issueStages;                                       // 发射流水线级数
+    
+    // 选择器策略
+    BaseSelector* selector;                                // 指令选择策略
+    
+    // 端口配置
+    std::vector<IssuePort> oports;                        // 输出端口
+    int inports;                                          // 输入端口数
+    
+    // 统计信息
+    struct IssueQueStats {
+        statistics::Histogram exec_stall_cycle;   // 执行停顿周期
+        statistics::Vector mem_stall_cycle;       // 内存停顿（按级别）
+        statistics::Scalar issued;               // 发射指令数
+        statistics::Scalar cancelled;            // 取消指令数
+    } issueQueStats;
+};
+```
+
+### 2.3 推测唤醒网络 (`SpecWakeupChannel`)
+
+推测唤醒是现代超标量处理器的关键优化技术：
+
+```cpp
+class SpecWakeupChannel {
+    std::vector<std::string> srcIQs;     // 源发射队列列表
+    std::vector<std::string> dstIQs;     // 目标发射队列列表
+    int wakeupDelay;                     // 唤醒延迟
+    bool crossCluster;                   // 是否跨集群唤醒
+};
+
+// 推测唤醒事件类
+class SpecWakeupCompletion : public Event {
+    DynInstPtr inst;                     // 触发唤醒的指令
+    IssueQue* targetQueue;               // 目标队列
+    std::map<DynInstPtr, std::vector<Event*>>* eventMap;
+    
+public:
+    void process() override {
+        targetQueue->wakeUpDependents(inst, true);  // 执行推测唤醒
+        // 清理事件映射
+        (*eventMap)[inst].erase(
+            std::remove((*eventMap)[inst].begin(), 
+                       (*eventMap)[inst].end(), this),
+            (*eventMap)[inst].end());
+    }
+};
+```
+
+### 2.4 LSQ：内存子系统接口
+
+LSQ专门处理内存访问的复杂性：
+
+```cpp
+class LSQ {
+    // 加载队列
+    std::vector<LSQUnit> LQs;           // 每线程的加载队列
+    
+    // 存储队列  
+    std::vector<LSQUnit> SQs;           // 每线程的存储队列
+    
+    // 内存依赖跟踪
+    MemDepUnit memDepUnit;              // 内存依赖单元
+    
+    // 性能优化
+    bool enableStoreSetTrain;           // 存储集训练
+    
+    // 统计信息
+    struct LSQStats {
+        statistics::Scalar loadTLBMisses;      // Load TLB缺失
+        statistics::Scalar storeTLBMisses;     // Store TLB缺失
+        statistics::Scalar loadCacheMisses;    // Load Cache缺失
+        statistics::Scalar storeCacheMisses;   // Store Cache缺失
+    } lsqStats;
+};
+```
+
+---
+
+## 3. 分布式调度器架构深度解析
+
+### 3.1 香山V3调度器配置实例
+
+基于代码分析，香山V3处理器采用了高度分布式的调度器架构，具体配置如下：
+
+#### 3.1.1 KMHV3Scheduler配置
+```python
+# 整数执行队列 - 6个独立队列
+intIQ0-5: size=16, 支持ALU/Branch/Mul/Div等操作
+
+# 内存执行队列 - 7个专门队列  
+load0-2:  size=16, 专门处理Load操作
+store0-1: size=16, 处理Store地址计算
+std0-1:   size=16, 处理Store数据操作
+
+# 浮点/向量队列 - 5个队列
+fpIQ0-3:  size=16, 浮点运算
+vecIQ0:   size=16, 向量运算
+```
+
+这种配置能够：
+- **最大化并行度**: 18个独立队列并行工作
+- **避免资源冲突**: 不同类型操作使用独立资源
+- **优化关键路径**: Load/Store分离减少内存访问延迟
+
+#### 3.1.2 推测唤醒网络拓扑
+
+```cpp
+// 关键的跨队列唤醒通道
+SpecWakeupChannel examples[] = {
+    // 整数间唤醒
+    {.srcIQs={"intIQ0"}, .dstIQs={"intIQ1", "intIQ2"}, .delay=1},
+    
+    // 整数到内存唤醒  
+    {.srcIQs={"intIQ0", "intIQ1"}, .dstIQs={"load0", "store0"}, .delay=2},
+    
+    // 浮点内部唤醒
+    {.srcIQs={"fpIQ0"}, .dstIQs={"fpIQ1", "fpIQ2", "fpIQ3"}, .delay=1},
+    
+    // 跨域唤醒（整数->浮点）
+    {.srcIQs={"intIQ0"}, .dstIQs={"fpIQ0"}, .delay=3},
+};
+```
+
+### 3.2 指令选择器策略详解
+
+#### 3.2.1 基础选择器 (BaseSelector)
+```cpp
+class BaseSelector {
+public:
+    std::vector<DynInstPtr> select(std::queue<DynInstPtr>& readyQ, 
+                                   int numSelect) {
+        std::vector<DynInstPtr> selected;
+        for (int i = 0; i < numSelect && !readyQ.empty(); i++) {
+            selected.push_back(readyQ.front());
+            readyQ.pop();
+        }
+        return selected;
+    }
+};
+```
+
+#### 3.2.2 伪年龄选择器 (PAgeSelector)
+```cpp
+class PAgeSelector : public BaseSelector {
+    std::vector<std::vector<bool>> groupConflict;  // 分组冲突矩阵
+    
+public:
+    std::vector<DynInstPtr> select(std::queue<DynInstPtr>& readyQ, 
+                                   int numSelect) override {
+        std::vector<DynInstPtr> selected;
+        std::vector<bool> usedGroups(numGroups, false);
+        
+        std::vector<DynInstPtr> candidates;
+        while (!readyQ.empty()) {
+            candidates.push_back(readyQ.front());
+            readyQ.pop();
+        }
+        
+        // 按年龄排序
+        std::sort(candidates.begin(), candidates.end(), 
+                  [](const DynInstPtr& a, const DynInstPtr& b) {
+                      return a->seqNum < b->seqNum;
+                  });
+        
+        // 选择时避免分组冲突
+        for (auto& inst : candidates) {
+            int group = getInstructionGroup(inst);
+            if (!usedGroups[group] && selected.size() < numSelect) {
+                selected.push_back(inst);
+                
+                // 标记冲突组
+                for (int i = 0; i < numGroups; i++) {
+                    if (groupConflict[group][i]) {
+                        usedGroups[i] = true;
+                    }
+                }
+            } else {
+                readyQ.push(inst);  // 放回队列
+            }
+        }
+        return selected;
+    }
+};
+```
+
+### 3.3 寄存器文件端口仲裁机制
+
+#### 3.3.1 端口编码系统
+```cpp
+// 端口编码格式：[7:6]类型 [5:2]端口ID [1:0]优先级
+#define MAKE_PORT_ID(type, port, pri) (((type) << 6) | ((port) << 2) | (pri))
+
+// 整数寄存器读端口
+#define IntRD(id, p)   MAKE_PORT_ID(0, id, p)  // 0x00-0x3F
+#define IntWR(id, p)   MAKE_PORT_ID(0, id+8, p)// 0x20-0x3F
+
+// 浮点寄存器端口  
+#define FpRD(id, p)    MAKE_PORT_ID(1, id, p)  // 0x40-0x7F
+#define FpWR(id, p)    MAKE_PORT_ID(1, id+8, p)// 0x60-0x7F
+
+// 向量寄存器端口
+#define VecRD(id, p)   MAKE_PORT_ID(2, id, p)  // 0x80-0xBF
+#define VecWR(id, p)   MAKE_PORT_ID(2, id+8, p)// 0xA0-0xBF
+```
+
+#### 3.3.2 端口仲裁逻辑
+```cpp
+// src/cpu/o3/issue_queue.cc 中的关键函数
+void Scheduler::useRegfilePort(const DynInstPtr& inst, 
+                              const PhysRegIdPtr& regid, 
+                              int typePortId, int pri) {
+    // 检查端口是否已被占用
+    if (rfPortOccupancy[typePortId].first) {
+        // 优先级比较仲裁
+        if (rfPortOccupancy[typePortId].second < pri) {
+            // 当前指令仲裁失败，加入失败列表
+            arbFailedInsts.push_back(inst);
+            schedulerStats.arbFailed++;
+            return;
+        } else {
+            // 已占用指令仲裁失败，替换
+            DynInstPtr failedInst = rfPortOccupancy[typePortId].first;
+            arbFailedInsts.push_back(failedInst);
+        }
+    }
+    
+    // 分配端口给当前指令
+    rfPortOccupancy[typePortId] = std::make_pair(inst, pri);
+    schedulerStats.portissued[typePortId]++;
+    
+    DPRINTF(IssueQueue, "[sn:%lli] allocated port %d (type=%d, port=%d, pri=%d)\n",
+            inst->seqNum, typePortId, 
+            (typePortId >> 6) & 0x3,     // type
+            (typePortId >> 2) & 0xF,     // port id  
+            typePortId & 0x3);           // priority
+}
+```
+
+---
+
+## 4. IEW核心执行流程详解
+
+### 4.1 IEW::tick() - 主驱动函数
+
+```cpp
+void IEW::tick() {
+    // 1. 统计信息收集
+    for (int i = 0; i < fromRename->fetchStallReason.size(); i++) {
+        iewStats.fetchStallReason[fromRename->fetchStallReason[i]]++;
+    }
+    
+    // 2. 初始化周期状态
+    wbNumInst = 0;
+    wbCycle = 0;
+    wroteToTimeBuffer = false;
+    updatedQueues = false;
+    
+    // 3. 子模块时钟推进
+    scheduler->tick();        // 分布式调度器时钟
+    ldstQueue.tick();         // LSQ时钟
+    
+    // 4. 指令排序和分类
+    sortInsts();              // 从Rename接收的指令按线程分类
+    
+    // 5. 各线程处理循环
+    std::list<ThreadID>::iterator threads = activeThreads->begin();
+    while (threads != activeThreads->end()) {
+        ThreadID tid = *threads++;
+        
+        // 获取LSQ统计信息
+        lastClockLQPopEntries[tid] = ldstQueue.getAndResetLastLQPopEntries(tid);
+        lastClockSQPopEntries[tid] = ldstQueue.getAndResetLastSQPopEntries(tid);
+        
+        // 检查信号和更新状态
+        checkSignalsAndUpdate(tid);
+        
+        // 执行分发
+        dispatch(tid);
+        
+        // 计算停顿原因
+        toRename->iewInfo[tid].robHeadStallReason = 
+            checkDispatchStall(tid, NumDQ, nullptr, -1);
+        toRename->iewInfo[tid].lqHeadStallReason =
+            ldstQueue.lqEmpty() ? StallReason::NoStall : checkLSQStall(tid, true);
+        toRename->iewInfo[tid].sqHeadStallReason =
+            ldstQueue.sqEmpty() ? StallReason::NoStall : checkLSQStall(tid, false);
+    }
+    
+    // 6. 执行阶段（非Squashing状态）
+    if (exeStatus != Squashing) {
+        instQueue.scheduleReadyInsts();   // 调度就绪指令
+        executeInsts();                   // 执行指令
+        writebackInsts();                 // 写回指令
+    }
+    
+    // 7. 调度器发射和选择
+    scheduler->issueAndSelect();
+    
+    // 8. 后处理
+    ldstQueue.writebackStoreBuffer();     // Store Buffer写回
+    
+    // 9. 提交阶段处理
+    processCommitSignals();
+    
+    // 10. 状态更新
+    updateStatus();
+}
+```
+
+### 4.2 两阶段分发机制详解
+
+#### 4.2.1 第一阶段：分类到分发队列
+```cpp
+void IEW::classifyInstToDispQue(ThreadID tid) {
+    std::deque<DynInstPtr> &insts_to_dispatch = 
+        dispatchStatus[tid] == Unblocking ? skidBuffer[tid] : insts[tid];
+    
+    bool emptyROB = fromCommit->commitInfo[tid].emptyROB;
+    unsigned dispatched = 0;
+    
+    while (!insts_to_dispatch.empty()) {
+        auto& inst = insts_to_dispatch.front();
+        
+        // 确定指令类型
+        int dqType = getInstDQType(inst);  // IntDQ/FVDQ/MemDQ
+        
+        // 检查分发队列容量
+        if (dispQue[dqType].size() < dqSize[dqType]) {
+            // 处理已废除指令
+            if (inst->isSquashed()) {
+                updateDispatchStats(inst, tid);
+                insts_to_dispatch.pop_front();
+                continue;
+            }
+            
+            // 序列化检查
+            if ((inst->isSerializeBefore() && !inst->isSerializeHandled()) 
+                ? !emptyROB : false) {
+                // 需要等待ROB为空
+                break;
+            }
+            
+            // 设置HTM状态
+            setHtmTransactionalState(inst, tid);
+            
+            // 添加到对应分发队列!!!
+            dispQue[dqType].push_back(inst);
+            inst->enterDQTick = curTick();  // 记录进入时间
+            
+            // 生产者依赖管理
+            if (!inst->isNop() && !inst->isEliminated()) {
+                scheduler->addProducer(inst);
+            }
+            
+            // 更新统计
+            updateDispatchStats(inst, tid);
+            insts_to_dispatch.pop_front();
+            dispatched++;
+        } else {
+            // 队列满，停止分发
+            break;
+        }
+    }
+    
+    // 处理阻塞情况
+    if (!insts_to_dispatch.empty()) {
+        block(tid);
+        disp_stall = true;
+    }
+}
+```
+
+#### 4.2.2 第二阶段：从分发队列到调度器
+```cpp
+void IEW::dispatchInstFromDispQue(ThreadID tid) {
+    bool add_to_iq = false;
+    int totalDispatched = 0;
+    
+    // 遍历所有分发队列类型
+    for (int dqType = 0; dqType < NumDQ; dqType++) {
+        int dispatched = 0;
+        int disp_seq = -1;
+        
+        // 预调度分析
+        scheduler->lookahead(dispQue[dqType]);
+        
+        // 按分发带宽处理
+        while (!dispQue[dqType].empty() && dispatched < dispWidth[dqType]) {
+            DynInstPtr inst = dispQue[dqType].front();
+            disp_seq++;
+            
+            // 跳过已废除指令
+            if (inst->isSquashed()) {
+                dispQue[dqType].pop_front();
+                continue;
+            }
+            
+            // 检查调度器就绪状态
+            if (!scheduler->ready(inst, disp_seq)) {
+                // 调度器忙或满
+                break;
+            }
+            
+            // 检查LSQ容量
+            if (checkLSQCapacity(inst, tid)) {
+                break;
+            }
+            
+            // 指令分类处理
+            if (inst->isAtomic()) {
+                handleAtomicInst(inst, tid);
+                add_to_iq = false;
+            } else if (inst->isLoad()) {
+                handleLoadInst(inst, tid);
+                add_to_iq = true;
+            } else if (inst->isStore()) {
+                handleStoreInst(inst, tid);
+                add_to_iq = !inst->isStoreConditional();
+            } else if (inst->isReadBarrier() || inst->isWriteBarrier()) {
+                handleBarrierInst(inst);
+                add_to_iq = false;
+            } else if (inst->isNop() || inst->isEliminated()) {
+                handleNopInst(inst, tid);
+                add_to_iq = false;
+            } else {
+                add_to_iq = true;
+            }
+            
+            // 非推测指令处理
+            if (add_to_iq && inst->isNonSpeculative()) {
+                inst->setCanCommit();
+                instQueue.insertNonSpec(inst);
+                add_to_iq = false;
+            }
+            
+            // 插入到分布式指令队列，当两个源操作数都准备好后，会进入readyQ中
+            if (add_to_iq) {
+                instQueue.insert(inst, disp_seq);
+            }
+            
+            // 清理和统计
+            inst->exitDQTick = curTick();
+            ppDispatch->notify(inst);
+            dispQue[dqType].pop_front();
+            dispatched++;
+            totalDispatched++;
+        }
+    }
+    
+    // 更新分发统计
+    iewStats.dispDist.sample(totalDispatched);
+}
+```
+
+### 4.3 执行阶段：分布式并行执行
+
+#### 4.3.1 executeInsts() - 执行控制器
+```cpp
+void IEW::executeInsts() {
+    wbNumInst = 0;
+    wbCycle = 0;
+    
+    // 重置重定向标志
+    std::list<ThreadID>::iterator threads = activeThreads->begin();
+    while (threads != activeThreads->end()) {
+        ThreadID tid = *threads++;
+        fetchRedirect[tid] = false;
+    }
+    
+    // 从调度器获取待执行指令
+    int insts_to_execute = fromIssue->size;
+    fromIssue->size = 0;
+    
+    for (int inst_num = 0; inst_num < insts_to_execute; ++inst_num) {
+        DynInstPtr inst = instQueue.getInstToExecute();
+        
+        DPRINTF(IEW, "Execute: Processing PC %s, [tid:%i] [sn:%llu].\n",
+                inst->pcState(), inst->threadNumber, inst->seqNum);
+        
+        // 通知执行开始
+        ppExecute->notify(inst);
+        
+        // 跳过已废除指令
+        if (inst->isSquashed()) {
+            inst->setExecuted();
+            inst->setCanCommit();
+            ++iewStats.executedInstStats.numSquashedInsts;
+            continue;
+        }
+        
+        Fault fault = NoFault;
+        
+        // 内存指令执行
+        if (inst->isMemRef()) {
+            if (inst->isAtomic()) {
+                fault = ldstQueue.executeAmo(inst);
+                handleTranslationDelay(inst, fault);
+            } else if (inst->isLoad()) {
+                ldstQueue.issueToLoadPipe(inst);    // 发射到Load流水线
+            } else if (inst->isStore()) {
+                ldstQueue.issueToStorePipe(inst);   // 发射到Store流水线
+            }
+        } else {
+            // 非内存指令直接执行
+            if (inst->getFault() == NoFault) {
+                inst->execute();
+                if (!inst->readPredicate()) {
+                    inst->forwardOldRegs();  // 条件执行失败时恢复寄存器
+                }
+            }
+            
+            // 处理分离的Store数据
+            if (!inst->isSplitStoreData()) {
+                inst->setExecuted();
+                readyToFinish(inst);  // 准备写回
+            } else {
+                handleSplitStoreData(inst);
+            }
+        }
+        
+        updateExeInstStats(inst);
+        
+        // 分支预测和内存序冲突检查
+        if (!(inst->isLoad() || inst->isStore() || inst->isSplitStoreData())) {
+            SquashCheckAfterExe(inst);  // 非内存指令立即检查
+        }
+    }
+    
+    // 执行内存流水线
+    ldstQueue.executePipeSx();
+    
+    // 更新执行状态
+    if (inst_num) {
+        if (exeStatus == Idle) exeStatus = Running;
+        updatedQueues = true;
+        cpu->activityThisCycle();
+    }
+}
+```
+
+#### 4.3.2 推测执行与异常处理
+```cpp
+void IEW::SquashCheckAfterExe(DynInstPtr inst) {
+    ThreadID tid = inst->threadNumber;
+    
+    // 检查之前是否已有重定向
+    if (!fetchRedirect[tid] || !execWB->squash[tid] ||
+        execWB->squashedSeqNum[tid] > inst->seqNum) {
+        
+        // 分支预测错误检测
+        bool loadNotExecuted = !inst->isExecuted() && inst->isLoad();
+        if (inst->mispredicted() && !loadNotExecuted) {
+            fetchRedirect[tid] = true;
+            
+            DPRINTF(IEW, "[tid:%i] [sn:%llu] Branch mispredict detected.\n",
+                    tid, inst->seqNum);
+            DPRINTF(IEW, "[tid:%i] [sn:%llu] Predicted: %s, Actual: %s\n",
+                    tid, inst->seqNum, inst->readPredTarg(), inst->pcState());
+            
+            squashDueToBranch(inst, tid);  // 发起分支错误冲刷
+            ppMispredict->notify(inst);
+            
+            // 更新预测统计
+            if (inst->readPredTaken()) {
+                iewStats.predictedTakenIncorrect++;
+            } else {
+                iewStats.predictedNotTakenIncorrect++;
+            }
+        }
+        // 内存序冲突检测
+        else if (ldstQueue.violation(tid)) {
+            DynInstPtr violator = ldstQueue.getMemDepViolator(tid);
+            
+            DPRINTF(IEW, "Memory violation detected. Violator PC: %s [sn:%lli]\n",
+                    violator->pcState(), violator->seqNum);
+            
+            fetchRedirect[tid] = true;
+            
+            // 存储集训练
+            if (enableStoreSetTrain) {
+                instQueue.violation(inst, violator);
+            }
+            
+            squashDueToMemOrder(violator, tid);  // 发起内存序冲刷
+            ++iewStats.memOrderViolationEvents;
+        }
+    }
+}
+```
+
+### 4.4 写回阶段：结果广播与依赖唤醒
+
+#### 4.4.1 writebackInsts() - 写回控制器
+```cpp
+void IEW::writebackInsts() {
+    // 处理执行完成的指令
+    for (int inst_num = 0; inst_num < wbWidth && 
+         execWB->insts[inst_num]; inst_num++) {
+        
+        DynInstPtr inst = execWB->insts[inst_num];
+        ThreadID tid = inst->threadNumber;
+        
+        // 处理预取信息
+        if (inst->savedRequest && inst->isLoad()) {
+            inst->pf_source = inst->savedRequest->mainReq()->getPFSource();
+        }
+        
+        DPRINTF(IEW, "Writeback: [sn:%lli] PC %s to commit.\n",
+                inst->seqNum, inst->pcState());
+        
+        iewStats.instsToCommit[tid]++;
+        ppToCommit->notify(inst);  // 通知即将提交
+        
+        // 只有成功执行的指令才进行依赖唤醒
+        if (!inst->isSquashed() && inst->isExecuted() && 
+            inst->getFault() == NoFault) {
+            
+            // 调度器写回唤醒
+            scheduler->writebackWakeup(inst);
+            
+            // 指令队列依赖唤醒
+            int dependents = instQueue.wakeDependents(inst);
+            
+            // 更新物理寄存器记分板
+            for (int i = 0; i < inst->numDestRegs(); i++) {
+                auto destReg = inst->renamedDestIdx(i);
+                if (destReg->getNumPinnedWritesToComplete() == 0) {
+                    DPRINTF(IEW, "Setting destination register %i (%s) ready\n",
+                            destReg->index(), destReg->className());
+                    scoreboard->setReg(destReg);  // 标记寄存器就绪
+                }
+            }
+            
+            // 更新唤醒统计
+            if (dependents) {
+                iewStats.producerInst[tid]++;
+                iewStats.consumerInst[tid] += dependents;
+            }
+            iewStats.writebackCount[tid]++;
+        }
+    }
+}
+```
+
+#### 4.4.2 推测性唤醒实现
+```cpp
+void Scheduler::specWakeUpDependents(const DynInstPtr& inst, 
+                                    IssueQue* from_issue_queue) {
+    // 只有流水化操作且非Load指令才推测唤醒
+    if (!opPipelined[inst->opClass()] || inst->numDestRegs() == 0 || 
+        inst->isLoad()) {
+        return;
+    }
+    
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        auto dst = inst->renamedDestIdx(i);
+        
+        // 遍历推测唤醒网络
+        for (auto& channel : specWakeupNetwork) {
+            if (!channelMatch(from_issue_queue->name(), channel.srcIQs)) {
+                continue;
+            }
+            
+            for (auto& dstName : channel.dstIQs) {
+                IssueQue* targetQueue = findIssueQueue(dstName);
+                if (!targetQueue) continue;
+                
+                // 计算唤醒延迟
+                int oplat = getCorrectedOpLat(inst);
+                int wakeDelay = oplat - 1;
+                
+                // 跨队列延迟调整
+                int diff = std::abs(from_issue_queue->getIssueStages() - 
+                                   targetQueue->getIssueStages());
+                wakeDelay += diff;
+                
+                if (wakeDelay == 0) {
+                    // 立即推测唤醒
+                    targetQueue->wakeUpDependents(inst, true);
+                    earlyScoreboard[dst->flatIndex()] = true;
+                } else {
+                    // 调度延迟唤醒事件
+                    auto wakeEvent = new SpecWakeupCompletion(
+                        inst, targetQueue, &specWakeEvents);
+                    
+                    specWakeEvents[inst].push_back(wakeEvent);
+                    
+                    Tick when = cpu->clockEdge(Cycles(wakeDelay)) - 1;
+                    cpu->schedule(wakeEvent, when);
+                    
+                    DPRINTF(IssueQueue, 
+                            "[sn:%lli] Scheduled spec wakeup for %s in %d cycles\n",
+                            inst->seqNum, dstName.c_str(), wakeDelay);
+                }
+            }
+        }
+    }
+}
+```
+
+### 4.5 内存指令特殊处理
+
+#### 4.5.1 Load指令处理流程
+```cpp
+void LSQ::issueToLoadPipe(const DynInstPtr& load_inst) {
+    ThreadID tid = load_inst->threadNumber;
+    
+    // 分配LQ表项
+    int lq_idx = loadQueue[tid].allocate(load_inst);
+    if (lq_idx == -1) {
+        // LQ满，延迟处理
+        DPRINTF(LSQUnit, "[tid:%i] Load queue full, deferring [sn:%lli]\n",
+                tid, load_inst->seqNum);
+        return;
+    }
+    
+    load_inst->setLSQIdx(lq_idx);
+    
+    // S0阶段：地址计算
+    if (load_inst->isUncacheable()) {
+        loadQueue[tid][lq_idx].setUncacheable();
+    }
+    
+    // 检查Store forwarding
+    auto forward_result = checkStoreForwarding(load_inst, tid);
+    if (forward_result.first) {
+        // 可以从Store buffer获取数据
+        loadQueue[tid][lq_idx].setForwarded();
+        load_inst->setExecuted();
+        
+        DPRINTF(LSQUnit, "[tid:%i] Load [sn:%lli] forwarded from store\n",
+                tid, load_inst->seqNum);
+        return;
+    }
+    
+    // S1阶段：TLB查找
+    loadPipeS1[tid].push(load_inst);
+}
+
+void LSQ::executeLoadPipeS1() {
+    for (ThreadID tid = 0; tid < numThreads; tid++) {
+        if (loadPipeS1[tid].empty()) continue;
+        
+        DynInstPtr load_inst = loadPipeS1[tid].front();
+        loadPipeS1[tid].pop();
+        
+        // TLB转换
+        Fault fault = load_inst->initiateAcc();
+        if (fault != NoFault) {
+            // TLB miss或页错误
+            handleLoadFault(load_inst, fault);
+            continue;
+        }
+        
+        // S2阶段：Cache访问
+        loadPipeS2[tid].push(load_inst);
+    }
+}
+```
+
+#### 4.5.2 Store指令处理流程  
+```cpp
+void LSQ::issueToStorePipe(const DynInstPtr& store_inst) {
+    ThreadID tid = store_inst->threadNumber;
+    
+    // 分配SQ表项
+    int sq_idx = storeQueue[tid].allocate(store_inst);
+    store_inst->setSQIdx(sq_idx);
+    
+    if (store_inst->isSplitStoreData()) {
+        // Store地址计算
+        storePipeSTA[tid].push(store_inst);
+    } else {
+        // 完整Store操作
+        storePipeSTD[tid].push(store_inst);
+    }
+}
+
+void LSQ::executeStorePipeSTA() {
+    // Store地址计算阶段
+    for (ThreadID tid = 0; tid < numThreads; tid++) {
+        while (!storePipeSTA[tid].empty()) {
+            DynInstPtr store_inst = storePipeSTA[tid].front();
+            storePipeSTA[tid].pop();
+            
+            // 计算有效地址
+            Fault fault = store_inst->initiateAcc();
+            if (fault != NoFault) {
+                handleStoreFault(store_inst, fault);
+                continue;
+            }
+            
+            // 检查内存序冲突
+            if (checkMemoryOrderViolation(store_inst, tid)) {
+                signalMemoryOrderViolation(store_inst, tid);
+                continue;
+            }
+            
+            store_inst->setExecuted();
+            
+            // 地址计算完成，等待数据
+            if (store_inst->splitStoreFinish()) {
+                // 地址和数据都准备好
+                readyToCommitStores[tid].push(store_inst);
+            }
+        }
+    }
+}
+```
+
+## 5. 模块间交互机制详解
+
+### 5.1 IEW与Rename阶段的接口协议
+
+#### 5.1.1 指令接收接口
+```cpp
+// IEW从Rename接收指令的数据结构
+struct RenameStruct {
+    DynInstPtr insts[renameWidth];           // 重命名完成的指令数组
+    int size;                                // 本周期指令数量
+    
+    // 停顿原因统计
+    std::vector<StallReason> fetchStallReason;   // Fetch阶段停顿原因
+    std::vector<StallReason> decodeStallReason;  // Decode阶段停顿原因  
+    std::vector<StallReason> renameStallReason;  // Rename阶段停顿原因
+    
+    bool squash[MaxThreads];                 // 各线程是否需要冲刷
+    InstSeqNum squashedSeqNum[MaxThreads];   // 冲刷起始序号
+};
+
+// IEW向Rename反馈的状态信息
+struct IEWInfo {
+    bool usedIQ;                    // 是否使用了IQ
+    bool usedLSQ;                   // 是否使用了LSQ
+    
+    unsigned freeLQEntries;         // 可用Load队列表项
+    unsigned freeSQEntries;         // 可用Store队列表项
+    
+    unsigned dispatched;            // 本周期分发的指令数
+    unsigned dispatchedToLQ;        // 分发到LQ的指令数
+    unsigned dispatchedToSQ;        // 分发到SQ的指令数
+    
+    bool iewBlock;                  // IEW是否阻塞
+    bool iewUnblock;                // IEW是否解除阻塞
+    
+    // 停顿原因分析
+    StallReason robHeadStallReason; // ROB头指令停顿原因
+    StallReason lqHeadStallReason;  // LQ头指令停顿原因
+    StallReason sqHeadStallReason;  // SQ头指令停顿原因
+    StallReason blockReason;        // 阻塞原因
+};
+```
+
+#### 5.1.2 反压控制机制
+```cpp
+void IEW::checkSignalsAndUpdate(ThreadID tid) {
+    // 处理来自Commit的冲刷信号
+    if (fromCommit->commitInfo[tid].squash) {
+        squash(tid);  // 执行冲刷操作
+        localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
+        
+        // 解除可能的阻塞状态
+        if (dispatchStatus[tid] == Blocked || dispatchStatus[tid] == Unblocking) {
+            toRename->iewUnblock[tid] = true;
+            wroteToTimeBuffer = true;
+        }
+        
+        dispatchStatus[tid] = Squashing;
+        return;
+    }
+    
+    // 处理ROB冲刷状态
+    if (fromCommit->commitInfo[tid].robSquashing) {
+        dispatchStatus[tid] = Squashing;
+        emptyRenameInsts(tid);  // 清空来自Rename的指令
+        setAllStalls(StallReason::CommitSquash);
+        return;
+    }
+    
+    // 检查是否需要阻塞
+    if (checkStall(tid)) {
+        block(tid);
+        dispatchStatus[tid] = Blocked;
+        return;
+    }
+    
+    // 处理解除阻塞
+    if (dispatchStatus[tid] == Blocked) {
+        dispatchStatus[tid] = Unblocking;
+        unblock(tid);
+    }
+}
+```
+
+### 5.2 IEW与Commit阶段的协调
+
+#### 5.2.1 指令提交接口
+```cpp
+// IEW向Commit发送执行完成指令的结构
+struct IEWStruct {
+    DynInstPtr insts[wbWidth];       // 写回的指令数组
+    int size;                        // 指令数量
+    
+    // 冲刷信息
+    bool squash[MaxThreads];                    // 是否需要冲刷
+    bool includeSquashInst[MaxThreads];         // 是否包含冲刷指令本身
+    InstSeqNum squashedSeqNum[MaxThreads];      // 冲刷序号
+    
+    // 分支预测信息
+    std::unique_ptr<PCStateBase> pc[MaxThreads];     // 正确的PC
+    bool branchTaken[MaxThreads];                    // 分支是否跳转
+    DynInstPtr mispredictInst[MaxThreads];          // 预测错误的指令
+    
+    // 前端重定向信息（香山扩展）
+    uint64_t squashedStreamId[MaxThreads];      // 冲刷的流ID
+    uint64_t squashedTargetId[MaxThreads];      // 冲刷的目标ID
+    uint32_t squashedLoopIter[MaxThreads];      // 冲刷的循环迭代
+};
+
+// 来自Commit的反馈信息
+struct CommitInfo {
+    bool squash;                        // 是否冲刷
+    bool robSquashing;                  // ROB是否正在冲刷
+    InstSeqNum doneSeqNum;              // 已提交的最大序号
+    InstSeqNum doneMemSeqNum;           // 已提交的最大内存序号
+    
+    // 非推测执行控制
+    InstSeqNum nonSpecSeqNum;           // 需要非推测执行的序号
+    bool strictlyOrdered;               // 是否严格有序
+    DynInstPtr strictlyOrderedLoad;     // 严格有序的Load指令
+    
+    bool emptyROB;                      // ROB是否为空
+    SquashVersion squashVersion;        // 冲刷版本号
+};
+```
+
+#### 5.2.2 写回调度逻辑
+```cpp
+void IEW::readyToFinish(const DynInstPtr& inst) {
+    // 寻找可用的写回时间槽
+    while ((*iewQueue)[wbCycle].insts[wbNumInst]) {
+        ++wbNumInst;
+        if (wbNumInst == wbWidth) {
+            ++wbCycle;      // 延迟到下一个周期
+            wbNumInst = 0;
+        }
+    }
+    
+    // 调度器旁路写回优化
+    scheduler->bypassWriteback(inst);
+    inst->completionTick = curTick();
+    
+    // 添加到写回队列
+    (*iewQueue)[wbCycle].insts[wbNumInst] = inst;
+    (*iewQueue)[wbCycle].size++;
+    
+    DPRINTF(IEW, "Scheduled writeback for [sn:%lli] at cycle %d, slot %d\n",
+            inst->seqNum, wbCycle, wbNumInst);
+}
+```
+
+### 5.3 与功能单元池(FUPool)的接口
+
+#### 5.3.1 功能单元分配策略
+```cpp
+class IssuePort {
+    std::string fuType;          // 功能单元类型（如"IntALU", "FpMul"）
+    int opLat;                   // 操作延迟
+    int pipelined;               // 是否流水化
+    
+    // 端口资源编码
+    std::vector<int> srcPorts;   // 源操作数端口
+    std::vector<int> dstPorts;   // 目标操作数端口
+};
+
+// 香山处理器的典型功能单元配置
+std::vector<IssuePort> intIQ0_ports = {
+    {.fuType="IntALU", .opLat=1, .pipelined=1, .srcPorts={IntRD(0,0), IntRD(1,0)}, .dstPorts={IntWR(0,0)}},
+    {.fuType="IntMul", .opLat=3, .pipelined=1, .srcPorts={IntRD(0,1), IntRD(1,1)}, .dstPorts={IntWR(0,1)}},
+    {.fuType="Branch", .opLat=1, .pipelined=1, .srcPorts={IntRD(0,2), IntRD(1,2)}, .dstPorts={}},
+};
+```
+
+#### 5.3.2 发射端口仲裁
+```cpp
+bool Scheduler::issueInstToFU(const DynInstPtr& inst, IssueQue* srcQueue) {
+    // 选择合适的发射端口
+    IssuePort* selectedPort = nullptr;
+    for (auto& port : srcQueue->getOutputPorts()) {
+        if (port.canHandle(inst->opClass()) && port.isAvailable()) {
+            selectedPort = &port;
+            break;
+        }
+    }
+    
+    if (!selectedPort) {
+        DPRINTF(IssueQueue, "[sn:%lli] No available FU port\n", inst->seqNum);
+        return false;
+    }
+    
+    // 寄存器端口分配
+    bool portAllocSuccess = true;
+    for (int i = 0; i < inst->numSrcRegs(); i++) {
+        auto srcReg = inst->renamedSrcIdx(i);
+        int portId = selectedPort->srcPorts[i];
+        
+        if (!allocateRegPort(inst, srcReg, portId)) {
+            portAllocSuccess = false;
+            break;
+        }
+    }
+    
+    if (!portAllocSuccess) {
+        // 端口分配失败，释放已分配的端口
+        releaseAllocatedPorts(inst);
+        return false;
+    }
+    
+    // 成功分配，发射指令
+    selectedPort->issue(inst);
+    instsToFu.push_back(inst);
+    
+    DPRINTF(IssueQueue, "[sn:%lli] Issued to %s FU\n", 
+            inst->seqNum, selectedPort->fuType.c_str());
+    return true;
+}
+```
+
+---
+
+## 6. 性能优化与调优策略
+
+### 6.1 关键性能瓶颈分析
+
+#### 6.1.1 分发带宽限制
+```cpp
+// 分发带宽配置（香山V3实例）
+std::vector<uint32_t> dispWidth = {
+    4,  // IntDQ: 每周期最多分发4条整数指令
+    2,  // FVDQ: 每周期最多分发2条浮点/向量指令
+    3   // MemDQ: 每周期最多分发3条内存指令
+};
+
+// 分发效率统计
+struct DispatchStats {
+    statistics::Distribution dispDist;           // 分发指令数分布
+    statistics::Vector dispatchStallReason;     // 分发停顿原因
+    statistics::Scalar dispBWFull;              // 分发带宽满的次数
+};
+```
+
+#### 6.1.2 调度器瓶颈识别
+```cpp
+// 调度器性能监控点
+void Scheduler::collectPerfStats() {
+    // 发射队列利用率
+    for (auto& iq : issueQues) {
+        float utilization = (float)iq->getOccupancy() / iq->getCapacity();
+        schedulerStats.queueUtilization[iq->getName()].sample(utilization);
+        
+        // 检测热点队列
+        if (utilization > 0.8) {
+            schedulerStats.hotQueues[iq->getName()]++;
+        }
+    }
+    
+    // 端口冲突统计
+    for (int i = 0; i < rfPortOccupancy.size(); i++) {
+        if (rfPortOccupancy[i].first) {
+            schedulerStats.portBusy[i]++;
+        }
+    }
+    
+    // 推测唤醒效果
+    int totalSpecWakeups = 0;
+    int successfulSpecWakeups = 0;
+    for (auto& [inst, events] : specWakeEvents) {
+        totalSpecWakeups += events.size();
+        if (!inst->isSquashed()) {
+            successfulSpecWakeups += events.size();
+        }
+    }
+    
+    float specWakeupAccuracy = (float)successfulSpecWakeups / totalSpecWakeups;
+    schedulerStats.specWakeupAccuracy.sample(specWakeupAccuracy);
+}
+```
+
+### 6.2 性能调优建议
+
+#### 6.2.1 队列容量调优
+```python
+# 基于工作负载特征的队列容量调优
+class IQSizeOptimizer:
+    def __init__(self):
+        self.workload_profiles = {
+            'compute_intensive': {
+                'intIQ_size': 20,      # 增大整数队列
+                'fpIQ_size': 24,       # 大幅增大浮点队列
+                'memIQ_size': 12       # 适中的内存队列
+            },
+            'memory_intensive': {
+                'intIQ_size': 16,      # 标准整数队列
+                'fpIQ_size': 16,       # 标准浮点队列  
+                'memIQ_size': 32       # 大幅增大内存队列
+            },
+            'mixed_workload': {
+                'intIQ_size': 18,      # 平衡配置
+                'fpIQ_size': 18,
+                'memIQ_size': 20
+            }
+        }
+    
+    def tune_for_workload(self, workload_type):
+        config = self.workload_profiles[workload_type]
+        print(f"Optimizing for {workload_type}:")
+        for queue, size in config.items():
+            print(f"  {queue}: {size} entries")
+```
+
+#### 6.2.2 推测唤醒网络优化
+```cpp
+// 基于分析的唤醒网络调优
+class WakeupNetworkTuner {
+public:
+    struct WakeupStats {
+        int totalWakeups;
+        int successfulWakeups;
+        int cancelledWakeups;
+        float averageDelay;
+    };
+    
+    void optimizeWakeupNetwork() {
+        // 分析跨队列依赖模式
+        std::map<std::pair<std::string, std::string>, WakeupStats> channelStats;
+        
+        for (auto& channel : specWakeupNetwork) {
+            for (auto& src : channel.srcIQs) {
+                for (auto& dst : channel.dstIQs) {
+                    auto key = std::make_pair(src, dst);
+                    auto& stats = channelStats[key];
+                    
+                    // 计算推测唤醒效率
+                    if (stats.totalWakeups > 0) {
+                        float accuracy = (float)stats.successfulWakeups / stats.totalWakeups;
+                        
+                        if (accuracy < 0.7) {
+                            // 准确率低，考虑移除或增加延迟
+                            DPRINTF(Optimize, "Low accuracy channel %s->%s: %.2f\n",
+                                    src.c_str(), dst.c_str(), accuracy);
+                        } else if (accuracy > 0.95 && stats.averageDelay > 2) {
+                            // 准确率高但延迟大，考虑减少延迟
+                            DPRINTF(Optimize, "High latency channel %s->%s: %.2f cycles\n",
+                                    src.c_str(), dst.c_str(), stats.averageDelay);
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+```
+
+#### 6.2.3 内存子系统协调优化
+```cpp
+// LSQ与缓存系统的协调优化
+class LSQOptimizer {
+public:
+    struct MemoryPerfProfile {
+        float l1HitRate;
+        float l2HitRate;
+        float l3HitRate;
+        int averageMemLatency;
+    };
+    
+    void optimizeLSQForMemProfile(const MemoryPerfProfile& profile) {
+        // 基于缓存性能调整LSQ容量
+        if (profile.l1HitRate < 0.8) {
+            // L1缓存命中率低，增大LQ容量以容纳更多在途请求
+            int recommendedLQSize = baseLQSize * (1.5 - profile.l1HitRate);
+            DPRINTF(Optimize, "Recommending LQ size: %d (based on L1 hit rate %.2f)\n",
+                    recommendedLQSize, profile.l1HitRate);
+        }
+        
+        if (profile.averageMemLatency > 300) {
+            // 内存延迟高，启用更激进的Store-to-Load forwarding
+            enableAggressiveForwarding = true;
+            DPRINTF(Optimize, "Enabling aggressive store forwarding due to high mem latency\n");
+        }
+        
+        // 调整预取策略
+        if (profile.l2HitRate > 0.9) {
+            // L2命中率高，可以启用更激进的预取
+            prefetchAggressiveness = 2;
+        }
+    }
+};
+```
+
+### 6.3 调试和性能分析工具
+
+#### 6.3.1 实时性能监控
+```cpp
+// IEW性能监控面板
+class IEWPerfMonitor {
+    struct RealTimeStats {
+        float iewIPC;                    // IEW阶段的IPC
+        float dispatchUtilization;       // 分发利用率
+        float issueQueueUtilization;     // 发射队列利用率
+        float memoryStallRatio;          // 内存停顿比例
+        
+        // 热点分析
+        std::string bottleneckQueue;     // 瓶颈队列
+        std::string hottestStallReason;  // 主要停顿原因
+    };
+    
+public:
+    void updateRealTimeStats() {
+        RealTimeStats stats;
+        
+        // 计算实时IPC
+        stats.iewIPC = (float)executedInsts / totalCycles;
+        
+        // 找出瓶颈队列
+        float maxUtil = 0;
+        for (auto& iq : issueQues) {
+            float util = (float)iq->getOccupancy() / iq->getCapacity();
+            if (util > maxUtil) {
+                maxUtil = util;
+                stats.bottleneckQueue = iq->getName();
+            }
+        }
+        
+        // 分析主要停顿原因
+        auto maxStallReason = std::max_element(
+            stallReasonCounts.begin(), stallReasonCounts.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+        stats.hottestStallReason = stallReasonToString(maxStallReason->first);
+        
+        // 输出性能报告
+        if (curTick() % 1000000 == 0) {  // 每100万个周期报告一次
+            DPRINTF(PerfMonitor, 
+                    "IEW Performance: IPC=%.2f, Bottleneck=%s, Main stall=%s\n",
+                    stats.iewIPC, stats.bottleneckQueue.c_str(), 
+                    stats.hottestStallReason.c_str());
+        }
+    }
+};
+```
+
+---
+
+## 7. 总结与展望
+
+### 7.1 XS-GEM5 IEW的创新特性
+
+香山V3处理器的IEW实现体现了现代超标量处理器设计的最新趋势：
+
+1. **分布式调度架构**: 18个独立发射队列支持高度并行的指令处理
+2. **智能推测唤醒**: 跨队列的推测唤醒网络显著减少依赖链延迟  
+3. **灵活的分发机制**: 两阶段分发提供了更好的负载均衡和阻塞处理
+4. **精确的资源管理**: 寄存器文件端口的精确仲裁避免资源冲突
+5. **现代内存子系统**: 支持Store forwarding、内存序检测等高级特性
+
+### 7.2 性能影响与优化空间
+
+通过对IEW各个组件的深入分析，可以识别出几个关键的性能优化方向：
+
+- **调度延迟**: 推测唤醒网络可进一步优化，减少跨队列通信延迟
+- **端口利用**: 寄存器文件端口的动态分配策略可以更加智能化
+- **内存流水**: Load/Store流水线可以进一步深化，支持更高的内存访问带宽
+- **能耗优化**: 分布式设计在降低复杂度的同时，也为功耗优化提供了机会
+
+### 7.3 理解IEW的价值
+
+掌握IEW阶段的实现原理对于：
+- **处理器设计**: 理解现代超标量处理器的核心机制
+- **性能调优**: 识别和解决性能瓶颈
+- **架构研究**: 探索新的乱序执行优化技术
+- **系统优化**: 在软硬件协同设计中发挥重要作用
+
+IEW阶段作为乱序执行的核心，其设计质量直接决定了处理器的指令级并行度和整体性能。通过深入理解其dispatch、issue、execute、writeback四个环节以及分布式调度器的工作原理，我们能够更好地把握现代高性能处理器的设计精髓，为未来的处理器架构创新奠定坚实的理论基础。
+3.  **指令分类**:
+    -   如果指令是内存操作(isLoad/isStore),则调用`ldstQueue.insertLoad/insertStore()`将其插入LSQ。
+    -   如果指令是计算或其他类型,则调用`instQueue.insert()`将其插入IQ。
+    -   在插入IQ时,`Scheduler`会立即分析其依赖关系,并更新依赖图。
+
+### 3.2 Issue 阶段 (`InstructionQueue::scheduleReadyInsts`)
+
+这是**真正的乱序发生点**。指令不再按照程序顺序执行,而是"谁先准备好,谁先执行"。
+
+-   **选择就绪指令**: `Scheduler`会遍历IQ中的指令,寻找那些所有源寄存器都已就绪的指令。
+-   **分配功能单元(FU)**: `Scheduler`会为就绪指令寻找一个可用的功能单元(如整数ALU, 浮点乘法器等)。
+-   **发射**: 如果找到了可用的FU,指令就被"发射"出去,从IQ中移除,并放入一个名为`instsToExecute`的待执行队列中。
+
+**举例说明**:
+假设有两条指令:
+`1. ADD R3, R1, R2`
+`2. SUB R4, R3, R5`
+
+-   `ADD`指令进入IQ,它的源寄存器R1和R2都是就绪的,所以它可以被立即发射。
+-   `SUB`指令进入IQ,它依赖于R3。此时,`Scheduler`会在依赖图中记录: "SUB指令正在等待R3"。
+-   即使`SUB`指令比其他后来的、但不依赖R3的指令更早进入IQ,它也必须等待。
+
+### 3.3 Execute 阶段 (`IEW::executeInsts`)
+
+1.  **执行**: 从`instsToExecute`队列中取出指令,调用`inst->execute()`。
+    -   对于内存指令,会调用`ldstQueue`中的相应执行函数,与缓存系统交互。
+2.  **异常检测**:
+    -   **分支预测错误**: 如果一条分支指令的实际跳转方向/地址与预测不符,它会被标记为`mispredicted`。`IEW`会立即调用`squashDueToBranch()`,通知流水线前端(Fetch)从正确的地址重新取指,并废弃掉所有错误路径上的指令。这是一个**Squash(冲刷)**信号的来源。
+    -   **内存顺序冲突**: `ldstQueue`会检测到此问题(例如,一个load比一个更早的、地址相同的store先执行了)。`IEW`会调用`squashDueToMemOrder()`,同样触发流水线冲刷,但这次需要重新执行发生冲突的load以及它之后的所有指令。
+
+### 3.4 Writeback 阶段 (`IEW::writebackInsts` & `InstructionQueue::wakeDependents`)
+
+1.  **广播结果**: 指令执行完毕后,其结果(如果有)和目标物理寄存器ID会被广播出去。
+2.  **更新Scoreboard**: `Scoreboard`是一个位图,用于跟踪每个物理寄存器是否准备就绪。写回阶段会更新这个位图,将指令的目标寄存器标记为"就绪"。
+3.  **唤醒依赖者**: 这是至关重要的一步。`instQueue.wakeDependents()`被调用。
+    -   它会查找依赖图中所有等待这个刚刚写回结果的指令。
+    -   对于每一条等待指令,它会检查其对应的源操作数,并将其标记为"就绪"。
+    -   如果一条等待指令的所有源操作数现在都已就绪,那么它在下一个周期就可以被`scheduleReadyInsts`发射了。
+
+**继续上面的例子**:
+-   当`ADD`指令执行完毕,进入写回阶段。
+-   它的目标寄存器R3被标记为就绪。
+-   `wakeDependents`被调用,它发现`SUB`指令正在等待R3。
+-   于是,`SUB`指令的R3源操作数被标记为就绪。假设R5也已就绪,那么`SUB`指令在下一个周期就可以被发射执行了。
+
+---
+
+## 4. 总结
+
+IEW阶段通过指令队列(IQ)和加载/存储队列(LSQ)实现了指令的乱序发射和执行。其核心机制是基于**依赖关系图**和**唤醒逻辑**: 指令完成执行后,会"唤醒"所有等待其结果的后续指令,从而驱动整个乱序引擎的运转。同时,IEW也肩负着检测分支预测错误和内存访问冲突的重任,是确保程序正确执行的关键保障。理解了`dispatch`, `issue`, `execute`, `writeback`这四个环节以及它们之间的数据流和控制流,就掌握了O3 CPU的精髓。
+
+---
+
+## 5. 深入细节：分布式调度器(Scheduler)与发射逻辑
+
+现代O3 CPU的实现已经从一个单一、庞大的指令队列(monolithic IQ)演变为一个更精细化的**分布式调度系统**。GEM5中的`Scheduler`和`IssueQue`类正是这一思想的体现。这种设计旨在降低硬件复杂性、减少功耗并可能提高时钟频率。
+
+### 5.1 分布式指令队列架构 (`Scheduler` & `IssueQue`)
+
+取代原先单一的`InstructionQueue`,新的架构由两个核心组件构成：
+
+1.  **`Scheduler`**: 扮演着**中央协调者**的角色。它本身不存储指令,但负责：
+    *   **指令分派**: 决定一条新来的指令应该进入哪个`IssueQue`。
+    *   **全局仲裁**: 在所有`IssueQue`都选出待发射指令后,进行最终的资源仲裁(如读寄存器堆端口冲突)。
+    *   **唤醒协调**: 管理不同`IssueQue`之间的唤醒事件。
+
+2.  **`IssueQue`**: 多个`IssueQue`实例,每个都是一个**小型的、独立的指令队列**。通常,它们会根据指令类型进行划分,例如一个用于整数和内存操作,一个用于浮点操作。每个`IssueQue`负责：
+    *   存储一小部分指令。
+    *   维护自己的局部依赖图。
+    *   独立地进行指令选择(selection),找出自己队列中的就绪指令。
+
+这种架构的好处是,每个`IssueQue`的规模变小了,使得在其中寻找就绪指令的逻辑(通常是硬件实现中最复杂和耗电的部分之一)变得更简单、更快。
+
+### 5.2 分发详解：两阶段分发流程
+
+在`IEW.cc`中,当`enableDispatchStage`被启用时,分发过程分为两个步骤,这提供了一个更灵活的缓冲机制。
+
+1.  **`classifyInstToDispQue` (分类到分发队列)**
+    *   **目的**: 这是第一阶段,作为进入`Scheduler`前的**预处理/缓冲池**。
+    *   **逻辑**:
+        *   从Rename阶段接收指令(`insts[tid]`)。
+        *   调用`getInstDQType()`判断指令类型(例如,`IntDQ`, `FVDQ`, `MemDQ`)。
+        *   将指令放入对应类型的**分发队列** `dispQue[type]`中。`dispQue`是一个简单的FIFO队列。
+    *   **作用**: 这一步将不同类型的指令流分离开,并提供了一个缓冲层。如果下游的某个`IssueQue`满了,只有对应类型的`dispQue`会开始积压,而不会立即阻塞整个Dispatch阶段。
+
+2.  **`dispatchInstFromDispQue` (从分发队列到IQ)**
+    *   **目的**: 这是第二阶段,正式将指令插入到`Scheduler`管理的`IssueQue`中。
+    *   **逻辑**:
+        *   遍历所有的`dispQue`。
+        *   从每个`dispQue`中取出指令。
+        *   调用`scheduler->ready()`检查`Scheduler`中对应的`IssueQue`是否还有空间。
+        *   如果`Scheduler`准备好了,就调用`instQueue.insert(inst, ...)` (这里的`instQueue`实际上会把请求转发给`Scheduler`)将指令正式插入。
+    *   **总结**: 这个两阶段设计解耦了从Rename接收指令和向`Scheduler`插入指令两个过程,提高了流水线的弹性和吞吐量。
+
+### 5.3 发射与选择详解 (`Scheduler::issueAndSelect` & `IssueQue::tick`)
+
+这是分布式调度最核心的部分,整个过程被分解到`Scheduler`和`IssueQue`的`tick`函数中,可以概括为 **“局部选择,全局仲裁”**。
+
+`Scheduler::issueAndSelect()`是每周期由`IEW::tick()`调用的驱动函数,它协调所有`IssueQue`完成以下多步操作：
+
+1.  **唤醒 (Wakeup)**:
+    *   当一条指令执行完毕,`Scheduler::writebackWakeup()`被调用。
+    *   `Scheduler`使用`wakeMatrix` (一个唤醒关系矩阵)来确定这个结果需要通知哪些`IssueQue`。
+    *   被通知的`IssueQue`调用自己的`wakeUpDependents()`,更新其内部的依赖关系,并将新就绪的指令放入**就绪队列**`readyQ`。
+
+2.  **调度/选择 (Schedule/Select) - 在每个`IssueQue`内部并行进行**:
+    *   每个`IssueQue`的`tick()`函数会调用`scheduleInst()`和`selectInst()`。
+    *   `scheduleInst()`: 处理`readyQ`,准备进行选择。
+    *   `selectInst()`: 这是**局部选择**阶段。`IssueQue`会使用一个`Selector`对象(例如 `PAgeSelector`, 它实现了基于年龄和分组的选择策略)来遍历`readyQ`。
+    *   `Selector`会根据一定的策略(如最老优先)选出若干条最佳的待发射指令,并将它们放入`IssueQue`的**选择队列**`selectQ`中。此时,只考虑了指令是否就绪,尚未考虑跨`IssueQue`的资源冲突。
+
+3.  **仲裁 (Arbitrate) - 在`Scheduler`中集中进行**:
+    *   `Scheduler::issueAndSelect()`会遍历所有的`issueQues`。
+    *   它会收集所有`IssueQue`的`selectQ`中的候选指令。
+    *   **全局仲裁**开始。`Scheduler`会检查这些候选指令是否会竞争同一资源,最典型的就是**物理寄存器堆的读端口**。
+    *   `checkRfPortBusy()`函数用于检查读端口是否冲突。如果多条指令需要同时读取同一个端口,`Scheduler`会根据优先级进行裁决,失败的指令(`arbFailedInsts`)会在下一个周期重试。
+
+4.  **发射 (Issue)**:
+    *   通过了全局仲裁的指令,最终被`Scheduler`放入`instsToFu`队列,正式发射到功能单元。
+
+### 5.4 推测性唤醒 (`SpecWakeupChannel`)
+
+这是一个高级性能优化。
+
+*   **问题**: 传统的唤醒机制必须等待指令完全执行完毕(例如,一个长延迟的除法运算)才能唤醒其依赖者。
+*   **解决方案**: 对于某些延迟可知且固定的操作,可以在指令**发射时**就预知它何时会完成。因此,可以提前安排一个唤醒事件,在结果实际可用之前就**推测性地**唤醒依赖指令。
+*   **`SpecWakeupChannel`**: 定义了哪些`IssueQue`之间可以进行这种推测性唤醒。例如,整数`IssueQue`中的一条指令可能会推测性地唤醒浮点`IssueQue`中的依赖指令。
+*   **风险与回滚**: 如果推测出错(例如,指令被squash了),这个推测性唤醒必须被取消。`Scheduler`中的`specWakeEvents`和`SpecWakeupCompletion`事件类就是用来管理和取消这些在飞行中的推测性事件的。

--- a/docs/Gem5_Docs/midcore/rename.md
+++ b/docs/Gem5_Docs/midcore/rename.md
@@ -1,0 +1,247 @@
+# GEM5 O3 CPU Rename Stage 源码解析
+
+## 1. 引言
+
+Rename (重命名) 阶段是乱序处理器 (Out-of-Order Processor) 的核心,其主要职责是消除写后读 (WAR) 和写后写 (WAW) 伪相关,将指令中的体系结构寄存器 (Architectural Registers) 映射到一组数量更多的物理寄存器 (Physical Registers) 上,从而发掘指令级并行性。
+
+本文档将深入分析 GEM5 O3 CPU `Rename` 阶段的实现,重点关注其关键数据结构和核心逻辑,帮助你理解其工作原理。
+
+## 2. 关键数据结构
+
+`Rename` 阶段的实现主要围绕 `Rename` 类 (`src/cpu/o3/rename.hh`, `src/cpu/o3/rename.cc`) 和 `UnifiedRenameMap` 类 (`src/cpu/o3/rename_map.hh`) 展开。
+
+### 2.1. `Rename` 类
+
+`Rename` 类是重命名阶段的顶层封装,负责管理整个阶段的状态、数据流和逻辑。
+
+- **`renameStatus[MaxThreads]`**: `enum ThreadStatus`
+  这是一个为每个线程维护的状态机,用于描述 Rename 阶段当前所处的状态,如 `Running` (正常运行)、`Idle` (空闲)、`Blocked` (阻塞)、`Squashing` (正在清空)、`Unblocking` (正在解除阻塞) 等。`tick()` 函数的行为很大程度上取决于这个状态。
+
+- **`insts[MaxThreads]`**: `InstQueue` (即 `std::deque<DynInstPtr>`)
+  用于暂存当前周期从 `Decode` 阶段传递过来的指令。
+
+- **`skidBuffer[MaxThreads]`**: `InstQueue`
+  这是 Rename 阶段和 Decode 阶段之间的"缓冲垫"。当 Rename 阶段因为某些原因 (如后端资源不足) `Blocked` 时,从 Decode 阶段新来的指令就会被存入 `skidBuffer`。当 `unblock` 时,Rename 会优先处理 `skidBuffer` 中的指令。这是一种处理流水线反压 (backpressure) 的经典机制。
+
+- **`historyBuffer[MaxThreads]`**: `std::list<RenameHistory>`
+  **这是实现推测执行和精确异常的关键数据结构**。每当一个指令的目的寄存器被重命名,一条记录 (`RenameHistory`) 就会被添加到 `historyBuffer` 的头部。
+  - `RenameHistory` 结构体包含:
+    - `instSeqNum`: 指令的序列号。
+    - `archReg`: 体系结构寄存器。
+    - `newPhysReg`: 新映射的物理寄存器。
+    - `prevPhysReg`: 该体系结构寄存器之前映射的物理寄存器。
+  - `historyBuffer` 的作用:
+    1.  **指令Squash**: 当发生分支预测错误或异常时,流水线需要被清空 (squash)。Rename 阶段会从新到旧遍历 `historyBuffer`,将所有被 squash 的指令的重命名操作"撤销",即将体系结构寄存器的映射恢复到 `prevPhysReg`,并释放 `newPhysReg`。
+    2.  **指令Commit**: 当一条指令成功提交 (commit) 后,其 `prevPhysReg` 就再也不会被任何非推测性指令所需要了。此时,`historyBuffer` 中对应的记录会被移除,并且 `prevPhysReg` 会被真正地释放回 `freeList` 中,以供后续指令使用。
+
+- **`renameMap[MaxThreads]`**: `UnifiedRenameMap *`
+  指向 `UnifiedRenameMap` 的指针,负责维护体系结构寄存器到物理寄存器的映射关系。详见 2.2节。
+
+- **`freeList`**: `UnifiedFreeList *`
+  指向 `UnifiedFreeList` 的指针,负责管理所有可用的物理寄存器。当需要为目的寄存器分配新的物理寄存器时,就会从 `freeList` 中获取。
+
+- **`scoreboard`**: `Scoreboard *`
+  记分板,用于跟踪每个物理寄存器是否已经准备好 (即计算出结果)。在重命名源寄存器时,Rename 阶段会查询 `scoreboard` 来确定源操作数是否就绪。
+
+- **流水线通信接口**:
+  - `fromDecode`: 从 Decode 阶段接收指令。
+  - `toIEW`: 将重命名后的指令发送到 IEW (Issue/Execute/Writeback) 阶段。
+  - `fromIEW`, `fromCommit`: 从后续阶段接收反馈信号,如 ROB/IQ/LSQ 的空闲条目数、squash 信号等。
+
+### 2.2. `UnifiedRenameMap` 和 `SimpleRenameMap`
+
+`UnifiedRenameMap` 是一个统一的重命名映射表,它内部为每种寄存器类型 (如整数、浮点、向量等) 都包含一个 `SimpleRenameMap`。
+
+- **`SimpleRenameMap`**:
+  - `map`: 一个 `std::vector<VirtRegId>`，是实际的映射表, `map[arch_reg_idx]` 存储了该体系结构寄存器当前映射到的物理寄存器 ID (`VirtRegId`)。
+  - `freeList`: 指向对应类型寄存器的 `SimpleFreeList`。
+  - `rename(arch_reg, bypass_reg)`: 核心方法。它从 `freeList` 获取一个新的物理寄存器,更新 `map`,并返回新的和旧的物理寄存器。`bypass_reg` 用于实现**移动消除(move elimination)**优化。
+
+- **`UnifiedRenameMap`**:
+  - `rename(dest_reg, bypass_reg)`: 根据 `dest_reg` 的类型,将调用分发给对应的 `SimpleRenameMap`。
+  - `lookup(arch_reg)`: 查找一个体系结构寄存器当前映射到的物理寄存器。
+  - `setEntry(arch_reg, virt_reg)`: 直接设置一个映射关系,主要用于 squash 时恢复旧的映射。
+
+## 3. 核心代码逻辑
+
+`Rename` 阶段的逻辑在每个时钟周期的 `tick()` 函数中被驱动。
+
+### 3.1. `tick()` - 周期性的主循环
+
+`tick()` 函数是 Rename 阶段的入口,其主要流程如下:
+
+1.  **`sortInsts()`**: 从 `fromDecode` 接口读取指令,并根据线程ID分发到各自的 `insts` 队列中。
+
+2.  **遍历Active Threads**: 对每个活跃的线程执行以下操作。
+
+3.  **`checkSignalsAndUpdate(tid)`**:
+    - 检查来自 Commit 阶段的 `squash` 信号。如果存在,则调用 `squash()`。
+    - 检查来自 IEW 等后续阶段的 `stall` 信号。
+    - 根据这些信号和当前的资源状况 (如 ROB 是否满),更新当前线程的 `renameStatus`。例如,如果之前是 `Blocked` 状态且阻塞条件已解除,则切换到 `Unblocking` 状态。
+
+4.  **`rename(status_change, tid)`**:
+    - 这是一个分发函数,根据 `renameStatus` 调用核心的 `renameInsts()`。
+    - 如果状态是 `Running` 或 `Idle`, 对 `insts` 队列中的新指令进行重命名。
+    - 如果状态是 `Unblocking`, 对 `skidBuffer` 中缓存的指令进行重命名。
+    - 如果状态是 `Blocked` 或 `Squashing`, 则不进行重命名,只更新统计信息。
+
+### 3.2. `renameInsts(tid)` - 指令重命名核心
+
+这是实际执行重命名工作的主函数,其逻辑非常关键:
+
+1.  **选择指令源**: 根据 `renameStatus` 判断是从 `insts` 队列还是 `skidBuffer` 获取指令。
+
+2.  **资源检查**:
+    - 调用 `calcFreeROBEntries()`, `calcFreeIQEntries()`, `calcFreeLQEntries()`, `calcFreeSQEntries()` 计算 ROB、IQ (Issue Queue)、LQ/SQ (Load/Store Queue) 的可用空间。这些计算会考虑已发送但尚未被后续阶段确认的 "in-flight" 指令。
+    - 如果任何一个关键资源耗尽,则调用 `block(tid)` 将当前阶段设为阻塞状态,并将未处理的指令存入 `skidBuffer`,然后返回。
+
+3.  **物理寄存器预检查 (`canRename()`)**: 在开始重命名之前,会检查 `freeList` 中是否有足够数量、正确类型的物理寄存器来满足本周期内待重命名指令的需求。这是一个重要的预判,避免在重命名中途因缺少物理寄存器而卡住。
+
+4.  **循环重命名**: 在一个 `while` 循环中,逐条处理指令,直到达到 `renameWidth` (重命名带宽) 或没有更多指令/资源。
+
+    - **`renameSrcRegs(inst, tid)`**:
+        - 遍历指令的所有源寄存器。
+        - 对每个源寄存器,调用 `renameMap->lookup()` 找到其映射的物理寄存器。
+        - 查询 `scoreboard` 检查该物理寄存器的数据是否就绪,并相应地标记指令的源操作数状态。
+        - 如果每一个src 源寄存器都ready,则调用 `setCanIssue()` 标记指令状态为 `CanIssue`。
+        
+    - **`renameDestRegs(inst, tid)`**:
+        - 遍历指令的所有目的寄存器。
+        - 调用 `renameMap->rename()`:
+            - `renameMap` 从 `freeList` 获取一个新物理寄存器 (`newPhysReg`)。
+            - 更新映射表,使 `archReg` 指向 `newPhysReg`。
+            - 返回 `newPhysReg` 和 `archReg` 之前映射的 `prevPhysReg`。
+        - **创建历史记录**: 将 `instSeqNum`, `archReg`, `newPhysReg`, `prevPhysReg` 打包成一个 `RenameHistory` 对象,并压入 `historyBuffer` 的头部。
+        - 在 `scoreboard` 中将 `newPhysReg` 标记为 "未就绪"。
+        - **优化**: 此处实现了**移动消除 (Move Elimination)** 和**常量折叠 (Constant Folding)**。例如,对于 `mov x1, x2` 指令,可以直接让 `x1` 的映射指向 `x2` 当前映射的物理寄存器,从而消除一条指令。
+    - **发送到IEW**: 将重命名完成的指令放入 `toIEW` 队列,发送给下一阶段。
+
+### 3.3. `squash()` 和 `removeFromHistory()` - 推测执行的支柱
+
+这两个函数与 `historyBuffer` 紧密配合,是实现精确状态恢复的核心。
+
+- **`doSquash(squash_seq_num, tid)`**:
+  - 当收到 squash 信号时被调用。
+  - 从 `historyBuffer` 的头部 (最新条目) 开始遍历。
+  - 对于所有序列号大于 `squash_seq_num` 的历史记录:
+    1.  调用 `renameMap->setEntry()` 将体系结构寄存器的映射恢复到 `prevPhysReg`。
+    2.  调用 `tryFreePReg(newPhysReg)` 释放为错误路径指令分配的物理寄存器。`tryFreePReg` 会减少物理寄存器的引用计数,当计数为0时才将其归还 `freeList`。
+    3.  从 `historyBuffer` 中删除该条目。
+
+- **`removeFromHistory(inst_seq_num, tid)`**:
+  - 当 Commit 阶段通知有指令成功提交时被调用。
+  - 从 `historyBuffer` 的尾部 (最老条目) 开始遍历。
+  - 对于所有序列号小于等于 `inst_seq_num` 的历史记录:
+    1.  这条记录中的 `prevPhysReg` 现在可以被安全地回收了,因为它不再被任何有效的体系结构状态引用。
+    2.  调用 `tryFreePReg(prevPhysReg)` 释放这个旧的物理寄存器。
+    3.  从 `historyBuffer` 中删除该条目。
+
+## 4. 总结
+
+GEM5 的 Rename 阶段是一个精心设计的流水级,它通过一系列关键数据结构和清晰的逻辑实现了现代乱序处理器的核心功能:
+
+- **`UnifiedRenameMap`** 和 **`UnifiedFreeList`** 构成了寄存器重命名的基础。
+- **`historyBuffer`** 是实现推测执行、精确中断和高效物理寄存器回收的基石。
+- **`skidBuffer`** 提供了灵活的流水线流控机制。
+- **`tick()`** 函数中的状态机 (`renameStatus`) 清晰地组织了不同场景下的行为,如正常执行、阻塞和清空。
+
+通过理解这些组件如何协同工作,可以深入掌握乱序处理器中消除数据伪相关、支持推测执行的精髓。
+
+## 5. 辅助数据结构
+
+Rename 阶段的顺利运行依赖于几个关键的辅助数据结构,它们共同构成了物理寄存器管理和数据依赖跟踪的完整体系。
+
+### 5.1. 物理寄存器堆 (`PhysRegFile`)
+
+`PhysRegFile` (`src/cpu/o3/regfile.hh`) 是物理寄存器的“实体”所在。它并不直接参与重命名逻辑,而是作为物理寄存器的中央存储和管理器。
+
+- **核心职责**:
+  1.  **物理存储**: 内部为每种寄存器类型 (Int, Float, Vector等) 维护一个独立的 `RegFile` 对象,这些对象是真正存储寄存器值的地方。
+  2.  **ID 工厂**: 在初始化阶段,`PhysRegFile` 会创建所有物理寄存器的唯一标识符 (`PhysRegId`)。每个 `PhysRegId` 包含了寄存器类型、类型内的索引,以及一个全局唯一的扁平索引 (`flatIndex`)。
+  3.  **初始化 FreeList**: `PhysRegFile` 在创建完所有的 `PhysRegId` 后,会将它们全部添加到 `UnifiedFreeList` 中,为 Rename 阶段提供可用的物理寄存器池。
+  4.  **数据访问**: 在流水线的后端 (如 Writeback 阶段),当指令计算完成需要写入结果时,会通过 `PhysRegId` 在 `PhysRegFile` 中找到对应的位置并调用 `setReg()` 写入数据。同样,当需要读取寄存器值时,也会通过 `getReg()` 进行。
+
+可以把 `PhysRegFile` 理解为银行金库,它保管着所有的黄金(数据); `PhysRegId` 是金块的编号; `FreeList` 是记录哪些金块可用的账本; 而 `RenameMap` 则是记录哪个客户(体系结构寄存器)当前拥有哪个金块(物理寄存器)的账本。
+
+### 5.2. 记分板 (`Scoreboard`)
+
+`Scoreboard` (`src/cpu/o3/scoreboard.hh`) 是一个非常简单但至关重要的数据依赖跟踪机制。
+
+- **实现**: 其核心是一个 `std::vector<bool>`。这个向量的大小等于物理寄存器的总数,使用 `PhysRegId` 的 `flatIndex()` 作为索引。
+- **工作流程**:
+  1.  **分配时 (Rename)**: 当 `Rename` 阶段为一个指令的目的寄存器分配了一个新的物理寄存器时,它会调用 `scoreboard->unsetReg()` 将对应物理寄存器的状态位设置为 `false` (未就绪)。
+  2.  **检查时 (Rename)**: 当 `Rename` 阶段处理一个指令的源寄存器时,它会调用 `scoreboard->getReg()` 来检查其映射的物理寄存器状态位。如果为 `false`,则该源操作数未就绪,指令在进入 Issue Queue 后需要等待。
+  3.  **写回时 (Writeback)**: 当一条指令的计算结果被写回到 `PhysRegFile` 时,`Writeback` 阶段会调用 `scoreboard->setReg()` 将对应物理寄存器的状态位设置为 `true` (已就绪)。这会通知所有等待该寄存器的指令,它们的操作数已经准备好了。
+
+`Scoreboard` 完美地解决了乱序执行中的读后写 (RAW) 数据相关问题,确保指令只有在所有源操作数都可用时才会被执行。
+
+### 5.3. 虚拟寄存器ID (`VirtRegId`) 与优化
+
+`VirtRegId` (`src/cpu/o3/regfile.hh`) 是对 `PhysRegId` 的一层封装,它是实现移动消除和常量折叠等高级优化的关键。
+
+- **结构**: `VirtRegId` 包含两个主要部分:
+  - `phyReg`: 一个指向物理寄存器ID (`PhysRegIdPtr`) 的指针。
+  - `ieop`: 一个指向 `IEOperand` 的智能指针。`IEOperand` (Immediate Early Operand) 代表一个可以被“吸收”或“折叠”的立即数操作。
+
+- **优化原理**:
+  - **移动消除 (Move Elimination)**: 当 `Rename` 阶段遇到一条 `mov rd, rs` 指令时,它不会分配一个新的物理寄存器。取而代之的是,它在 `RenameMap` 中直接让 `rd` 指向 `rs` 当前映射的 `VirtRegId`。这样,后续使用 `rd` 的指令实际上会直接使用 `rs` 的物理寄存器,`mov` 指令本身则变成了一个空操作 (Nop),无需进入执行阶段。
+  - **常量折叠 (Constant Folding)**: 当遇到 `addi rd, rs, imm1` 这样的指令时,`Rename` 阶段会为 `rd` 分配一个新的物理寄存器,并创建一个 `VirtRegId`。这个 `VirtRegId` 不仅包含新的 `phyReg`,还包含一个 `IEOperand`,记录了 `type=ADD` 和 `imm=imm1`。如果紧接着有一条指令 `addi r_new, rd, imm2`, `Rename` 阶段可以检查到 `rd` 的 `VirtRegId` 中有一个待处理的 `ADD` 操作,于是它可以将两个立即数相加,为 `r_new` 创建一个新的 `VirtRegId`,其 `IEOperand` 记录为 `imm=imm1+imm2`。这样就将两条 `addi` 指令折叠成了一条。
+
+通过 `VirtRegId` 这种方式,`Rename` 阶段超越了简单的寄存器映射,具备了在流水线前端进行微架构级别优化的能力,从而减少了后端执行单元的压力,提升了处理器的整体性能。
+
+## 6. Scoreboard 在现代架构中的角色
+
+您提出的关于 Scoreboard 的问题非常关键,它触及了现代乱序处理器设计的核心。GEM5 O3 CPU 的架构是现代的 **寄存器重命名/物理寄存器堆 (Register Renaming/PRF)** 架构,是 Tomasulo 算法的演进。而 `Scoreboard` 在其中扮演的是一个高度特化、角色单一的辅助角色,它**不是**传统意义上那个负责全局调度、会产生 WAW 冒险阻塞的记分牌。
+
+### 6.1. GEM5 O3 CPU 架构分解
+
+GEM5 将现代乱序处理器的功能拆分到了不同的模块中,这是一种更模块化、更接近硬件设计的思路:
+
+1.  **`Rename` 阶段 + `UnifiedRenameMap` + `UnifiedFreeList`**:
+    *   这三个组件协同工作,完美对应了现代模型中的 `rename_table` 和 `free_list`。
+    *   它们的核心职责是**消除命名冒险 (WAW/WAR)**。通过为每条指令的目的寄存器从 `free_list` 分配一个新的物理寄存器,并更新 `rename_map`,从根本上解决了这些伪相关,而**不是**像传统记分牌那样去检测并阻塞它们。
+
+2.  **`PhysRegFile` (物理寄存器堆)**:
+    *   这对应了现代模型中物理寄存器里的 `value` 部分。
+    *   它是一个纯粹的数据存储阵列,是所有物理寄存器真实值的存放地。
+
+3.  **`Scoreboard` (记分板)**:
+    *   这精确地对应了现代模型中物理寄存器里的 `ready` 位。
+    *   **GEM5 的 `Scoreboard` 的唯一职责就是: 跟踪每一个物理寄存器的“就绪”状态。**
+    *   它的内部实现极其简单,就是一个 `std::vector<bool>`,用物理寄存器的全局唯一ID (`flatIndex`) 作为索引。
+    *   它**不**包含任何复杂的调度逻辑。它只回答一个问题：“这个物理寄存器的数据准备好了吗？”
+
+### 6.2. 工作流程串讲
+
+让我们把这些组件在一条指令的生命周期中串联起来:
+
+1.  **Rename 阶段**:
+    *   一条指令 `add r3, r1, r2` 进入 Rename 阶段。
+    *   **源寄存器**: 查找 `rename_map` 得到 `r1` 和 `r2` 当前映射的物理寄存器 `p10` 和 `p12`。然后,它会去问 `Scoreboard`：“`p10` ready 吗？”、“`p12` ready 吗？”。这个信息会随着指令一起传递下去。
+    *   **目的寄存器**: 为 `r3` 从 `free_list` 申请一个新的物理寄存器,比如 `p25`。然后更新 `rename_map`,让 `r3 -> p25`。同时,它会立刻通知 `Scoreboard`：“`p25` 现在**不** ready 了 (`unsetReg(p25)`)”,因为它的值即将被这条 `add` 指令计算。
+
+2.  **Issue Queue (发射队列)**:
+    *   重命名后的指令被放入发射队列。发射队列的逻辑会持续监控 `Scoreboard`。
+    *   只有当指令的所有源物理寄存器 (`p10`, `p12`) 在 `Scoreboard` 中的状态都变为 `ready` 时,这条指令才可能被发射到执行单元。
+
+3.  **Writeback (写回) 阶段**:
+    *   `add` 指令执行完毕,计算出了结果。
+    *   结果被写入 `PhysRegFile` 中 `p25` 寄存器所在的位置。
+    *   同时,写回阶段会立即通知 `Scoreboard`：“`p25` 现在**已经 ready** 了 (`setReg(p25)`)”。
+
+4.  **唤醒**:
+    *   `Scoreboard` 中 `p25` 的状态变为 `ready` 后,发射队列中所有等待 `p25` 的指令都会被“唤醒”,它们的一个依赖条件满足了。
+
+### 6.3. 结论
+
+所以,GEM5 的实现确实比传统 Scoreboard 更先进。它的架构是现代的,而 **`Scoreboard` 只是这个现代架构中用于实现“ready 位跟踪”功能的一个具体组件**。
+
+| 现代处理器模型组件 | GEM5 O3 CPU 对应组件 |
+| :--- | :--- |
+| `rename_table` | `UnifiedRenameMap` |
+| `free_list` | `UnifiedFreeList` |
+| `PhysicalRegister.value` | `PhysRegFile` |
+| `PhysicalRegister.ready` | **`Scoreboard`** |
+| `PhysicalRegister.producer_rob` | 这个追踪逻辑分布在 `ROB` 和指令对象 `DynInst` 自身中 |
+
+GEM5 之所以保留 `Scoreboard` 这个名字,很可能是出于历史和习惯,但它的功能已经从一个中央集权的“调度官”退化成了一个分布式的“状态查询服务”。真正的“智能”存在于 `Rename` 阶段的重命名逻辑和 `Issue Queue` 的指令唤醒逻辑中。

--- a/docs/Gem5_Docs/midcore/scheduler.md
+++ b/docs/Gem5_Docs/midcore/scheduler.md
@@ -1,0 +1,1658 @@
+# 调度器相关代码介绍
+
+## 1. 架构概述与演进历程
+
+### 1.1 从集中式到分布式的演进
+
+XS-GEM5的调度器架构体现了现代超标量处理器设计的重要演进：从传统的**集中式指令队列(Monolithic IQ)**向**分布式发射队列(Distributed IssueQueue)**架构的转变。这一转变不仅降低了硬件复杂性和功耗，还为提高时钟频率创造了条件。
+
+#### 传统集中式架构的限制
+```cpp
+// 传统设计：单一庞大的指令队列
+class MonolithicInstructionQueue {
+    std::vector<DynInstPtr> entries[128];    // 大容量单一队列
+    std::vector<std::vector<bool>> depMatrix; // NxN依赖矩阵，复杂度O(N²)
+    ComplexSelector selector;                 // 复杂的全局选择逻辑
+    // 问题：随着队列增大，硬件复杂度呈指数增长
+};
+```
+
+#### 现代分布式架构的优势
+```cpp
+// 现代设计：多个小规模专用队列
+class DistributedScheduler {
+    std::vector<IssueQue*> issueQues;        // 多个小队列
+    // 每个队列: 复杂度O(N/k)，总复杂度降为O(N)
+    WakeupNetwork specWakeupChannels;         // 灵活的唤醒网络
+    GlobalArbitrator portArbitrator;          // 全局资源仲裁
+};
+```
+
+### 1.2 XS-GEM5调度器主要组件
+
+- **Scheduler**: 中央协调者，负责指令分发、全局仲裁和唤醒协调
+- **IssueQue**: 分布式发射队列，每个专门处理特定类型指令
+- **InstructionQueue**: 兼容性包装器，提供对旧接口的支持
+- **SpecWakeupChannel**: 推测性唤醒通道，实现跨队列性能优化
+
+### 1.3 指令生命周期流程
+```
+Rename Stage → Dispatch Queues → Scheduler Distribution
+       |              |                    |
+       V              V                    V
+   指令重命名 → 两阶段分发缓冲 → 分布式队列分配
+       |              |                    |
+       V              V                    V
+   依赖分析   →   类型分类   →   局部依赖图构建
+       |              |                    |
+       V              V                    V
+┌─────────────────────────────────────────────────┐
+│              分布式发射逻辑                        │
+│   ┌─────────┐ ┌─────────┐ ┌─────────┐           │
+│   │ IntIQ0  │ │ FpIQ0   │ │ MemIQ0  │ ...       │
+│   │ Ready   │ │ Ready   │ │ Ready   │           │
+│   │ Select  │ │ Select  │ │ Select  │           │
+│   └─────────┘ └─────────┘ └─────────┘           │
+│            ↓        ↓        ↓                  │
+│         Global Port Arbitration                │
+│                    ↓                           │
+│            Issue to Function Units             │
+└─────────────────────────────────────────────────┘
+       |              |                    |
+       V              V                    V
+   功能单元执行 → 推测性唤醒网络 → 依赖链传播
+       |              |                    |
+       V              V                    V
+   结果写回    →   正式唤醒    →   下一轮发射
+```
+
+## 2. 核心数据结构深度解析
+
+### 2.1 Scheduler 类：中央协调器 (src/cpu/o3/issue_queue.hh:231)
+
+Scheduler作为分布式调度器的大脑，其设计体现了现代处理器"分治思想"的精髓。
+
+#### 2.1.1 核心成员变量详解
+```cpp
+class Scheduler : public SimObject {
+    // === 发射队列管理 ===
+    std::vector<IssueQue*> issueQues;              // 管理的所有发射队列
+    std::vector<DispPolicy> dispTable;             // OpClass→IssueQue映射表
+    std::vector<int> dispSeqVec;                    // 分发序列缓存
+
+    // === 三级记分板系统 ===
+    std::vector<bool> scoreboard;                  // 正式记分板：真实数据就绪
+    std::vector<bool> bypassScoreboard;            // 旁路记分板：旁路数据就绪  
+    std::vector<bool> earlyScoreboard;             // 早期记分板：推测数据就绪
+
+    // === 推测唤醒网络 ===
+    std::vector<std::vector<IssueQue*>> wakeMatrix; // 唤醒矩阵[srcIQ][dstIQs]
+    PendingWakeEventsType specWakeEvents;          // 待处理的推测唤醒事件
+    
+    // === 寄存器文件端口仲裁 ===
+    std::vector<std::pair<DynInstPtr, int>> rfPortOccupancy; // 端口占用状态
+    std::vector<DynInstPtr> arbFailedInsts;        // 仲裁失败的指令列表
+    int rfMaxTypePortId;                           // 最大端口类型ID
+
+    // === 执行控制 ===
+    std::vector<DynInstPtr> instsToFu;             // 发射到功能单元的指令
+    std::vector<bool> opPipelined;                 // 操作是否流水化
+    std::vector<int> opExecTimeTable;              // 操作执行延迟表
+
+    // === 性能统计 ===
+    SchedulerStats stats;                          // 调度器性能统计
+};
+```
+
+#### 2.1.2 三级记分板系统的设计哲学
+
+**TODO: 似乎有问题，没有在代码中找到对应函数！**
+
+```cpp
+/*
+ * 三级记分板系统实现了精确的数据依赖跟踪：
+ * 
+ * Level 1 - Early Scoreboard (推测就绪)：
+ *   当指令发射时立即设置，用于激进的推测唤醒
+ *   风险：可能被取消，需要回滚机制
+ * 
+ * Level 2 - Bypass Scoreboard (旁路就绪)：
+ *   当指令开始执行、结果可通过旁路网络获取时设置
+ *   用于支持back-to-back指令执行
+ * 
+ * Level 3 - Regular Scoreboard (正式就绪)：
+ *   当指令完全执行完毕、结果写入寄存器文件时设置
+ *   最保守但最可靠的就绪状态
+ */
+
+void Scheduler::updateScoreboard(const DynInstPtr& inst, ScoreboardLevel level) {
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        auto dst = inst->renamedDestIdx(i);
+        if (dst->isFixedMapping()) continue;
+        
+        switch (level) {
+        case EARLY_READY:
+            earlyScoreboard[dst->flatIndex()] = true;
+            DPRINTF(Schedule, "[sn:%lli] Early ready: p%d\n", 
+                    inst->seqNum, dst->flatIndex());
+            break;
+        case BYPASS_READY:
+            bypassScoreboard[dst->flatIndex()] = true;
+            DPRINTF(Schedule, "[sn:%lli] Bypass ready: p%d\n", 
+                    inst->seqNum, dst->flatIndex());
+            break;
+        case FINAL_READY:
+            scoreboard[dst->flatIndex()] = true;
+            DPRINTF(Schedule, "[sn:%lli] Final ready: p%d\n", 
+                    inst->seqNum, dst->flatIndex());
+            break;
+        }
+    }
+}
+```
+
+### 2.2 IssueQue 类：分布式微调度器 (src/cpu/o3/issue_queue.hh:102)
+
+每个IssueQue实际上是一个完整的小型调度器，具备独立的指令管理、依赖跟踪和选择逻辑能力。
+
+#### 2.2.1 指令存储与管理架构
+```cpp
+class IssueQue : public SimObject {
+    // === 指令存储层次 ===
+    std::list<DynInstPtr> instList;                    // 主存储：所有指令
+    std::vector<ReadyQue*> readyQs;                     // 就绪队列：按输出端口分组
+    SelectQue selectQ;                                  // 选择队列：仲裁后的候选
+    std::queue<DynInstPtr> replayQ;                     // 重放队列：需重试的指令
+    
+    // === 多级发射流水线 ===
+    TimeBuffer<IssueStream> inflightIssues;            // 发射流水线缓冲
+    TimeBuffer<IssueStream>::wire toIssue;              // S0: 选择输出
+    TimeBuffer<IssueStream>::wire toFu;                 // Sn: 发射到FU
+    int scheduleToExecDelay;                            // 发射流水线深度
+    
+    // === 局部依赖图 ===
+    // subDepGraph[physRegId] = [(srcOpIdx, dependentInst), ...]
+    std::vector<std::vector<std::pair<uint8_t, DynInstPtr>>> subDepGraph;
+    
+    // === 端口配置与管理 ===
+    std::vector<IssuePort*> oports;                     // 输出端口配置
+    std::vector<int64_t> portBusy;                      // 端口占用状态
+    int inports;                                        // 输入端口数量
+    int outports;                                       // 输出端口数量
+    
+    // === 指令选择策略 ===
+    BaseSelector* selector;                             // 选择器策略对象
+    
+    // === 容量管理 ===
+    const int iqsize;                                   // 队列最大容量
+    uint64_t instNum;                                   // 当前指令数
+    std::vector<uint8_t> opNum;                         // 按OpClass的指令计数
+};
+```
+
+#### 2.2.2 依赖图的精巧实现
+
+**TODO: 有问题，没有在代码中找到对应函数！**
+
+```cpp
+/*
+ * 局部依赖图设计：
+ * - 索引方式：按物理寄存器索引 subDepGraph[physRegId]
+ * - 存储内容：依赖该寄存器的所有指令及其源操作数位置
+ * - 优势：O(1)查找依赖者，高效的唤醒传播
+ */
+
+void IssueQue::buildDependencyGraph(const DynInstPtr& inst) {
+    DPRINTF(Schedule, "[sn:%lli] Building dependency graph\n", inst->seqNum);
+    
+    bool hasUnresolvedDeps = false;
+    
+    // 遍历所有源操作数
+    for (int srcIdx = 0; srcIdx < inst->numSrcRegs(); srcIdx++) {
+        auto srcReg = inst->renamedSrcIdx(srcIdx);
+        
+        if (srcReg->isFixedMapping()) {
+            // 架构寄存器，总是就绪
+            inst->markSrcRegReady(srcIdx);
+            continue;
+        }
+        
+        // 检查三级记分板状态
+        if (scheduler->scoreboard[srcReg->flatIndex()]) {
+            // 数据已在寄存器文件中
+            inst->markSrcRegReady(srcIdx);
+        } else if (scheduler->earlyScoreboard[srcReg->flatIndex()]) {
+            // 可能通过推测获得数据
+            inst->markSrcRegReady(srcIdx);
+        } else {
+            // 需要等待，建立依赖关系
+            subDepGraph[srcReg->flatIndex()].emplace_back(srcIdx, inst);
+            hasUnresolvedDeps = true;
+            
+            DPRINTF(Schedule, "[sn:%lli] Depends on p%d (src%d)\n", 
+                    inst->seqNum, srcReg->flatIndex(), srcIdx);
+        }
+    }
+    
+    // 如果所有依赖都解决，加入就绪队列
+    if (!hasUnresolvedDeps) {
+        addToReadyQueue(inst);
+    }
+}
+```
+
+### 2.3 InstructionQueue 类：兼容性适配器 (src/cpu/o3/inst_queue.hh:106)
+
+InstructionQueue现在主要作为向后兼容的适配器，将旧的集中式接口转换为新的分布式调度器调用。
+
+#### 2.3.1 适配器模式的实现
+```cpp
+class InstructionQueue {
+    // === 核心组件委托 ===
+    Scheduler* scheduler;                               // 委托给分布式调度器
+    MemDepUnit memDepUnit[MaxThreads];                  // 内存依赖单元
+    
+    // === 兼容性接口维护 ===
+    std::list<DynInstPtr> instsToExecute;               // 执行就绪指令队列
+    std::list<DynInstPtr> deferredMemInsts;             // 延迟的内存指令
+    std::unordered_set<DynInstPtr> cacheMissLdInsts;    // 缓存缺失的Load
+    std::list<STLFFailLdInst> stlfFailLdInsts;          // Store-to-Load转发失败
+    std::list<DynInstPtr> blockedMemInsts;              // 被阻塞的内存指令
+    std::list<DynInstPtr> retryMemInsts;                // 重试内存指令
+    
+    // === 非推测指令管理 ===
+    std::map<InstSeqNum, DynInstPtr> nonSpecInsts;      // 非推测指令映射
+    
+    // === 统计信息 ===
+    IQStats iqStats;                                    // 指令队列统计
+    IQIOStats iqIOStats;                                // IO访问统计
+    
+public:
+    // === 主要适配接口 ===
+    void insert(const DynInstPtr &new_inst, int disp_seq) {
+        scheduler->insert(new_inst, disp_seq);          // 委托给Scheduler
+        ++iqStats.instsAdded;
+    }
+    
+    bool hasReadyInsts() {
+        return scheduler->hasReadyInsts();               // 委托查询
+    }
+    
+    DynInstPtr getInstToExecute() {
+        assert(!instsToExecute.empty());
+        DynInstPtr inst = std::move(instsToExecute.front());
+        instsToExecute.pop_front();
+        return inst;
+    }
+    
+    int wakeDependents(const DynInstPtr &completed_inst) {
+        // 处理物理寄存器的释放逻辑（兼容性需要）
+        completed_inst->lastWakeDependents = curTick();
+        
+        // 实际唤醒由Scheduler处理
+        return 0;  // 分布式架构中，依赖计数不在此维护
+    }
+};
+```
+
+### 2.4 推测唤醒网络：性能加速的核心 (src/cpu/o3/issue_queue.hh:220)
+
+推测唤醒是现代超标量处理器的关键性能优化技术，通过预测指令完成时间实现提前唤醒。
+
+#### 2.4.1 唤醒通道的定义与配置
+```cpp
+class SpecWakeupChannel : public SimObject {
+public:
+    std::vector<std::string> srcIQs;                    // 源发射队列列表
+    std::vector<std::string> dstIQs;                    // 目标发射队列列表
+    
+    SpecWakeupChannel(const SpecWakeupChannelParams& params)
+        : SimObject(params), srcIQs(params.srcs), dstIQs(params.dsts) {}
+};
+
+/*
+ * 香山V3处理器的典型唤醒网络配置：
+ */
+class KMHV3Scheduler : public Scheduler {
+    // 定义各功能域的队列
+    std::vector<std::string> intBank = {"intIQ0", "intIQ1", "intIQ2", "intIQ3", "intIQ4", "intIQ5"};
+    std::vector<std::string> memBank = {"ld0", "ld1", "ld2", "sta0", "sta1", "std0", "std1"};
+    std::vector<std::string> fpBank = {"fpIQ0", "fpIQ1", "fpIQ2", "fpIQ3"};
+    
+    // 配置唤醒网络
+    std::vector<SpecWakeupChannel*> specWakeupNetwork = {
+        // 整数域内部唤醒 + 整数到内存域唤醒
+        new SpecWakeupChannel({.srcs = intBank + memBank, .dsts = intBank + memBank}),
+        
+        // 浮点域内部唤醒（隔离设计避免跨域干扰）
+        new SpecWakeupChannel({.srcs = fpBank, .dsts = fpBank})
+    };
+};
+```
+
+对应scheduler 中wakeMatrix的构建
+
+#### 2.4.2 推测唤醒事件的生命周期管理
+```cpp
+class SpecWakeupCompletion : public Event {
+    DynInstPtr inst;                                    // 触发唤醒的指令
+    IssueQue* to_issue_queue;                          // 目标发射队列
+    PendingWakeEventsType* owner;                       // 事件管理器引用
+    
+public:
+    SpecWakeupCompletion(const DynInstPtr& _inst, IssueQue* to, 
+                        PendingWakeEventsType* _owner)
+        : Event(Stat_Event_Pri, AutoDelete), inst(_inst), 
+          to_issue_queue(to), owner(_owner) {}
+    
+    void process() override {
+        // 执行推测唤醒
+        to_issue_queue->wakeUpDependents(inst, true);
+        
+        // 清理事件记录
+        (*owner)[inst->seqNum].erase(this);
+        if ((*owner)[inst->seqNum].empty()) {
+            owner->erase(inst->seqNum);
+        }
+        
+        DPRINTF(Schedule, "[sn:%lli] Speculative wakeup completed\n", 
+                inst->seqNum);
+    }
+    
+    const char* description() const override {
+        return "Speculative wakeup completion";
+    }
+};
+
+/*
+ * 推测唤醒的风险管理：
+ * 如果推测失败（指令被squash），需要取消所有相关的推测唤醒事件
+ */
+void Scheduler::cancelSpeculativeWakeups(const DynInstPtr& inst) {
+    auto it = specWakeEvents.find(inst->seqNum);
+    if (it != specWakeEvents.end()) {
+        for (auto* event : it->second) {
+            cpu->deschedule(event);  // 取消事件调度
+            delete event;            // 释放事件对象
+        }
+        specWakeEvents.erase(it);
+        
+        DPRINTF(Schedule, "[sn:%lli] Cancelled %d speculative wakeup events\n", 
+                inst->seqNum, it->second.size());
+    }
+}
+```
+**TODO: 没有在代码中找到对应函数！cancelSpeculativeWakeups**
+
+## 3. 分布式调度核心流程深度解析
+
+### 3.1 两阶段指令分发机制
+
+XS-GEM5实现了创新的两阶段分发机制，解耦了指令接收和队列分配，提高了流水线弹性。
+
+#### 3.1.1 阶段一：分类到分发队列 (IEW::classifyInstToDispQue)
+```cpp
+/*
+ * 第一阶段：预处理和缓冲
+ * 目标：将来自Rename的指令按类型分类到缓冲队列
+ * 优势：提供缓冲层，避免下游阻塞影响上游
+ */
+void IEW::classifyInstToDispQue(ThreadID tid) {
+    std::deque<DynInstPtr> &insts_to_dispatch = 
+        dispatchStatus[tid] == Unblocking ? skidBuffer[tid] : insts[tid];
+    
+    bool emptyROB = fromCommit->commitInfo[tid].emptyROB;
+    unsigned dispatched = 0;
+    
+    while (!insts_to_dispatch.empty()) {
+        auto& inst = insts_to_dispatch.front();
+        
+        // 1. 指令类型分类
+        DQType dqType = getInstDQType(inst);  // IntDQ/FVDQ/MemDQ
+        
+        // 2. 容量检查
+        if (dispQue[dqType].size() >= dqSize[dqType]) {
+            // 对应类型的分发队列已满，暂停分发
+            DPRINTF(Dispatch, "DispQueue[%d] full, blocking dispatch\n", dqType);
+            break;
+        }
+        
+        // 3. 序列化指令特殊处理
+        if ((inst->isSerializeBefore() && !inst->isSerializeHandled()) && !emptyROB) {
+            // 序列化指令需要等待ROB为空
+            DPRINTF(Dispatch, "[sn:%lli] Serialize before, waiting for empty ROB\n", 
+                    inst->seqNum);
+            break;
+        }
+        
+        // 4. 添加到分发队列
+        dispQue[dqType].push_back(inst);
+        inst->enterDQTick = curTick();  // 记录进入分发队列的时间
+        
+        // 5. 生产者注册（用于依赖图构建）
+        if (!inst->isNop() && !inst->isEliminated()) {
+            scheduler->addProducer(inst);  // 标记为数据生产者
+        }
+        
+        insts_to_dispatch.pop_front();
+        dispatched++;
+    }
+    
+    // 更新分发统计
+    iewStats.dispatchedInst[tid] += dispatched;
+    
+    // 处理阻塞情况
+    if (!insts_to_dispatch.empty()) {
+        block(tid);  // 阻塞当前线程的分发
+    }
+}
+
+/*
+ * 指令类型分类逻辑
+ */
+IEW::DQType IEW::getInstDQType(const DynInstPtr &inst) {
+    // 内存相关指令进入MemDQ
+    if (inst->isMemRef() || inst->isReadBarrier() || 
+        inst->isWriteBarrier() || inst->isNonSpeculative()) {
+        return MemDQ;
+    }
+    
+    // 浮点和向量指令进入FVDQ
+    if (inst->isFloating() || inst->isVector()) {
+        return FVDQ;
+    }
+    
+    // 其他指令进入IntDQ
+    return IntDQ;
+}
+```
+
+#### 3.1.2 阶段二：从分发队列到调度器 (IEW::dispatchInstFromDispQue)
+```cpp
+/*
+ * 第二阶段：正式分发到调度器
+ * 目标：将缓冲队列中的指令分发到具体的IssueQue
+ * 特点：支持负载均衡和智能分发策略
+ */
+void IEW::dispatchInstFromDispQue(ThreadID tid) {
+    bool add_to_iq = false;
+    int totalDispatched = 0;
+    
+    // 遍历所有分发队列类型
+    for (int dqType = 0; dqType < NumDQ; dqType++) {
+        int dispatched = 0;
+        int disp_seq = -1;
+        
+        // === 关键优化：预调度分析 ===
+        // lookahead()会分析即将分发的指令，提前计算分发策略
+        scheduler->lookahead(dispQue[dqType]);
+        
+        // 按分发带宽限制处理
+        while (!dispQue[dqType].empty() && dispatched < dispWidth[dqType]) {
+            DynInstPtr inst = dispQue[dqType].front();
+            disp_seq++;  // 分发序列号，用于负载均衡
+            
+            // 跳过已废除指令
+            if (inst->isSquashed()) {
+                dispQue[dqType].pop_front();
+                continue;
+            }
+            
+            // === 关键检查：调度器就绪状态 ===
+            if (!scheduler->ready(inst, disp_seq)) {
+                // 目标IssueQue没有空间，停止当前类型的分发
+                DPRINTF(Dispatch, "[sn:%lli] Scheduler not ready for %s\n", 
+                        inst->seqNum, enums::OpClassStrings[inst->opClass()]);
+                break;
+            }
+            
+            // === LSQ容量检查（内存指令特有） ===
+            if (checkLSQCapacity(inst, tid)) {
+                DPRINTF(Dispatch, "[sn:%lli] LSQ capacity exhausted\n", inst->seqNum);
+                break;
+            }
+            
+            // === 指令分类处理 ===
+            add_to_iq = classifyAndHandleInst(inst, tid);
+            
+            // === 非推测指令特殊处理 ===
+            if (add_to_iq && inst->isNonSpeculative()) {
+                inst->setCanCommit();
+                instQueue.insertNonSpec(inst);  // 非推测指令专用队列
+                add_to_iq = false;
+            }
+            
+            // === 正式插入调度器 ===
+            if (add_to_iq) {
+                instQueue.insert(inst, disp_seq);  // 委托给调度器
+            }
+            
+            // 清理和统计
+            inst->exitDQTick = curTick();
+            ppDispatch->notify(inst);  // 性能探针通知
+            dispQue[dqType].pop_front();
+            dispatched++;
+            totalDispatched++;
+        }
+    }
+    
+    // 更新整体分发统计  
+    iewStats.dispDist.sample(totalDispatched);
+}
+```
+
+### 3.2 Scheduler智能分发策略
+
+#### 3.2.1 预测性负载均衡 (Scheduler::lookahead)
+```cpp
+/*
+ * lookahead机制：预测性分发策略
+ * 目标：在实际分发前分析指令序列，优化队列分配
+ * 核心思想：避免某个IssueQue成为瓶颈
+ */
+void Scheduler::lookahead(std::deque<DynInstPtr>& insts) {
+    if (old_disp) {
+        return;  // 传统分发模式，不使用预测
+    }
+    
+    // 按OpClass统计即将分发的指令数量
+    uint8_t disp_op_num[Num_OpClasses];
+    std::memset(disp_op_num, 0, sizeof(disp_op_num));
+    
+    int i = 0;
+    for (auto& inst : insts) {
+        OpClass opClass = inst->opClass();
+        
+        // 获取该OpClass对应的IssueQue列表
+        auto& iqs = dispTable[opClass];
+        
+        // === 关键策略：按负载排序 ===
+        // 根据当前队列中该OpClass的指令数量排序，负载小的优先
+        // 由于iqs 是引用，这里排序后已经修改了dispTable中的顺序！之后ready 就会按负载顺序放进去！
+        std::sort(iqs.begin(), iqs.end(), disp_policy(opClass));
+        
+        // === Split Store特殊处理 ===
+        if (inst->isSplitStoreAddr()) {
+            // Store指令会被拆分为地址和数据两部分
+            auto& stdIqs = dispTable[StoreDataOp];
+            std::sort(stdIqs.begin(), stdIqs.end(), disp_policy(StoreDataOp));
+        }
+        
+        // 计算该指令应该分发到哪个IssueQue（轮询策略）
+        dispSeqVec[i] = disp_op_num[opClass] % iqs.size();
+        disp_op_num[opClass]++;
+        i++;
+        
+        DPRINTF(Schedule, "[sn:%lli] %s will go to IQ[%d] (load balancing)\n", 
+                inst->seqNum, enums::OpClassStrings[opClass], dispSeqVec[i-1]);
+    }
+}
+
+/*
+ * 分发策略比较器：负载均衡核心算法
+ */
+bool Scheduler::disp_policy::operator()(IssueQue* a, IssueQue* b) const {
+    // 比较两个IssueQue中指定OpClass的指令数量
+    int loadA = a->opNum[disp_op];  // 队列A中该OpClass的指令数
+    int loadB = b->opNum[disp_op];  // 队列B中该OpClass的指令数
+    
+    // 负载小的队列优先级更高
+    return loadA < loadB;
+}
+```
+
+#### 3.2.2 智能分发决策 (Scheduler::insert)
+```cpp
+/*
+ * 主分发接口：将指令插入到最优的IssueQue
+ */
+void Scheduler::insert(const DynInstPtr& inst, int disp_seq) {
+    DPRINTF(Schedule, "[sn:%lli] Inserting %s instruction\n", 
+            inst->seqNum, enums::OpClassStrings[inst->opClass()]);
+    
+    // === Split Store指令特殊处理 ===
+    if (inst->isSplitStoreAddr()) {
+        // 1. 创建Store数据微操作
+        auto stduop = inst->createStoreDataUop();
+        this->insert(stduop, disp_seq);  // 递归插入数据部分
+        
+        // 2. 将原指令转换为Store地址微操作
+        inst->buildStoreAddrUop();
+        DPRINTF(Schedule, "[sn:%lli] Split store: addr=%lli, data=%lli\n", 
+                inst->seqNum, inst->seqNum, stduop->seqNum);
+    }
+    
+    // 获取目标IssueQue列表
+    auto& iqs = dispTable[inst->opClass()];
+    assert(!iqs.empty());
+    
+    if (old_disp) {
+        // === 传统分发：遍历查找可用队列 ===
+        bool inserted = false;
+        std::sort(iqs.begin(), iqs.end(), disp_policy(inst->opClass()));
+        
+        for (auto iq : iqs) { // 遍历所有IssueQue，找到一个ready的IssueQue，将指令插入进去，RTL开销大
+            if (iq->ready()) {
+                iq->insert(inst);
+                inserted = true;
+                break;
+            }
+        }
+        panic_if(!inserted, "No available IQ for opClass %s", 
+                 enums::OpClassStrings[inst->opClass()]);
+    } else {
+        // === 现代分发：基于预测的精确分配 ===
+        IssueQue* targetIQ = iqs[dispSeqVec.at(disp_seq)]; // 按照lookahead 的顺序，将指令插入到对应的IssueQue中
+        assert(targetIQ->ready());
+        targetIQ->insert(inst);
+        
+        DPRINTF(Schedule, "[sn:%lli] Assigned to %s (seq=%d)\n", 
+                inst->seqNum, targetIQ->getName().c_str(), disp_seq);
+    }
+}
+```
+
+### 3.3 分布式发射与选择机制
+
+#### 3.3.1 "局部选择，全局仲裁"架构
+```cpp
+/*
+ * 核心调度函数：协调所有IssueQue的发射过程
+ * 实现"局部选择，全局仲裁"的分布式调度策略
+ */
+void Scheduler::issueAndSelect() {
+    DPRINTF(Schedule, "=== Starting distributed issue and select cycle ===\n");
+    
+    // === 第一步：局部选择阶段 ===
+    // 每个IssueQue独立选择其最佳候选指令
+    for (auto iq : issueQues) {
+        iq->selectInst();  // 局部选择，结果存储在iq->selectQ中
+    }
+    
+    // === 第二步：全局仲裁阶段 ===
+    // 处理跨队列的资源冲突（主要是寄存器文件端口冲突）
+    globalPortArbitration();
+    
+    // === 第三步：正式发射阶段 ===  
+    // 通过仲裁的指令正式发射到功能单元
+    for (auto iq : issueQues) {
+        iq->issueToFu();  // 将selectQ中的获胜指令发射出去
+    }
+    
+    // === 第四步：性能统计更新 ===
+    updateIssueStats();
+}
+
+/*
+ * 全局寄存器文件端口仲裁
+ * 解决多个队列同时请求相同读端口的冲突
+ */
+void Scheduler::globalPortArbitration() {
+    // 清空仲裁失败列表
+    arbFailedInsts.clear();
+    
+    // 重置端口占用状态
+    std::fill(rfPortOccupancy.begin(), rfPortOccupancy.end(), 
+              std::make_pair(nullptr, 0));
+    
+    // 收集所有候选指令的端口需求
+    for (auto iq : issueQues) {
+        for (auto& [portId, inst] : iq->selectQ) {
+            // 检查每个源操作数的端口需求
+            for (int srcIdx = 0; srcIdx < inst->numSrcRegs(); srcIdx++) {
+                auto srcReg = inst->renamedSrcIdx(srcIdx);
+                if (srcReg->isFixedMapping()) continue;
+                
+                // 获取端口配置
+                int typePortId = getRegFilePortId(iq, portId, srcIdx, srcReg);
+                int priority = getPortPriority(iq, portId, srcIdx);
+                
+                // 尝试分配端口
+                if (!allocateRegFilePort(inst, srcReg, typePortId, priority)) {
+                    // 仲裁失败，将指令加入失败列表
+                    arbFailedInsts.push_back(inst);
+                    DPRINTF(Schedule, "[sn:%lli] Port arbitration failed for p%d\n", 
+                            inst->seqNum, srcReg->flatIndex());
+                    break;  // 该指令失败，检查下一条指令
+                }
+            }
+        }
+    }
+    
+    // 通知各IssueQue仲裁结果
+    for (auto& inst : arbFailedInsts) {
+        inst->setArbFailed();  // 标记仲裁失败，下周期重试
+    }
+    
+    DPRINTF(Schedule, "Port arbitration: %d instructions failed\n", 
+            arbFailedInsts.size());
+}
+```
+
+#### 3.3.2 IssueQue局部选择逻辑
+```cpp
+/*
+ * 单个IssueQue的指令选择过程
+ * 目标：从就绪队列中选出最优候选指令
+ */
+void IssueQue::selectInst() {
+    selectQ.clear();  // 清空上一周期的选择结果
+    
+    // 遍历所有输出端口
+    for (int portId = 0; portId < outports; portId++) {
+        auto readyQ = readyQs[portId];
+        if (readyQ->empty()) continue;
+        
+        // 使用选择器策略选择最佳指令
+        selector->begin(readyQ);  // 设置选择范围
+        
+        // 按照选择器策略，逐个选择最佳指令
+        for (auto it = selector->select(readyQ->begin(), portId); 
+             it != readyQ->end(); 
+             it = selector->select(++it, portId)) {
+            
+            auto& inst = *it;
+            
+            // 跳过已取消的指令
+            if (inst->canceled()) {
+                inst->clearInReadyQ();
+                it = readyQ->erase(it);
+                continue;
+            }
+            
+            // === 关键检查：端口可用性 ===
+            // 检查该端口在未来几个周期是否被占用
+            uint64_t futureBusyMask = portBusy[portId];
+            int instOpLatency = scheduler->getCorrectedOpLat(inst);
+            
+            if (!(futureBusyMask & (1llu << instOpLatency))) {
+                // 端口可用，选择该指令
+                DPRINTF(Schedule, "[sn:%lli] Selected for port %d\n", 
+                        inst->seqNum, portId);
+                
+                // 预分配寄存器文件读端口
+                bool portAllocSuccess = preAllocateRegFilePorts(inst, portId);
+                if (portAllocSuccess) {
+                    selectQ.push_back(std::make_pair(portId, inst));
+                    inst->clearInReadyQ();
+                    readyQ->erase(it);
+                    break;  // 该端口已选定指令，选择下一个端口
+                } else {
+                    // 端口预分配失败，尝试下一条指令
+                    continue;
+                }
+            } else {
+                // 端口忙，记录统计信息
+                iqstats->portBusy[portId]++;
+                DPRINTF(Schedule, "[sn:%lli] Port %d busy, mask=0x%llx\n", 
+                        inst->seqNum, portId, futureBusyMask);
+            }
+        }
+    }
+    
+    DPRINTF(Schedule, "%s selected %d instructions this cycle\n", 
+            iqname.c_str(), selectQ.size());
+}
+
+/*
+ * 寄存器文件端口预分配
+ * 在全局仲裁前，先进行本地端口需求分析
+ */
+bool IssueQue::preAllocateRegFilePorts(const DynInstPtr& inst, int portId) {
+    // 获取该端口的寄存器文件配置
+    auto& intPorts = intRfTypePortId[portId];
+    auto& fpPorts = fpRfTypePortId[portId];
+    
+    // 检查每个源操作数
+    for (int srcIdx = 0; srcIdx < inst->numSrcRegs(); srcIdx++) {
+        auto srcReg = inst->srcRegIdx(srcIdx);
+        auto physReg = inst->renamedSrcIdx(srcIdx);
+        
+        if (physReg->isFixedMapping()) continue;
+        
+        std::pair<int, int> typePortIdPri;
+        bool portFound = false;
+        
+        // 根据寄存器类型选择端口
+        if (srcReg.isIntReg() && srcIdx < intPorts.size()) {
+            typePortIdPri = intPorts[srcIdx];
+            portFound = true;
+        } else if (srcReg.isFloatReg() && srcIdx < fpPorts.size()) {
+            typePortIdPri = fpPorts[srcIdx];
+            portFound = true;
+        }
+        
+        if (portFound) {
+            // 通知调度器进行端口分配
+            scheduler->useRegfilePort(inst, physReg, 
+                                    typePortIdPri.first,   // typePortId
+                                    typePortIdPri.second); // priority
+        }
+    }
+    
+    return true;  // 预分配总是成功，实际冲突由全局仲裁解决
+}
+```
+
+### 3.4 多级唤醒机制深度解析
+
+#### 3.4.1 推测性唤醒：性能优化的核心
+```cpp
+/*
+ * 推测性唤醒：现代超标量处理器的关键技术
+ * 原理：在指令发射时就预测其完成时间，提前唤醒依赖指令
+ * 优势：减少依赖链延迟，提高指令级并行度
+ * 风险：推测错误需要回滚机制
+ */
+void Scheduler::specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_queue) {
+    // 只有流水化且有目标寄存器的非Load指令才进行推测唤醒
+    if (!opPipelined[inst->opClass()] || inst->numDestRegs() == 0 || inst->isLoad()) {
+        DPRINTF(Schedule, "[sn:%lli] Skip spec wakeup: not eligible\n", inst->seqNum);
+        return;
+    }
+    
+    DPRINTF(Schedule, "[sn:%lli] Starting speculative wakeup from %s\n", 
+            inst->seqNum, from_issue_queue->getName().c_str());
+    
+    // 遍历推测唤醒网络，找到所有目标队列
+    for (auto to : wakeMatrix[from_issue_queue->getId()]) {
+        // 计算唤醒延迟
+        int baseOpLatency = getCorrectedOpLat(inst);
+        int wakeDelay = baseOpLatency - 1;  // 提前一个周期唤醒
+        
+        // === 跨队列延迟调整 ===
+        // 不同深度的发射流水线需要调整唤醒时机
+        int stagesDiff = std::abs(from_issue_queue->getIssueStages() - 
+                                 to->getIssueStages());
+        
+        if (from_issue_queue->getIssueStages() > to->getIssueStages()) {
+            wakeDelay += stagesDiff;  // 目标队列更浅，延迟增加
+        } else if (wakeDelay >= stagesDiff) {
+            wakeDelay -= stagesDiff;  // 目标队列更深，延迟减少
+        }
+        
+        DPRINTF(Schedule, "[sn:%lli] Wakeup %s->%s, delay=%d cycles\n", 
+                inst->seqNum, from_issue_queue->getName().c_str(), 
+                to->getName().c_str(), wakeDelay);
+        
+        if (wakeDelay == 0) {
+            // === 立即推测唤醒 ===
+            to->wakeUpDependents(inst, true);  // 推测性标志为true
+            
+            // 更新早期记分板（仅限整数指令）
+            if (!(inst->isFloating() || inst->isVector())) {
+                for (int i = 0; i < inst->numDestRegs(); i++) {
+                    auto dst = inst->renamedDestIdx(i);
+                    if (!dst->isFixedMapping()) {
+                        earlyScoreboard[dst->flatIndex()] = true;
+                        DPRINTF(Schedule, "[sn:%lli] Early scoreboard set: p%d\n", 
+                                inst->seqNum, dst->flatIndex());
+                    }
+                }
+            }
+        } else {
+            // === 延迟推测唤醒 ===
+            // 创建推测唤醒事件
+            auto wakeEvent = new SpecWakeupCompletion(inst, to, &specWakeEvents);
+            
+            // 记录事件用于可能的取消操作
+            specWakeEvents[inst->seqNum].insert(wakeEvent);
+            
+            // 调度事件
+            Tick whenToWake = cpu->clockEdge(Cycles(wakeDelay)) - 1;
+            cpu->schedule(wakeEvent, whenToWake);
+            
+            DPRINTF(Schedule, "[sn:%lli] Scheduled spec wakeup event at tick %llu\n", 
+                    inst->seqNum, whenToWake);
+        }
+    }
+}
+
+/*
+ * Load指令专用的推测唤醒
+ * Load的特殊性：延迟不确定，但可以在流水线中提前唤醒依赖者
+ */
+void Scheduler::specWakeUpFromLoadPipe(const DynInstPtr& inst) {
+    assert(inst->isLoad());
+    
+    auto from_issue_queue = inst->issueQue;
+    DPRINTF(Schedule, "[sn:%lli] Load pipe spec wakeup from %s\n", 
+            inst->seqNum, from_issue_queue->getName().c_str());
+    
+    // Load指令的推测唤醒总是立即进行（在Load流水线中）
+    for (auto to : wakeMatrix[from_issue_queue->getId()]) {
+        to->wakeUpDependents(inst, true);
+        
+        // 设置早期记分板
+        for (int i = 0; i < inst->numDestRegs(); i++) {
+            auto dst = inst->renamedDestIdx(i);
+            if (!dst->isFixedMapping()) {
+                earlyScoreboard[dst->flatIndex()] = true;
+            }
+        }
+    }
+}
+```
+
+#### 3.4.2 正式唤醒：可靠的依赖解除
+```cpp
+/*
+ * 写回阶段的正式唤醒
+ * 特点：数据已经真实可用，唤醒是安全和可靠的
+ */
+void Scheduler::writebackWakeup(const DynInstPtr& inst) {
+    DPRINTF(Schedule, "[sn:%lli] Writeback wakeup started\n", inst->seqNum);
+    
+    inst->setWriteback();  // 标记指令已写回
+    cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtWriteVal);
+    
+    // 更新正式记分板
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        auto dst = inst->renamedDestIdx(i);
+        if (!dst->isFixedMapping()) {
+            scoreboard[dst->flatIndex()] = true;
+            DPRINTF(Schedule, "[sn:%lli] Scoreboard set: p%d\n", 
+                    inst->seqNum, dst->flatIndex());
+        }
+    }
+    
+    // 通知所有IssueQue进行正式唤醒
+    for (auto iq : issueQues) {
+        iq->wakeUpDependents(inst, false);  // 非推测性唤醒
+    }
+}
+
+/*
+ * IssueQue内的依赖唤醒实现
+ */
+void IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative) {
+    if (speculative && inst->canceled()) {
+        // 推测性唤醒时，如果指令已被取消，则跳过
+        return;
+    }
+    
+    DPRINTF(Schedule, "[sn:%lli] %s wakeup in %s\n", 
+            inst->seqNum, speculative ? "Speculative" : "Writeback", iqname.c_str());
+    
+    // 遍历该指令的所有目标寄存器
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        auto dst = inst->renamedDestIdx(i);
+        if (dst->isFixedMapping() || dst->getNumPinnedWritesToComplete() != 1) {
+            continue;  // 跳过架构寄存器和多写端口寄存器
+        }
+        
+        // 寄存器缓存更新（整数寄存器优化）
+        if (dst->is(IntRegClass)) {
+            scheduler->regCache.insert(dst->flatIndex(), {});
+        }
+        
+        // 查找依赖该寄存器的所有指令
+        auto& depList = subDepGraph[dst->flatIndex()];
+        for (auto it = depList.begin(); it != depList.end(); ) {
+            int srcIdx = it->first;
+            auto& consumer = it->second;
+            
+            // 检查依赖指令是否已被废弃
+            if (consumer->isSquashed()) {
+                it = depList.erase(it);
+                continue;
+            }
+            
+            // 检查该源操作数是否已经就绪
+            if (consumer->readySrcIdx(srcIdx)) {
+                ++it;  // 已经就绪，跳过
+                continue;
+            }
+            
+            // === 关键步骤：标记源操作数就绪 ===
+            consumer->markSrcRegReady(srcIdx);
+            DPRINTF(Schedule, "[sn:%lli] src%d woken by [sn:%lli]\n", 
+                    consumer->seqNum, srcIdx, inst->seqNum);
+            
+            // 检查指令是否所有依赖都已解决
+            addIfReady(consumer);
+            
+            ++it;
+        }
+        
+        // 正式唤醒时清理依赖图
+        if (!speculative) {
+            depList.clear();
+        }
+    }
+}
+
+/*
+ * 检查指令是否就绪并加入就绪队列
+ */
+void IssueQue::addIfReady(const DynInstPtr& inst) {
+    if (!inst->readyToIssue()) {
+        return;  // 还有未解决的依赖
+    }
+    
+    // 记录就绪时间戳
+    if (inst->readyTick == -1) {
+        inst->readyTick = curTick();
+        DPRINTF(Counters, "[sn:%lli] Ready at tick %llu\n", 
+                inst->seqNum, curTick());
+    }
+    
+    // 内存指令需要额外检查内存依赖
+    if (inst->isMemRef() && !inst->memDepSolved()) {
+        DPRINTF(Schedule, "[sn:%lli] Memory dependency not solved\n", inst->seqNum);
+        return;
+    }
+    
+    // 清除取消标志并加入就绪队列
+    inst->clearCancel();
+    if (!inst->inReadyQ()) {
+        READYQ_PUSH(inst);  // 宏定义的就绪队列插入操作
+        DPRINTF(Schedule, "[sn:%lli] Added to ready queue\n", inst->seqNum);
+    }
+}
+```
+
+## 4. Dispatch与Execute深度交互机制
+
+### 4.1 调度器与执行单元的精密协调
+
+#### 4.1.1 指令发射到功能单元的完整流程
+```cpp
+/*
+ * 从调度器到功能单元的完整路径
+ * 体现了现代处理器精确的资源管理和时序控制
+ */
+DynInstPtr Scheduler::getInstToFU() {
+    if (instsToFu.empty()) {
+        return DynInstPtr(nullptr);  // 没有待发射指令
+    }
+    
+    // 从发射队列取出指令
+    auto inst = instsToFu.back();
+    instsToFu.pop_back();
+    
+    DPRINTF(Schedule, "[sn:%lli] Issued to FU: %s\n", 
+            inst->seqNum, enums::OpClassStrings[inst->opClass()]);
+    
+    // 更新指令状态和时间戳
+    inst->setIssued();
+    inst->issueTick = curTick();
+    
+    // 性能跟踪点
+    cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtFU);
+    
+    return inst;
+}
+
+/*
+ * 执行单元延迟管理：动态延迟预测
+ * 某些指令的执行延迟取决于操作数值，需要动态计算
+ */
+uint32_t Scheduler::getOpLatency(const DynInstPtr& inst) {
+    OpClass opClass = inst->opClass();
+    
+    // 浮点转换指令的特殊处理
+    if (opClass == FloatCvtOp) {
+        if (inst->destRegIdx(0).isFloatReg()) {
+            // 整数到浮点转换需要额外延迟
+            return 2 + opExecTimeTable[opClass];
+        }
+    }
+    
+    // 查表获取基础延迟
+    uint32_t baseLatency = opExecTimeTable[opClass];
+    
+    DPRINTF(Schedule, "[sn:%lli] Op latency for %s: %d cycles\n", 
+            inst->seqNum, enums::OpClassStrings[opClass], baseLatency);
+    
+    return baseLatency;
+}
+
+/*
+ * 修正后的操作延迟：考虑流水线和旁路因素
+ */
+uint32_t Scheduler::getCorrectedOpLat(const DynInstPtr& inst) {
+    uint32_t baseLatency = getOpLatency(inst);
+    
+    // 未来可以在这里添加更多修正因素：
+    // - 操作数准备时间
+    // - 旁路网络延迟
+    // - 功能单元流水线深度
+    
+    return baseLatency;
+}
+```
+
+#### 4.1.2 功能单元完成事件处理
+```cpp
+/*
+ * 功能单元完成事件类：处理长延迟操作
+ * 对于延迟超过1个周期的操作，使用事件驱动机制
+ */
+class InstructionQueue::FUCompletion : public Event {
+    DynInstPtr inst;                    // 执行完成的指令 
+    int fuIdx;                         // 功能单元索引
+    InstructionQueue *iqPtr;           // 指令队列指针
+    bool freeFU;                       // 是否释放功能单元
+
+public:
+    FUCompletion(const DynInstPtr &_inst, int fu_idx, InstructionQueue *iq_ptr)
+        : Event(Stat_Event_Pri, AutoDelete), inst(_inst), fuIdx(fu_idx), 
+          iqPtr(iq_ptr), freeFU(false) {}
+    
+    void process() override {
+        DPRINTF(IEW, "[sn:%lli] FU completion event processed\n", inst->seqNum);
+        
+        // 处理功能单元完成
+        iqPtr->processFUCompletion(inst, fuIdx);
+        
+        // 清理指令引用
+        inst = nullptr;
+    }
+    
+    const char* description() const override {
+        return "Functional unit completion";
+    }
+    
+    void setFreeFU() { freeFU = true; }
+};
+
+/*
+ * 处理功能单元完成的核心逻辑
+ */
+void InstructionQueue::processFUCompletion(const DynInstPtr &inst, int fu_idx) {
+    DPRINTF(IEW, "[sn:%lli] Processing FU completion\n", inst->seqNum);
+    
+    // 检查CPU是否处于睡眠状态
+    assert(!cpu->switchedOut());
+    
+    // 减少未完成的写回操作计数
+    --wbOutstanding;
+    
+    // 唤醒可能睡眠的CPU
+    iewStage->wakeCPU();
+    
+    // 将指令添加到写回队列
+    // 注：这些FU完成事件应该在周期开始时处理，避免时序问题
+    issueToExecuteQueue->access(0)->size++;
+    instsToExecute.push_back(inst);
+    
+    DPRINTF(IEW, "[sn:%lli] Added to execute queue, size=%d\n", 
+            inst->seqNum, issueToExecuteQueue->access(0)->size);
+}
+```
+
+### 4.2 执行延迟的精确建模
+
+#### 4.2.1 动态延迟计算：真实硬件的精确建模
+```cpp
+/*
+ * 执行延迟检查：基于操作数值的动态延迟预测
+ * 体现了现代处理器对执行延迟的精确建模
+ */
+bool InstructionQueue::execLatencyCheck(const DynInstPtr& inst, uint32_t& op_latency) {
+    // Leading zero count：用于除法延迟计算的辅助函数
+    auto clz = [](RegVal val) -> int {
+#if defined(__GNUC__) || defined(__clang__)
+        return val == 0 ? 64 : __builtin_clzll(val);
+#else
+        // 软件实现的前导零计数
+        for (int i = 0; i < 64; i++) {
+            if (val & (0x1lu << 63)) return i;
+            val <<= 1;
+        }
+        return 64;
+#endif
+    };
+
+    RegVal rs1, rs2;
+    int delay_;
+    
+    switch (inst->opClass()) {
+    case OpClass::IntDiv: {
+        // 整数除法：延迟取决于操作数的位宽差异
+        rs1 = cpu->readArchIntReg(inst->srcRegIdx(0).index(), inst->threadNumber);
+        rs2 = cpu->readArchIntReg(inst->srcRegIdx(1).index(), inst->threadNumber);
+        
+        // 计算前导零差异：rs1和rs2的有效位宽差异
+        delay_ = std::max(clz(rs2) - clz(rs1), 0);
+        
+        if (rs2 == 1) {
+            // 除以1的特殊情况：rs1 / 1 = rs1
+            op_latency = 5;
+        } else if (rs1 == rs2) {
+            // 相等除法：rs1 / rs2 = 1 余 0
+            op_latency = 7;
+        } else if (clz(rs2) - clz(rs1) < 0) {
+            // 被除数小于除数：rs1/rs2 = 0 余 rs1
+            op_latency = 5;
+        } else {
+            // 一般情况：基础延迟 + 动态延迟
+            op_latency = 7 + delay_ / 4;
+        }
+        
+        DPRINTF(IEW, "[sn:%lli] IntDiv latency: %d (rs1=0x%llx, rs2=0x%llx)\n", 
+                inst->seqNum, op_latency, rs1, rs2);
+        return true;
+    }
+    
+    case OpClass::FloatSqrt: {
+        // 浮点平方根：延迟取决于精度和特殊值
+        rs1 = cpu->readArchFloatReg(inst->srcRegIdx(0).index(), inst->threadNumber);
+        rs2 = cpu->readArchFloatReg(inst->srcRegIdx(1).index(), inst->threadNumber);
+        
+        switch (inst->staticInst->operWid()) {
+        case 32: {  // 单精度
+            float* f1 = reinterpret_cast<float*>(&rs1);
+            float* f2 = reinterpret_cast<float*>(&rs2);
+            
+            if (__isnanf(*f1) || __isnanf(*f2) || __isinff(*f1) || __isinff(*f2)) {
+                // 特殊值（NaN, Inf）快速完成
+                op_latency = 2;
+            } else {
+                // 正常单精度平方根
+                op_latency = 8;
+            }
+            break;
+        }
+        case 64: {  // 双精度
+            double* d1 = reinterpret_cast<double*>(&rs1);
+            double* d2 = reinterpret_cast<double*>(&rs2);
+            
+            if (__isnan(*d1) || __isnan(*d2) || __isinf(*d1) || __isinf(*d2)) {
+                // 特殊值快速完成
+                op_latency = 2;
+            } else {
+                // 正常双精度平方根
+                op_latency = 15;
+            }
+            break;
+        }
+        default:
+            panic("Unsupported float width: %d\n", inst->staticInst->operWid());
+            return false;
+        }
+        
+        DPRINTF(IEW, "[sn:%lli] FloatSqrt latency: %d (%d-bit)\n", 
+                inst->seqNum, op_latency, inst->staticInst->operWid());
+        return true;
+    }
+    
+    case OpClass::FloatDiv: {
+        // 浮点除法：类似平方根的处理
+        rs1 = cpu->readArchFloatReg(inst->srcRegIdx(0).index(), inst->threadNumber);
+        rs2 = cpu->readArchFloatReg(inst->srcRegIdx(1).index(), inst->threadNumber);
+        
+        switch (inst->staticInst->operWid()) {
+        case 32: {
+            float* f1 = reinterpret_cast<float*>(&rs1);
+            float* f2 = reinterpret_cast<float*>(&rs2);
+            
+            op_latency = (__isnanf(*f1) || __isnanf(*f2) || 
+                         __isinff(*f1) || __isinff(*f2)) ? 2 : 7;
+            break;
+        }
+        case 64: {
+            double* d1 = reinterpret_cast<double*>(&rs1);
+            double* d2 = reinterpret_cast<double*>(&rs2);
+            
+            op_latency = (__isnan(*d1) || __isnan(*d2) || 
+                         __isinf(*d1) || __isinf(*d2)) ? 2 : 12;
+            break;
+        }
+        default:
+            panic("Unsupported float width: %d\n", inst->staticInst->operWid());
+            return false;
+        }
+        
+        DPRINTF(IEW, "[sn:%lli] FloatDiv latency: %d (%d-bit)\n", 
+                inst->seqNum, op_latency, inst->staticInst->operWid());
+        return true;
+    }
+    
+    default:
+        // 其他指令使用固定延迟
+        return false;
+    }
+}
+```
+
+### 4.3 执行流水线的精确时序控制
+
+#### 4.3.1 多级发射流水线管理
+```cpp
+/*
+ * IssueQue的多级发射流水线实现
+ * 支持不同深度的发射流水线，精确控制指令时序
+ */
+void IssueQue::scheduleInst() {
+    DPRINTF(Schedule, "%s: Scheduling %d instructions\n", iqname.c_str(), selectQ.size());
+    
+    // 处理选择队列中的每条指令
+    for (auto& [portId, inst] : selectQ) {
+        if (inst->canceled()) {
+            DPRINTF(Schedule, "[sn:%lli] Canceled during schedule\n", inst->seqNum);
+            continue;
+        }
+        
+        if (inst->arbFailed()) {
+            // 仲裁失败，放回就绪队列重试
+            DPRINTF(Schedule, "[sn:%lli] Arbitration failed, retry\n", inst->seqNum);
+            iqstats->arbFailed++;
+            
+            assert(inst->readyToIssue());
+            READYQ_PUSH(inst);  // 重新加入就绪队列
+        } else {
+            // 成功调度
+            DPRINTF(Schedule, "[sn:%lli] Successfully scheduled to port %d\n", 
+                    inst->seqNum, portId);
+            
+            iqstats->portissued[portId]++;
+            inst->setScheduled();
+            inst->issueportid = portId;
+            
+            // === 关键：加入发射流水线 ===
+            toIssue->push(inst);  // 进入发射流水线的第一级
+            
+            // 端口占用管理
+            if (!opPipelined[inst->opClass()]) {
+                // 非流水化操作：完全占用端口
+                portBusy[portId] = -1ll;  // 全部位设置为1
+            } else if (scheduler->getCorrectedOpLat(inst) > 1) {
+                // 流水化操作：按延迟设置占用位
+                uint32_t latency = scheduler->getCorrectedOpLat(inst);
+                portBusy[portId] |= (1ll << latency);
+            }
+            
+            // === 启动推测唤醒 ===
+            scheduler->specWakeUpDependents(inst, this);
+            
+            // 性能跟踪
+            cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueArb);
+        }
+        
+        // 清理仲裁失败标志
+        inst->clearArbFailed();
+    }
+}
+
+/*
+ * 发射流水线推进：从选择到功能单元的多级缓冲
+ */
+void IssueQue::tick() {
+    // 更新统计信息
+    iqstats->avgInsts = instNum;
+    
+    if (instNumInsert > 0) {
+        iqstats->insertDist[instNumInsert]++;
+        instNumInsert = 0;
+    }
+    
+    // === 核心：调度当前周期选中的指令 ===
+    scheduleInst();
+    
+    // === 推进发射流水线 ===
+    inflightIssues.advance();  // 所有级都向前推进一级
+    
+    // === 更新端口占用状态 ===
+    for (auto& busyMask : portBusy) {
+        busyMask = busyMask >> 1;  // 所有占用位右移一位
+    }
+    
+    DPRINTF(Schedule, "%s tick complete, %d insts in flight\n", 
+            iqname.c_str(), getTotalInflightInsts());
+}
+
+/*
+ * 从发射流水线末端发射到功能单元
+ */
+void IssueQue::issueToFu() {
+    int size = toFu->size;  // 本周期可发射的指令数
+    int replayed = 0;       // 重放指令计数
+    int issued = 0;         // 总发射指令计数
+    
+    int issuedLoad = 0;     // 发射的Load指令数
+    int issuedStore = 0;    // 发射的Store指令数
+    
+    // === 第一优先级：处理重放队列 ===
+    // 重放指令通常是因为缓存缺失等原因需要重试的内存指令
+    while (!replayQ.empty() && replayed < outports) {
+        auto& inst = replayQ.front();
+        
+        // 检查Load/Store流水线容量限制
+        if (inst->isLoad() && issuedLoad >= numLoadPipe) break;
+        if (inst->isStore() && issuedStore >= numStorePipe) break;
+        
+        // 直接发射到功能单元，无需再次检查记分板
+        scheduler->addToFU(inst);
+        DPRINTF(Schedule, "[sn:%lli] Replayed to FU\n", inst->seqNum);
+        
+        replayQ.pop();
+        issued++;
+        replayed++;
+        
+        if (inst->isLoad()) issuedLoad++;
+        if (inst->isStore()) issuedStore++;
+    }
+    
+    // === 第二优先级：处理发射流水线输出 ===
+    for (int i = 0; i < size; i++) {
+        auto inst = toFu->pop();
+        if (!inst) continue;
+        
+        // 检查发射端口和流水线容量
+        if ((i + replayed >= outports) ||
+            (inst->isLoad() && issuedLoad >= numLoadPipe) ||
+            (inst->isStore() && issuedStore >= numStorePipe)) {
+            
+            // 容量不足，将指令放回就绪队列
+            inst->clearScheduled();
+            READYQ_PUSH(inst);
+            
+            DPRINTF(Schedule, "[sn:%lli] Issue port/pipe occupied, retry\n", inst->seqNum);
+            iqstats->issueOccupy++;
+            continue;
+        }
+        
+        // === 关键检查：记分板状态验证 ===
+        if (!checkScoreboard(inst)) {
+            // 记分板检查失败（通常是推测唤醒错误）
+            DPRINTF(Schedule, "[sn:%lli] Scoreboard check failed\n", inst->seqNum);
+            continue;  // 指令被取消，不计入发射统计
+        }
+        
+        // 成功发射
+        if (inst->isLoad()) issuedLoad++;
+        if (inst->isStore()) issuedStore++;
+        
+        addToFu(inst);  // 实际发射到功能单元
+        cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueReadReg);
+        issued++;
+    }
+    
+    // 更新统计信息
+    if (issued > 0) {
+        iqstats->issueDist[issued]++;
+    }
+    if (replayed > 0) {
+        iqstats->issueOccupy += replayed;  // 记录重放开销
+    }
+    
+    DPRINTF(Schedule, "%s issued %d insts (%d replayed) this cycle\n", 
+            iqname.c_str(), issued, replayed);
+}
+```
+
+### 4.4 记分板验证与推测恢复
+
+#### 4.4.1 精确的记分板检查机制
+```cpp
+/*
+ * 记分板检查：验证推测唤醒的正确性
+ * 这是防止错误推测导致程序错误的关键机制
+ */
+bool IssueQue::checkScoreboard(const DynInstPtr& inst) {
+    DPRINTF(Schedule, "[sn:%lli] Checking scoreboard\n", inst->seqNum);
+    
+    for (int i = 0; i < inst->numSrcRegs(); i++) {
+        auto src = inst->renamedSrcIdx(i);
+        
+        if (src->isFixedMapping()) {
+            // 架构寄存器总是可用
+            continue;
+        }
+        
+        // === 关键检查：旁路数据可用性 ===
+        if (!scheduler->bypassScoreboard[src->flatIndex()]) {
+            // 旁路数据不可用，需要找到生产者指令
+            auto dst_inst = scheduler->getInstByDstReg(src->flatIndex());
+            // 如果dst_inst 是null，或者不是load，则说明这个指令的源操作数没有被任何指令生产，panic
+            if (!dst_inst || !dst_inst->isLoad()) {
+                panic("Invalid dependency: expected load producer for p%d", 
+                      src->flatIndex());
+            }
+            
+            DPRINTF(Schedule, "[sn:%lli] Cannot get bypass data from [sn:%lli], canceling\n", 
+                    inst->seqNum, dst_inst->seqNum);
+            
+            // === 推测错误处理：Load取消传播 ===
+            scheduler->loadCancel(dst_inst);
+            return false;  // 检查失败
+        }
+    }
+    
+    DPRINTF(Schedule, "[sn:%lli] Scoreboard check passed\n", inst->seqNum);
+    return true;  // 所有源操作数都可用
+}
+
+/*
+ * Load取消传播：处理推测错误的级联影响
+ * 当Load指令缓存缺失时，需要取消所有推测唤醒的依赖指令
+ */
+void Scheduler::loadCancel(const DynInstPtr& inst) {
+    DPRINTF(Schedule, "[sn:%lli] Load miss, starting cancel propagation\n", inst->seqNum);
+    
+    if (inst->issueQue) {
+        inst->issueQue->iqstats->loadmiss++;
+    }
+    
+    // 使用DFS遍历依赖链，取消所有受影响的指令
+    std::stack<DynInstPtr> cancelStack;
+    cancelStack.push(inst);
+    
+    while (!cancelStack.empty()) {
+        auto cancelInst = cancelStack.top();
+        cancelStack.pop();
+        
+        // === 清理推测唤醒事件 ===
+        auto eventIt = specWakeEvents.find(cancelInst->seqNum);
+        if (eventIt != specWakeEvents.end()) {
+            for (auto* event : eventIt->second) {
+                cpu->deschedule(event);  // 取消调度的事件
+                delete event;            // 释放事件对象
+            }
+            specWakeEvents.erase(eventIt);
+            
+            DPRINTF(Schedule, "[sn:%lli] Cancelled %d spec wakeup events\n", 
+                    cancelInst->seqNum, eventIt->second.size());
+        }
+        
+        // === 更新记分板状态 ===
+        for (int i = 0; i < cancelInst->numDestRegs(); i++) {
+            auto dst = cancelInst->renamedDestIdx(i);
+            if (dst->isFixedMapping()) continue;
+            
+            // 清除早期记分板标记
+            earlyScoreboard[dst->flatIndex()] = false;
+            
+            // === 递归取消依赖者 ===
+            for (auto iq : issueQues) {
+                auto& depList = iq->subDepGraph[dst->flatIndex()];
+                
+                for (auto& [srcIdx, depInst] : depList) {
+                    if (depInst->readySrcIdx(srcIdx)) {
+                        // 该依赖指令被错误唤醒，需要取消
+                        DPRINTF(Schedule, "[sn:%lli] Canceling dependent inst [sn:%lli]\n", 
+                                cancelInst->seqNum, depInst->seqNum);
+                        
+                        depInst->issueQue->cancel(depInst);  // 取消指令
+                        depInst->clearSrcRegReady(srcIdx);   // 清除就绪标记
+                        cancelStack.push(depInst);           // 递归取消
+                    }
+                }
+            }
+        }
+    }
+    
+    // === 清理流水线中的取消指令 ===
+    // 从发射流水线中移除已取消的指令
+    for (auto iq : issueQues) {
+        for (int i = 0; i <= iq->getIssueStages(); i++) {
+            auto& stage = iq->inflightIssues[-i];
+            
+            for (int j = 0; j < stage.size; j++) {
+                if (stage.insts[j] && stage.insts[j]->canceled()) {
+                    DPRINTF(Schedule, "[sn:%lli] Removed from issue pipeline stage %d\n", 
+                            stage.insts[j]->seqNum, i);
+                    stage.insts[j] = nullptr;
+                }
+            }
+        }
+    }
+}
+```
+
+## 5. 配置和参数化
+
+### 5.1 调度器配置 (configs/common/FUScheduler.py)
+
+支持多种调度器配置：
+- **ECoreScheduler**: 基础E-Core配置
+- **KunminghuScheduler**: 昆明湖V3配置
+- **KMHV3Scheduler**: V3优化配置
+- **IdealScheduler**: 理想化配置
+
+### 5.2 寄存器文件端口配置
+
+通过 `rp` 参数配置寄存器读端口：
+```python
+# 整数寄存器读端口: [type_id(2bit)] [port_id(4bit)] [priority(2bit)]
+def IntRD(id, p):
+    return (0 << 6) | (id << 2) | (p)
+
+# 浮点寄存器读端口
+def FpRD(id, p):
+    return (1 << 6) | (id << 2) | (p)
+```
+
+## 6. 关键代码位置
+
+### 6.1 主要文件
+- `src/cpu/o3/issue_queue.hh/cc`: 分布式发射队列实现
+- `src/cpu/o3/inst_queue.hh/cc`: 兼容性包装器
+- `configs/common/FUScheduler.py`: 调度器配置
+
+### 6.2 重要函数
+- `Scheduler::insert()`: 指令分发入口
+- `IssueQue::selectInst()`: 指令选择逻辑  
+- `Scheduler::specWakeUpDependents()`: 投机唤醒机制
+- `IssueQue::checkScoreboard()`: 记分板检查
+- `Scheduler::lookahead()`: 分发预测
+
+### 6.3 数据流关键点
+- `dispTable[opClass]`: OpClass到IssueQue的映射
+- `wakeMatrix[srcIQ][dstIQ]`: 唤醒通道配置
+- `subDepGraph[regIdx]`: 寄存器依赖关系
+- `portBusy[]`: 端口占用管理
+
+## 7. 调试和统计
+
+### 7.1 调试标志
+- `Debug::Schedule`: 调度相关调试信息
+- `Debug::Dispatch`: 分发阶段调试信息
+
+### 7.2 性能统计
+- `iqstats->issueDist`: 发射指令分布
+- `iqstats->portBusy`: 端口忙碌统计  
+- `stats.exec_stall_cycle`: 执行停顿周期
+- `stats.memstall_*`: 内存停顿统计

--- a/docs/Gem5_Docs/top/difftest.md
+++ b/docs/Gem5_Docs/top/difftest.md
@@ -1,0 +1,361 @@
+# GEM5 Difftest 流程分析
+
+## 概述
+
+GEM5的difftest（差分测试）是一个验证CPU正确性的机制，通过与参考模型（如NEMU或Spike）逐周期比较所有架构状态来检测实现错误。本文档详细分析difftest的工作流程，特别关注异常处理和RISC-V CSR不一致的处理机制。
+
+## 架构组件
+
+### 1. 代理模型（Proxy）
+```cpp
+// src/cpu/difftest.hh
+class RefProxy {
+    void (*memcpy)(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction);
+    void (*regcpy)(void *dut, bool direction);
+    void (*csrcpy)(void *dut, bool direction);
+    void (*exec)(uint64_t n);
+    vaddr_t (*guided_exec)(void *disambiguate_para);
+    void (*raise_intr)(uint64_t no);
+    void (*isa_reg_display)();
+};
+```
+
+支持两种参考模型：
+- **NemuProxy**: 使用NEMU作为参考模型，支持多核
+- **SpikeProxy**: 使用Spike作为参考模型，仅支持单核
+
+### 2. 寄存器文件结构
+```cpp
+struct riscv64_CPU_regfile {
+    union { uint64_t _64; } gpr[32];      // 通用寄存器
+    union { uint64_t _64; } fpr[32];      // 浮点寄存器
+    
+    // CSR寄存器
+    uint64_t mode;                        // 特权模式
+    uint64_t mstatus, sstatus;           // 状态寄存器
+    uint64_t mepc, sepc;                 // 异常PC
+    uint64_t mtval, stval;               // 异常值
+    uint64_t mcause, scause;             // 异常原因
+    uint64_t satp, mip, mie;             // 地址转换和中断
+    
+    // 虚拟化扩展
+    uint64_t mtval2, mtinst, hstatus;
+    uint64_t hideleg, hedeleg;
+    
+    // 向量扩展
+    union { uint64_t _64[VENUM64]; } vr[32];
+    uint64_t vtype, vl, vstart;
+};
+```
+
+## 主要工作流程
+
+### 1. 初始化阶段
+```cpp
+// src/cpu/base.cc:209
+if (enableDifftest) {
+    // 选择参考模型
+    if (params().difftest_ref_so.find("spike") != std::string::npos) {
+        diffAllStates->proxy = new SpikeProxy(...);
+    } else {
+        diffAllStates->proxy = new NemuProxy(...);
+    }
+    
+    // 初始化参考模型状态
+    diffAllStates->proxy->regcpy(&(diffAllStates->gem5RegFile), REF_TO_DUT);
+}
+```
+
+### 2. 指令执行与状态收集
+在O3 CPU的commit阶段，每条指令都会调用`diffInst`收集执行信息：
+
+```cpp
+// src/cpu/o3/commit.cc:1429
+void Commit::diffInst(ThreadID tid, const DynInstPtr &inst) {
+    // 收集指令基本信息
+    cpu->diffInfo.inst = inst->staticInst;
+    cpu->diffInfo.pc = &inst->pcState();
+    
+    // 收集目标寄存器值
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        const auto &dest = inst->destRegIdx(i);
+        if ((dest.isFloatReg() || dest.isIntReg()) && !dest.isZeroReg()) {
+            cpu->diffInfo.scalarResults.at(i) = cpu->getArchReg(dest, tid);
+        } else if (dest.isVecReg()) {
+            cpu->getArchReg(dest, &(cpu->diffInfo.vecResult), tid);
+        }
+    }
+    
+    // 收集内存访问信息
+    cpu->diffInfo.physEffAddr = inst->physEffAddr;
+    cpu->diffInfo.effSize = inst->effSize;
+    
+    // 执行difftest步骤
+    cpu->difftestStep(tid, inst->seqNum);
+}
+```
+
+### 3. Difftest执行逻辑
+```cpp
+// src/cpu/base.cc:1431
+void BaseCPU::difftestStep(ThreadID tid, InstSeqNum seq) {
+    // 判断哪些指令需要进行difftest
+    bool fence_should_diff = is_fence && !diffInfo.inst->isMicroop();
+    bool lr_should_diff = diffInfo.inst->isLoadReserved();
+    bool amo_should_diff = diffInfo.inst->isAtomic() && diffInfo.inst->numDestRegs() > 0;
+    bool is_sc = diffInfo.inst->isStoreConditional() && diffInfo.inst->isDelayedCommit();
+    bool other_should_diff = !diffInfo.inst->isAtomic() && !is_fence && !is_sc &&
+                             (!diffInfo.inst->isMicroop() || diffInfo.inst->isLastMicroop());
+
+    if (should_diff) {
+        // 首次执行时初始化内存和寄存器状态
+        if (!diffAllStates->hasCommit && diffInfo.pc->instAddr() == 0x80000000u) {
+            initializeDifftest();
+        }
+        
+        // 执行difftest比较
+        auto [diff_at, npc_match] = diffWithNEMU(tid, seq);
+        handleDiffResult(diff_at, npc_match, tid, seq);
+    }
+}
+```
+
+## 异常处理机制
+
+### 1. 异常引导执行
+当GEM5遇到异常时，需要通过引导执行让参考模型也产生相同的异常：
+
+```cpp
+// src/cpu/base.cc:1639
+void BaseCPU::setExceptionGuideExecInfo(uint64_t exception_num, uint64_t mtval, 
+                                       uint64_t stval, bool force_set_jump_target,
+                                       uint64_t jump_target, ThreadID tid) {
+    auto &gd = diffAllStates->diff.guide;
+    
+    // 设置异常信息
+    gd.force_raise_exception = true;
+    gd.exception_num = exception_num;
+    gd.mtval = mtval;
+    gd.stval = stval;
+    
+    // 虚拟化扩展相关异常值
+    gd.mtval2 = readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MTVAL2, tid);
+    gd.htval = readMiscReg(RiscvISA::MiscRegIndex::MISCREG_HTVAL, tid);
+    gd.vstval = readMiscReg(RiscvISA::MiscRegIndex::MISCREG_VSTVAL, tid);
+    
+    // 执行引导执行，让参考模型产生相同异常
+    diffAllStates->proxy->guided_exec(&(diffAllStates->diff.guide));
+    
+    // 同步参考模型状态
+    diffAllStates->proxy->regcpy(diffAllStates->diff.nemu_reg, REF_TO_DIFFTEST);
+    diffAllStates->diff.nemu_this_pc = diffAllStates->diff.nemu_reg->pc;
+}
+```
+
+### 2. 异常提交处理
+在commit阶段发现异常时的处理：
+
+```cpp
+// src/cpu/o3/commit.cc:1571
+if (cpu->difftestEnabled() && inst_fault->isFromISA()) {
+    auto priv = cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_PRV, tid);
+    RegVal cause = 0;
+    
+    // 根据特权级别读取异常原因
+    if (priv == RiscvISA::PRV_M) {
+        cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
+    } else if (priv == RiscvISA::PRV_S) {
+        cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_SCAUSE, tid);
+    } else {
+        cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_UCAUSE, tid);
+    }
+    
+    // 设置异常引导信息
+    cpu->setExceptionGuideExecInfo(
+        exception_no, 
+        cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MTVAL, tid),
+        cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_STVAL, tid), 
+        false, 0, tid);
+}
+```
+
+## CSR状态比较与处理
+
+### 1. 跳过性能计数器CSR
+某些CSR在不同实现中表现不一致，需要跳过比较：
+
+```cpp
+// src/cpu/difftest.cc:47
+void skipPerfCntCsr() {
+    // 跳过周期和指令计数器
+    skipCSRs.push_back(GetCSROPInstCode(gem5::RiscvISA::CSR_MCYCLE));
+    skipCSRs.push_back(GetCSROPInstCode(gem5::RiscvISA::CSR_MINSTRET));
+    
+    // 跳过性能监控计数器
+    for (uint64_t counter = gem5::RiscvISA::CSR_MMHPMCOUNTER3;
+                  counter <= gem5::RiscvISA::CSR_MMHPMCOUNTER31; counter++) {
+        skipCSRs.push_back(GetCSROPInstCode(counter));
+    }
+}
+```
+
+### 2. CSR值比较
+在`diffWithNEMU`中逐一比较所有重要的CSR：
+
+```cpp
+// src/cpu/base.cc:1041
+std::pair<int, bool> BaseCPU::diffWithNEMU(ThreadID tid, InstSeqNum seq) {
+    // 比较基本CSR
+    
+    // 1. mstatus比较
+    auto gem5_val = readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_STATUS, tid);
+    auto ref_val = diffAllStates->referenceRegFile.mstatus;
+    if (gem5_val != ref_val) {
+        csrDiffMessage(gem5_val, ref_val, CsrRegIndex::mstatus, 
+                      diffAllStates->gem5RegFile.mstatus, seq, "mstatus", diff_at);
+    }
+    
+    // 2. 异常相关CSR
+    // mtval, stval, mcause, scause, mepc, sepc
+    
+    // 3. 地址转换CSR
+    // satp
+    
+    // 4. 中断相关CSR  
+    // mip, mie
+    
+    // 5. 虚拟化扩展CSR (如果启用)
+    if (enableRVHDIFF) {
+        // mtval2, mtinst, hstatus, hideleg, hedeleg等
+    }
+    
+    // 6. 向量扩展CSR (如果启用)
+    if (enableRVV) {
+        // vtype, vl, vstart, vcsr等
+    }
+}
+```
+
+### 3. CSR差异报告
+发现CSR不一致时的报告机制：
+
+```cpp
+// src/cpu/base.cc:859
+void BaseCPU::csrDiffMessage(uint64_t gem5_val, uint64_t ref_val, int error_num, 
+                            uint64_t &error_reg, InstSeqNum seq,
+                            std::string error_csr_name, int &diff_at) {
+    DPRINTF(DiffValue, "Inst [sn:%lli] pc: %#lx\n", seq, diffInfo.pc->instAddr());
+    DPRINTF(DiffValue, "Diff at \033[31m%s\033[0m Ref value: \033[31m%#lx\033[0m, "
+                      "GEM5 value: \033[31m%#lx\033[0m\n",
+            error_csr_name, ref_val, gem5_val);
+    
+    // 标记错误CSR
+    diffInfo.errorCsrsValue[error_num] = 1;
+    error_reg = gem5_val;
+    if (!diff_at)
+        diff_at = ValueDiff;
+}
+```
+
+## 特殊情况处理
+
+### 1. PC不匹配的恢复机制
+```cpp
+// src/cpu/base.cc:1472
+if (diff_at != NoneDiff) {
+    if (npc_match && diff_at == PCDiff) {
+        // PC不匹配但下一PC匹配，让NEMU再执行一条指令
+        std::tie(diff_at, npc_match) = diffWithNEMU(tid, 0);
+        if (diff_at != NoneDiff) {
+            reportDiffMismatch(tid, seq);
+            panic("Difftest failed again!\n");
+        } else {
+            clearDiffMismatch(tid, seq);
+            DPRINTF(Diff, "Difftest matched again, NEMU seems to commit the failed mem instruction\n");
+        }
+    } else {
+        reportDiffMismatch(tid, seq);
+        panic("Difftest failed!\n");
+    }
+}
+```
+
+### 2. MMIO指令处理
+对于MMIO访问，跳过参考模型执行：
+
+```cpp
+// src/cpu/base.cc:883
+if (is_mmio) {
+    DPRINTF(Diff, "Skip step NEMU due to mmio access\n");
+    // 直接更新参考模型的PC和寄存器，不执行指令
+    diffAllStates->referenceRegFile.pc = diffInfo.pc->as<RiscvISA::PCState>().npc();
+    if (diffInfo.inst->numDestRegs() > 0) {
+        const auto &dest = diffInfo.inst->destRegIdx(0);
+        unsigned index = dest.index() + (dest.isFloatReg() ? FPRegIndexBase : IntRegIndexBase);
+        diffAllStates->referenceRegFile[index] = diffInfo.scalarResults[0];
+    }
+    diffAllStates->proxy->regcpy(&(diffAllStates->referenceRegFile), DUT_TO_REF);
+    return std::make_pair(NoneDiff, true);
+}
+```
+
+### 3. 性能计数器CSR跳过
+在寄存器比较时检查是否为需要跳过的CSR指令：
+
+```cpp
+// src/cpu/base.cc:1360
+bool skipCSR = false;
+for (auto iter : skipCSRs) {
+    if ((machInst & 0xfff00073) == iter) {
+        skipCSR = true;
+        DPRINTF(Diff, "This is an csr instruction, skip!\n");
+        // 强制同步参考模型的值
+        diffAllStates->referenceRegFile[dest_tag] = gem5_val;
+        diffAllStates->proxy->regcpy(&(diffAllStates->referenceRegFile), DUT_TO_REF);
+        break;
+    }
+}
+```
+
+## 错误报告与调试
+
+### 1. 错误报告函数
+```cpp
+// src/cpu/base.cc:1405
+void BaseCPU::reportDiffMismatch(ThreadID tid, InstSeqNum seq) {
+    warn("%s", diffMsg.str());                    // 输出差异信息
+    diffAllStates->proxy->isa_reg_display();      // 显示参考模型寄存器
+    displayGem5Regs();                            // 显示GEM5寄存器
+    
+    // 输出最近提交的指令历史
+    warn("start dump last %lu committed msg\n", diffInfo.lastCommittedMsg.size());
+    while (diffInfo.lastCommittedMsg.size()) {
+        auto &inst = diffInfo.lastCommittedMsg.front();
+        warn("V %s\n", inst->genDisassembly());
+        diffInfo.lastCommittedMsg.pop();
+    }
+}
+```
+
+### 2. 状态清理
+```cpp
+// src/cpu/base.cc:1399
+void BaseCPU::clearDiffMismatch(ThreadID tid, InstSeqNum seq) {
+    diffMsg.str(std::string());                                    // 清空消息缓冲
+    memset(diffInfo.errorRegsValue, 0, sizeof(diffInfo.errorRegsValue));  // 清空寄存器错误标记
+    memset(diffInfo.errorCsrsValue, 0, sizeof(diffInfo.errorCsrsValue));  // 清空CSR错误标记
+    diffInfo.errorPcValue = 0;                                     // 清空PC错误标记
+}
+```
+
+## 总结
+
+GEM5的difftest机制通过以下关键特性确保CPU实现的正确性：
+
+1. **逐指令比较**: 每条提交的指令都与参考模型进行状态比较
+2. **异常同步**: 通过引导执行机制确保异常在两个模型中一致产生
+3. **CSR精确比较**: 重点关注架构状态CSR，跳过实现相关的性能计数器
+4. **错误恢复**: 针对某些特殊情况（如PC不匹配）提供恢复机制
+5. **详细调试**: 提供丰富的错误报告和状态显示功能
+
+这套机制为RISC-V处理器的验证提供了强有力的保障，特别是在异常处理和特权级状态管理方面。

--- a/docs/Gem5_Docs/top/event-tick.md
+++ b/docs/Gem5_Docs/top/event-tick.md
@@ -1,0 +1,428 @@
+# GEM5 事件驱动机制详解
+
+## 核心概念
+
+### 1. 事件驱动架构
+GEM5是一个**事件驱动的模拟器**，意味着模拟的推进完全基于事件的调度和执行。模拟器的时间推进不是连续的，而是跳跃式的，从一个事件的执行时间跳到下一个事件的执行时间。
+
+### 2. 时间单位：Tick
+- **Tick** 是GEM5中的基本时间单位
+- 1 Tick = 1皮秒 (picosecond)
+- 对于3GHz的CPU，1个时钟周期 = 333.33 Tick (1/3e9 秒 = 333.33e-12 秒)
+
+### 3. 时钟与周期
+- **clockPeriod()**: 返回时钟周期的Tick数
+- **clockEdge(Cycles(n))**: 返回从当前时间开始第n个时钟周期边沿的Tick值
+- **curCycle()**: 返回当前时钟周期数
+
+## 事件系统核心组件
+
+### 1. Event类 (src/sim/eventq.hh:239-400)
+```cpp
+class Event : public EventBase, public Serializable {
+private:
+    Tick _when;         // 事件执行时间戳
+    Priority _priority; // 事件优先级
+    Flags flags;        // 事件标志
+    
+public:
+    virtual void process() = 0;  // 事件处理函数(纯虚函数)
+    bool scheduled() const;      // 检查是否已调度
+    Tick when() const;           // 获取执行时间
+    Priority priority() const;   // 获取优先级
+};
+```
+
+### 2. EventQueue类 (src/sim/eventq.hh:751-900)
+```cpp
+class EventQueue {
+private:
+    Event *head;                 // 事件队列头部
+    Tick _curTick;              // 当前Tick时间
+    
+public:
+    void schedule(Event *event, Tick when, bool global=false);
+    void deschedule(Event *event);
+    void reschedule(Event *event, Tick when, bool always=false);
+    Event *serviceOne();         // 执行一个事件
+    void serviceEvents(Tick when); // 执行所有when时间之前的事件
+};
+```
+
+### 3. 事件优先级 (src/sim/eventq.hh:113-170)
+同一个Tick内的事件按优先级排序执行：
+```cpp
+static const Priority CPU_Tick_Pri =     50;   // CPU tick事件
+static const Priority Default_Pri =       0;   // 默认优先级  
+static const Priority Sim_Exit_Pri =    100;   // 模拟退出事件
+```
+
+## CPU tick事件调度机制
+
+### 1. CPU tick函数 (src/cpu/o3/cpu.cc:548-607)
+```cpp
+void CPU::tick() {
+    // 执行CPU各个阶段
+    fetch.tick();
+    decode.tick(); 
+    rename.tick();
+    iew.tick();
+    commit.tick();
+    
+    // 推进时间缓冲区
+    timeBuffer.advance();
+    fetchQueue.advance();
+    // ...
+    
+    // 调度下一个tick事件
+    if (!tickEvent.scheduled()) {
+        if (_status == SwitchedOut || !activityRec.active() || _status == Idle) {
+            // CPU空闲，不调度下一个tick
+            lastRunningCycle = curCycle();
+            cpuStats.timesIdled++;
+        } else {
+            // CPU活跃，调度下一个周期的tick
+            schedule(tickEvent, clockEdge(Cycles(1)));
+        }
+    }
+}
+```
+
+### 2. 关键调度语句分析
+```cpp
+schedule(tickEvent, clockEdge(Cycles(1)));
+```
+- `clockEdge(Cycles(1))`: 计算下一个时钟周期边沿的Tick时间
+- 如果当前时间是100 Tick，下一个周期边沿就是433 Tick (100 + 333)
+- 这确保了CPU以恒定的时钟频率运行
+
+## 事件调度流程
+
+### 1. 事件插入和排序
+事件队列使用链表的链表结构：
+- **nextBin**: 指向相同时间+优先级的事件bin
+- **nextInBin**: 同一bin内的事件链表(LIFO顺序)
+
+### 2. 事件执行流程
+```cpp
+void EventQueue::serviceEvents(Tick when) {
+    while (!empty()) {
+        if (nextTick() > when) break;  // 没有更多事件需要执行
+        serviceOne();                  // 执行一个事件
+    }
+    setCurTick(when);                 // 更新当前时间
+}
+```
+
+### 3. 并行模式下的异步事件
+```cpp
+if (inParallelMode && (this != curEventQueue() || global)) {
+    asyncInsert(event);  // 异步插入到async_queue
+} else {
+    insert(event);       // 直接插入到主队列
+}
+```
+
+## 关键问题解答
+
+### Q: 如果当前tick没有事件，是否不执行tick函数？
+**A: 是的！** 这是事件驱动的核心特征：
+- 模拟器只在有事件需要处理时才推进时间
+- 如果CPU空闲(没有指令执行)，就不会调度下一个tick事件
+- 时间会直接跳到下一个有事件的时间点
+
+### Q: 优先级如何确保同一tick中事件的执行顺序？  
+**A: 通过Event::Priority枚举值**:
+- 相同时间的事件按优先级排序
+- 数值越小优先级越高
+- CPU_Tick_Pri = 50，确保CPU tick在大多数事件之后执行
+
+### Q: CPU各阶段如何与事件系统协作？
+**A: 分层调度**:
+1. CPU::tick()作为主控制器，每个周期调用一次
+2. 各阶段(fetch, decode等)的tick()方法执行流水线逻辑  
+3. 各阶段内部可能调度异步事件(如内存访问完成事件)
+4. 主tick完成后调度下一个周期的tick事件
+
+## 事件包装器
+
+### EventFunctionWrapper (src/sim/eventq.hh:1108-1135)
+```cpp
+EventFunctionWrapper event([this]{processEvent();}, name());
+```
+允许将任意函数包装成事件，简化事件的创建和使用。
+
+默认每个event 都有process() 方法, 用于执行事件. 例如EventFunctionWrapper 的process() 方法就是调用callback 函数(tick 函数)
+
+## ClockedObject集成
+
+### 时钟域管理 (src/sim/clocked_object.hh)
+```cpp
+class ClockedObject : public SimObject, public Clocked {
+    Tick clockEdge(Cycles cycles=Cycles(0)) const;  // 计算时钟边沿
+    Cycles curCycle() const;                        // 当前周期
+    Tick clockPeriod() const;                       // 时钟周期
+};
+```
+
+ClockedObject为所有需要时钟的组件提供统一的时钟接口，确保整个系统的时钟同步。
+
+## simObject
+
+每个simObject 有init()、startup() 和 drain() 方法
+
+init() 在模拟开始时调用，用于初始化对象, 并开始schedule 事件
+
+startup() 在模拟开始时调用，用于初始化对象, 并开始schedule 事件, 例如RiscvBareMetal 的startup() 会schedule 一个tick 事件
+还有dramsim3 的startup() 会schedule 一个tick 事件.
+
+## 实际运行机制分析 - Event Trace 解读
+
+### 1. 多EventQueue支持 (src/sim/eventq.hh:70-80)
+```cpp
+extern uint32_t numMainEventQueues;          // 主事件队列数量
+extern std::vector<EventQueue *> mainEventQueue;  // 主事件队列数组
+extern __thread EventQueue *_curEventQueue;  // 当前线程的事件队列
+```
+
+GEM5支持多个EventQueue用于并行模拟，但默认情况下使用**MainEventQueue**作为主要的事件调度器。
+
+### 2. Event命名与调试
+从Event trace可以看到，每个事件都有描述性的名称：
+```
+O3CPU tick.wrapped_function_event          // CPU tick事件，优先级20
+system.mem_ctrls.wrapped_function_event    // 内存控制器事件，优先级9  
+system.cpu.icache.mem_side_port-MemSidePort.wrapped_function_event  // icache访问事件，优先级52
+```
+
+事件名称格式：`<组件名>.<事件类型>.wrapped_function_event`
+
+### 3. 实际运行时序分析
+以你的trace为例，分析3GHz CPU (333 tick/cycle)的运行：
+
+```
+时间    事件类型                               优先级   说明
+0:      Event_122 (sim exit)                  122     调度在40000000 tick的退出事件
+0:      O3CPU tick                            20      CPU开始tick，调度下次在333 tick
+0:      system.mem_ctrls                      9       内存控制器，调度下次在630 tick
+333:    O3CPU tick                            20      CPU第1个周期，调度下次在666 tick  
+630:    system.mem_ctrls                      9       内存控制器执行，调度下次在1260 tick
+666:    O3CPU tick                            20      CPU第2个周期，调度下次在999 tick
+999:    O3CPU tick + icache access           20,52   CPU第3个周期+icache访问同时发生
+```
+
+### 4. 周期性vs按需事件的对比
+
+#### 周期性事件 (如CPU tick)
+- **CPU tick事件**: 优先级20，每333 tick执行一次
+- **内存控制器**: 优先级9，每630 tick执行一次 (可能是2倍CPU周期)
+- 只要组件处于活跃状态，就会持续调度下一个周期
+
+#### 按需事件 (如缓存访问)  
+- **icache访问**: 优先级52，只在CPU需要取指时触发
+- **L2/L3缓存访问**: 优先级81/88，只在缓存miss时触发
+- **总线仲裁**: 优先级107/117，只在有传输请求时触发
+
+### 5. CPU流水线的动态调度验证
+
+从代码分析可以确认你的理解是正确的：
+
+```cpp
+// src/cpu/o3/cpu.cc:587-601
+if (!tickEvent.scheduled()) {
+    if (_status == SwitchedOut) {
+        // CPU切换状态，不调度
+    } else if (!activityRec.active() || _status == Idle) {
+        // CPU空闲或无活动，不调度下一个tick
+        cpuStats.timesIdled++;
+    } else {
+        // CPU有活动，调度下一个周期的tick
+        schedule(tickEvent, clockEdge(Cycles(1)));
+    }
+}
+```
+
+**验证结论**:
+1. **CPU tick**: 只有在流水线有指令或有活动时才调度下一拍
+2. **缓存访问**: 只有在有实际访问请求时才触发事件
+3. **优先级确保**: 相同tick内，优先级数字小的先执行
+
+### 6. EventQueue的线程安全机制
+
+```cpp
+// src/sim/eventq.hh:770-785 
+void schedule(Event *event, Tick when, bool global=false) {
+    if (inParallelMode && (this != curEventQueue() || global)) {
+        asyncInsert(event);  // 跨线程异步插入
+    } else {
+        insert(event);       // 同线程直接插入
+    }
+}
+```
+
+支持多线程并行模拟，通过async_queue处理跨EventQueue的事件调度。
+
+## 流水线事件驱动模拟机制
+
+### 1. 流水线阶段的事件化表示
+
+在GEM5中，流水线的每个阶段都被抽象为具有tick()方法的对象：
+
+```cpp
+// src/cpu/o3/cpu.cc:557-566
+void CPU::tick() {
+    // 按顺序调用各个流水线阶段
+    fetch.tick();
+    decode.tick(); 
+    rename.tick();
+    iew.tick();
+    commit.tick();
+}
+```
+
+每个阶段的tick()方法实现该阶段在当前周期的行为逻辑。
+
+### 2. TimeBuffer: 流水线延迟的核心机制
+
+GEM5使用**TimeBuffer**来模拟流水线阶段之间的延迟：
+参考[https://github.com/mytbk/gem5-docs/blob/master/data_structure.rst](https://github.com/mytbk/gem5-docs/blob/master/data_structure.rst)
+
+```cpp
+// src/cpu/o3/decode.cc:193-200
+void Decode::setFetchQueue(TimeBuffer<FetchStruct> *fq_ptr) {
+    fetchQueue = fq_ptr;
+    // 设置读取延迟：fromFetch指向fetchToDecodeDelay周期前的数据
+    fromFetch = fetchQueue->getWire(-fetchToDecodeDelay);
+}
+```
+
+配置参数控制各阶段延迟：
+```python
+# src/cpu/o3/BaseO3CPU.py:129-134
+fetchToDecodeDelay = Param.Cycles(4, "Fetch to decode delay")
+renameToDecodeDelay = Param.Cycles(1, "Rename to decode delay")
+iewToDecodeDelay = Param.Cycles(1, "Issue/Execute/Writeback to decode delay")
+commitToDecodeDelay = Param.Cycles(1, "Commit to decode delay")
+```
+
+### 3. 反向执行的设计原理
+
+基于Minor CPU模型的文档[^1]，流水线阶段需要**反向执行**：
+
+> "The evaluate method of the pipeline class calls the evaluate method on each of the pipeline stages in the reverse order. The order here is important because the updates from the later stages of the pipeline should be visible to the earlier stages of the pipeline."
+
+#### 为什么要反向执行？
+
+```
+正常流水线数据流: Fetch → Decode → Rename → IEW → Commit
+事件执行顺序:     Commit → IEW → Rename → Decode → Fetch
+```
+
+**原因分析**：
+
+1. **反馈信号处理**: 后续阶段产生的stall、flush、branch misprediction等信号需要传播到前面阶段
+2. **依赖关系正确性**: 后面阶段的状态更新必须在前面阶段读取之前完成
+3. **流水线控制**: 避免读取到"未来"的错误状态
+
+#### 具体实例
+```cpp
+// 伪代码示例
+void Pipeline::evaluate() {
+    // 反向执行确保控制信号传播正确
+    commit.tick();    // 可能产生flush信号
+    iew.tick();       // 可能产生stall信号  
+    rename.tick();    // 可能产生backpressure
+    decode.tick();    // 读取rename的反馈
+    fetch.tick();     // 读取所有下游反馈，决定是否继续取指
+}
+```
+
+### 4. TimeBuffer的工作机制
+
+```cpp
+template<class T>
+class TimeBuffer {
+private:
+    T *data;           // 环形缓冲区
+    int size;          // 缓冲区大小  
+    int index;         // 当前写入位置
+    
+public:
+    // 获取延迟为delay的读取接口
+    wire getWire(int delay) {
+        return &data[(index + delay + size) % size];
+    }
+    
+    // 推进一个周期
+    void advance() {
+        index = (index + 1) % size;
+    }
+};
+```
+
+#### 延迟模拟示例
+```
+Cycle:     0    1    2    3    4
+Fetch:     I1   I2   I3   I4   I5
+Decode:    -    -    -    -    I1  (fetchToDecodeDelay=4)
+```
+
+### 5. 流水线事件的层次结构
+
+```
+CPU tick 事件 (每333 ticks)
+    ├── fetch.tick()      - 取指逻辑
+    ├── decode.tick()     - 译码逻辑  
+    ├── rename.tick()     - 重命名逻辑
+    ├── iew.tick()        - 发射执行逻辑
+    └── commit.tick()     - 提交逻辑
+        └── 可能调度其他异步事件(如内存访问)
+```
+
+### 6. 与硬件的对应关系
+
+| 硬件概念 | GEM5实现 | 说明 |
+|---------|---------|------|
+| 流水线寄存器 | TimeBuffer | 存储阶段间传递的数据 |
+| 流水线延迟 | fetchToDecodeDelay等 | 配置参数控制延迟周期数 |
+| 控制信号 | 反向执行 | 确保stall/flush信号正确传播 |
+| 时钟边沿 | tick()方法 | 每个周期执行的逻辑 |
+
+### 7. Event process()方法的统一接口
+
+默认每个event都有process()方法，用于执行事件。例如EventFunctionWrapper的process()方法就是调用callback函数(tick函数)：
+
+```cpp
+class EventFunctionWrapper : public Event {
+private:
+    std::function<void(void)> callback;
+public:
+    void process() { callback(); }  // 调用包装的函数
+};
+
+// CPU tick事件的创建
+EventFunctionWrapper tickEvent([this]{tick();}, name());
+```
+
+这种设计统一了事件接口，使得任何函数都可以被包装成事件在指定时间执行。
+
+## 总结
+
+GEM5的事件驱动机制通过以下方式实现高效的模拟：
+
+1. **时间跳跃**: 只在有事件时推进时间，避免无用的空循环
+2. **优先级排序**: 确保同一时刻事件的正确执行顺序  
+3. **异步调度**: 支持跨组件的事件通信
+4. **时钟集成**: 与时钟域系统无缝集成，支持不同频率的组件
+5. **动态调度**: CPU等核心组件根据工作状态动态调度，空闲时停止tick
+6. **按需触发**: 缓存、总线等组件只在有实际需求时才触发事件
+7. **流水线建模**: 通过TimeBuffer和反向执行正确模拟流水线行为
+8. **延迟精确**: 通过配置参数精确控制流水线阶段间的延迟
+
+这种设计使得GEM5能够高效地模拟复杂的计算机系统，同时保持时序的准确性。
+
+## 参考文献
+
+[^1]: [A Tutorial on the Gem5 Minor CPU Model](https://nitish2112.github.io/post/gem5-minor-cpu/) - Nitish Srivastava
+
+


### PR DESCRIPTION
add detailed documentation for GEM5 O3 CPU stages including Fetch, Decode, IEW, Rename, Scheduler, and Difftest

This commit introduces comprehensive documentation for various stages of the GEM5 O3 CPU, covering the Fetch, Decode, IEW, Rename, and Scheduler stages, as well as the Difftest mechanism. The documentation includes configuration parameters, core functionalities, key data structures, and detailed code explanations to enhance understanding and facilitate future development.

Change-Id: I29b1bb2c96bf6079cc926d0ffb542f77eb7a673b