### PR TITLE
misc: pin scons python package version to protect compatibility

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -43,7 +43,7 @@
           pythonPackages.distutils
           pythonPackages.pydot
           pythonPackages.six
-          scons
+          (scons.override {python3Packages = pkgs.python310Packages;})
           sqlite
           swig
           zlib


### PR DESCRIPTION
Change-Id: Ic6fcc7eca217c9d15b0fd3dccf0fd9d2814c962

Currently the newest SCons in nixpkgs has a built-in Python 3.13 library which cause error when building GEM5. Override the input python packages and pin to 3.10 can improve project robust.