### PR TITLE
Auto-calibration

### DIFF
--- a/configs/example/auto_xiangshan.py
+++ b/configs/example/auto_xiangshan.py
@@ -1,0 +1,86 @@
+import argparse
+import sys
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.util import addToPath, fatal, warn
+from m5.util.fdthelper import *
+
+addToPath('../')
+
+from ruby import Ruby
+
+from common.FSConfig import *
+from common.SysPaths import *
+from common.Benchmarks import *
+from common import Simulation
+from common import CacheConfig
+from common import CpuConfig
+from common import MemConfig
+from common import ObjectList
+from common import XSConfig
+from common.Caches import *
+from common import Options
+from example.xiangshan import *
+
+def autoCalibrateParams(args, system):
+    for cpu in system.cpu:
+        cpu.decodeWidth=6
+        cpu.renameWidth=6
+        cpu.commitWidth=8
+        cpu.LQEntries=72
+        cpu.SQEntries=56
+
+
+
+
+
+if __name__ == '__m5_main__':
+
+    # Add args
+    parser = argparse.ArgumentParser()
+    Options.addCommonOptions(parser, configure_xiangshan=True)
+    Options.addXiangshanFSOptions(parser)
+
+    # Add the ruby specific and protocol specific args
+    if '--ruby' in sys.argv:
+        Ruby.define_options(parser)
+
+    args = parser.parse_args()
+
+    args.xiangshan_system = True
+    args.enable_difftest = False
+    args.enable_riscv_vector = True
+
+    args.raw_cpt = True
+    args.no_pf = True
+
+    # l1cache prefetcher use stream, stride
+    # l2cache prefetcher use pht, bop, cmc
+    # disable l1prefetcher store pf train
+    # disable l1 berti, l2 cdp
+    args.l2_hwp_type = "L2CompositeWithWorkerPrefetcher"
+    #args.pht_pf_level = 2
+    #args.kmh_align = True
+
+    assert not args.external_memory_system
+
+    test_mem_mode = 'timing'
+
+    # override cpu class and clock
+    if args.xiangshan_ecore:
+        FutureClass = None
+        args.cpu_clock = '2.4GHz'
+    else:
+        FutureClass = None
+
+    # Match the memories with the CPUs, based on the options for the test system
+    TestMemClass = Simulation.setMemClass(args)
+
+    test_sys = build_test_system(args.num_cpus, args)
+    autoCalibrateParams(args, test_sys)
+
+    root = Root(full_system=True, system=test_sys)
+
+    Simulation.run_vanilla(args, root, test_sys, FutureClass)

