### PR TITLE
mem: fix functional access in L2CacheWrapper

### DIFF
--- a/src/mem/cache/xs_l2/CacheWrapper.cc
+++ b/src/mem/cache/xs_l2/CacheWrapper.cc
@@ -116,6 +116,20 @@ CacheWrapper::innerCpuPortRecvTimingSnoopReq(PacketPtr pkt)
 }
 
 void
+CacheWrapper::innerCpuPortRecvFunctionalSnoop(PacketPtr pkt)
+{
+    DPRINTF(CacheWrapper, "Got functional snoop from inner cache for addr: %#x\n", pkt->getAddr());
+    cpu_side_port.sendFunctionalSnoop(pkt);
+}
+
+Tick
+CacheWrapper::innerCpuPortRecvAtomicSnoop(PacketPtr pkt)
+{
+    DPRINTF(CacheWrapper, "Got atomic snoop from inner cache for addr: %#x\n", pkt->getAddr());
+    return cpu_side_port.sendAtomicSnoop(pkt);
+}
+
+void
 CacheWrapper::innerCpuPortRecvRangeChange()
 {
     DPRINTF(CacheWrapper, "Got range change from inner cache\n");
@@ -211,6 +225,20 @@ CacheWrapper::memSidePortRecvRangeChange()
 {
     DPRINTF(CacheWrapper, "Got range change from memory side\n");
     inner_mem_port.sendRangeChange();
+}
+
+void
+CacheWrapper::memSidePortRecvFunctionalSnoop(PacketPtr pkt)
+{
+    DPRINTF(CacheWrapper, "Got functional snoop from memory side for addr: %#x\n", pkt->getAddr());
+    inner_mem_port.sendFunctionalSnoop(pkt);
+}
+
+Tick
+CacheWrapper::memSidePortRecvAtomicSnoop(PacketPtr pkt)
+{
+    DPRINTF(CacheWrapper, "Got atomic snoop from memory side for addr: %#x\n", pkt->getAddr());
+    return inner_mem_port.sendAtomicSnoop(pkt);
 }
 
 } // namespace gem5

--- a/src/mem/cache/xs_l2/CacheWrapper.hh
+++ b/src/mem/cache/xs_l2/CacheWrapper.hh
@@ -56,6 +56,12 @@ class CacheWrapper : public ClockedObject
         void recvTimingSnoopReq(PacketPtr pkt) override {
           return owner->memSidePortRecvTimingSnoopReq(pkt);
         }
+        void recvFunctionalSnoop(PacketPtr pkt) override {
+          return owner->memSidePortRecvFunctionalSnoop(pkt);
+        }
+        Tick recvAtomicSnoop(PacketPtr pkt) override {
+          return owner->memSidePortRecvAtomicSnoop(pkt);
+        }
         void recvRangeChange() override {
           return owner->memSidePortRecvRangeChange();
         }
@@ -79,6 +85,12 @@ class CacheWrapper : public ClockedObject
         }
         void recvTimingSnoopReq(PacketPtr pkt) override {
           return owner->innerCpuPortRecvTimingSnoopReq(pkt);
+        }
+        void recvFunctionalSnoop(PacketPtr pkt) override {
+          return owner->innerCpuPortRecvFunctionalSnoop(pkt);
+        }
+        Tick recvAtomicSnoop(PacketPtr pkt) override {
+          return owner->innerCpuPortRecvAtomicSnoop(pkt);
         }
         void recvRangeChange() override {
           return owner->innerCpuPortRecvRangeChange();
@@ -138,12 +150,16 @@ class CacheWrapper : public ClockedObject
     virtual bool memSidePortRecvTimingResp(PacketPtr pkt);
     virtual void memSidePortRecvReqRetry();
     virtual void memSidePortRecvTimingSnoopReq(PacketPtr pkt);
+    virtual void memSidePortRecvFunctionalSnoop(PacketPtr pkt);
+    virtual Tick memSidePortRecvAtomicSnoop(PacketPtr pkt);
     virtual void memSidePortRecvRangeChange();
 
     // Inner CPU side port methods
     virtual bool innerCpuPortRecvTimingResp(PacketPtr pkt);
     virtual void innerCpuPortRecvReqRetry();
     virtual void innerCpuPortRecvTimingSnoopReq(PacketPtr pkt);
+    virtual void innerCpuPortRecvFunctionalSnoop(PacketPtr pkt);
+    virtual Tick innerCpuPortRecvAtomicSnoop(PacketPtr pkt);
     virtual void innerCpuPortRecvRangeChange();
 
     // Inner Mem side port methods

--- a/src/mem/cache/xs_l2/L2CacheWrapper.cc
+++ b/src/mem/cache/xs_l2/L2CacheWrapper.cc
@@ -185,6 +185,22 @@ L2CacheWrapper::SliceCPUSidePort::recvTimingSnoopReq(PacketPtr pkt)
     owner.cpu_side_port.sendTimingSnoopReq(pkt);
 }
 
+void
+L2CacheWrapper::SliceCPUSidePort::recvFunctionalSnoop(PacketPtr pkt)
+{
+    DPRINTF(L2CacheWrapper, "Got functional snoop req for addr %#x from slice %d,"
+                            " forwarding to CPU\n", pkt->getAddr(), id);
+    owner.cpu_side_port.sendFunctionalSnoop(pkt);
+}
+
+Tick
+L2CacheWrapper::SliceCPUSidePort::recvAtomicSnoop(PacketPtr pkt)
+{
+    DPRINTF(L2CacheWrapper, "Got atomic snoop req for addr %#x from slice %d,"
+                            " forwarding to CPU\n", pkt->getAddr(), id);
+    return owner.cpu_side_port.sendAtomicSnoop(pkt);
+}
+
 bool
 L2CacheWrapper::SliceCPUSidePort::recvTimingResp(PacketPtr pkt)
 {

--- a/src/mem/cache/xs_l2/L2CacheWrapper.hh
+++ b/src/mem/cache/xs_l2/L2CacheWrapper.hh
@@ -130,6 +130,8 @@ class L2CacheWrapper : public ClockedObject
         void recvReqRetry() override;
         void recvRangeChange() override;
         void recvTimingSnoopReq(PacketPtr pkt) override;
+        void recvFunctionalSnoop(PacketPtr pkt) override;
+        Tick recvAtomicSnoop(PacketPtr pkt) override;
         bool isSnooping() const override { return true;}
     };
 


### PR DESCRIPTION
Add function/atomic port in L2CacheWrapper to handle functional accesses.

Change-Id: I7d66a4b30034aedeb2b8a006f12ac39cb55e37fb