### PR TITLE
Smaller regport

### DIFF
--- a/configs/common/FUScheduler.py
+++ b/configs/common/FUScheduler.py
@@ -190,62 +190,55 @@ class KMHV3Scheduler(Scheduler):
             IssuePort(fu=[IntALU()],
                       rp=[IntRD(0, 0), IntRD(1, 0), IntWR(0, 0)]),
             IssuePort(fu=[IntBRU()],
-                      rp=[IntWR(0, 1)])
+                      rp=[IntRD(1, 1), IntRD(7, 2), IntWR(0, 1)])
         ]),
         IssueQue(name='intIQ1', inports=2, size=16, oports=[
             IssuePort(fu=[IntALU()],
                       rp=[IntRD(2, 0), IntRD(3, 0), IntWR(1, 0)]),
             IssuePort(fu=[IntBRU()],
-                      rp=[IntWR(1, 1)])
+                      rp=[IntRD(3, 1), IntRD(9, 2), IntWR(1, 1)])
         ]),
         IssueQue(name='intIQ2', inports=2, size=16, oports=[
             IssuePort(fu=[IntALU()],
                       rp=[IntRD(4, 0), IntRD(5, 0), IntWR(2, 0)]),
             IssuePort(fu=[IntBRU()],
-                      rp=[IntWR(2, 1)])
+                      rp=[IntRD(5, 1), IntRD(11, 2), IntWR(2, 1)])
         ]),
         IssueQue(name='intIQ3', inports=2, size=16, oports=[
             IssuePort(fu=[IntALU(), IntMult()],
-                      rp=[IntRD(6, 0), IntRD(7, 0)]),
+                      rp=[IntRD(6, 0), IntRD(7, 1)]),
         ]),
         IssueQue(name='intIQ4', inports=2, size=16, oports=[
             IssuePort(fu=[IntALU(), IntMult()],
-                      rp=[IntRD(8, 0), IntRD(9, 0)]),
+                      rp=[IntRD(8, 0), IntRD(9, 1)]),
         ]),
         IssueQue(name='intIQ5', inports=2, size=16, oports=[
             IssuePort(fu=[IntALU(), IntDiv(), IntMisc()],
-                      rp=[IntRD(10, 0), IntRD(11, 0)])
+                      rp=[IntRD(10, 0), IntRD(11, 1)])
         ]),
     ]
     __memIQs = [
         IssueQue(name='ld0', inports=2, size=16, oports=[
             IssuePort(fu=[ReadPort()],
-                      rp=[IntRD(12, 0)])
-        ]),
+                      rp=[IntRD(7, 0)])]),
         IssueQue(name='ld1', inports=2, size=16, oports=[
             IssuePort(fu=[ReadPort()],
-                      rp=[IntRD(13, 0)])
-        ]),
+                      rp=[IntRD(9, 0)])]),
         IssueQue(name='ld2', inports=2, size=16, oports=[
             IssuePort(fu=[ReadPort()],
-                      rp=[IntRD(14, 0)])
-        ]),
+                      rp=[IntRD(11, 0)])]),
         IssueQue(name='sta0', inports=2, size=16, oports=[
             IssuePort(fu=[WritePort()],
-                      rp=[IntRD(5, 1)])
-        ]),
+                      rp=[IntRD(6, 1)])]),
         IssueQue(name='sta1', inports=2, size=16, oports=[
             IssuePort(fu=[WritePort()],
-                      rp=[IntRD(7, 1)])
-        ]),
+                      rp=[IntRD(8, 1)])]),
         IssueQue(name='std0', inports=2, size=16, oports=[
             IssuePort(fu=[StoreDataPort()],
-                      rp=[IntRD(9, 1), FpRD(12, 0)])
-        ]),
+                      rp=[IntRD(0, 1), FpRD(12, 0)])]),
         IssueQue(name='std1', inports=2, size=16, oports=[
             IssuePort(fu=[StoreDataPort()],
-                      rp=[IntRD(11, 1), FpRD(13, 0)])
-        ]),
+                      rp=[IntRD(2, 1), FpRD(13, 0)])]),
     ]
     __fpIQs = [
         IssueQue(name='fpIQ0', inports=2, size=18, oports=[
@@ -285,6 +278,8 @@ class KMHV3Scheduler(Scheduler):
         SpecWakeupChannel(srcs=__int_bank + __mem_bank, dsts=__int_bank + __mem_bank),
         SpecWakeupChannel(srcs=__fp_bank, dsts=__fp_bank)
     ]
+
+    enableMainRdpOpt = True  # TX dynamic read port optimization
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -96,3 +96,4 @@ class Scheduler(SimObject):
     specWakeupNetwork = VectorParam.SpecWakeupChannel([], "")
     xbarWakeup = Param.Bool(False, "use xbar wakeup network, (will override specWakeupNetwork)")
     useOldDisp = Param.Bool(False, "Use old dispatch algorithm")
+    enableMainRdpOpt = Param.Bool(False, "Enable TX dynamic read port optimization")

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -561,7 +561,13 @@ IssueQue::selectInst()
                     std::pair<int, int> rfTypePortId;
                     // read port is point to point with srcid
                     if (psrc->isIntReg() && intRdRfTPI[pi].size() > i) {
-                        rfTypePortId = intRdRfTPI[pi][i];
+                        // TX dynamic port optimization: src1 can borrow src0's port if src0 is in regcache
+                        if (enableMainRdpOpt && i == 1 &&
+                            scheduler->regCache.contains(inst->renamedSrcIdx(0)->flatIndex())) {
+                            rfTypePortId = intRdRfTPI[pi][0]; // borrow src0's port
+                        } else {
+                            rfTypePortId = intRdRfTPI[pi][i];
+                        }
                         scheduler->useRfRdPort(inst, psrc, rfTypePortId.first, rfTypePortId.second);
                     } else if (psrc->isFloatReg() && fpRdRfTPI[pi].size() > i) {
                         rfTypePortId = fpRdRfTPI[pi][i];
@@ -860,6 +866,9 @@ Scheduler::Scheduler(const SchedulerParams& params)
     assert(maxWrTypePortId <= MAXVAL_TYPEPORTID);
     rdRfPortOccupancy.resize(maxRdTypePortId, {nullptr, 0});
     wrRfPortOccupancy.resize(maxWrTypePortId, {nullptr, 0, 0});
+
+    // Set TX dynamic read port optimization for all IssueQues
+    setMainRdpOpt(params.enableMainRdpOpt);
 
     if (opChecker.count() != enums::Num_OpClass) {
         for (int i = 0; i < enums::Num_OpClass; i++) {
@@ -1429,6 +1438,14 @@ Scheduler::getIQInsts()
         total += iq->instNum;
     }
     return total;
+}
+
+void
+Scheduler::setMainRdpOpt(bool enable)
+{
+    for (auto iq : issueQues) {
+        iq->setMainRdpOpt(enable);
+    }
 }
 
 }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -149,6 +149,10 @@ class IssueQue : public SimObject
     std::vector<std::vector<std::pair<int, int>>> intWrRfTPI;
 
     std::vector<int64_t> portBusy;
+
+    // TX dynamic port optimization control
+    bool enableMainRdpOpt = false;
+
     // opclass mapping to pipeid
     std::vector<ReadyQue*> readyQclassify;
     // s0: wakeup inst, add ready inst to readyInstsQue
@@ -196,6 +200,7 @@ class IssueQue : public SimObject
     IssueQue(const IssueQueParams& params);
     void setIQID(int id) { IQID = id; }
     void setCPU(CPU* cpu);
+    void setMainRdpOpt(bool enable) { enableMainRdpOpt = enable; }
     void resetDepGraph(int numPhysRegs);
 
     void tick();
@@ -315,6 +320,7 @@ class Scheduler : public SimObject
     void setCPU(CPU* cpu, LSQ* lsq);
     void resetDepGraph(uint64_t numPhysRegs);
     void setMemDepUnit(MemDepUnit* memDepUnit) { this->memDepUnit = memDepUnit; }
+    void setMainRdpOpt(bool enable);
 
     void tick();
     void issueAndSelect();


### PR DESCRIPTION
1.  6个ALU 都使用优先级最高的12个读端口
2.3个BRU 使用优先级1 的6个读端口，其中src0 和 alu 的src1 共享，结合enableMainRdpOpt 可以降低bru 和alu 的冲突情况
3.3个LOAD 使用优先级1 的3个读端口，分别共享alu3/4/5 的src1, 也是相对不太使用的读端口
4.剩下的sta,std 相对不太紧急，使用剩下的读端口
<img width="950" height="265" alt="image" src="https://github.com/user-attachments/assets/15baa062-6994-42a4-bd6d-28ad4c4827b2" />
