### PR TITLE
cpu-o3: Fix storebuffer clear in the v-extension. 

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -750,13 +750,6 @@ class DynInst : public ExecContext, public RefCounted
         }
     }
 
-    void clearForwardPackets() {
-        if (savedRequest) {
-            savedRequest->SQforwardPackets.clear();
-            savedRequest->SBforwardPackets.clear();
-        }
-    }
-
     /** Temporarily sets this instruction as a serialize before instruction. */
     void setSerializeBefore() { status.set(SerializeBefore); }
 

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1489,11 +1489,6 @@ LSQUnit::executeLoadPipeSx()
                 }
             }
 
-            // Clear forward packets when replayed
-            if (inst->needReplay()) {
-                inst->clearForwardPackets();
-            }
-
             // If inst was replyed, must clear inst in pipeline
             if (inst->needSTLFReplay() || inst->needCacheBlockedReplay() || inst->needRescheduleReplay()) {
                 DPRINTF(LoadPipeline, "Load [sn:%llu] replayed\n", inst->seqNum);
@@ -3061,6 +3056,10 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         DPRINTF(LoadPipeline, "Load [sn:%llu] local access, setSkipFollowingPipe",
                 load_inst->seqNum);
         return NoFault;
+    }
+
+    if (request) {
+        request->SQforwardPackets.clear();
     }
 
     // Check the SQ for any previous stores that might lead to forwarding

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -122,11 +122,11 @@ class StoreBufferEntry
 
 class StoreBuffer
 {
-    using mapIter = typename std::unordered_map<int, StoreBufferEntry*>::iterator;
+    using mapIter = typename std::unordered_map<uint64_t, StoreBufferEntry*>::iterator;
 
     // key = (paddr & cacheblockmask)
     uint64_t _size;
-    std::unordered_map<int, StoreBufferEntry*> data_map;
+    std::unordered_map<uint64_t, StoreBufferEntry*> data_map;
     std::vector<mapIter> crossRef;
     boost::circular_buffer<int> lru_index;
     boost::circular_buffer<int> free_list;


### PR DESCRIPTION
1. Modify the position of SQForwardPackets to resolve the error in rvv testing.
2. Modify the mapping data structure of StoreBufferEntry, int32_t is not sufficient to represent all appropriate address ranges.

Change-Id: I2ef1843b824a9b026aa796cd1ab1b363c4765d5c