### PR TITLE
cpu-o3: add new phr folded history hash

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -395,9 +395,9 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.ftq_size = 256
             cpu.branchPred.fsq_size = 256
             cpu.branchPred.tage.numPredictors = 8
-            cpu.branchPred.tage.TTagBitSizes = [13] * 8
+            cpu.branchPred.tage.TTagBitSizes = [11] * 8
             cpu.branchPred.tage.TTagPcShifts = [1] * 8
-            cpu.branchPred.tage.histLengths = [4, 8, 15, 28, 50, 90, 160, 300]
+            cpu.branchPred.tage.histLengths = [4, 9, 17, 29, 56, 109, 211, 397]
 
         # ideal l1 caches
         if args.caches:

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -920,7 +920,7 @@ BTBMGSC::satDecrement(int min, unsigned &counter)
  */
 void
 BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
-                        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc)
+                        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc, Addr target)
 {
     if (debugFlagOn) {
         std::string buf;
@@ -934,7 +934,7 @@ BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
     }
 
     for (int t = 0; t < foldedHist.size(); t++) {
-        foldedHist[t].update(history, shamt, taken, pc);
+        foldedHist[t].update(history, shamt, taken, pc, target);
     }
 }
 
@@ -975,10 +975,8 @@ BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPredictio
 void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    Addr pc;
-    bool cond_taken;
-    std::tie(pc, cond_taken) = pred.getPHistInfo();
-    doUpdateHist(history, 1, cond_taken, indexPFoldedHist, pc); // only path history needs pc!
+    auto [pc, target, taken] = pred.getPHistInfo();
+    doUpdateHist(history, 2, taken, indexPFoldedHist, pc, target); // only path history needs pc!
 }
 
 
@@ -1092,7 +1090,7 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
     for (int i = 0; i < pTableNum; i++) {
         indexPFoldedHist[i].recover(predMeta->indexPFoldedHist[i]);
     }
-    doUpdateHist(history, 1, cond_taken, indexPFoldedHist, entry.getControlPC());
+    doUpdateHist(history, 2, cond_taken, indexPFoldedHist, entry.getControlPC(), entry.getTakenTarget());
 }
 
 /**

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -263,7 +263,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
     // Update branch history
     void doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
-        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc=0);
+        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc = 0, Addr target = 0);
 
     /** global backward branch history indexed tables */
     // number of global backward branch history indexed tables

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -7,6 +7,7 @@
 #include "base/debug_helper.hh"
 #include "base/intmath.hh"
 #include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/TAGE.hh"
 
@@ -760,7 +761,7 @@ BTBTAGE::getUseAltIdx(Addr pc) {
  * @param taken Whether the branch was taken
  */
 void
-BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr pc)
+BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr pc, Addr target)
 {
     if (debugFlagOn) {
         std::string buf;
@@ -776,7 +777,7 @@ BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr p
         for (int type = 0; type < 3; type++) {
             auto &foldedHist = type == 0 ? indexFoldedHist[t] : type == 1 ? tagFoldedHist[t] : altTagFoldedHist[t];
             // since we have folded path history, we can put arbitrary shamt here, and it wouldn't make a difference
-            foldedHist.update(history, 2, taken, pc);
+            foldedHist.update(history, 2, taken, pc, target);
         }
     }
 }
@@ -796,10 +797,8 @@ BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr p
 void
 BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    Addr pc;
