### PR TITLE
cpu-o3: Match on taken pc/target; drop uBTB dummy and numNTConds

### DIFF
--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -116,16 +116,6 @@ UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPred
     }
 
     if (entry.valid) {
-        // push back dummy conditional branches before the taken branch, to create the correct speculative history
-        // information, these dummy entries are not taken, thanks to them not being in stagePreds.condTakens.
-        for (int i = 0; i < entry.numNTConds; i++) {
-            auto dummy = BTBEntry();
-            dummy.valid = true;
-            dummy.isCond = true;
-            dummy.pc = 0xdeadbeef;  // a magic number to indicate a dummy entry
-            FillStageLoop(s) stagePreds[s].btbEntries.push_back(dummy);
-        }
-
         FillStageLoop(s) stagePreds[s].btbEntries.push_back(BTBEntry(entry));
         if (entry.isCond) {
             // the always taken field of BTBEntry is ignored in uBTB
@@ -199,14 +189,6 @@ UBTB::replaceOldEntry(UBTBIter oldEntryIter, FullBTBPrediction &newPrediction)
     newEntry.target = newPrediction.getTarget(predictWidth);
     // important: update tag (mbtb and ubtb have different tags, even diffferent tag length)
     newEntry.tag = getTag(newPrediction.bbStart);
-    /*  save the number of conditional branches before the taken branch
-     *  this is useful in the prediction phase: to generate the correct speculative history information
-     */
-    newEntry.numNTConds = newPrediction.getHistInfo().first;
-    if (newPrediction.getTakenEntry().isCond) {
-        newEntry.numNTConds--;
-        assert(newEntry.numNTConds >= 0);
-    }
     *oldEntryIter = newEntry;
 }
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -88,15 +88,13 @@ class UBTB : public TimedBaseBTBPredictor
      * - uctr: 2-bit saturation counter used in replacement policy
      * - tag: tag bits from branch address [23:1]
      * - tick: timestamp used for MRU (Most Recently Used) replacement policy
-     * - numNTConds: number of not-taken conditional branches before the taken branch
      */
     typedef struct TickedUBTBEntry : public BTBEntry
     {
         unsigned uctr; //2-bit saturation counter used in replacement policy
         uint64_t tick;  // timestamp for MRU replacement
-        int  numNTConds; // number of conditional branches before the taken branch
-        TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0), numNTConds(0) {}
-        TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick), numNTConds(0) {}
+        TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0) {}
+        TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick) {}
     }TickedUBTBEntry;
 
     using UBTBIter = typename std::vector<TickedUBTBEntry>::iterator;

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -545,13 +545,6 @@ struct FullBTBPrediction
                 else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
                     return std::make_pair(false, OverrideReason::TARGET);
                 }
-                else if (this->getEnd(predictWidth) != other.getEnd(predictWidth)) {
-                    // execution will never come here
-                    return std::make_pair(false, OverrideReason::END);
-                }
-                else if (this->getHistInfo() != other.getHistInfo()) {
-                    return std::make_pair(false, OverrideReason::HIST_INFO);
-                }
                 else {
                     return std::make_pair(true, btb_pred::OverrideReason::NO_OVERRIDE);
                 }


### PR DESCRIPTION
Rationale:
- Align stage matching with control-flow equivalence: if both predict taken at the same control PC and to the same target, treat them as equal.
- finalPred drives all history updates (GHR/PHR/Bw/Local), so early-stage shamt alignment is unnecessary for match.
- Remove the uBTB dummy mechanism and the numNTConds field used to emulate not-taken conditionals.

Changes:
- FullBTBPrediction::match: remove END and HIST_INFO comparisons; keep only taken/not-taken, controlAddr, and target checks.
- uBTB: remove insertion of dummy conditional entries and the numNTConds field/storage.
- Clean out dead code related to dummy handling.

Impact:
- Reduces overrides caused by history-length mismatches while preserving redirect equivalence.
- Unblocks placing TAGE at S0 to correct uBTB/ABTB direction without dummy artifacts.
- Avoids potential assertions or mis-indexing caused by out-of-block dummy entries.

Change-Id: I0bd7cece129aff436dea5537369663336e8ca72f