### PR TITLE
cpu-o3: fix warmup dump when fusion

### DIFF
--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1377,11 +1377,14 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
             cpi_r.roll(1);
         }
 
-        if (this->nextDumpInstCount
-                && totalInsts() == this->nextDumpInstCount) {
+        uint64_t committedInsts = totalInsts();
+
+        if (this->nextDumpInstCount && !dump_done
+                && committedInsts >= this->nextDumpInstCount) {
             fprintf(stderr, "Will trigger stat dump and reset\n");
             statistics::schedStatEvent(true, true, curTick(), 0);
             scheduleInstStop(tid,0,"Will trigger stat dump and reset");
+            dump_done = true;
 
             /*if (this->repeatDumpInstCount) {
                 this->nextDumpInstCount += this->repeatDumpInstCount;
@@ -1391,10 +1394,11 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
         // Check for instruction-count-based events.
         thread[tid]->comInstEventQueue.serviceEvents(thread[tid]->numInst);
 
-        if (this->warmupInstCount && totalInsts() == this->warmupInstCount) {
+        if (this->warmupInstCount && !warmup_done && committedInsts >= this->warmupInstCount) {
             fprintf(stderr, "Will trigger stat dump and reset\n");
             statistics::schedStatEvent(true, true, curTick(), 0);
             scheduleInstStop(tid,0,"Will trigger stat dump and reset");
+            warmup_done = true;
         }
     }
 

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -130,6 +130,10 @@ class CPU : public BaseCPU
 
   private:
 
+    bool dump_done = false;
+    bool warmup_done = false;
+
+
     /** The tick event used for scheduling CPU ticks. */
     EventFunctionWrapper tickEvent;
 


### PR DESCRIPTION
Change-Id: I1dc6d6e1d967bcdad181018fb6b1ad3282074bc8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed instruction-count-based event triggering to fire only once per simulation run, preventing unintended repeated triggers and ensuring consistent event behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->