-    bool cond_taken;
-    std::tie(pc, cond_taken) = pred.getPHistInfo();
-    doUpdateHist(history, cond_taken, pc);
+    auto [pc, target, taken] = pred.getPHistInfo();
+    doUpdateHist(history, taken, pc, target);
 }
 
 /**
@@ -825,7 +824,7 @@ BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
         altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
         indexFoldedHist[i].recover(predMeta->indexFoldedHist[i]);
     }
-    doUpdateHist(history, cond_taken, entry.getControlPC());
+    doUpdateHist(history, cond_taken, entry.getControlPC(), entry.getTakenTarget());
 }
 
 // Check folded history after speculative update and recovery

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -94,7 +94,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     struct AllocationResult {
         bool allocate_valid;             // Whether allocation is valid
         bitset allocate_mask;            // Mask for allocation
-        
+
         AllocationResult() : allocate_valid(false) {}
     };
 
@@ -157,7 +157,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     }
 
     // Update branch history
-    void doUpdateHist(const bitset &history, bool taken, Addr pc);
+    void doUpdateHist(const bitset &history, bool taken, Addr pc, Addr target);
 
     // Number of TAGE predictor tables
     const unsigned numPredictors;
@@ -254,7 +254,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
         statistics::Distribution updateTableHits;
         statistics::Scalar updateNoHitUseBim;
         statistics::Scalar updateUseAlt;
-    
+
         statistics::Scalar updateUseAltCorrect;
         statistics::Scalar updateUseAltWrong;
         statistics::Scalar updateAltDiffers;
@@ -283,7 +283,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
         TageStats(statistics::Group* parent, int numPredictors);
         void updateStatsWithTagePrediction(const TagePrediction &pred, bool when_pred);
     } ;
-    
+
     TageStats tageStats;
 
     TraceManager *tageMissTrace;
@@ -329,14 +329,14 @@ private:
     void recordUsefulMask(const Addr &startPC);
 
     // Helper method to generate prediction for a single BTB entry
-    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry, 
+    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry,
                                            const Addr &startPC);
 
     // Helper method to prepare BTB entries for update
     std::vector<BTBEntry> prepareUpdateEntries(const FetchStream &stream);
 
     // Helper method to update predictor state for a single entry
-    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry, 
+    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
                                  bool actual_taken,
                                  const TagePrediction &pred,
                                  const FetchStream &stream);

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1736,8 +1736,8 @@ DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<>
     }
     if(taken){
         // Calculate path hash
-        const uint64_t hash_length = 30;
-        uint64_t path_hash = ((pc & ((1ULL << 15) - 1)) ^ (target & ((1ULL << 30) - 1)));
+        const uint64_t hash_length = 15;
+        uint64_t path_hash = ((((pc >> 1) & ((1ULL << 9) - 1)) << 4) ^ ((target >> 2) & ((1ULL << 15) - 1)));
         path_hash &= ((1ULL << hash_length) - 1);
 
         history <<= shamt;
@@ -1975,7 +1975,7 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     histShiftIn(bw_shamt, bw_taken, s0BwHistory);
 
     // Update path history
-    pHistShiftIn(2, taken, s0PHistory, p_pc, p_target);
+    pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);
 #ifndef NDEBUG
     tage->checkFoldedHist(s0PHistory, "speculative update");
 #endif

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1626,7 +1626,7 @@ DecoupledBPUWithBTB::validateFTQEnqueue()
     // 3. Get FTQ enqueue state and find corresponding stream
     auto &ftq_enq_state = fetchTargetQueue.getEnqState();
     auto streamIt = fetchStreamQueue.find(ftq_enq_state.streamId);
-    
+
     if (streamIt == fetchStreamQueue.end()) {
         dbpBtbStats.fsqNotValid++;
         DPRINTF(DecoupleBP, "Cannot enqueue - Stream ID %lu not found in FSQ\n",
@@ -1729,15 +1729,23 @@ DecoupledBPUWithBTB::histShiftIn(int shamt, bool taken, boost::dynamic_bitset<> 
 }
 
 void
-DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<> &history, Addr pc)
+DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<> &history, Addr pc, Addr target)
 {
     if (shamt == 0) {
         return;
     }
     if(taken){
-        history <<= 2;
-        history[0] = (((pc>>1)^(pc>>3)^(pc>>5)^(pc>>7)) & 1);       // pc[1] ^ pc[3] ^ pc[5] ^ pc[7]
-        history[1] = (((pc>>1)^(pc>>3)^(pc>>5)^(pc>>7)) & 2) >> 1;  // pc[2] ^ pc[4] ^ pc[6] ^ pc[8]
+        // Calculate path hash
+        const uint64_t hash_length = 30;
+        uint64_t path_hash = ((pc & ((1ULL << 15) - 1)) ^ (target & ((1ULL << 30) - 1)));
+        path_hash &= ((1ULL << hash_length) - 1);
+
+        history <<= shamt;
+        assert(shamt == 2);
+        for (auto i = 0; i < hash_length && i < history.size(); i++) {
+            history[i] = (path_hash & 1) ^ history[i];
+            path_hash >>= 1;
+        }
     }
 }
 
@@ -1847,9 +1855,9 @@ DecoupledBPUWithBTB::makeNewPrediction(bool create_new_stream)
 
     // 7. Debug output and update statistics
     dumpFsq("after insert new stream");
-    DPRINTF(DecoupleBP, "Inserted fetch stream %lu starting at PC %#lx\n", 
+    DPRINTF(DecoupleBP, "Inserted fetch stream %lu starting at PC %#lx\n",
             fsqId, entry.startPC);
-    
+
     // 8. Update FSQ ID and increment statistics
     fsqId++;
     printStream(entry);
@@ -1961,15 +1969,13 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     std::tie(bw_shamt, bw_taken) = finalPred.getBwHistInfo();
 
     // Get prediction information for path history updates
-    bool p_taken;
-    Addr p_pc;
-    std::tie(p_pc, p_taken) = finalPred.getPHistInfo(); // p_taken = taken
+    auto [p_pc, p_target, p_taken]= finalPred.getPHistInfo(); // p_taken = taken
 
     // Update global backward history
     histShiftIn(bw_shamt, bw_taken, s0BwHistory);
 
     // Update path history
-    pHistShiftIn(1, taken, s0PHistory, p_pc);
+    pHistShiftIn(2, taken, s0PHistory, p_pc, p_target);
 #ifndef NDEBUG
     tage->checkFoldedHist(s0PHistory, "speculative update");
 #endif
@@ -2036,7 +2042,7 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     histShiftIn(real_shamt, real_taken, s0History);
 
     // Update path history with actual outcome
-    pHistShiftIn(1, real_taken, s0PHistory, squash_pc.instAddr());
+    pHistShiftIn(2, real_taken, s0PHistory, squash_pc.instAddr(), redirect_pc);
 
     // Update global backward history with actual outcome
     histShiftIn(real_bw_shamt, real_bw_taken, s0BwHistory);

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "arch/generic/pcstate.hh"
+#include "base/types.hh"
 #include "config/the_isa.hh"
 #include "cpu/o3/cpu_def.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
@@ -193,7 +194,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     // TODO: compare phr and ghr
     void histShiftIn(int shamt, bool taken, boost::dynamic_bitset<> &history);
 
-    void pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<> &history, Addr pc);
+    void pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<> &history, Addr pc, Addr target);
 
     void printStream(const FetchStream &e)
     {

--- a/src/cpu/pred/btb/folded_hist.cc
+++ b/src/cpu/pred/btb/folded_hist.cc
@@ -10,6 +10,34 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+uint64_t
+FoldedHist::fold(const boost::dynamic_bitset<> &ghr)
+{
+    // Create ideal folded history from GHR
+    uint64_t folded = 0;
+
+    // Create mask for foldedLen bits
+    const uint64_t foldedMask = ((1ULL << foldedLen) - 1);
+
+    // Process in chunks of foldedLen bits
+    for (size_t startBit = 0; startBit < histLen; startBit += foldedLen) {
+        uint64_t chunk = 0;
+        size_t chunkSize = std::min(foldedLen, histLen - startBit);
+
+        // Extract chunk from bitset
+        for (size_t i = 0; i < chunkSize; i++) {
+            chunk |= (ghr[startBit + i] << i);
+        }
+
+        // XOR this chunk into the ideal folded history
+        folded ^= chunk;
+    }
+
+    folded &= foldedMask;
+
+    return folded;
+}
+
 /**
  * Update the folded history with a new branch outcome.
  * Note: pc is used only for path history update!
@@ -34,10 +62,14 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
     const uint64_t foldedMask = ((1ULL << foldedLen) - 1);
 
     if (type == HistoryType::GLOBAL || type == HistoryType::GLOBALBW || type == HistoryType::LOCAL) {
-        uint64_t temp = folded;
+        uint64_t temp = _folded;
 
-        // Case 1: When folded length >= history length
-        if (foldedLen >= histLen) {
+        // Case 1: shamt >= history length, calculate completely new folded
+        if (shamt >= histLen) {
+            _folded = fold(ghr);
+        }
+        // Case 2: When folded length >= history length
+        else if (foldedLen >= histLen) {
             // Simple shift and set case
             temp <<= shamt;
             // Clear any bits beyond histLen
@@ -47,7 +79,7 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
                 temp |= 1;
             }
         }
-        // Case 2: When folded length < history length
+        // Case 3: When folded length < history length
         else {
             // Step 1: Handle the bits that would be lost in shift
             for (int i = 0; i < shamt; i++) {
@@ -72,11 +104,11 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
             // Step 5: Mask to folded length
             temp &= foldedMask;
         }
-        folded = temp;
+        _folded = temp;
     } else if (type == HistoryType::IMLI) {
         // Case 1: When folded length >= history length
         assert(foldedLen >= histLen);  // Requirement of IMLI
-        uint64_t temp = folded;
+        uint64_t temp = _folded;
         // Simple shift and set case
         if (taken && temp < ((1ULL << histLen) - 1) && shamt == 1) {  // backward taken, inner most loop
             temp = temp + 1;                                          // counter++ (index++)
@@ -85,9 +117,10 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
         } else if (!taken) {  // backward not taken, hist = 0
             temp = 0;
         }
-        folded = temp & foldedMask;
+        _folded = temp & foldedMask;
     } else if (type == HistoryType::PATH) {
         assert(shamt == 2);
+        assert(shamt < histLen);
         if (taken) {
             // Calculate path hash
             const uint64_t hash_length = 15;
@@ -95,7 +128,7 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
             path_hash &= ((1ULL << hash_length) - 1);
 
 
-            uint64_t temp = folded;
+            uint64_t temp = _folded;
             // Case 1: When folded length >= history length
             if (foldedLen >= histLen) {
                 // Simple shift and set case
@@ -136,7 +169,7 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
                 // Mask to folded length
                 temp &= foldedMask;
             }
-            folded = temp;
+            _folded = temp;
         }
     }
 }
@@ -153,7 +186,7 @@ FoldedHist::recover(FoldedHist &other)
     assert(maxShamt == other.maxShamt);
     assert(histLen == other.histLen);
     // Copy the folded history
-    folded = other.folded;
+    _folded = other._folded;
 }
 
 /**
@@ -164,34 +197,10 @@ FoldedHist::recover(FoldedHist &other)
  * this method can be commonly used for checking both GHR and PHR
  */
 void