--- a/util/xs_scripts/automated_parameter_calibration/args_template.py
+++ b/util/xs_scripts/automated_parameter_calibration/args_template.py
@@ -1,0 +1,115 @@
+# args_template.py
+from __future__ import annotations
+from typing import Dict, Any, List, Optional
+import shlex
+
+class CliffArgsTemplate:
+    """
+    A reusable template for simulator CLI arguments.
+    - Only supports inline brace placeholders now, e.g. '--arch-xlen={XLEN}'
+      which will be replaced by params['XLEN'].
+    """
+
+    # Optional program (first token). If None, you can prepend externally.
+    program: Optional[str] = None
+
+    # Base argument tokens. Keep them as a flat list.
+    base_arguments: List[str] = [
+        #"configs/example/cliff.py",
+        #"--no-l3cache",
+        #"--arch-xlen={XLEN}",   # inline placeholder
+        "cpu.decodeWidth={DecodeWidth}\n",   # inline placeholder
+        "cpu.renameWidth={RenameWidth}\n",
+        "cpu.commitWidth={CommitWidth}\n",
+        "cpu.LQEntries={VirtualLoadQueueSize}\n",
+        "cpu.SQEntries={StoreQueueSize}\n",
+        # more options...
+    ]
+
+    def __init__(
+        self,
+        program: Optional[str] = None,
+        base_arguments: Optional[List[str]] = None,
+    ) -> None:
+        if program is not None:
+            self.program = program
+        if base_arguments is not None:
+            self.base_arguments = list(base_arguments)
+
+    @staticmethod
+    def _format_inline_placeholders(token: str, params: Dict[str, Any]) -> str:
+        """Replace {KEY} with params[KEY] (as str)."""
+        out = token
+        for k, v in params.items():
+            placeholder = "{" + str(k) + "}"
+            if placeholder in out:
+                out = out.replace(placeholder, str(v))
+        return out
+
+    def render(
+        self,
+        params: Dict[str, Any],
+        extra_overrides: Optional[Dict[str, Any]] = None,
+        prepend_program: Optional[str] = None,
+    ) -> List[str]:
+        """
+        Render final CLI list.
+        - params: parameters dict, e.g. {"XLEN": 64, "VLEN": 128, ...}
+        - extra_overrides: ad-hoc runtime overrides applied on top of 'params'
+        - prepend_program: if provided, put it as the first token
+        """
+        effective_params = dict(params)
+        if extra_overrides:
+            effective_params.update(extra_overrides)
+
+        final_args: List[str] = []
+        if prepend_program:
+            final_args.append(prepend_program)
+        elif self.program:
+            final_args.append(self.program)
+
+        for tok in self.base_arguments:
+            t = self._format_inline_placeholders(tok, effective_params)
+            final_args.append(t)
+
+        return final_args
+
+    @staticmethod
+    def join_cli(tokens: List[str]) -> str:
+        """Safe shell-quoted command line string."""
+        return " ".join(shlex.quote(x) for x in tokens)
+
+
+# ---- minimal-change helper for existing scripts ----
+def get_base_arguments(
+    params: Optional[Dict[str, Any]] = None,
+    program: Optional[str] = None,
+    extra_overrides: Optional[Dict[str, Any]] = None,
+    as_string: bool = False,
+) -> List[str] | str:
+    """
+    Minimal-change accessor for existing scripts.
+
+    - If params is None: return the raw template list (placeholders intact).
+    - If params is provided: return the rendered list with placeholders resolved.
+    - program: prepend a program/binary (e.g., 'python' or your simulator).
+    - extra_overrides: ad-hoc updates applied on top of 'params'.
+    - as_string: when True, return a shell-quoted command line string.
+    """
+    tmpl = CliffArgsTemplate()
+    if params is None:
+        argv = []
+        if program:
+            argv.append(program)
+        argv.extend(tmpl.base_arguments)
+    else:
+        argv = tmpl.render(
+            params=params,
+            extra_overrides=extra_overrides,
+            prepend_program=program,
+        )
+
+    if as_string:
+        return CliffArgsTemplate.join_cli(argv)
+    return argv
+

