### PR TITLE
cpu-o3: smaller mgsc

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1068,9 +1068,11 @@ class BTBMGSC(TimedBaseBTBPredictor):
 
     needMoreHistories = Param.Bool(True, "MGSC needs more histories")
 
-    bwTableNum = Param.Unsigned(2, "Num global backward branch GEHL tables")
-    bwHistLen = VectorParam.Int([4, 8], "Global backward branch GEHL history lengths")
-    bwTableIdxWidth = Param.Unsigned(11,
+    blockSize = 32  # mgsc index function uses 32B aligned block address
+
+    bwTableNum = Param.Unsigned(0, "Num global backward branch GEHL tables")
+    bwHistLen = VectorParam.Int([], "Global backward branch GEHL history lengths")
+    bwTableIdxWidth = Param.Unsigned(10,
             "Log num of global backward branch GEHL entries")
     bwWeightInitValue = Param.Int(7,
      "Initial value of the weights of the global backward branch GEHL entries") # not used
@@ -1079,32 +1081,32 @@ class BTBMGSC(TimedBaseBTBPredictor):
         "Number of entries for first local histories")
     lTableNum = Param.Unsigned(2, "Num first local history GEHL tables")
     lHistLen = VectorParam.Int([4, 8], "First local history GEHL history lengths")
-    lTableIdxWidth = Param.Unsigned(11,
+    lTableIdxWidth = Param.Unsigned(10,
             "Log number of first local history GEHL entries")
     lWeightInitValue = Param.Int(7,
         "Initial value of the weights of the first local history GEHL entries")
 
-    iTableNum = Param.Unsigned(1, "Num IMLI GEHL tables")
-    iHistLen = VectorParam.Int([8], "IMLI history GEHL history lengths")
-    iTableIdxWidth = Param.Unsigned(11, "Log number of IMLI GEHL entries")
+    iTableNum = Param.Unsigned(0, "Num IMLI GEHL tables")
+    iHistLen = VectorParam.Int([], "IMLI history GEHL history lengths")
+    iTableIdxWidth = Param.Unsigned(10, "Log number of IMLI GEHL entries")
     iWeightInitValue = Param.Int(7,
         "Initial value of the weights of the IMLI history GEHL entries")
 
     gTableNum = Param.Unsigned(2, "Num global branch GEHL tables")
     gHistLen = VectorParam.Int([8, 16], "Global branch GEHL history lengths")
-    gTableIdxWidth = Param.Unsigned(11, "Log number of global branch GEHL entries")
+    gTableIdxWidth = Param.Unsigned(10, "Log number of global branch GEHL entries")
     gWeightInitValue = Param.Int(7,
         "Initial value of the weights of the global history GEHL entries")
 
-    pTableNum = Param.Unsigned(2, "Num global branch path history tables")
-    pHistLen = VectorParam.Int([8, 16], "Global branch path history lengths")
-    pTableIdxWidth = Param.Unsigned(11,
+    pTableNum = Param.Unsigned(1, "Num global branch path history tables")
+    pHistLen = VectorParam.Int([16], "Global branch path history lengths")
+    pTableIdxWidth = Param.Unsigned(10,
                     "Log number of global branch path history entries")
     pWeightInitValue = Param.Int(7,
         "Initial value of the weights of the path history GEHL entries")
 
     biasTableNum = Param.Unsigned(1, "Num bias tables")
-    biasTableIdxWidth = Param.Unsigned(11, "Log number of bias entries")
+    biasTableIdxWidth = Param.Unsigned(9, "Log number of bias entries")
 
     thresholdTablelogSize = Param.Unsigned(6,
         "Log size of update threshold counters tables")
@@ -1126,7 +1128,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")
 
-    numWays = Param.Unsigned(8, "Number of ways per set")
+    numWays = Param.Unsigned(6, "Number of ways per set")
 
     numDelay = 3
 


### PR DESCRIPTION
disable global backward table, IMLI table.
use 2 global, 2 local, 1 path, 1 bias
bias use 512, others use 1024
6 ways

Change-Id: I9655821e1fe1cd797c20872e53edc20e9b29e6a4