-FoldedHist::check(const boost::dynamic_bitset<> &ghr)
+FoldedHist::check(const boost::dynamic_bitset<> &historyBitVec)
 {
-    // TODO: support path history in the future
-
-    // Create ideal folded history from GHR
-    uint64_t idealFolded = 0;
-
-    // Create mask for foldedLen bits
-    const uint64_t foldedMask = ((1ULL << foldedLen) - 1);
-
-    // Process in chunks of foldedLen bits
-    for (size_t startBit = 0; startBit < histLen; startBit += foldedLen) {
-        uint64_t chunk = 0;
-        size_t chunkSize = std::min(static_cast<size_t>(foldedLen), histLen - startBit);
-
-        // Extract chunk from bitset
-        for (size_t i = 0; i < chunkSize; i++) {
-            chunk |= (ghr[startBit + i] << i);
-        }
-
-        // XOR this chunk into the ideal folded history
-        idealFolded ^= chunk;
-    }
-
-    idealFolded &= foldedMask;
-
     // Verify our folded history matches ideal
-    assert(idealFolded == folded);
+    assert(_folded == fold(historyBitVec));
 }
 
 }  // namespace btb_pred

--- a/src/cpu/pred/btb/folded_hist.cc
+++ b/src/cpu/pred/btb/folded_hist.cc
@@ -1,4 +1,5 @@
 #include "cpu/pred/btb/folded_hist.hh"