--- a/util/xs_scripts/automated_parameter_calibration/get_automated_parameter_calibration.py
+++ b/util/xs_scripts/automated_parameter_calibration/get_automated_parameter_calibration.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import json
+import csv
+import argparse
+from typing import Any, Dict, Optional, List
+
+# Target case class name
+CASE_CLASS_NAME = r"XSCoreParameters"
+
+# Parameters to extract: key -> type ("int" or "bool")
+TARGET_KEYS: Dict[str, str] = {
+    "XLEN": "int",
+    "VLEN": "int",
+    "HartId": "int",
+    "HasPrefetch": "bool",
+    "DecodeWidth": "int",
+    "RenameWidth": "int",
+    "CommitWidth": "int",
+    "VirtualLoadQueueSize": "int",
+    "StoreQueueSize": "int",
+}
+
+def strip_comments(code: str) -> str:
+    """Remove /* ... */ block comments and // line comments."""
+    code = re.sub(r"/\*.*?\*/", "", code, flags=re.S)
+    code = re.sub(r"//.*?$", "", code, flags=re.M)
+    return code
+
+def find_params_block(code: str) -> Optional[str]:
+    """Locate the parameter block inside case class XSCoreParameters(...)."""
+    m = re.search(rf"case\s+class\s+{CASE_CLASS_NAME}\s*\(", code)
+    if not m:
+        return None
+    i = m.end()
+    depth = 1
+    while i < len(code) and depth > 0:
+        c = code[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return code[m.end(): i-1]  # exclude the final ')'
+
+def normalize_value(raw: str) -> str:
+    """Trim whitespace, remove trailing commas, and strip outer parentheses."""
+    v = raw.strip()
+    if v.endswith(","):
+        v = v[:-1].rstrip()
+    while v.startswith("(") and v.endswith(")"):
+        v = v[1:-1].strip()
+    return v
+
+def parse_scalar(value: str, expected_type: str) -> Optional[Any]:
+    """Convert the raw string value to the expected type (int or bool)."""
+    v = value.strip()
+    if expected_type == "bool":
+        if re.fullmatch(r"true", v, flags=re.I):
+            return True
+        if re.fullmatch(r"false", v, flags=re.I):
+            return False
+        return None
+    if expected_type == "int":
+        m = re.fullmatch(r"(0x[0-9a-fA-F]+|\d+)", v)
+        if m:
+            try:
+                return int(m.group(1), 0)
+            except ValueError:
+                return None
+        return None
+    return None
+
+def extract_values(params_block: str, targets: Dict[str, str]) -> Dict[str, Optional[Any]]:
+    """Extract default values of the target keys from the parameter block."""
+    results: Dict[str, Optional[Any]] = {k: None for k in targets}
+    for key, expected_type in targets.items():
+        pat = rf"""\b{key}\b\s*(?::\s*[\w\[\]]+)?\s*=\s*(.+?)(?=,\s*[\w]|,\s*$|\n|$|\))"""
+        m = re.search(pat, params_block, flags=re.S)
+        if m:
+            raw = normalize_value(m.group(1))
+            results[key] = parse_scalar(raw, expected_type)
+    return results
+
+def process_file(path: str) -> Optional[Dict[str, Optional[Any]]]:
+    """Read a Parameters.scala file and extract the target parameters."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            code = f.read()
+    except Exception:
+        return None
+    code_nc = strip_comments(code)
+    params_block = find_params_block(code_nc)
+    if not params_block:
+        return None
+    return extract_values(params_block, TARGET_KEYS)
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Extract XSCoreParameters from Parameters.scala")
+    p.add_argument("directory", help="Root dir to search")
+    p.add_argument("--format", "-f", choices=["json", "csv", "text"], default="json",
+                   help="Output format (default: json)")
+    p.add_argument("--output", "-o", help="Write to file instead of stdout")
+    return p.parse_args()
+
+def ensure_parent(path: Optional[str]) -> None:
+    if not path:
+        return
+    d = os.path.dirname(path)
+    if d:
+        os.makedirs(d, exist_ok=True)
+
+def main():
+    args = parse_args()
+    base = args.directory
+    fmt = args.format
+    out_path = args.output
+
+    results: List[Dict[str, Any]] = []
+    for root, _, files in os.walk(base):
+        for fn in files:
+            if fn == "Parameters.scala":
+                fp = os.path.join(root, fn)
+                vals = process_file(fp)
+                if vals is None:
+                    continue
+                entry = {"file": fp}
+                entry.update(vals)
+                results.append(entry)
+
+    # No results -> stderr + non-zero, do NOT emit fake JSON
+    if not results:
+        print(f"No Parameters.scala with XSCoreParameters(...) found under: {base}", file=sys.stderr)
+        sys.exit(2)
+
+    if fmt == "json":
+        payload = json.dumps(results, indent=2, ensure_ascii=False)
+        if out_path:
+            ensure_parent(out_path)
+            with open(out_path, "w", encoding="utf-8") as f:
+                f.write(payload + "\n")
+        else:
+            print(payload)
+    elif fmt == "csv":
+        fieldnames = ["file"] + list(TARGET_KEYS.keys())
+        if out_path:
+            ensure_parent(out_path)
+            with open(out_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                for row in results:
+                    writer.writerow(row)
+        else:
+            writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in results:
+                writer.writerow(row)
+    else:  # text
+        lines = []
+        for r in results:
+            kv = " ".join(f"{k}={r.get(k)}" for k in TARGET_KEYS)
+            lines.append(f"{r['file']}: {kv}")
+        if out_path:
+            ensure_parent(out_path)
+            with open(out_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        else:
+            print("\n".join(lines))
+
+if __name__ == "__main__":
+    main()

--- a/util/xs_scripts/automated_parameter_calibration/print_args.py
+++ b/util/xs_scripts/automated_parameter_calibration/print_args.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+import argparse, json, os, sys, re
+from args_template import CliffArgsTemplate
+
+def load_json(path: str):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except FileNotFoundError:
+        sys.exit(f"[Error] JSON file not found: {path}")
+    if not raw.strip():
+        sys.exit("[Error] JSON file is empty.")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"[Error] Invalid JSON: {e}", file=sys.stderr)
+        print(f"[Hint] First 200 chars: {raw[:200]!r}", file=sys.stderr)
+        sys.exit(3)
+    if not isinstance(data, list) or not data:
+        sys.exit("[Error] JSON must be a non-empty list.")
+    return data
+
+def pick_record(records, file_exact=None):
+    if file_exact is None:
+        return records[0]
+    for r in records:
+        if str(r.get("file")) == file_exact:
+            return r
+    sys.exit(f"[Error] file='{file_exact}' not found in JSON.")
+
+def main():
+    ap = argparse.ArgumentParser(description="Replace function body in existing .py file from JSON.")
+    ap.add_argument("--params-json", required=True)
+    ap.add_argument("--file", default=None)
+    ap.add_argument("--out-py", required=True, help="Existing .py file path to modify")
+    ap.add_argument("--function-name", default="autoCalibrateParams")
+    args = ap.parse_args()
+
+    # 1. Load JSON and pick the desired record
+    records = load_json(args.params_json)
+    rec = pick_record(records, args.file)
+    params = {k: v for k, v in rec.items() if k != "file"}
+
+    # 2. Render the function body from the templat
+    tmpl = CliffArgsTemplate()
+    lines = tmpl.render(params=params)
+    new_func_lines = []
+    new_func_lines.append(f"def {args.function_name}(args, system):\n")
+    new_func_lines.append("    for cpu in system.cpu:\n")
+    for line in lines:
+        code_line = line.strip()
+        new_func_lines.append(f"        {code_line}\n")
+    new_func_code = "".join(new_func_lines)
+
+    # 3. Read the existing Python file
+    if not os.path.exists(args.out_py):
+        sys.exit(f"[Error] File not found: {args.out_py}")
+    with open(args.out_py, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # 4. Use regex to replace the existing function definition and body
+    #    - Match from 'def <function_name>(' to the next non-indented line or end of file
+    pattern = rf"(^def\s+{re.escape(args.function_name)}\(.*?\):\n)(?:[ \t].*\n)*"
+    if re.search(pattern, content, flags=re.MULTILINE):
+        # Function found → replace it entirely
+        content = re.sub(pattern, new_func_code + "\n", content, flags=re.MULTILINE)
+        print(f"[OK] Replaced function '{args.function_name}' in {args.out_py}")
+    else:
+        # Function not found → append to the end of the file
+        content += "\n\n" + new_func_code + "\n"
+        print(f"[OK] Appended new function '{args.function_name}' to {args.out_py}")
+
+    # 5. Write back the modified file
+    with open(args.out_py, "w", encoding="utf-8") as f:
+        f.write(content)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
get_auto*.py is responsible for writing the relevant parameters into a JSON file. 
args_template.py defines the mapping between RTL and XS-GEM5 parameters. 
print_args.py outputs a Python script that writes the XS-GEM5 and RTL parameters directly in Python. 
The overall framework has been completed;
details remain to be debugged.

The corresponding commands are as follows:
python3 get_automated_parameter_calibration.py /nfs-nvme/home/zhenhao/xiangshan-kmh-0107-noddrl3/src/main/scala/xiangshan --format json -o params1.json

python3 print_args.py --params-json params1.json --out-py /nfs-nvme/home/zhenhao/xs-gem5-cliff-0318/configs/example/auto_xiangshan.py

Change-Id: I5a489a41a81abf4fec44afdc62d9da1a43eba72a

configs: add auto_xiangshan.py

Change-Id: Ie043f5e51119c3b313d3f679b6ddd1fff233b225