### PR TITLE
cpu-o3: Add performance counters of replay events [skip ci] 

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -46,6 +46,7 @@
 #include <array>
 #include <deque>
 #include <list>
+#include <optional>
 #include <string>
 
 #include "base/refcnt.hh"
@@ -60,6 +61,7 @@
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/dyn_inst_xsmeta.hh"
 #include "cpu/o3/lsq_unit.hh"
+#include "cpu/o3/replay_events.hh"
 #include "cpu/op_class.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/static_inst.hh"
@@ -182,15 +184,6 @@ class DynInst : public ExecContext, public RefCounted
         FullForward,
         LocalAccess,
         NeedReplay,
-        TLBMissReplay,
-        CacheMissReplay,
-        RescheduleReplay,
-        STLFReplay,
-        NukeReplay,
-        CacheBlockedReplay,
-        BankConflicyReplay,
-        RARReplay,
-        RAWReplay,
         SkipFollowingPipe,
 
         // load/store pipe state end
@@ -247,6 +240,9 @@ class DynInst : public ExecContext, public RefCounted
 
     /** The status of this BaseDynInst.  Several bits can be set. */
     std::bitset<NumStatus> status;
+
+    /* replay type of this instruction */
+    std::optional<LdStReplayType> replayType;
 
   protected:
     /** The result of the instruction; assumes an instruction can have many
@@ -945,17 +941,9 @@ class DynInst : public ExecContext, public RefCounted
                     (1 << FullForward) |
                     (1 << LocalAccess) |
                     (1 << NeedReplay) |
-                    (1 << TLBMissReplay) |
-                    (1 << CacheMissReplay) |
-                    (1 << RescheduleReplay) |
-                    (1 << STLFReplay) |
-                    (1 << NukeReplay) |
-                    (1 << CacheBlockedReplay) |
-                    (1 << BankConflicyReplay) |
-                    (1 << RARReplay) |
-                    (1 << RAWReplay) |
                     (1 << SkipFollowingPipe));
         status.set(InPipe);
+        clearReplayType();
     }
 
     void endPipelining() {
@@ -967,6 +955,15 @@ class DynInst : public ExecContext, public RefCounted
     void setCacheHit() { status.set(CacheHit); }
     bool cacheHit() const { return status[CacheHit]; }
 
+    void setReplay(LdStReplayType type) {
+        setNeedReplay();
+        replayType = type;
+    }
+    std::optional<LdStReplayType> getReplayType() const {
+        return replayType;
+    }
+    void clearReplayType() { replayType.reset(); }
+
     // only can be set once!!!
     void setNeedReplay() {
         assert(!status[NeedReplay]);
@@ -974,35 +971,33 @@ class DynInst : public ExecContext, public RefCounted
     }
     bool needReplay() const { return status[NeedReplay]; }
 
-    void setTLBMissReplay() { setNeedReplay(); status.set(TLBMissReplay); }
-    bool needTLBMissReplay() const { return status[TLBMissReplay]; }
+    void setTLBMissReplay() { setReplay(LdStReplayType::TLBMissReplay); }
+    bool needTLBMissReplay() const { return getReplayType() == LdStReplayType::TLBMissReplay; }
 
-    void setCacheMissReplay() { setNeedReplay(); status.set(CacheMissReplay); }
-    bool needCacheMissReplay() const { return status[CacheMissReplay]; }
+    void setCacheMissReplay() { setReplay(LdStReplayType::CacheMissReplay); }
+    bool needCacheMissReplay() const { return getReplayType() == LdStReplayType::CacheMissReplay; }
 
-    void setRescheduleReplay() { setNeedReplay(); status.set(RescheduleReplay); }
-    bool needRescheduleReplay() const { return status[RescheduleReplay]; }
+    void setRescheduleReplay() { setReplay(LdStReplayType::RescheduleReplay); }
+    bool needRescheduleReplay() const { return getReplayType() == LdStReplayType::RescheduleReplay; }
 
-    void setSTLFReplay() { setNeedReplay(); status.set(STLFReplay); }
-    bool needSTLFReplay() const { return status[STLFReplay]; }
+    void setSTLFReplay() { setReplay(LdStReplayType::STLFReplay); }
+    bool needSTLFReplay() const { return getReplayType() == LdStReplayType::STLFReplay; }
 
-    void setNukeReplay() { setNeedReplay(); status.set(NukeReplay); }
-    bool needNukeReplay() const { return status[NukeReplay]; }
+    void setNukeReplay() { setReplay(LdStReplayType::NukeReplay); }
+    bool needNukeReplay() const { return getReplayType() == LdStReplayType::NukeReplay; }
 
-    void setCacheBlockedReplay() { setNeedReplay(); status.set(CacheBlockedReplay); }
-    bool needCacheBlockedReplay() const { return status[CacheBlockedReplay]; }
+    void setCacheBlockedReplay() { setReplay(LdStReplayType::CacheBlockedReplay); }
+    bool needCacheBlockedReplay() const { return getReplayType() == LdStReplayType::CacheBlockedReplay; }
 
-    void setBankConflicyReplay() { setNeedReplay(); status.set(BankConflicyReplay); }
-    bool needBankConflicyReplay() const { return status[BankConflicyReplay]; }
+    void setBankConflicyReplay() { setReplay(LdStReplayType::BankConflictReplay); }
+    bool needBankConflicyReplay() const { return getReplayType() == LdStReplayType::BankConflictReplay; }
 
-    void setRARReplay() { setNeedReplay(); status.set(RARReplay); }
-    bool needRARReplay() const { return status[RARReplay]; }
+    void setRARReplay() { setReplay(LdStReplayType::RARReplay); }
+    bool needRARReplay() const { return getReplayType() == LdStReplayType::RARReplay; }
 
-    void setRAWReplay() { setNeedReplay(); status.set(RAWReplay); }
-    bool needRAWReplay() const { return status[RAWReplay]; }
+    void setRAWReplay() { setReplay(LdStReplayType::RAWReplay); }
+    bool needRAWReplay() const { return getReplayType() == LdStReplayType::RAWReplay; }
 
-    void clearRARReplay() { status.reset(RARReplay); }
-    void clearRAWReplay() { status.reset(RAWReplay); }
     void clearNeedReplay() { status.reset(NeedReplay); }
 
     void setFullForward() { status.set(FullForward); }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -58,6 +58,7 @@
 #include "cpu/o3/issue_queue.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/o3/lsq.hh"
+#include "cpu/o3/replay_events.hh"
 #include "cpu/utils.hh"
 #include "debug/Activity.hh"
 #include "debug/Diff.hh"
@@ -765,7 +766,8 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(RARQueueLatency, statistics::units::Cycle::get(), "RAR queue latency distribution"),
       ADD_STAT(RAWQueueFull, "Number of times RAW queue was full"),
       ADD_STAT(RAWQueueReplay, "Number of instructions replayed from RAW queue"),
-      ADD_STAT(RAWQueueLatency, statistics::units::Cycle::get(), "RAW queue latency distribution")
+      ADD_STAT(RAWQueueLatency, statistics::units::Cycle::get(), "RAW queue latency distribution"),
+      ADD_STAT(loadReplayEvents, statistics::units::Count::get(), "event distribution of load replay")
 {
     loadToUse
         .init(0, 299, 10)
@@ -781,6 +783,12 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
     RAWQueueLatency
         .init(0, 500, 20)
         .flags(statistics::nozero);
+    loadReplayEvents
+        .init(LdStReplayTypeCount)
+        .flags(statistics::total);
+    for (int i = 0; i < LdStReplayTypeCount; i++) {
+        loadReplayEvents.subname(i, load_store_replay_event_str[static_cast<LdStReplayType>(i)]);
+    }
 }
 
 void
@@ -1489,6 +1497,10 @@ LSQUnit::executeLoadPipeSx()
             // If inst was replyed, must clear inst in pipeline
             if (inst->needSTLFReplay() || inst->needCacheBlockedReplay() || inst->needRescheduleReplay()) {
                 DPRINTF(LoadPipeline, "Load [sn:%llu] replayed\n", inst->seqNum);
+                // record replay stats
+                assert(inst->getReplayType());
+                stats.loadReplayEvents[*inst->getReplayType()]++;
+
                 iewStage->loadCancel(inst);
                 inst->endPipelining();
                 inst = nullptr;
@@ -1497,6 +1509,9 @@ LSQUnit::executeLoadPipeSx()
 
             if (i == loadWhenToReplay && inst->needReplay()) [[unlikely]] {
                 DPRINTF(LoadPipeline, "Load [sn:%llu] replayed\n", inst->seqNum);
+                // record replay stats
+                assert(inst->getReplayType());
+                stats.loadReplayEvents[*inst->getReplayType()]++;
 
                 if (inst->needBankConflicyReplay()) inst->issueQue->retryMem(inst);
                 else if (inst->needCacheMissReplay()) iewStage->cacheMissLdReplay(inst);
@@ -3462,14 +3477,13 @@ LSQUnit::processReplayQueues()
             if (isRAR) {
                 stats.RARQueueLatency.sample(cycleLatency);
                 stats.RARQueueReplay++;
-                inst->clearRARReplay();
             } else {
                 stats.RAWQueueLatency.sample(cycleLatency);
                 stats.RAWQueueReplay++;
-                inst->clearRAWReplay();
             }
         }
 
+        inst->clearReplayType();
         inst->clearNeedReplay();
         inst->issueQue->retryMem(inst);
     }

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -66,6 +66,7 @@
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/o3/lsq.hh"
+#include "cpu/o3/replay_events.hh"
 #include "cpu/timebuf.hh"
 #include "debug/HtmCpu.hh"
 #include "debug/LSQUnit.hh"
@@ -905,6 +906,8 @@ class LSQUnit
         statistics::Scalar RAWQueueFull;
         statistics::Scalar RAWQueueReplay;
         statistics::Distribution RAWQueueLatency;
+
+        statistics::Vector loadReplayEvents;
     } stats;
 
     void bankConflictReplay();

--- a/src/cpu/o3/replay_events.hh
+++ b/src/cpu/o3/replay_events.hh
@@ -1,0 +1,39 @@
+#ifndef __CPU_O3_REPLAY_EVENTS_HH__
+#define __CPU_O3_REPLAY_EVENTS_HH__
+
+namespace gem5
+{
+namespace o3
+{
+
+enum LdStReplayType
+{
+    TLBMissReplay,
+    CacheMissReplay,
+    RescheduleReplay,
+    STLFReplay,
+    NukeReplay,
+    CacheBlockedReplay,
+    BankConflictReplay,
+    RARReplay,
+    RAWReplay,
+    LdStReplayTypeCount
+};
+
+static const char *load_store_replay_event_str[LdStReplayTypeCount] =
+{
+    "TLBMissReplay",
+    "CacheMissReplay",
+    "RescheduleReplay",
+    "STLFReplay",
+    "NukeReplay",
+    "CacheBlockedReplay",
+    "BankConflictReplay",
+    "RARReplay",
+    "RAWReplay",
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_REPLAY_EVENTS_HH__


### PR DESCRIPTION
This commit introduces a new statistics vector, `loadReplayEvents`, to the LSQUnit to provide a detailed breakdown of instruction replay events. This allows for better performance analysis by quantifying the frequency of different replay reasons, such as TLB misses, cache misses, and memory dependency nukes.

To support this and improve code quality, the way replay reasons are tracked within DynInst has been refactored:

- A new shared enum, `LdStReplayType`, is created in `replay_events.hh` to act as a single source of truth for all replay types, removing duplicated definitions.

- In DynInst, multiple boolean flags for different replay reasons within the `status` bitset have been consolidated into a single `std::optional<LdStReplayType> replayType` member. This centralizes the instruction's replay state.

The existing convenience methods (e.g., `setTLBMissReplay()`, `needCacheMissReplay()`) are retained for ease of use, but they now wrap the new centralized `replayType` member.

Change-Id: I5cfe042271cc831e86c1d24af170428085303583