+#include <cstdint>
 
 namespace gem5
 {
@@ -27,7 +28,7 @@ namespace btb_pred
  * - Then shift and set new bit
  */
 void
-FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc)
+FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc, Addr target)
 {
     // Create mask for folded length
     const uint64_t foldedMask = ((1ULL << foldedLen) - 1);
@@ -86,42 +87,51 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
         }
         folded = temp & foldedMask;
     } else if (type == HistoryType::PATH) {
+        assert(shamt == 2);
         if (taken) {
+            // Calculate path hash
+            const uint64_t hash_length = 30;
+            uint64_t path_hash = ((pc & ((1ULL << 15) - 1)) ^ (target & ((1ULL << 30) - 1)));
+            path_hash &= ((1ULL << hash_length) - 1);
+
+
             uint64_t temp = folded;
             // Case 1: When folded length >= history length
             if (foldedLen >= histLen) {
                 // Simple shift and set case
-                temp <<= 2;
+                temp <<= shamt;
+                temp ^= path_hash;
                 // Clear any bits beyond histLen
                 temp &= ((1ULL << histLen) - 1);
-                // Set the newest bits based on PC
-                uint64_t pcBits = ((pc >> 1) ^ (pc >> 3) ^ (pc >> 5) ^ (pc >> 7));
-                temp |= (pcBits & 0b11);
             }
             // Case 2: When folded length < history length
             else {
-                assert(maxShamt >= 2);
-
-                int phrShamt = 2; // hardcoded to be 2, the shamt passed in the arguments is ignored
+                assert(shamt <= maxShamt);
                 // Step 1: Handle the bits that would be lost in shift
-                for (int i = 0; i < phrShamt; i++) {
+                for (int i = 0; i < shamt; i++) {
                     // XOR the highest bits from GHR with corresponding positions in folded history
                     temp ^= (ghr[posHighestBitsInGhr[i]] << posHighestBitsInOldFoldedHist[i]);
                 }
 
                 // Step 2: Perform the shift
-                temp <<= phrShamt;
+                temp <<= shamt;
 
 
                 // Step 3: Copy the XORed bits back to lower positions
-                for (int i = 0; i < phrShamt; i++) {
+                for (int i = 0; i < shamt; i++) {
                     uint64_t highBit = (temp >> (foldedLen + i)) & 1;
                     temp |= (highBit << i);
                 }
 
                 // Step 4: Add new branch outcome
-                temp ^= (((pc>>1)^(pc>>3)^(pc>>5)^(pc>>7)) & 1);
-                temp ^= (((pc>>1)^(pc>>3)^(pc>>5)^(pc>>7)) & 2) ;
+                int bits_left = hash_length;
+                uint64_t folded_hash = 0;
+                while (bits_left > 0) {
+                    folded_hash ^= path_hash;
+                    path_hash >>= foldedLen;
+                    bits_left -= foldedLen;
+                }
+                temp ^= folded_hash;
 
                 // Mask to folded length
                 temp &= foldedMask;

--- a/src/cpu/pred/btb/folded_hist.cc
+++ b/src/cpu/pred/btb/folded_hist.cc
@@ -90,8 +90,8 @@ FoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Ad
         assert(shamt == 2);
         if (taken) {
             // Calculate path hash
-            const uint64_t hash_length = 30;
-            uint64_t path_hash = ((pc & ((1ULL << 15) - 1)) ^ (target & ((1ULL << 30) - 1)));
+            const uint64_t hash_length = 15;
+            uint64_t path_hash = ((((pc >> 1) & ((1ULL << 9) - 1)) << 4) ^ ((target >> 2) & ((1ULL << 15) - 1)));
             path_hash &= ((1ULL << hash_length) - 1);
 
 

--- a/src/cpu/pred/btb/folded_hist.hh
+++ b/src/cpu/pred/btb/folded_hist.hh
@@ -28,17 +28,20 @@ class FoldedHist
 {
   private:
     constexpr static int staticMaxShamtLimit = 16;
-    int histLen;    // Length of the original history
-    int foldedLen;  // Length of the folded (compressed) history
-    int maxShamt;   // Maximum shift amount for history updates
+    std::size_t histLen;    // Length of the original history
+    std::size_t foldedLen;  // Length of the folded (compressed) history
+    std::size_t maxShamt;   // Maximum shift amount for history updates
     HistoryType type;
-    uint64_t folded;  // The folded history bits
+    uint64_t _folded;  // The folded history bits
 
     // Pre-calculated positions for efficient history updates
     // Use static sized type to avoid heap alloc
     // This class is very frequently used in fetch/BP, so ensure it is a fixed-sized object
     std::array<std::size_t, staticMaxShamtLimit> posHighestBitsInGhr;  // Positions of highest bits in global history
     std::array<std::size_t, staticMaxShamtLimit> posHighestBitsInOldFoldedHist;  // Positions in old folded history
+
+    // Perform a immediate fold on given history bitvec
+    uint64_t fold(const boost::dynamic_bitset<> &historyBitVec);
 
   public:
     /**
@@ -48,7 +51,7 @@ class FoldedHist
      * @param maxShamt Maximum number of bits to shift during updates
      */
     FoldedHist(int histLen, int foldedLen, int maxShamt, HistoryType type = HistoryType::GLOBAL)
-        : histLen(histLen), foldedLen(foldedLen), maxShamt(maxShamt), type(type), folded(0)
+        : histLen(histLen), foldedLen(foldedLen), maxShamt(maxShamt), type(type), _folded(0)
     {
         assert(maxShamt <= staticMaxShamtLimit);
         assert(foldedLen + maxShamt < 64);  // Ensure folded history fits in uint64_t
@@ -58,18 +61,17 @@ class FoldedHist
         }
     }
 
-  public:
     /**
      * Get the current folded history as uint64_t
      * @return The folded history bits
      */
-    uint64_t get() const { return folded; }
+    uint64_t get() const { return _folded; }
 
     /**
      * Get the current folded history as bitset for compatibility
      * @return The folded history as boost::dynamic_bitset
      */
-    boost::dynamic_bitset<> getAsBitset() const { return boost::dynamic_bitset<>(foldedLen, folded); }
+    boost::dynamic_bitset<> getAsBitset() const { return boost::dynamic_bitset<>(foldedLen, _folded); }
 
     /**
      * Update the folded history with a new branch outcome

--- a/src/cpu/pred/btb/folded_hist.hh
+++ b/src/cpu/pred/btb/folded_hist.hh
@@ -77,7 +77,7 @@ class FoldedHist
      * @param shamt Number of bits to shift
      * @param taken Whether the branch was taken
      */
-    void update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc = 0);
+    void update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken, Addr pc = 0, Addr target = 0);
 
     /**
      * Recover the folded history from another instance

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -635,6 +635,9 @@ struct FullBTBPrediction
                     }
                 } else {
                     // uncond
+                    taken = true;
+                    pc = entry.pc; // get the pc of the cond branch
+                    target = entry.target;
                     break;
                 }
             }

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -67,7 +67,7 @@ enum class HistoryType
 
 /**
  * @brief Branch information structure containing branch properties and targets
- * 
+ *
  * Stores essential information about a branch instruction including:
  * - PC and target address
  * - Branch type (conditional, indirect, call, return)
@@ -152,7 +152,7 @@ struct BranchInfo
 
 /**
  * @brief Branch Target Buffer entry extending BranchInfo with prediction metadata
- * 
+ *
  * Contains branch information plus prediction state:
  * - Valid bit
  * - Always taken bit
@@ -262,7 +262,7 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
 /**
  * @brief Fetch Stream representing a sequence of instructions with prediction info
- * 
+ *
  * Key structure for decoupled frontend that contains:
  * - Stream boundaries (start PC, end PC)
  * - Prediction information (branch info, targets)
@@ -395,7 +395,7 @@ struct FetchStream
         }
         return std::make_pair(shamt, cond_taken);
     }
-    
+
     // should be called before components update
     void setUpdateInstEndPC(unsigned predictWidth)
     {
@@ -425,7 +425,7 @@ struct FetchStream
 };
 /**
  * @brief Full branch prediction combining predictions from all predictors
- * 
+ *
  * Aggregates predictions from:
  * - BTB entries for targets
  * - Direction predictors for conditional branches
@@ -615,10 +615,11 @@ struct FullBTBPrediction
         return std::make_pair(shamt, taken);
     }
 
-    std::pair<Addr, bool> getPHistInfo() //path
+    std::tuple<Addr, Addr, bool> getPHistInfo() //path
     {
         bool taken = false;
         Addr pc = 0;
+        Addr target = 0;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) {
@@ -628,6 +629,7 @@ struct FullBTBPrediction
                         if (it->second) {
                             taken = true;
                             pc = entry.pc; // get the pc of the cond branch
+                            target = entry.target;
                             break;
                         }
                     }
@@ -637,14 +639,14 @@ struct FullBTBPrediction
                 }
             }
         }
-        return std::make_pair(pc, taken);
+        return std::make_tuple(pc, target, taken);
     }
 
 };
 
 /**
  * @brief Fetch Target Queue entry representing a fetch block
- * 
+ *
  * Contains information needed for instruction fetch:
  * - Address range (start PC, end PC)
  * - Branch information (taken PC, target)


### PR DESCRIPTION
Very basic phr with more pc and target bits. Observed improvement on 10-iter coremark.
Just run CI perf.