### PR TITLE
util: add gem5 Ideal BTB noSC Test workflow

### DIFF
--- a/.github/workflows/gem5-ideal-btb-perf-nosc.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-nosc.yml
@@ -1,0 +1,20 @@
+name: gem5 Ideal BTB Performance Test (no SC)
+
+on:
+  push:
+    branches: [ xs-dev, '*-perf' ]  # xs-dev for normal CI, *-perf for BTB-only performance testing
+  pull_request:
+    branches: [ xs-dev ]
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Branch to test (leave empty for current branch)'
+        required: false
+        type: string
+
+jobs:
+  perf_test:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      script_path: ../kmh_v3_btb_nosc.sh
+      benchmark_type: "spec06-0.8c"

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -273,6 +273,8 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         "available subdatabase: basic, tage, ras, loop")
     parser.add_argument("--disable-sc", default=False, action="store_true",
                         help="disable SC (enabled by default, only for FTBTAGE)")
+    parser.add_argument("--disable-mgsc", default=False, action="store_true",
+                        help="disable MGSC (only for BTBTAGE)")
     parser.add_argument("--enable-loop-buffer", default=False, action="store_true",
                         help="enable loop buffer (only for ftb branch predictor)")
     parser.add_argument("--enable-loop-predictor", default=False, action="store_true",

--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -391,6 +391,7 @@ def setKmhV3IdealParams(args, system):
                 # TODO: BTB TAGE do not bave base table, do not support SC
                 cpu.branchPred.tage.tableSizes = [2048] * 8  # 2 way, 2048 sets
                 cpu.branchPred.tage.numWays = 2
+                cpu.branchPred.mgsc.enableMGSC = not args.disable_mgsc
 
             cpu.branchPred.tage.enableSC = False # TODO(bug): When numBr changes, enabling SC will trigger an assert
             cpu.branchPred.ftq_size = 256

--- a/util/xs_scripts/kmh_v3_btb_nosc.sh
+++ b/util/xs_scripts/kmh_v3_btb_nosc.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
+source $script_dir/common.sh
+
+for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
+    checkForVariable $var
+done
+
+$gem5 $gem5_home/configs/example/xiangshan.py --generic-rv-cpt=$1 --bp-type=DecoupledBPUWithBTB --ideal-kmhv3 --disable-mgsc


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for gem5 Ideal BTB performance testing without SC.
- Added a command-line option to disable MGSC in Options.py for BTBTAGE.
- Updated the xiangshan.py configuration to set the branch predictor type to DecoupledBPUWithBTB and handle MGSC enabling based on the new option.
- Created a new script for running the performance test.

This enhances the testing framework for TAGE and provides more flexibility in configuration.

Change-Id: I78b1f7a86a6d90ea661068f6b1cbe21f0ca5640d