### PR TITLE
cpu-o3: pred MGSC remove tag cmp and reduce storage

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1106,9 +1106,9 @@ class BTBMGSC(TimedBaseBTBPredictor):
     gWeightInitValue = Param.Int(7,
         "Initial value of the weights of the global history GEHL entries")
 
-    pTableNum = Param.Unsigned(2, "Num global branch path history tables")
-    pHistLen = VectorParam.Int([8, 16], "Global branch path history lengths")
-    pTableIdxWidth = Param.Unsigned(11,
+    pTableNum = Param.Unsigned(4, "Num global branch path history tables")
+    pHistLen = VectorParam.Int([4, 10, 22, 46], "Global branch path history lengths")
+    pTableIdxWidth = Param.Unsigned(10,
                     "Log number of global branch path history entries")
     pWeightInitValue = Param.Int(7,
         "Initial value of the weights of the path history GEHL entries")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1136,6 +1136,9 @@ class BTBMGSC(TimedBaseBTBPredictor):
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")
 
+    # How many counters readed per prediction (usually per cycle)
+    numCtrsPerLine = Param.Unsigned(8, "Counters per SRAM line")
+
     numDelay = 2
 
 class DecoupledBPUWithBTB(BranchPredictor):

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1119,10 +1119,10 @@ class BTBMGSC(TimedBaseBTBPredictor):
     thresholdTablelogSize = Param.Unsigned(6,
         "Log size of update threshold counters tables")
 
-    updateThresholdWidth = Param.Unsigned(15,
+    updateThresholdWidth = Param.Unsigned(12,
         "Number of bits for the update threshold counter")
 
-    pUpdateThresholdWidth = Param.Unsigned(13,
+    pUpdateThresholdWidth = Param.Unsigned(8,
         "Number of bits for the pUpdate threshold counters")
 
     extraWeightsWidth = Param.Unsigned(6,

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1108,7 +1108,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
 
     pTableNum = Param.Unsigned(4, "Num global branch path history tables")
     pHistLen = VectorParam.Int([4, 10, 22, 46], "Global branch path history lengths")
-    pTableIdxWidth = Param.Unsigned(10,
+    pTableIdxWidth = Param.Unsigned(11,
                     "Log number of global branch path history entries")
     pWeightInitValue = Param.Int(7,
         "Initial value of the weights of the path history GEHL entries")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1136,7 +1136,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")
 
-    numDelay = 3
+    numDelay = 2
 
 class DecoupledBPUWithBTB(BranchPredictor):
     type = 'DecoupledBPUWithBTB'

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1122,7 +1122,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     updateThresholdWidth = Param.Unsigned(15,
         "Number of bits for the update threshold counter")
 
-    pUpdateThresholdWidth = Param.Unsigned(8,
+    pUpdateThresholdWidth = Param.Unsigned(13,
         "Number of bits for the pUpdate threshold counters")
 
     extraWeightsWidth = Param.Unsigned(6,

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1082,8 +1082,6 @@ class BTBMGSC(TimedBaseBTBPredictor):
     bwHistLen = VectorParam.Int([4, 8], "Global backward branch GEHL history lengths")
     bwTableIdxWidth = Param.Unsigned(11,
             "Log num of global backward branch GEHL entries")
-    bwWeightInitValue = Param.Int(7,
-     "Initial value of the weights of the global backward branch GEHL entries") # not used
 
     numEntriesFirstLocalHistories = Param.Unsigned(32,
         "Number of entries for first local histories")
@@ -1091,27 +1089,19 @@ class BTBMGSC(TimedBaseBTBPredictor):
     lHistLen = VectorParam.Int([4, 8], "First local history GEHL history lengths")
     lTableIdxWidth = Param.Unsigned(11,
             "Log number of first local history GEHL entries")
-    lWeightInitValue = Param.Int(7,
-        "Initial value of the weights of the first local history GEHL entries")
 
     iTableNum = Param.Unsigned(1, "Num IMLI GEHL tables")
     iHistLen = VectorParam.Int([8], "IMLI history GEHL history lengths")
     iTableIdxWidth = Param.Unsigned(12, "Log number of IMLI GEHL entries")
-    iWeightInitValue = Param.Int(7,
-        "Initial value of the weights of the IMLI history GEHL entries")
 
     gTableNum = Param.Unsigned(2, "Num global branch GEHL tables")
     gHistLen = VectorParam.Int([8, 16], "Global branch GEHL history lengths")
     gTableIdxWidth = Param.Unsigned(11, "Log number of global branch GEHL entries")
-    gWeightInitValue = Param.Int(7,
-        "Initial value of the weights of the global history GEHL entries")
 
     pTableNum = Param.Unsigned(4, "Num global branch path history tables")
     pHistLen = VectorParam.Int([4, 10, 22, 46], "Global branch path history lengths")
     pTableIdxWidth = Param.Unsigned(11,
                     "Log number of global branch path history entries")
-    pWeightInitValue = Param.Int(7,
-        "Initial value of the weights of the path history GEHL entries")
 
     biasTableNum = Param.Unsigned(1, "Num bias tables")
     biasTableIdxWidth = Param.Unsigned(11, "Log number of bias entries")
@@ -1129,9 +1119,6 @@ class BTBMGSC(TimedBaseBTBPredictor):
         "Number of bits for the extra weights")
 
     scCountersWidth = Param.Unsigned(8, "Statistical corrector counters width")
-
-    initialUpdateThresholdValue = Param.Int(0,
-        "Initial pUpdate threshold counter value")
 
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1098,8 +1098,8 @@ class BTBMGSC(TimedBaseBTBPredictor):
     gHistLen = VectorParam.Int([8, 16], "Global branch GEHL history lengths")
     gTableIdxWidth = Param.Unsigned(11, "Log number of global branch GEHL entries")
 
-    pTableNum = Param.Unsigned(4, "Num global branch path history tables")
-    pHistLen = VectorParam.Int([4, 10, 22, 46], "Global branch path history lengths")
+    pTableNum = Param.Unsigned(2, "Num global branch path history tables")
+    pHistLen = VectorParam.Int([8, 16], "Global branch path history lengths")
     pTableIdxWidth = Param.Unsigned(11,
                     "Log number of global branch path history entries")
 
@@ -1118,7 +1118,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     extraWeightsWidth = Param.Unsigned(6,
         "Number of bits for the extra weights")
 
-    scCountersWidth = Param.Unsigned(8, "Statistical corrector counters width")
+    scCountersWidth = Param.Unsigned(6, "Statistical corrector counters width")
 
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1096,7 +1096,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
 
     iTableNum = Param.Unsigned(1, "Num IMLI GEHL tables")
     iHistLen = VectorParam.Int([8], "IMLI history GEHL history lengths")
-    iTableIdxWidth = Param.Unsigned(11, "Log number of IMLI GEHL entries")
+    iTableIdxWidth = Param.Unsigned(12, "Log number of IMLI GEHL entries")
     iWeightInitValue = Param.Int(7,
         "Initial value of the weights of the IMLI history GEHL entries")
 
@@ -1119,7 +1119,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     thresholdTablelogSize = Param.Unsigned(6,
         "Log size of update threshold counters tables")
 
-    updateThresholdWidth = Param.Unsigned(12,
+    updateThresholdWidth = Param.Unsigned(15,
         "Number of bits for the update threshold counter")
 
     pUpdateThresholdWidth = Param.Unsigned(8,
@@ -1135,8 +1135,6 @@ class BTBMGSC(TimedBaseBTBPredictor):
 
     weightTableIdxWidth = Param.Unsigned(5,
         "Log size of weight table")
-
-    numWays = Param.Unsigned(8, "Number of ways per set")
 
     numDelay = 3
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1128,7 +1128,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     extraWeightsWidth = Param.Unsigned(6,
         "Number of bits for the extra weights")
 
-    scCountersWidth = Param.Unsigned(6, "Statistical corrector counters width")
+    scCountersWidth = Param.Unsigned(8, "Statistical corrector counters width")
 
     initialUpdateThresholdValue = Param.Int(0,
         "Initial pUpdate threshold counter value")

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -243,28 +243,28 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     // Calculate indices for all tables
     for (unsigned int i = 0; i < bwTableNum; ++i) {
-        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth - log2i(numCtrsPerLine), indexBwFoldedHist[i].get());
+        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth, indexBwFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < lTableNum; ++i) {
-        lIndex[i] = getHistIndex(startPC, lTableIdxWidth - log2i(numCtrsPerLine),
+        lIndex[i] = getHistIndex(startPC, lTableIdxWidth,
                                  indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][i].get());
     }
 
     for (unsigned int i = 0; i < iTableNum; ++i) {
-        iIndex[i] = getHistIndex(startPC, iTableIdxWidth - log2i(numCtrsPerLine), indexIFoldedHist[i].get());
+        iIndex[i] = getHistIndex(startPC, iTableIdxWidth, indexIFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < gTableNum; ++i) {
-        gIndex[i] = getHistIndex(startPC, gTableIdxWidth - log2i(numCtrsPerLine), indexGFoldedHist[i].get());
+        gIndex[i] = getHistIndex(startPC, gTableIdxWidth, indexGFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < pTableNum; ++i) {
-        pIndex[i] = getHistIndex(startPC, pTableIdxWidth - log2i(numCtrsPerLine), indexPFoldedHist[i].get());
+        pIndex[i] = getHistIndex(startPC, pTableIdxWidth, indexPFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
-        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - log2i(numCtrsPerLine), tage_info.tage_pred_taken,
+        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth, tage_info.tage_pred_taken,
                                     tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
     }
 

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <ctime>
+#include <type_traits>
 
 #include "base/debug_helper.hh"
 #include "base/intmath.hh"
@@ -164,9 +165,6 @@ BTBMGSC::BTBMGSC(const Params &p)
     }
 
     pUpdateThreshold.resize(std::pow(2, thresholdTablelogSize));
-    for (unsigned int j = 0; j < (std::pow(2, thresholdTablelogSize)); ++j) {
-        pUpdateThreshold[j].resize(numCtrsPerLine);
-    }
 
     updateThreshold = 35;
 }
@@ -250,11 +248,11 @@ BTBMGSC::calculateScaledPercsum(int weight, int percsum)
  * @return Found threshold or default value if not found
  */
 int
-BTBMGSC::findThreshold(const std::vector<std::vector<int16_t>> &thresholdTable, Addr tableIndex, Addr pc,
-                       int defaultValue)
+BTBMGSC::findThreshold(const std::vector<uint16_t> &thresholdTable, Addr pc)
 {
-    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
-    auto &entry = thresholdTable[tableIndex][pos];
+    auto mask = (1 << thresholdTablelogSize) - 1;
+    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto &entry = thresholdTable[pcHash];
     return entry;
 }
 
@@ -330,11 +328,10 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     int total_sum = bw_percsum + l_percsum + i_percsum + g_percsum + p_percsum + bias_percsum;
 
     // Find thresholds
-    // pc-indexed threshold table, default value = initialUpdateThresholdValue = 0
-    // int p_update_thres = findThreshold(pUpdateThreshold, getPcIndex(startPC, thresholdTablelogSize), btb_entry.pc,
-    //                                    initialUpdateThresholdValue);
+    // pc-indexed threshold table
+    int p_update_thres = findThreshold(pUpdateThreshold, btb_entry.pc);
 
-    int total_thres = updateThreshold;
+    int total_thres = (updateThreshold >> 3) + p_update_thres;
 
     bool use_sc_pred = true;
     if (tage_info.tage_pred_conf_high && abs(total_sum) < total_thres) {
@@ -534,10 +531,11 @@ BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<int16_t>> &weightT
  * @param update_direction Direction to update (true=increment, false=decrement)
  */
 void
-BTBMGSC::updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition, bool update_direction)
+BTBMGSC::updatePCThresholdTable(Addr pc, bool update_direction)
 {
-    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
-    auto &entry = pUpdateThreshold[tableIndex][pos];
+    auto mask = (1 << thresholdTablelogSize) - 1;
+    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto &entry = pUpdateThreshold[pcHash];
     updateCounter(update_direction, pUpdateThresholdWidth, entry);
 }
 
@@ -634,8 +632,7 @@ BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_tak
                                      (pred.bias_percsum >= 0) == actual_taken);
 
         // Update PC-indexed threshold table
-        // updatePCThresholdTable(getPcIndex(stream.startPC, thresholdTablelogSize), entry.pc,
-        //                        tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
+        updatePCThresholdTable(entry.pc, sc_pred_taken != actual_taken);
 
         // Update global threshold table
         updateGlobalThreshold(entry.pc, sc_pred_taken != actual_taken);
@@ -671,31 +668,49 @@ BTBMGSC::update(const FetchStream &stream)
     DPRINTF(MGSC, "end update\n");
 }
 
-// Update signed counter with saturation
+// Update counter with saturation (template for all integer types)
+template<typename T>
 void
-BTBMGSC::updateCounter(bool taken, unsigned width, short &counter)
+BTBMGSC::updateCounter(bool taken, unsigned width, T &counter)
 {
-    int max = (1 << (width - 1)) - 1;
-    int min = -(1 << (width - 1));
-    if (taken) {
-        satIncrement(max, counter);
+    static_assert(std::is_integral<T>::value, "Counter type must be integral");
+
+    if constexpr (std::is_signed<T>::value) {
+        T max = static_cast<T>((1LL << (width - 1)) - 1);
+        T min = static_cast<T>(-(1LL << (width - 1)));
+        if (taken) {
+            satIncrement(max, counter);
+        } else {
+            satDecrement(min, counter);
+        }
     } else {
-        satDecrement(min, counter);
+        T max = static_cast<T>((1LL << width) - 1);
+        T min = static_cast<T>(0);
+        if (taken) {
+            satIncrement(max, counter);
+        } else {
+            satDecrement(min, counter);
+        }
     }
 }
 
-// Update unsigned counter with saturation
-void
-BTBMGSC::updateCounter(bool taken, unsigned width, uint64_t &counter)
-{
-    int max = (1 << width) - 1;
-    int min = 0;
-    if (taken) {
-        satIncrement(max, counter);
-    } else {
-        satDecrement(min, counter);
-    }
-}
+// Explicit instantiations for commonly used types
+template void
+BTBMGSC::updateCounter<int8_t>(bool taken, unsigned width, int8_t &counter);
+template void
+BTBMGSC::updateCounter<int16_t>(bool taken, unsigned width, int16_t &counter);
+template void
+BTBMGSC::updateCounter<int32_t>(bool taken, unsigned width, int32_t &counter);
+template void
+BTBMGSC::updateCounter<int64_t>(bool taken, unsigned width, int64_t &counter);
+template void
+BTBMGSC::updateCounter<uint8_t>(bool taken, unsigned width, uint8_t &counter);
+template void
+BTBMGSC::updateCounter<uint16_t>(bool taken, unsigned width, uint16_t &counter);
+template void
+BTBMGSC::updateCounter<uint32_t>(bool taken, unsigned width, uint32_t &counter);
+template void
+BTBMGSC::updateCounter<uint64_t>(bool taken, unsigned width, uint64_t &counter);
 
 
 Addr
@@ -733,41 +748,63 @@ BTBMGSC::getPcIndex(Addr pc, unsigned tableIndexBits)
     return (pc >> floorLog2(blockSize)) & mask;
 }
 
+template<typename T>
 bool
-BTBMGSC::satIncrement(int max, short &counter)
+BTBMGSC::satIncrement(T max, T &counter)
 {
+    static_assert(std::is_integral<T>::value, "Counter type must be integral");
     if (counter < max) {
         ++counter;
     }
     return counter == max;
 }
 
-bool
-BTBMGSC::satIncrement(int max, uint64_t &counter)
-{
-    if (counter < max) {
-        ++counter;
-    }
-    return counter == max;
-}
+// Explicit instantiations for commonly used types
+template bool
+BTBMGSC::satIncrement<int8_t>(int8_t max, int8_t &counter);
+template bool
+BTBMGSC::satIncrement<int16_t>(int16_t max, int16_t &counter);
+template bool
+BTBMGSC::satIncrement<int32_t>(int32_t max, int32_t &counter);
+template bool
+BTBMGSC::satIncrement<int64_t>(int64_t max, int64_t &counter);
+template bool
+BTBMGSC::satIncrement<uint8_t>(uint8_t max, uint8_t &counter);
+template bool
+BTBMGSC::satIncrement<uint16_t>(uint16_t max, uint16_t &counter);
+template bool
+BTBMGSC::satIncrement<uint32_t>(uint32_t max, uint32_t &counter);
+template bool
+BTBMGSC::satIncrement<uint64_t>(uint64_t max, uint64_t &counter);
 
+template<typename T>
 bool
-BTBMGSC::satDecrement(int min, short &counter)
+BTBMGSC::satDecrement(T min, T &counter)
 {
+    static_assert(std::is_integral<T>::value, "Counter type must be integral");
     if (counter > min) {
         --counter;
     }
     return counter == min;
 }
 
-bool
-BTBMGSC::satDecrement(int min, uint64_t &counter)
-{
-    if (counter > min) {
-        --counter;
-    }
-    return counter == min;
-}
+// Explicit instantiations for commonly used types
+template bool
+BTBMGSC::satDecrement<int8_t>(int8_t min, int8_t &counter);
+template bool
+BTBMGSC::satDecrement<int16_t>(int16_t min, int16_t &counter);
+template bool
+BTBMGSC::satDecrement<int32_t>(int32_t min, int32_t &counter);
+template bool
+BTBMGSC::satDecrement<int64_t>(int64_t min, int64_t &counter);
+template bool
+BTBMGSC::satDecrement<uint8_t>(uint8_t min, uint8_t &counter);
+template bool
+BTBMGSC::satDecrement<uint16_t>(uint16_t min, uint16_t &counter);
+template bool
+BTBMGSC::satDecrement<uint32_t>(uint32_t min, uint32_t &counter);
+template bool
+BTBMGSC::satDecrement<uint64_t>(uint64_t min, uint64_t &counter);
 
 /**
  * @brief Updates branch history for speculative execution

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -135,35 +135,11 @@ BTBMGSC::BTBMGSC(const Params &p)
     biasIndex.resize(biasTableNum);
 
     bwWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        bwWeightTable[j].resize(numCtrsPerLine);
-    }
-
     lWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        lWeightTable[j].resize(numCtrsPerLine);
-    }
-
     iWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        iWeightTable[j].resize(numCtrsPerLine);
-    }
-
     gWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        gWeightTable[j].resize(numCtrsPerLine);
-    }
-
     pWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        pWeightTable[j].resize(numCtrsPerLine);
-    }
-
     biasWeightTable.resize(std::pow(2, weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        biasWeightTable[j].resize(numCtrsPerLine);
-    }
-
     pUpdateThreshold.resize(std::pow(2, thresholdTablelogSize));
 
     updateThreshold = 35 * 8;
@@ -218,16 +194,17 @@ BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &
  * @return Found weight or 0 if not found
  */
 int
-BTBMGSC::findWeight(const std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc)
+BTBMGSC::findWeight(const std::vector<int16_t> &weightTable, Addr pc)
 {
-    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
-    auto &entry = weightTable[tableIndex][pos];
+    auto mask = (1 << weightTableIdxWidth) - 1;
+    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto &entry = weightTable[pcHash];
     return entry;
 }
 
 /**
  * Calculate scaled percsum using weight
- * weight range is [-32, 31], return value range is [0, 2 * percsum]
+ * weight range is [-32, 31], return value range is percsum or 2x percsum
  * @param weight Weight value
  * @param percsum Original percsum value
  * @return Scaled percsum value
@@ -235,7 +212,7 @@ BTBMGSC::findWeight(const std::vector<std::vector<int16_t>> &weightTable, Addr t
 int
 BTBMGSC::calculateScaledPercsum(int weight, int percsum)
 {
-    return (double)((double)(weight + 32) / 32.0) * percsum;
+    return ((weight + 64) / 32) * percsum;
 }
 
 /**
@@ -312,19 +289,32 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     }
 
     int bw_percsum = calculatePercsum(bwTable, bwIndex, bwTableNum, btb_entry.pc);
+    int bw_weight = findWeight(bwWeightTable, btb_entry.pc);
+    int bw_scaled_percsum = calculateScaledPercsum(bw_weight, bw_percsum);
 
     int l_percsum = calculatePercsum(lTable, lIndex, lTableNum, btb_entry.pc);
+    int l_weight = findWeight(lWeightTable, btb_entry.pc);
+    int l_scaled_percsum = calculateScaledPercsum(l_weight, l_percsum);
 
     int i_percsum = calculatePercsum(iTable, iIndex, iTableNum, btb_entry.pc);
+    int i_weight = findWeight(iWeightTable, btb_entry.pc);
+    int i_scaled_percsum = calculateScaledPercsum(i_weight, i_percsum);
 
     int g_percsum = calculatePercsum(gTable, gIndex, gTableNum, btb_entry.pc);
+    int g_weight = findWeight(gWeightTable, btb_entry.pc);
+    int g_scaled_percsum = calculateScaledPercsum(g_weight, g_percsum);
 
     int p_percsum = calculatePercsum(pTable, pIndex, pTableNum, btb_entry.pc);
+    int p_weight = findWeight(pWeightTable, btb_entry.pc);
+    int p_scaled_percsum = calculateScaledPercsum(p_weight, p_percsum);
 
     int bias_percsum = calculatePercsum(biasTable, biasIndex, biasTableNum, btb_entry.pc);
+    int bias_weight = findWeight(biasWeightTable, btb_entry.pc);
+    int bias_scaled_percsum = calculateScaledPercsum(bias_weight, bias_percsum);
 
     // Calculate total sum of all weighted percsums
-    int total_sum = bw_percsum + l_percsum + i_percsum + g_percsum + p_percsum + bias_percsum;
+    int total_sum = bw_scaled_percsum + l_scaled_percsum + i_scaled_percsum + g_scaled_percsum + p_scaled_percsum +
+                    bias_scaled_percsum;
 
     // Find thresholds
     // pc-indexed threshold table
@@ -350,12 +340,12 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     bool taken = (enableMGSC && use_sc_pred) ? (total_sum >= 0) : tage_info.tage_pred_taken;
 
     // Calculate weight scale differences
-    bool bw_weight_scale_diff = false;
-    bool l_weight_scale_diff = false;
-    bool i_weight_scale_diff = false;
-    bool g_weight_scale_diff = false;
-    bool p_weight_scale_diff = false;
-    bool bias_weight_scale_diff = false;
+    bool bw_weight_scale_diff = calculateWeightScaleDiff(total_sum, bw_scaled_percsum, bw_percsum);
+    bool l_weight_scale_diff = calculateWeightScaleDiff(total_sum, l_scaled_percsum, l_percsum);
+    bool i_weight_scale_diff = calculateWeightScaleDiff(total_sum, i_scaled_percsum, i_percsum);
+    bool g_weight_scale_diff = calculateWeightScaleDiff(total_sum, g_scaled_percsum, g_percsum);
+    bool p_weight_scale_diff = calculateWeightScaleDiff(total_sum, p_scaled_percsum, p_percsum);
+    bool bias_weight_scale_diff = calculateWeightScaleDiff(total_sum, bias_scaled_percsum, bias_percsum);
 
     DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
 
@@ -508,11 +498,12 @@ BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>
  * @param percsum_matches_actual Whether the raw percsum correctly predicted the outcome
  */
 void
-BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc,
+BTBMGSC::updateAndAllocateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc,
                                       bool weight_scale_diff, bool percsum_matches_actual)
 {
-    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
-    auto &entry = weightTable[tableIndex][pos];
+    auto mask = (1 << weightTableIdxWidth) - 1;
+    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto &entry = weightTable[pcHash];
     // Only update if weight scale could affect prediction
     if (weight_scale_diff) {
         // Increase weight if percsum was correct, decrease if incorrect

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -70,8 +70,7 @@ BTBMGSC::BTBMGSC(const Params &p)
     assert(bwTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < bwTableNum; ++i) {
         bwTable[i].resize(bwTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexBwFoldedHist.push_back(
-            FoldedHist(bwHistLen[i], bwTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBALBW));
+        indexBwFoldedHist.push_back(FoldedHist(bwHistLen[i], bwTableIdxWidth, 16, HistoryType::GLOBALBW));
     }
     bwIndex.resize(bwTableNum);
 
@@ -82,8 +81,7 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < lTableNum; ++i) {
         lTable[i].resize(lTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
-            indexLFoldedHist[k].push_back(
-                FoldedHist(lHistLen[i], lTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::LOCAL));
+            indexLFoldedHist[k].push_back(FoldedHist(lHistLen[i], lTableIdxWidth, 16, HistoryType::LOCAL));
         }
     }
     lIndex.resize(lTableNum);
@@ -92,10 +90,9 @@ BTBMGSC::BTBMGSC(const Params &p)
     auto iTableSize = std::pow(2, iTableIdxWidth);
     assert(iTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < iTableNum; ++i) {
-        assert(std::pow(2, iHistLen[i]) <= iTableSize / numCtrsPerLine);
+        assert(std::pow(2, iHistLen[i]) <= iTableSize);
         iTable[i].resize(iTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexIFoldedHist.push_back(
-            FoldedHist(iHistLen[i], iTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::IMLI));
+        indexIFoldedHist.push_back(FoldedHist(iHistLen[i], iTableIdxWidth, 16, HistoryType::IMLI));
     }
     iIndex.resize(iTableNum);
 
@@ -105,8 +102,7 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
         gTable[i].resize(gTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexGFoldedHist.push_back(
-            FoldedHist(gHistLen[i], gTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBAL));
+        indexGFoldedHist.push_back(FoldedHist(gHistLen[i], gTableIdxWidth, 16, HistoryType::GLOBAL));
     }
     gIndex.resize(gTableNum);
 
@@ -116,8 +112,7 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < pTableNum; ++i) {
         assert(pTable.size() >= pTableNum);
         pTable[i].resize(pTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexPFoldedHist.push_back(
-            FoldedHist(pHistLen[i], pTableIdxWidth - log2i(numCtrsPerLine), 2, HistoryType::PATH));
+        indexPFoldedHist.push_back(FoldedHist(pHistLen[i], pTableIdxWidth, 2, HistoryType::PATH));
     }
     pIndex.resize(pTableNum);
 
@@ -170,12 +165,12 @@ BTBMGSC::tickStart()
  */
 int
 BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &table,
-                          const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc)
+                          const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc)
 {
     int percsum = 0;
-    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
     for (unsigned int i = 0; i < numTables; ++i) {
-        auto &entry = table[i][tableIndices[i]][pos];
+        auto [idx1, idx2] = posHash(pc, tableIndices[i]);
+        auto &entry = table[i][idx1][idx2];
         percsum += (2 * entry + 1);  // align to zero center
     }
     return percsum;
@@ -465,12 +460,12 @@ BTBMGSC::prepareUpdateEntries(const FetchStream &stream)
  */
 void
 BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
-                                    const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
+                                    const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc,
                                     bool actual_taken)
 {
     for (unsigned int i = 0; i < numTables; ++i) {
-        auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
-        auto &entry = table[i][tableIndices[i]][pos];
+        auto [idx1, idx2] = posHash(pc, tableIndices[i]);
+        auto &entry = table[i][idx1][idx2];
         updateCounter(actual_taken, scCountersWidth, entry);
     }
 }

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -206,7 +206,6 @@ BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &
     for (unsigned int i = 0; i < numTables; ++i) {
         auto &entry = table[i][tableIndices[i]][pos];
         percsum += (2 * entry + 1);  // align to zero center
-        break;
     }
     return percsum;
 }

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -55,19 +55,21 @@ BTBMGSC::BTBMGSC(const Params &p)
       initialUpdateThresholdValue(p.initialUpdateThresholdValue),
       extraWeightsWidth(p.extraWeightsWidth),
       weightTableIdxWidth(p.weightTableIdxWidth),
+      numCtrsPerLine(p.numCtrsPerLine),
       enableMGSC(p.enableMGSC),
       mgscStats(this)
 {
     DPRINTF(MGSC, "BTBMGSC constructor\n");
     this->needMoreHistories = p.needMoreHistories;
+
     assert(isPowerOf2(numCtrsPerLine));
+    numCtrsPerLineBits = log2i(numCtrsPerLine);
+
     bwTable.resize(bwTableNum);
+    auto bwTableSize = std::pow(2, bwTableIdxWidth);
+    assert(bwTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < bwTableNum; ++i) {
-        assert(bwTable.size() >= bwTableNum);
-        bwTable[i].resize(std::pow(2, bwTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < bwTable[i].size(); ++j) {
-            bwTable[i][j].resize(numCtrsPerLine);
-        }
+        bwTable[i].resize(bwTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         indexBwFoldedHist.push_back(
             FoldedHist(bwHistLen[i], bwTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBALBW));
     }
@@ -75,12 +77,10 @@ BTBMGSC::BTBMGSC(const Params &p)
 
     lTable.resize(lTableNum);
     indexLFoldedHist.resize(numEntriesFirstLocalHistories);
+    auto lTableSize = std::pow(2, lTableIdxWidth);
+    assert(lTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < lTableNum; ++i) {
-        assert(lTable.size() >= lTableNum);
-        lTable[i].resize(std::pow(2, lTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < lTable[i].size(); ++j) {
-            lTable[i][j].resize(numCtrsPerLine);
-        }
+        lTable[i].resize(lTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
             indexLFoldedHist[k].push_back(
                 FoldedHist(lHistLen[i], lTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::LOCAL));
@@ -89,48 +89,43 @@ BTBMGSC::BTBMGSC(const Params &p)
     lIndex.resize(lTableNum);
 
     iTable.resize(iTableNum);
+    auto iTableSize = std::pow(2, iTableIdxWidth);
+    assert(iTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < iTableNum; ++i) {
-        assert(iTable.size() >= iTableNum);
-        iTable[i].resize(std::pow(2, iTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < iTable[i].size(); ++j) {
-            iTable[i][j].resize(numCtrsPerLine);
-        }
+        assert(std::pow(2, iHistLen[i]) <= iTableSize / numCtrsPerLine);
+        iTable[i].resize(iTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         indexIFoldedHist.push_back(
             FoldedHist(iHistLen[i], iTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::IMLI));
     }
     iIndex.resize(iTableNum);
 
     gTable.resize(gTableNum);
+    auto gTableSize = std::pow(2, gTableIdxWidth);
+    assert(gTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
-        gTable[i].resize(std::pow(2, gTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < gTable[i].size(); ++j) {
-            gTable[i][j].resize(numCtrsPerLine);
-        }
+        gTable[i].resize(gTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         indexGFoldedHist.push_back(
             FoldedHist(gHistLen[i], gTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBAL));
     }
     gIndex.resize(gTableNum);
 
     pTable.resize(pTableNum);
+    auto pTableSize = std::pow(2, pTableIdxWidth);
+    assert(pTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < pTableNum; ++i) {
         assert(pTable.size() >= pTableNum);
-        pTable[i].resize(std::pow(2, pTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < pTable[i].size(); ++j) {
-            pTable[i][j].resize(numCtrsPerLine);
-        }
+        pTable[i].resize(pTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         indexPFoldedHist.push_back(
             FoldedHist(pHistLen[i], pTableIdxWidth - log2i(numCtrsPerLine), 2, HistoryType::PATH));
     }
     pIndex.resize(pTableNum);
 
     biasTable.resize(biasTableNum);
+    auto biasTableSize = std::pow(2, biasTableIdxWidth);
+    assert(biasTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < biasTableNum; ++i) {
-        assert(biasTable.size() >= biasTableNum);
-        biasTable[i].resize(std::pow(2, biasTableIdxWidth) / numCtrsPerLine);
-        for (unsigned int j = 0; j < biasTable[i].size(); ++j) {
-            biasTable[i][j].resize(numCtrsPerLine);
-        }
+        biasTable[i].resize(biasTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
     }
     biasIndex.resize(biasTableNum);
 

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -181,7 +181,7 @@ int
 BTBMGSC::findWeight(const std::vector<int16_t> &weightTable, Addr pc)
 {
     auto mask = (1 << weightTableIdxWidth) - 1;
-    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto pcHash = ((pc >> instShiftAmt) ^ ((pc >> instShiftAmt) >> 2)) & mask;
     auto &entry = weightTable[pcHash];
     return entry;
 }
@@ -211,7 +211,7 @@ int
 BTBMGSC::findThreshold(const std::vector<int16_t> &thresholdTable, Addr pc)
 {
     auto mask = (1 << thresholdTablelogSize) - 1;
-    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto pcHash = ((pc >> instShiftAmt) ^ ((pc >> instShiftAmt) >> 2)) & mask;
     auto &entry = thresholdTable[pcHash];
     return entry;
 }
@@ -490,7 +490,7 @@ BTBMGSC::updateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, A
                            bool percsum_matches_actual)
 {
     auto mask = (1 << weightTableIdxWidth) - 1;
-    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto pcHash = ((pc >> instShiftAmt) ^ ((pc >> instShiftAmt) >> 2)) & mask;
     auto &entry = weightTable[pcHash];
     // Only update if weight scale could affect prediction
     if (weight_scale_diff) {
@@ -519,7 +519,7 @@ void
 BTBMGSC::updatePCThresholdTable(Addr pc, bool update_direction)
 {
     auto mask = (1 << thresholdTablelogSize) - 1;
-    auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
+    auto pcHash = ((pc >> instShiftAmt) ^ ((pc >> instShiftAmt) >> 2)) & mask;
     auto &entry = pUpdateThreshold[pcHash];
     updateCounter(update_direction, pUpdateThresholdWidth, entry);
 }

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -704,7 +704,7 @@ BTBMGSC::getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist)
     Addr mask = (1ULL << tableIndexBits) - 1;
 
     // Extract lower bits of PC and XOR with folded history directly
-    Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
+    Addr pcBits = ((pc >> floorLog2(blockSize)) << numCtrsPerLineBits) & mask;
     Addr foldedBits = foldedHist & mask;
 
     return pcBits ^ foldedBits;
@@ -948,7 +948,7 @@ void
 BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     if (!enableMGSC) {
-        return; // No recover when disabled
+        return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < gTableNum; i++) {
@@ -974,7 +974,7 @@ void
 BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     if (!enableMGSC) {
-        return; // No recover when disabled
+        return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < pTableNum; i++) {
@@ -1000,7 +1000,7 @@ void
 BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     if (!enableMGSC) {
-        return; // No recover when disabled
+        return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < bwTableNum; i++) {
@@ -1026,7 +1026,7 @@ void
 BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     if (!enableMGSC) {
-        return; // No recover when disabled
+        return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < iTableNum; i++) {
@@ -1053,7 +1053,7 @@ BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const
                       bool cond_taken)
 {
     if (!enableMGSC) {
-        return; // No recover when disabled
+        return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -1,7 +1,9 @@
 #include "cpu/pred/btb/btb_mgsc.hh"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <ctime>
 
 #include "base/debug_helper.hh"
@@ -52,20 +54,21 @@ BTBMGSC::BTBMGSC(const Params &p)
       initialUpdateThresholdValue(p.initialUpdateThresholdValue),
       extraWeightsWidth(p.extraWeightsWidth),
       weightTableIdxWidth(p.weightTableIdxWidth),
-      numWays(p.numWays),
       enableMGSC(p.enableMGSC),
       mgscStats(this)
 {
     DPRINTF(MGSC, "BTBMGSC constructor\n");
     this->needMoreHistories = p.needMoreHistories;
+    assert(isPowerOf2(numCtrsPerLine));
     bwTable.resize(bwTableNum);
     for (unsigned int i = 0; i < bwTableNum; ++i) {
         assert(bwTable.size() >= bwTableNum);
-        bwTable[i].resize(std::pow(2, bwTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, bwTableIdxWidth)); ++j) {
-            bwTable[i][j].resize(numWays);
+        bwTable[i].resize(std::pow(2, bwTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < bwTable[i].size(); ++j) {
+            bwTable[i][j].resize(numCtrsPerLine);
         }
-        indexBwFoldedHist.push_back(FoldedHist(bwHistLen[i], bwTableIdxWidth, 16, HistoryType::GLOBALBW));
+        indexBwFoldedHist.push_back(
+            FoldedHist(bwHistLen[i], bwTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBALBW));
     }
     bwIndex.resize(bwTableNum);
 
@@ -73,12 +76,13 @@ BTBMGSC::BTBMGSC(const Params &p)
     indexLFoldedHist.resize(numEntriesFirstLocalHistories);
     for (unsigned int i = 0; i < lTableNum; ++i) {
         assert(lTable.size() >= lTableNum);
-        lTable[i].resize(std::pow(2, lTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, lTableIdxWidth)); ++j) {
-            lTable[i][j].resize(numWays);
+        lTable[i].resize(std::pow(2, lTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < lTable[i].size(); ++j) {
+            lTable[i][j].resize(numCtrsPerLine);
         }
         for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
-            indexLFoldedHist[k].push_back(FoldedHist(lHistLen[i], lTableIdxWidth, 16, HistoryType::LOCAL));
+            indexLFoldedHist[k].push_back(
+                FoldedHist(lHistLen[i], lTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::LOCAL));
         }
     }
     lIndex.resize(lTableNum);
@@ -86,82 +90,85 @@ BTBMGSC::BTBMGSC(const Params &p)
     iTable.resize(iTableNum);
     for (unsigned int i = 0; i < iTableNum; ++i) {
         assert(iTable.size() >= iTableNum);
-        iTable[i].resize(std::pow(2, iTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, iTableIdxWidth)); ++j) {
-            iTable[i][j].resize(numWays);
+        iTable[i].resize(std::pow(2, iTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < iTable[i].size(); ++j) {
+            iTable[i][j].resize(numCtrsPerLine);
         }
-        indexIFoldedHist.push_back(FoldedHist(iHistLen[i], iTableIdxWidth, 16, HistoryType::IMLI));
+        indexIFoldedHist.push_back(
+            FoldedHist(iHistLen[i], iTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::IMLI));
     }
     iIndex.resize(iTableNum);
 
     gTable.resize(gTableNum);
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
-        gTable[i].resize(std::pow(2, gTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, gTableIdxWidth)); ++j) {
-            gTable[i][j].resize(numWays);
+        gTable[i].resize(std::pow(2, gTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < gTable[i].size(); ++j) {
+            gTable[i][j].resize(numCtrsPerLine);
         }
-        indexGFoldedHist.push_back(FoldedHist(gHistLen[i], gTableIdxWidth, 16, HistoryType::GLOBAL));
+        indexGFoldedHist.push_back(
+            FoldedHist(gHistLen[i], gTableIdxWidth - log2i(numCtrsPerLine), 16, HistoryType::GLOBAL));
     }
     gIndex.resize(gTableNum);
 
     pTable.resize(pTableNum);
     for (unsigned int i = 0; i < pTableNum; ++i) {
         assert(pTable.size() >= pTableNum);
-        pTable[i].resize(std::pow(2, pTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, pTableIdxWidth)); ++j) {
-            pTable[i][j].resize(numWays);
+        pTable[i].resize(std::pow(2, pTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < pTable[i].size(); ++j) {
+            pTable[i][j].resize(numCtrsPerLine);
         }
-        indexPFoldedHist.push_back(FoldedHist(pHistLen[i], pTableIdxWidth, 2, HistoryType::PATH));
+        indexPFoldedHist.push_back(
+            FoldedHist(pHistLen[i], pTableIdxWidth - log2i(numCtrsPerLine), 2, HistoryType::PATH));
     }
     pIndex.resize(pTableNum);
 
     biasTable.resize(biasTableNum);
     for (unsigned int i = 0; i < biasTableNum; ++i) {
         assert(biasTable.size() >= biasTableNum);
-        biasTable[i].resize(std::pow(2, biasTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2, biasTableIdxWidth)); ++j) {
-            biasTable[i][j].resize(numWays);
+        biasTable[i].resize(std::pow(2, biasTableIdxWidth) / numCtrsPerLine);
+        for (unsigned int j = 0; j < biasTable[i].size(); ++j) {
+            biasTable[i][j].resize(numCtrsPerLine);
         }
     }
     biasIndex.resize(biasTableNum);
 
     bwWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        bwWeightTable[j].resize(numWays);
+        bwWeightTable[j].resize(numCtrsPerLine);
     }
 
     lWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        lWeightTable[j].resize(numWays);
+        lWeightTable[j].resize(numCtrsPerLine);
     }
 
     iWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        iWeightTable[j].resize(numWays);
+        iWeightTable[j].resize(numCtrsPerLine);
     }
 
     gWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        gWeightTable[j].resize(numWays);
+        gWeightTable[j].resize(numCtrsPerLine);
     }
 
     pWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        pWeightTable[j].resize(numWays);
+        pWeightTable[j].resize(numCtrsPerLine);
     }
 
     biasWeightTable.resize(std::pow(2, weightTableIdxWidth));
     for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
-        biasWeightTable[j].resize(numWays);
+        biasWeightTable[j].resize(numCtrsPerLine);
     }
 
     pUpdateThreshold.resize(std::pow(2, thresholdTablelogSize));
     for (unsigned int j = 0; j < (std::pow(2, thresholdTablelogSize)); ++j) {
-        pUpdateThreshold[j].resize(numWays);
+        pUpdateThreshold[j].resize(numCtrsPerLine);
     }
 
-    updateThreshold.resize(numWays);
+    updateThreshold = 35;
 }
 
 BTBMGSC::~BTBMGSC() {}
@@ -182,14 +189,6 @@ BTBMGSC::tickStart()
 {
 }
 
-bool
-BTBMGSC::tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits)
-{
-    // Use bitwise operations directly to avoid overhead of creating bitset objects
-    // Create mask: when matchBits=5, mask=0x1F (binary 11111)
-    Addr mask = (1ULL << matchBits) - 1;
-    return ((pc_a >> instShiftAmt) & mask) == ((pc_b >> instShiftAmt) & mask);
-}
 
 /**
  * Calculate perceptron sum from a table for a given PC
@@ -201,18 +200,15 @@ BTBMGSC::tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits)
  * @return Calculated percsum value
  */
 int
-BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>> &table,
+BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &table,
                           const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc)
 {
     int percsum = 0;
+    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
     for (unsigned int i = 0; i < numTables; ++i) {
-        for (unsigned way = 0; way < numWays; way++) {
-            auto &entry = table[i][tableIndices[i]][way];
-            if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-                percsum += (2 * entry.counter + 1);  // 2*counter + 1 is always >= 0
-                break;
-            }
-        }
+        auto &entry = table[i][tableIndices[i]][pos];
+        percsum += (2 * entry + 1);  // align to zero center
+        break;
     }
     return percsum;
 }
@@ -225,15 +221,11 @@ BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>>
  * @return Found weight or 0 if not found
  */
 int
-BTBMGSC::findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc)
+BTBMGSC::findWeight(const std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc)
 {
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = weightTable[tableIndex][way];
-        if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-            return entry.counter;
-        }
-    }
-    return 0;
+    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
+    auto &entry = weightTable[tableIndex][pos];
+    return entry;
 }
 
 /**
@@ -258,16 +250,12 @@ BTBMGSC::calculateScaledPercsum(int weight, int percsum)
  * @return Found threshold or default value if not found
  */
 int
-BTBMGSC::findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable, Addr tableIndex, Addr pc,
+BTBMGSC::findThreshold(const std::vector<std::vector<int16_t>> &thresholdTable, Addr tableIndex, Addr pc,
                        int defaultValue)
 {
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = thresholdTable[tableIndex][way];
-        if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-            return entry.counter;
-        }
-    }
-    return defaultValue;
+    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
+    auto &entry = thresholdTable[tableIndex][pos];
+    return entry;
 }
 
 /**
@@ -301,105 +289,70 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     // Calculate indices for all tables
     for (unsigned int i = 0; i < bwTableNum; ++i) {
-        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth, indexBwFoldedHist[i].get());
+        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth - log2i(numCtrsPerLine), indexBwFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < lTableNum; ++i) {
-        lIndex[i] = getHistIndex(startPC, lTableIdxWidth,
+        lIndex[i] = getHistIndex(startPC, lTableIdxWidth - log2i(numCtrsPerLine),
                                  indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][i].get());
     }
 
     for (unsigned int i = 0; i < iTableNum; ++i) {
-        iIndex[i] = getHistIndex(startPC, iTableIdxWidth, indexIFoldedHist[i].get());
+        iIndex[i] = getHistIndex(startPC, iTableIdxWidth - log2i(numCtrsPerLine), indexIFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < gTableNum; ++i) {
-        gIndex[i] = getHistIndex(startPC, gTableIdxWidth, indexGFoldedHist[i].get());
+        gIndex[i] = getHistIndex(startPC, gTableIdxWidth - log2i(numCtrsPerLine), indexGFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < pTableNum; ++i) {
-        pIndex[i] = getHistIndex(startPC, pTableIdxWidth, indexPFoldedHist[i].get());
+        pIndex[i] = getHistIndex(startPC, pTableIdxWidth - log2i(numCtrsPerLine), indexPFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
-        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth, tage_info.tage_pred_taken,
+        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - log2i(numCtrsPerLine), tage_info.tage_pred_taken,
                                     tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
     }
 
-    // Calculate percsums and weights for all tables
-    Addr tableIndex = getPcIndex(startPC, weightTableIdxWidth);
-
     int bw_percsum = calculatePercsum(bwTable, bwIndex, bwTableNum, btb_entry.pc);
-    int bw_weight = findWeight(bwWeightTable, tableIndex, btb_entry.pc);
-    int bw_scale_percsum = calculateScaledPercsum(bw_weight, bw_percsum);
 
     int l_percsum = calculatePercsum(lTable, lIndex, lTableNum, btb_entry.pc);
-    int l_weight = findWeight(lWeightTable, tableIndex, btb_entry.pc);
-    int l_scale_percsum = calculateScaledPercsum(l_weight, l_percsum);
 
     int i_percsum = calculatePercsum(iTable, iIndex, iTableNum, btb_entry.pc);
-    int i_weight = findWeight(iWeightTable, tableIndex, btb_entry.pc);
-    int i_scale_percsum = calculateScaledPercsum(i_weight, i_percsum);
 
     int g_percsum = calculatePercsum(gTable, gIndex, gTableNum, btb_entry.pc);
-    int g_weight = findWeight(gWeightTable, tableIndex, btb_entry.pc);
-    int g_scale_percsum = calculateScaledPercsum(g_weight, g_percsum);
 
     int p_percsum = calculatePercsum(pTable, pIndex, pTableNum, btb_entry.pc);
-    int p_weight = findWeight(pWeightTable, tableIndex, btb_entry.pc);
-    int p_scale_percsum = calculateScaledPercsum(p_weight, p_percsum);
 
     int bias_percsum = calculatePercsum(biasTable, biasIndex, biasTableNum, btb_entry.pc);
-    int bias_weight = findWeight(biasWeightTable, tableIndex, btb_entry.pc);
-    int bias_scale_percsum = calculateScaledPercsum(bias_weight, bias_percsum);
 
     // Calculate total sum of all weighted percsums
-    int total_sum =
-        bw_scale_percsum + l_scale_percsum + i_scale_percsum + g_scale_percsum + p_scale_percsum + bias_scale_percsum;
+    int total_sum = bw_percsum + l_percsum + i_percsum + g_percsum + p_percsum + bias_percsum;
 
     // Find thresholds
     // pc-indexed threshold table, default value = initialUpdateThresholdValue = 0
-    int p_update_thres = findThreshold(pUpdateThreshold, getPcIndex(startPC, thresholdTablelogSize), btb_entry.pc,
-                                       initialUpdateThresholdValue);
+    // int p_update_thres = findThreshold(pUpdateThreshold, getPcIndex(startPC, thresholdTablelogSize), btb_entry.pc,
+    //                                    initialUpdateThresholdValue);
 
-    // global threshold table
-    int update_thres = 35 << 3;  // default value = 35 << 3 ?
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = updateThreshold[way];
-        if (tagMatch(btb_entry.pc, entry.pc, 5) && entry.valid) {
-            update_thres = entry.counter;
-            break;
-        }
+    int total_thres = updateThreshold;
+
+    bool use_sc_pred = true;
+    if (tage_info.tage_pred_conf_high && abs(total_sum) < total_thres) {
+        use_sc_pred = false;
     }
-
-    int total_thres = (update_thres >> 3) + p_update_thres;  // total_thres = global_thres + pc_thres
-
-    // Determine whether to use SC prediction based on confidence levels
-    bool use_sc_pred = false;
-    if (tage_info.tage_pred_conf_high) {
-        if (abs(total_sum) > total_thres / 2) {
-            use_sc_pred = true;
-        }
-    } else if (tage_info.tage_pred_conf_mid) {
-        if (abs(total_sum) > total_thres / 4) {
-            use_sc_pred = true;
-        }
-    } else if (tage_info.tage_pred_conf_low) {
-        if (abs(total_sum) > total_thres / 8) {
-            use_sc_pred = true;
-        }
+    if (tage_info.tage_pred_conf_mid && abs(total_sum) < total_thres / 3) {
+        use_sc_pred = false;
     }
-
     // Final prediction, total_sum >= 0 means taken if use_sc_pred
-    bool taken = (use_sc_pred && enableMGSC) ? (total_sum >= 0) : tage_info.tage_pred_taken;
+    bool taken = (enableMGSC && use_sc_pred) ? (total_sum >= 0) : tage_info.tage_pred_taken;
 
     // Calculate weight scale differences
-    bool bw_weight_scale_diff = calculateWeightScaleDiff(total_sum, bw_scale_percsum, bw_percsum);
-    bool l_weight_scale_diff = calculateWeightScaleDiff(total_sum, l_scale_percsum, l_percsum);
-    bool i_weight_scale_diff = calculateWeightScaleDiff(total_sum, i_scale_percsum, i_percsum);
-    bool g_weight_scale_diff = calculateWeightScaleDiff(total_sum, g_scale_percsum, g_percsum);
-    bool p_weight_scale_diff = calculateWeightScaleDiff(total_sum, p_scale_percsum, p_percsum);
-    bool bias_weight_scale_diff = calculateWeightScaleDiff(total_sum, bias_scale_percsum, bias_percsum);
+    bool bw_weight_scale_diff = false;
+    bool l_weight_scale_diff = false;
+    bool i_weight_scale_diff = false;
+    bool g_weight_scale_diff = false;
+    bool p_weight_scale_diff = false;
+    bool bias_weight_scale_diff = false;
 
     DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
 
@@ -523,31 +476,14 @@ BTBMGSC::prepareUpdateEntries(const FetchStream &stream)
  * @param actual_taken Actual branch outcome (true=taken, false=not taken)
  */
 void
-BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntry>>> &table,
+BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
                                     const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
                                     bool actual_taken)
 {
     for (unsigned int i = 0; i < numTables; ++i) {
-        bool found_entry = false;
-        // Search all ways in the set for a matching entry
-        for (unsigned way = 0; way < numWays; way++) {
-            auto &entry = table[i][tableIndices[i]][way];
-            if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-                // Entry found - update its counter based on branch outcome
-                updateCounter(actual_taken, scCountersWidth, entry.counter);
-                found_entry = true;
-                updateLRU(table[i], tableIndices[i], way);
-                break;
-            }
-        }
-        // Allocate if not found - use LRU replacement policy
-        if (!found_entry) {
-            unsigned alloc_way = getLRUVictim(table[i], tableIndices[i]);
-            auto &entry_to_alloc = table[i][tableIndices[i]][alloc_way];
-            // Initialize counter based on branch outcome
-            short newCounter = actual_taken ? 0 : -1;
-            entry_to_alloc = MgscEntry(true, newCounter, pc, 0);
-        }
+        auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
+        auto &entry = table[i][tableIndices[i]][pos];
+        updateCounter(actual_taken, scCountersWidth, entry);
     }
 }
 
@@ -569,31 +505,15 @@ BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntr
  * @param percsum_matches_actual Whether the raw percsum correctly predicted the outcome
  */
 void
-BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc,
+BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc,
                                       bool weight_scale_diff, bool percsum_matches_actual)
 {
-    bool found_entry = false;
-    // Search all ways in the set for a matching entry
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = weightTable[tableIndex][way];
-        if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-            // Only update if weight scale could affect prediction
-            if (weight_scale_diff) {
-                // Increase weight if percsum was correct, decrease if incorrect
-                updateCounter(percsum_matches_actual, extraWeightsWidth, entry.counter);
-            }
-            found_entry = true;
-            updateLRU(weightTable, tableIndex, way);
-            break;
-        }
-    }
-
-    // Allocate if not found - use LRU replacement policy
-    if (!found_entry) {
-        unsigned alloc_way = getLRUVictim(weightTable, tableIndex);
-        auto &entry_to_alloc = weightTable[tableIndex][alloc_way];
-        // Initialize weight to neutral value (0)
-        entry_to_alloc = MgscWeightEntry(true, pc, 0, 0);
+    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
+    auto &entry = weightTable[tableIndex][pos];
+    // Only update if weight scale could affect prediction
+    if (weight_scale_diff) {
+        // Increase weight if percsum was correct, decrease if incorrect
+        updateCounter(percsum_matches_actual, extraWeightsWidth, entry);
     }
 }
 
@@ -616,29 +536,9 @@ BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> 
 void
 BTBMGSC::updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition, bool update_direction)
 {
-    bool found_entry = false;
-    // Search all ways in the set for a matching entry
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = pUpdateThreshold[tableIndex][way];
-        if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-            // Only update if the update condition is met (TAGE and SC disagree)
-            if (update_condition) {
-                // Adjust threshold based on which prediction was correct
-                updateCounter(update_direction, pUpdateThresholdWidth, entry.counter);
-            }
-            found_entry = true;
-            updateLRU(pUpdateThreshold, tableIndex, way);
-            break;
-        }
-    }
-
-    // Allocate if not found - use LRU replacement policy
-    if (!found_entry) {
-        unsigned alloc_way = getLRUVictim(pUpdateThreshold, tableIndex);
-        auto &entry_to_alloc = pUpdateThreshold[tableIndex][alloc_way];
-        // Initialize with default value from class member
-        entry_to_alloc = MgscThresEntry(true, pc, initialUpdateThresholdValue, 0);
-    }
+    auto pos = (pc >> 2) & ((uint64_t)numCtrsPerLine - 1);
+    auto &entry = pUpdateThreshold[tableIndex][pos];
+    updateCounter(update_direction, pUpdateThresholdWidth, entry);
 }
 
 /**
@@ -655,30 +555,9 @@ BTBMGSC::updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition,
  * @param update_direction Direction to update (true=increment, false=decrement)
  */
 void
-BTBMGSC::updateGlobalThreshold(Addr pc, bool update_condition, bool update_direction)
+BTBMGSC::updateGlobalThreshold(Addr pc, bool update_direction)
 {
-    bool found_entry = false;
-    // Search all ways for a matching entry
-    for (unsigned way = 0; way < numWays; way++) {
-        auto &entry = updateThreshold[way];
-        if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-            // Only update if the update condition is met
-            if (update_condition) {
-                updateCounter(update_direction, updateThresholdWidth, entry.counter);
-            }
-            found_entry = true;
-            updateLRU(updateThreshold, way);
-            break;
-        }
-    }
-
-    // Allocate if not found - use LRU replacement policy
-    if (!found_entry) {
-        unsigned alloc_way = getLRUVictim(updateThreshold);
-        auto &entry_to_alloc = updateThreshold[alloc_way];
-        // Initialize with default hard-coded value (35 << 3)
-        entry_to_alloc = MgscThresEntry(true, pc, 35 << 3, 0);
-    }
+    updateCounter(update_direction, updateThresholdWidth, updateThreshold);
 }
 
 /**
@@ -755,11 +634,11 @@ BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_tak
                                      (pred.bias_percsum >= 0) == actual_taken);
 
         // Update PC-indexed threshold table
-        updatePCThresholdTable(getPcIndex(stream.startPC, thresholdTablelogSize), entry.pc,
-                               tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
+        // updatePCThresholdTable(getPcIndex(stream.startPC, thresholdTablelogSize), entry.pc,
+        //                        tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
 
         // Update global threshold table
-        updateGlobalThreshold(entry.pc, tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
+        updateGlobalThreshold(entry.pc, sc_pred_taken != actual_taken);
     }
 }
 
@@ -807,7 +686,7 @@ BTBMGSC::updateCounter(bool taken, unsigned width, short &counter)
 
 // Update unsigned counter with saturation
 void
-BTBMGSC::updateCounter(bool taken, unsigned width, unsigned &counter)
+BTBMGSC::updateCounter(bool taken, unsigned width, uint64_t &counter)
 {
     int max = (1 << width) - 1;
     int min = 0;
@@ -864,7 +743,7 @@ BTBMGSC::satIncrement(int max, short &counter)
 }
 
 bool
-BTBMGSC::satIncrement(int max, unsigned &counter)
+BTBMGSC::satIncrement(int max, uint64_t &counter)
 {
     if (counter < max) {
         ++counter;
@@ -882,7 +761,7 @@ BTBMGSC::satDecrement(int min, short &counter)
 }
 
 bool
-BTBMGSC::satDecrement(int min, unsigned &counter)
+BTBMGSC::satDecrement(int min, uint64_t &counter)
 {
     if (counter > min) {
         --counter;
@@ -1159,76 +1038,6 @@ BTBMGSC::MgscStats::MgscStats(statistics::Group *parent)
       ADD_STAT(scUsed, statistics::units::Count::get(), "number of sc used"),
       ADD_STAT(scNotUsed, statistics::units::Count::get(), "number of sc not used")
 {
-}
-
-// Update LRU counters for a set
-template<typename T>
-void
-BTBMGSC::updateLRU(std::vector<std::vector<T>> &table, Addr index, unsigned way)
-{
-    // Increment LRU counters for all entries in the set
-    for (unsigned i = 0; i < numWays; i++) {
-        if (i != way && table[index][i].valid) {
-            table[index][i].lruCounter++;
-        }
-    }
-    // Reset LRU counter for the accessed entry
-    table[index][way].lruCounter = 0;
-}
-
-template<typename T>
-void
-BTBMGSC::updateLRU(std::vector<T> &table, unsigned way)
-{
-    // Increment LRU counters for all entries in the set
-    for (unsigned i = 0; i < numWays; i++) {
-        if (i != way && table[i].valid) {
-            table[i].lruCounter++;
-        }
-    }
-    // Reset LRU counter for the accessed entry
-    table[way].lruCounter = 0;
-}
-
-// Find the LRU victim in a set
-template<typename T>
-unsigned
-BTBMGSC::getLRUVictim(std::vector<std::vector<T>> &table, Addr index)
-{
-    unsigned victim = 0;
-    unsigned maxLRU = 0;
-
-    // Find the entry with the highest LRU counter
-    for (unsigned i = 0; i < numWays; i++) {
-        if (!table[index][i].valid) {
-            return i;  // Use invalid entry if available
-        }
-        if (table[index][i].lruCounter > maxLRU) {
-            maxLRU = table[index][i].lruCounter;
-            victim = i;
-        }
-    }
-    return victim;
-}
-
-template<typename T>
-unsigned
-BTBMGSC::getLRUVictim(std::vector<T> &table)
-{
-    unsigned victim = 0;
-    unsigned maxLRU = 0;
-
-    // Find the entry with the highest LRU counter
-    for (unsigned i = 0; i < numWays; i++) {
-        if (!table[i].valid) {
-            return i;  // Use invalid entry if available
-        }
-        if (table[i].lruCounter > maxLRU) {
-            maxLRU = table[i].lruCounter;
-            victim = i;
-        }
-    }
-    return victim;
 }
 
 void

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -7,10 +7,6 @@
 #include <ctime>
 #include <type_traits>
 
-#include "base/debug_helper.hh"
-#include "base/intmath.hh"
-#include "base/trace.hh"
-#include "cpu/o3/dyn_inst.hh"
 #include "debug/MGSC.hh"
 
 namespace gem5
@@ -28,31 +24,25 @@ BTBMGSC::BTBMGSC(const Params &p)
       bwTableNum(p.bwTableNum),
       bwTableIdxWidth(p.bwTableIdxWidth),
       bwHistLen(p.bwHistLen),
-      bwWeightInitValue(p.bwWeightInitValue),
       numEntriesFirstLocalHistories(p.numEntriesFirstLocalHistories),
       lTableNum(p.lTableNum),
       lTableIdxWidth(p.lTableIdxWidth),
       lHistLen(p.lHistLen),
-      lWeightInitValue(p.lWeightInitValue),
       iTableNum(p.iTableNum),
       iTableIdxWidth(p.iTableIdxWidth),
       iHistLen(p.iHistLen),
-      iWeightInitValue(p.iWeightInitValue),
       gTableNum(p.gTableNum),
       gTableIdxWidth(p.gTableIdxWidth),
       gHistLen(p.gHistLen),
-      gWeightInitValue(p.gWeightInitValue),
       pTableNum(p.pTableNum),
       pTableIdxWidth(p.pTableIdxWidth),
       pHistLen(p.pHistLen),
-      pWeightInitValue(p.pWeightInitValue),
       biasTableNum(p.biasTableNum),
       biasTableIdxWidth(p.biasTableIdxWidth),
       scCountersWidth(p.scCountersWidth),
       thresholdTablelogSize(p.thresholdTablelogSize),
       updateThresholdWidth(p.updateThresholdWidth),
       pUpdateThresholdWidth(p.pUpdateThresholdWidth),
-      initialUpdateThresholdValue(p.initialUpdateThresholdValue),
       extraWeightsWidth(p.extraWeightsWidth),
       weightTableIdxWidth(p.weightTableIdxWidth),
       numCtrsPerLine(p.numCtrsPerLine),
@@ -387,7 +377,8 @@ BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
  * @param stagePreds Vector of predictions for different pipeline stages
  */
 void
-BTBMGSC::putPCHistory(Addr stream_start, const bitset &history, std::vector<FullBTBPrediction> &stagePreds)
+BTBMGSC::putPCHistory(Addr stream_start, const boost::dynamic_bitset<> &history,
+                      std::vector<FullBTBPrediction> &stagePreds)
 {
     DPRINTF(MGSC, "putPCHistory startAddr: %#lx\n", stream_start);
 
@@ -459,9 +450,8 @@ BTBMGSC::prepareUpdateEntries(const FetchStream &stream)
  * @param actual_taken Actual branch outcome (true=taken, false=not taken)
  */
 void
-BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
-                                    const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc,
-                                    bool actual_taken)
+BTBMGSC::updatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
+                         const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc, bool actual_taken)
 {
     for (unsigned int i = 0; i < numTables; ++i) {
         auto [idx1, idx2] = posHash(pc, tableIndices[i]);
@@ -488,8 +478,8 @@ BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>
  * @param percsum_matches_actual Whether the raw percsum correctly predicted the outcome
  */
 void
-BTBMGSC::updateAndAllocateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc,
-                                      bool weight_scale_diff, bool percsum_matches_actual)
+BTBMGSC::updateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc, bool weight_scale_diff,
+                           bool percsum_matches_actual)
 {
     auto mask = (1 << weightTableIdxWidth) - 1;
     auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
@@ -557,8 +547,8 @@ BTBMGSC::updateGlobalThreshold(Addr pc, bool update_direction)
  * @param stream The fetch stream containing update information
  */
 void
-BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
-                                          const FetchStream &stream)
+BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
+                               const FetchStream &stream)
 {
     // Extract prediction information
     auto total_sum = pred.total_sum;
@@ -589,34 +579,34 @@ BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_tak
         Addr weightTableIdx = getPcIndex(stream.startPC, weightTableIdxWidth);
 
         // Update BW tables
-        updateAndAllocatePredTable(bwTable, pred.bwIndex, bwTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(bwWeightTable, weightTableIdx, entry.pc, pred.bw_weight_scale_diff,
-                                     (pred.bw_percsum >= 0) == actual_taken);
+        updatePredTable(bwTable, pred.bwIndex, bwTableNum, entry.pc, actual_taken);
+        updateWeightTable(bwWeightTable, weightTableIdx, entry.pc, pred.bw_weight_scale_diff,
+                          (pred.bw_percsum >= 0) == actual_taken);
 
         // Update L tables
-        updateAndAllocatePredTable(lTable, pred.lIndex, lTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(lWeightTable, weightTableIdx, entry.pc, pred.l_weight_scale_diff,
-                                     (pred.l_percsum >= 0) == actual_taken);
+        updatePredTable(lTable, pred.lIndex, lTableNum, entry.pc, actual_taken);
+        updateWeightTable(lWeightTable, weightTableIdx, entry.pc, pred.l_weight_scale_diff,
+                          (pred.l_percsum >= 0) == actual_taken);
 
         // Update I tables
-        updateAndAllocatePredTable(iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
-                                     (pred.i_percsum >= 0) == actual_taken);
+        updatePredTable(iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
+        updateWeightTable(iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
+                          (pred.i_percsum >= 0) == actual_taken);
 
         // Update G tables
-        updateAndAllocatePredTable(gTable, pred.gIndex, gTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(gWeightTable, weightTableIdx, entry.pc, pred.g_weight_scale_diff,
-                                     (pred.g_percsum >= 0) == actual_taken);
+        updatePredTable(gTable, pred.gIndex, gTableNum, entry.pc, actual_taken);
+        updateWeightTable(gWeightTable, weightTableIdx, entry.pc, pred.g_weight_scale_diff,
+                          (pred.g_percsum >= 0) == actual_taken);
 
         // Update P tables
-        updateAndAllocatePredTable(pTable, pred.pIndex, pTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(pWeightTable, weightTableIdx, entry.pc, pred.p_weight_scale_diff,
-                                     (pred.p_percsum >= 0) == actual_taken);
+        updatePredTable(pTable, pred.pIndex, pTableNum, entry.pc, actual_taken);
+        updateWeightTable(pWeightTable, weightTableIdx, entry.pc, pred.p_weight_scale_diff,
+                          (pred.p_percsum >= 0) == actual_taken);
 
         // Update bias tables
-        updateAndAllocatePredTable(biasTable, pred.biasIndex, biasTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(biasWeightTable, weightTableIdx, entry.pc, pred.bias_weight_scale_diff,
-                                     (pred.bias_percsum >= 0) == actual_taken);
+        updatePredTable(biasTable, pred.biasIndex, biasTableNum, entry.pc, actual_taken);
+        updateWeightTable(biasWeightTable, weightTableIdx, entry.pc, pred.bias_weight_scale_diff,
+                          (pred.bias_percsum >= 0) == actual_taken);
 
         // Update PC-indexed threshold table
         updatePCThresholdTable(entry.pc, sc_pred_taken != actual_taken);
@@ -649,7 +639,7 @@ BTBMGSC::update(const FetchStream &stream)
         }
 
         // Update predictor state and check if need to allocate new entry
-        updateAndAllocateSinglePredictor(btb_entry, actual_taken, pred_it->second, stream);
+        updateSinglePredictor(btb_entry, actual_taken, pred_it->second, stream);
     }
 
     DPRINTF(MGSC, "end update\n");
@@ -813,7 +803,7 @@ void
 BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool taken,
                       std::vector<FoldedHist> &foldedHist, Addr pc, Addr target)
 {
-    if (debugFlagOn) {
+    if (debug::MGSC) {
         std::string buf;
         boost::to_string(history, buf);
         DPRINTF(MGSC, "in doUpdateHist, shamt %d, taken %d, history %s\n", shamt, taken, buf.c_str());

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -268,8 +268,8 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     }
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
-        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - numCtrsPerLineBits, tage_info.tage_pred_taken,
-                                    tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
+        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - numCtrsPerLineBits, tage_info.tage_main_taken,
+                                    tage_info.tage_pred_conf_low);
     }
 
     int bw_percsum = calculatePercsum(bwTable, bwIndex, bwTableNum, btb_entry.pc);
@@ -321,7 +321,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
         }
     }
     // Final prediction, total_sum >= 0 means taken if use_sc_pred
-    bool taken = use_sc_pred ? (total_sum >= 0) : tage_info.tage_pred_taken;
+    bool taken = use_sc_pred ? (total_sum >= 0) : tage_info.tage_main_taken;
 
     // Calculate weight scale differences
     bool bw_weight_scale_diff = calculateWeightScaleDiff(total_sum, bw_scaled_percsum, bw_percsum);
@@ -333,7 +333,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
 
-    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken, total_thres, bwIndex,
+    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_main_taken, total_thres, bwIndex,
                           lIndex, iIndex, gIndex, pIndex, biasIndex, bw_weight_scale_diff, l_weight_scale_diff,
                           i_weight_scale_diff, g_weight_scale_diff, p_weight_scale_diff, bias_weight_scale_diff,
                           bw_percsum, l_percsum, i_percsum, g_percsum, p_percsum, bias_percsum);

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -321,7 +321,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
         }
     }
     // Final prediction, total_sum >= 0 means taken if use_sc_pred
-    bool taken = use_sc_pred ? (total_sum >= 0) : tage_info.tage_main_taken;
+    bool taken = use_sc_pred ? (total_sum >= 0) : tage_info.tage_pred_taken;
 
     // Calculate weight scale differences
     bool bw_weight_scale_diff = calculateWeightScaleDiff(total_sum, bw_scaled_percsum, bw_percsum);
@@ -333,7 +333,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
 
-    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_main_taken, total_thres, bwIndex,
+    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken, total_thres, bwIndex,
                           lIndex, iIndex, gIndex, pIndex, biasIndex, bw_weight_scale_diff, l_weight_scale_diff,
                           i_weight_scale_diff, g_weight_scale_diff, p_weight_scale_diff, bias_weight_scale_diff,
                           bw_percsum, l_percsum, i_percsum, g_percsum, p_percsum, bias_percsum);

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -317,7 +317,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
         }
     }
     // Final prediction, total_sum >= 0 means taken if use_sc_pred
-    bool taken = (enableMGSC && use_sc_pred) ? (total_sum >= 0) : tage_info.tage_pred_taken;
+    bool taken = use_sc_pred ? (total_sum >= 0) : tage_info.tage_pred_taken;
 
     // Calculate weight scale differences
     bool bw_weight_scale_diff = calculateWeightScaleDiff(total_sum, bw_scaled_percsum, bw_percsum);
@@ -385,6 +385,10 @@ BTBMGSC::putPCHistory(Addr stream_start, const boost::dynamic_bitset<> &history,
     // IMPORTANT: when this function is called,
     // btb entries should already be in stagePreds
     // get prediction and save it
+
+    if (!enableMGSC) {
+        return;  // Just return if MGSC is disabled
+    }
 
     // Clear old prediction metadata and save current history state
     meta = std::make_shared<MgscMeta>();
@@ -619,6 +623,9 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
 void
 BTBMGSC::update(const FetchStream &stream)
 {
+    if (!enableMGSC) {
+        return;  // No update if disabled
+    }
     Addr startAddr = stream.getRealStartPC();
     DPRINTF(MGSC, "update startAddr: %#lx\n", startAddr);
 
@@ -940,6 +947,9 @@ BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, Fu
 void
 BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
+    if (!enableMGSC) {
+        return; // No recover when disabled
+    }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < gTableNum; i++) {
         indexGFoldedHist[i].recover(predMeta->indexGFoldedHist[i]);
@@ -963,6 +973,9 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &
 void
 BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
+    if (!enableMGSC) {
+        return; // No recover when disabled
+    }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < pTableNum; i++) {
         indexPFoldedHist[i].recover(predMeta->indexPFoldedHist[i]);
@@ -986,6 +999,9 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream 
 void
 BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
+    if (!enableMGSC) {
+        return; // No recover when disabled
+    }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < bwTableNum; i++) {
         indexBwFoldedHist[i].recover(predMeta->indexBwFoldedHist[i]);
@@ -1009,6 +1025,9 @@ BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream
 void
 BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
+    if (!enableMGSC) {
+        return; // No recover when disabled
+    }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < iTableNum; i++) {
         indexIFoldedHist[i].recover(predMeta->indexIFoldedHist[i]);
@@ -1033,6 +1052,9 @@ void
 BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchStream &entry, int shamt,
                       bool cond_taken)
 {
+    if (!enableMGSC) {
+        return; // No recover when disabled
+    }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
         for (int i = 0; i < lTableNum; i++) {

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -332,12 +332,19 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     int total_thres = (updateThreshold / 8) + p_update_thres;
 
-    bool use_sc_pred = true;
-    if (tage_info.tage_pred_conf_high && abs(total_sum) < total_thres) {
-        use_sc_pred = false;
-    }
-    if (tage_info.tage_pred_conf_mid && abs(total_sum) < total_thres / 3) {
-        use_sc_pred = false;
+    bool use_sc_pred = false;
+    if (tage_info.tage_pred_conf_high) {
+        if (abs(total_sum) > total_thres / 2) {
+            use_sc_pred = true;
+        }
+    } else if (tage_info.tage_pred_conf_mid) {
+        if (abs(total_sum) > total_thres / 4) {
+            use_sc_pred = true;
+        }
+    } else if (tage_info.tage_pred_conf_low) {
+        if (abs(total_sum) > total_thres / 8) {
+            use_sc_pred = true;
+        }
     }
     // Final prediction, total_sum >= 0 means taken if use_sc_pred
     bool taken = (enableMGSC && use_sc_pred) ? (total_sum >= 0) : tage_info.tage_pred_taken;

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -166,7 +166,7 @@ BTBMGSC::BTBMGSC(const Params &p)
 
     pUpdateThreshold.resize(std::pow(2, thresholdTablelogSize));
 
-    updateThreshold = 35;
+    updateThreshold = 35 * 8;
 }
 
 BTBMGSC::~BTBMGSC() {}
@@ -247,7 +247,7 @@ BTBMGSC::calculateScaledPercsum(int weight, int percsum)
  * @return Found threshold or default value if not found
  */
 int
-BTBMGSC::findThreshold(const std::vector<uint16_t> &thresholdTable, Addr pc)
+BTBMGSC::findThreshold(const std::vector<int16_t> &thresholdTable, Addr pc)
 {
     auto mask = (1 << thresholdTablelogSize) - 1;
     auto pcHash = ((pc >> instShiftAmt) ^ (pc >> instShiftAmt >> 2)) & mask;
@@ -330,7 +330,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     // pc-indexed threshold table
     int p_update_thres = findThreshold(pUpdateThreshold, btb_entry.pc);
 
-    int total_thres = (updateThreshold >> 3) + p_update_thres;
+    int total_thres = (updateThreshold / 8) + p_update_thres;
 
     bool use_sc_pred = true;
     if (tage_info.tage_pred_conf_high && abs(total_sum) < total_thres) {
@@ -676,7 +676,7 @@ BTBMGSC::updateCounter(bool taken, unsigned width, T &counter)
 
     if constexpr (std::is_signed<T>::value) {
         T max = static_cast<T>((1LL << (width - 1)) - 1);
-        T min = static_cast<T>(-(1LL << (width - 1)));
+        T min = static_cast<T>(-((1LL << (width - 1)) - 1));
         if (taken) {
             satIncrement(max, counter);
         } else {
@@ -754,6 +754,8 @@ BTBMGSC::satIncrement(T max, T &counter)
     static_assert(std::is_integral<T>::value, "Counter type must be integral");
     if (counter < max) {
         ++counter;
+    } else {
+        counter = max;
     }
     return counter == max;
 }
@@ -783,6 +785,8 @@ BTBMGSC::satDecrement(T min, T &counter)
     static_assert(std::is_integral<T>::value, "Counter type must be integral");
     if (counter > min) {
         --counter;
+    } else {
+        counter = min;
     }
     return counter == min;
 }

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -665,7 +665,7 @@ BTBMGSC::updateCounter(bool taken, unsigned width, T &counter)
 
     if constexpr (std::is_signed<T>::value) {
         T max = static_cast<T>((1LL << (width - 1)) - 1);
-        T min = static_cast<T>(-((1LL << (width - 1)) - 1));
+        T min = static_cast<T>(-(1LL << (width - 1)));
         if (taken) {
             satIncrement(max, counter);
         } else {

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -10,56 +10,59 @@
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/MGSC.hh"
 
-namespace gem5 {
+namespace gem5
+{
 
-namespace branch_prediction {
+namespace branch_prediction
+{
 
-namespace btb_pred{
+namespace btb_pred
+{
 
 // Constructor: Initialize MGSC predictor with given parameters
-BTBMGSC::BTBMGSC(const Params& p):
-TimedBaseBTBPredictor(p),
-bwTableNum(p.bwTableNum),
-bwTableIdxWidth(p.bwTableIdxWidth),
-bwHistLen(p.bwHistLen),
-bwWeightInitValue(p.bwWeightInitValue),
-numEntriesFirstLocalHistories(p.numEntriesFirstLocalHistories),
-lTableNum(p.lTableNum),
-lTableIdxWidth(p.lTableIdxWidth),
-lHistLen(p.lHistLen),
-lWeightInitValue(p.lWeightInitValue),
-iTableNum(p.iTableNum),
-iTableIdxWidth(p.iTableIdxWidth),
-iHistLen(p.iHistLen),
-iWeightInitValue(p.iWeightInitValue),
-gTableNum(p.gTableNum),
-gTableIdxWidth(p.gTableIdxWidth),
-gHistLen(p.gHistLen),
-gWeightInitValue(p.gWeightInitValue),
-pTableNum(p.pTableNum),
-pTableIdxWidth(p.pTableIdxWidth),
-pHistLen(p.pHistLen),
-pWeightInitValue(p.pWeightInitValue),
-biasTableNum(p.biasTableNum),
-biasTableIdxWidth(p.biasTableIdxWidth),
-scCountersWidth(p.scCountersWidth),
-thresholdTablelogSize(p.thresholdTablelogSize),
-updateThresholdWidth(p.updateThresholdWidth),
-pUpdateThresholdWidth(p.pUpdateThresholdWidth),
-initialUpdateThresholdValue(p.initialUpdateThresholdValue),
-extraWeightsWidth(p.extraWeightsWidth),
-weightTableIdxWidth(p.weightTableIdxWidth),
-numWays(p.numWays),
-enableMGSC(p.enableMGSC),
-mgscStats(this)
+BTBMGSC::BTBMGSC(const Params &p)
+    : TimedBaseBTBPredictor(p),
+      bwTableNum(p.bwTableNum),
+      bwTableIdxWidth(p.bwTableIdxWidth),
+      bwHistLen(p.bwHistLen),
+      bwWeightInitValue(p.bwWeightInitValue),
+      numEntriesFirstLocalHistories(p.numEntriesFirstLocalHistories),
+      lTableNum(p.lTableNum),
+      lTableIdxWidth(p.lTableIdxWidth),
+      lHistLen(p.lHistLen),
+      lWeightInitValue(p.lWeightInitValue),
+      iTableNum(p.iTableNum),
+      iTableIdxWidth(p.iTableIdxWidth),
+      iHistLen(p.iHistLen),
+      iWeightInitValue(p.iWeightInitValue),
+      gTableNum(p.gTableNum),
+      gTableIdxWidth(p.gTableIdxWidth),
+      gHistLen(p.gHistLen),
+      gWeightInitValue(p.gWeightInitValue),
+      pTableNum(p.pTableNum),
+      pTableIdxWidth(p.pTableIdxWidth),
+      pHistLen(p.pHistLen),
+      pWeightInitValue(p.pWeightInitValue),
+      biasTableNum(p.biasTableNum),
+      biasTableIdxWidth(p.biasTableIdxWidth),
+      scCountersWidth(p.scCountersWidth),
+      thresholdTablelogSize(p.thresholdTablelogSize),
+      updateThresholdWidth(p.updateThresholdWidth),
+      pUpdateThresholdWidth(p.pUpdateThresholdWidth),
+      initialUpdateThresholdValue(p.initialUpdateThresholdValue),
+      extraWeightsWidth(p.extraWeightsWidth),
+      weightTableIdxWidth(p.weightTableIdxWidth),
+      numWays(p.numWays),
+      enableMGSC(p.enableMGSC),
+      mgscStats(this)
 {
     DPRINTF(MGSC, "BTBMGSC constructor\n");
     this->needMoreHistories = p.needMoreHistories;
     bwTable.resize(bwTableNum);
     for (unsigned int i = 0; i < bwTableNum; ++i) {
         assert(bwTable.size() >= bwTableNum);
-        bwTable[i].resize(std::pow(2,bwTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,bwTableIdxWidth)); ++j) {
+        bwTable[i].resize(std::pow(2, bwTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, bwTableIdxWidth)); ++j) {
             bwTable[i][j].resize(numWays);
         }
         indexBwFoldedHist.push_back(FoldedHist(bwHistLen[i], bwTableIdxWidth, 16, HistoryType::GLOBALBW));
@@ -70,8 +73,8 @@ mgscStats(this)
     indexLFoldedHist.resize(numEntriesFirstLocalHistories);
     for (unsigned int i = 0; i < lTableNum; ++i) {
         assert(lTable.size() >= lTableNum);
-        lTable[i].resize(std::pow(2,lTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,lTableIdxWidth)); ++j) {
+        lTable[i].resize(std::pow(2, lTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, lTableIdxWidth)); ++j) {
             lTable[i][j].resize(numWays);
         }
         for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
@@ -83,8 +86,8 @@ mgscStats(this)
     iTable.resize(iTableNum);
     for (unsigned int i = 0; i < iTableNum; ++i) {
         assert(iTable.size() >= iTableNum);
-        iTable[i].resize(std::pow(2,iTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,iTableIdxWidth)); ++j) {
+        iTable[i].resize(std::pow(2, iTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, iTableIdxWidth)); ++j) {
             iTable[i][j].resize(numWays);
         }
         indexIFoldedHist.push_back(FoldedHist(iHistLen[i], iTableIdxWidth, 16, HistoryType::IMLI));
@@ -94,8 +97,8 @@ mgscStats(this)
     gTable.resize(gTableNum);
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
-        gTable[i].resize(std::pow(2,gTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,gTableIdxWidth)); ++j) {
+        gTable[i].resize(std::pow(2, gTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, gTableIdxWidth)); ++j) {
             gTable[i][j].resize(numWays);
         }
         indexGFoldedHist.push_back(FoldedHist(gHistLen[i], gTableIdxWidth, 16, HistoryType::GLOBAL));
@@ -105,8 +108,8 @@ mgscStats(this)
     pTable.resize(pTableNum);
     for (unsigned int i = 0; i < pTableNum; ++i) {
         assert(pTable.size() >= pTableNum);
-        pTable[i].resize(std::pow(2,pTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,pTableIdxWidth)); ++j) {
+        pTable[i].resize(std::pow(2, pTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, pTableIdxWidth)); ++j) {
             pTable[i][j].resize(numWays);
         }
         indexPFoldedHist.push_back(FoldedHist(pHistLen[i], pTableIdxWidth, 2, HistoryType::PATH));
@@ -116,55 +119,52 @@ mgscStats(this)
     biasTable.resize(biasTableNum);
     for (unsigned int i = 0; i < biasTableNum; ++i) {
         assert(biasTable.size() >= biasTableNum);
-        biasTable[i].resize(std::pow(2,biasTableIdxWidth));
-        for (unsigned int j = 0; j < (std::pow(2,biasTableIdxWidth)); ++j) {
+        biasTable[i].resize(std::pow(2, biasTableIdxWidth));
+        for (unsigned int j = 0; j < (std::pow(2, biasTableIdxWidth)); ++j) {
             biasTable[i][j].resize(numWays);
         }
     }
     biasIndex.resize(biasTableNum);
 
-    bwWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    bwWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         bwWeightTable[j].resize(numWays);
     }
 
-    lWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    lWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         lWeightTable[j].resize(numWays);
     }
 
-    iWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    iWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         iWeightTable[j].resize(numWays);
     }
 
-    gWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    gWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         gWeightTable[j].resize(numWays);
     }
 
-    pWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    pWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         pWeightTable[j].resize(numWays);
     }
 
-    biasWeightTable.resize(std::pow(2,weightTableIdxWidth));
-    for (unsigned int j = 0; j < (std::pow(2,weightTableIdxWidth)); ++j) {
+    biasWeightTable.resize(std::pow(2, weightTableIdxWidth));
+    for (unsigned int j = 0; j < (std::pow(2, weightTableIdxWidth)); ++j) {
         biasWeightTable[j].resize(numWays);
     }
 
-    pUpdateThreshold.resize(std::pow(2,thresholdTablelogSize));
-    for (unsigned int j = 0; j < (std::pow(2,thresholdTablelogSize)); ++j) {
+    pUpdateThreshold.resize(std::pow(2, thresholdTablelogSize));
+    for (unsigned int j = 0; j < (std::pow(2, thresholdTablelogSize)); ++j) {
         pUpdateThreshold[j].resize(numWays);
     }
 
     updateThreshold.resize(numWays);
-
 }
 
-BTBMGSC::~BTBMGSC()
-{
-}
+BTBMGSC::~BTBMGSC() {}
 
 // Set up tracing for debugging
 void
@@ -173,13 +173,18 @@ BTBMGSC::setTrace()
 }
 
 void
-BTBMGSC::tick() {}
+BTBMGSC::tick()
+{
+}
 
 void
-BTBMGSC::tickStart() {}
+BTBMGSC::tickStart()
+{
+}
 
 bool
-BTBMGSC::tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits) {
+BTBMGSC::tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits)
+{
     // Use bitwise operations directly to avoid overhead of creating bitset objects
     // Create mask: when matchBits=5, mask=0x1F (binary 11111)
     Addr mask = (1ULL << matchBits) - 1;
@@ -197,15 +202,14 @@ BTBMGSC::tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits) {
  */
 int
 BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>> &table,
-                         const std::vector<Addr> &tableIndices,
-                         unsigned numTables,
-                         Addr pc) {
+                          const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc)
+{
     int percsum = 0;
     for (unsigned int i = 0; i < numTables; ++i) {
         for (unsigned way = 0; way < numWays; way++) {
             auto &entry = table[i][tableIndices[i]][way];
             if (tagMatch(pc, entry.pc, 5) && entry.valid) {
-                percsum += (2 * entry.counter + 1); // 2*counter + 1 is always >= 0
+                percsum += (2 * entry.counter + 1);  // 2*counter + 1 is always >= 0
                 break;
             }
         }
@@ -221,9 +225,8 @@ BTBMGSC::calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>>
  * @return Found weight or 0 if not found
  */
 int
-BTBMGSC::findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable,
-                   Addr tableIndex,
-                   Addr pc) {
+BTBMGSC::findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc)
+{
     for (unsigned way = 0; way < numWays; way++) {
         auto &entry = weightTable[tableIndex][way];
         if (tagMatch(pc, entry.pc, 5) && entry.valid) {
@@ -241,8 +244,9 @@ BTBMGSC::findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable
  * @return Scaled percsum value
  */
 int
-BTBMGSC::calculateScaledPercsum(int weight, int percsum) {
-    return (double)((double)(weight + 32)/32.0) * percsum;
+BTBMGSC::calculateScaledPercsum(int weight, int percsum)
+{
+    return (double)((double)(weight + 32) / 32.0) * percsum;
 }
 
 /**
@@ -254,10 +258,9 @@ BTBMGSC::calculateScaledPercsum(int weight, int percsum) {
  * @return Found threshold or default value if not found
  */
 int
-BTBMGSC::findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable,
-                      Addr tableIndex,
-                      Addr pc,
-                      int defaultValue) {
+BTBMGSC::findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable, Addr tableIndex, Addr pc,
+                       int defaultValue)
+{
     for (unsigned way = 0; way < numWays; way++) {
         auto &entry = thresholdTable[tableIndex][way];
         if (tagMatch(pc, entry.pc, 5) && entry.valid) {
@@ -275,11 +278,12 @@ BTBMGSC::findThreshold(const std::vector<std::vector<MgscThresEntry>> &threshold
  * @return True if weight scale causes prediction to change
  */
 bool
-BTBMGSC::calculateWeightScaleDiff(int total_sum, int scale_percsum, int percsum) {
+BTBMGSC::calculateWeightScaleDiff(int total_sum, int scale_percsum, int percsum)
+{
     // First check if removing this table's contribution keeps the sum positive (predict taken)
     // Then check if doubling this table's contribution keeps the sum positive
     // If one is true and the other is false, the table's weight is crucial for prediction
-    return ((total_sum - scale_percsum) >= 0) != ((total_sum - scale_percsum + 2*percsum) >= 0);
+    return ((total_sum - scale_percsum) >= 0) != ((total_sum - scale_percsum + 2 * percsum) >= 0);
 }
 
 /**
@@ -290,11 +294,10 @@ BTBMGSC::calculateWeightScaleDiff(int total_sum, int scale_percsum, int percsum)
  * @return TagePrediction containing main and alternative predictions
  */
 BTBMGSC::MgscPrediction
-BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
-                                 const Addr &startPC,
-                                 const TageInfoForMGSC &tage_info) {
-    DPRINTF(MGSC, "generateSinglePrediction for btbEntry: %#lx, always taken %d\n",
-        btb_entry.pc, btb_entry.alwaysTaken);
+BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC, const TageInfoForMGSC &tage_info)
+{
+    DPRINTF(MGSC, "generateSinglePrediction for btbEntry: %#lx, always taken %d\n", btb_entry.pc,
+            btb_entry.alwaysTaken);
 
     // Calculate indices for all tables
     for (unsigned int i = 0; i < bwTableNum; ++i) {
@@ -303,7 +306,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
 
     for (unsigned int i = 0; i < lTableNum; ++i) {
         lIndex[i] = getHistIndex(startPC, lTableIdxWidth,
-                  indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][i].get());
+                                 indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][i].get());
     }
 
     for (unsigned int i = 0; i < iTableNum; ++i) {
@@ -320,7 +323,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
         biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth, tage_info.tage_pred_taken,
-                    tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
+                                    tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
     }
 
     // Calculate percsums and weights for all tables
@@ -351,18 +354,16 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
     int bias_scale_percsum = calculateScaledPercsum(bias_weight, bias_percsum);
 
     // Calculate total sum of all weighted percsums
-    int total_sum = bw_scale_percsum + l_scale_percsum + i_scale_percsum +
-               g_scale_percsum + p_scale_percsum + bias_scale_percsum;
+    int total_sum =
+        bw_scale_percsum + l_scale_percsum + i_scale_percsum + g_scale_percsum + p_scale_percsum + bias_scale_percsum;
 
     // Find thresholds
     // pc-indexed threshold table, default value = initialUpdateThresholdValue = 0
-    int p_update_thres = findThreshold(pUpdateThreshold,
-                                     getPcIndex(startPC, thresholdTablelogSize),
-                                     btb_entry.pc,
-                                     initialUpdateThresholdValue);
+    int p_update_thres = findThreshold(pUpdateThreshold, getPcIndex(startPC, thresholdTablelogSize), btb_entry.pc,
+                                       initialUpdateThresholdValue);
 
     // global threshold table
-    int update_thres = 35 << 3;     // default value = 35 << 3 ?
+    int update_thres = 35 << 3;  // default value = 35 << 3 ?
     for (unsigned way = 0; way < numWays; way++) {
         auto &entry = updateThreshold[way];
         if (tagMatch(btb_entry.pc, entry.pc, 5) && entry.valid) {
@@ -376,15 +377,15 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
     // Determine whether to use SC prediction based on confidence levels
     bool use_sc_pred = false;
     if (tage_info.tage_pred_conf_high) {
-        if (abs(total_sum) > total_thres/2) {
+        if (abs(total_sum) > total_thres / 2) {
             use_sc_pred = true;
         }
     } else if (tage_info.tage_pred_conf_mid) {
-        if (abs(total_sum) > total_thres/4) {
+        if (abs(total_sum) > total_thres / 4) {
             use_sc_pred = true;
         }
     } else if (tage_info.tage_pred_conf_low) {
-        if (abs(total_sum) > total_thres/8) {
+        if (abs(total_sum) > total_thres / 8) {
             use_sc_pred = true;
         }
     }
@@ -402,12 +403,10 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
 
     DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
 
-    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken,
-                        tage_info.tage_pred_taken, total_thres,
-                        bwIndex, lIndex, iIndex, gIndex, pIndex, biasIndex,
-                        bw_weight_scale_diff, l_weight_scale_diff, i_weight_scale_diff,
-                        g_weight_scale_diff, p_weight_scale_diff, bias_weight_scale_diff,
-                        bw_percsum, l_percsum, i_percsum, g_percsum, p_percsum, bias_percsum);
+    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken, total_thres, bwIndex,
+                          lIndex, iIndex, gIndex, pIndex, biasIndex, bw_weight_scale_diff, l_weight_scale_diff,
+                          i_weight_scale_diff, g_weight_scale_diff, p_weight_scale_diff, bias_weight_scale_diff,
+                          bw_percsum, l_percsum, i_percsum, g_percsum, p_percsum, bias_percsum);
 }
 
 /**
@@ -419,7 +418,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry,
  */
 void
 BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntries,
-                      const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results)
+                      const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results)
 {
     DPRINTF(MGSC, "lookupHelper startAddr: %#lx\n", startPC);
 
@@ -428,7 +427,7 @@ BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
         // Only predict for valid conditional branches
         if (btb_entry.isCond && btb_entry.valid) {
             auto tage_info = tageInfoForMgscs.find(btb_entry.pc);
-            if(tage_info != tageInfoForMgscs.end()){
+            if (tage_info != tageInfoForMgscs.end()) {
                 auto pred = generateSinglePrediction(btb_entry, startPC, tage_info->second);
                 meta->preds[btb_entry.pc] = pred;
                 results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
@@ -452,7 +451,8 @@ BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
  * @param stagePreds Vector of predictions for different pipeline stages
  */
 void
-BTBMGSC::putPCHistory(Addr stream_start, const bitset &history, std::vector<FullBTBPrediction> &stagePreds) {
+BTBMGSC::putPCHistory(Addr stream_start, const bitset &history, std::vector<FullBTBPrediction> &stagePreds)
+{
     DPRINTF(MGSC, "putPCHistory startAddr: %#lx\n", stream_start);
 
     // IMPORTANT: when this function is called,
@@ -473,11 +473,11 @@ BTBMGSC::putPCHistory(Addr stream_start, const bitset &history, std::vector<Full
         stage_pred.condTakens.clear();
         lookupHelper(stream_start, stage_pred.btbEntries, stage_pred.tageInfoForMgscs, stage_pred.condTakens);
     }
-
 }
 
 std::shared_ptr<void>
-BTBMGSC::getPredictionMeta() {
+BTBMGSC::getPredictionMeta()
+{
     return meta;
 }
 
@@ -488,18 +488,18 @@ BTBMGSC::getPredictionMeta() {
  * @return Vector of BTB entries that need to be updated
  */
 std::vector<BTBEntry>
-BTBMGSC::prepareUpdateEntries(const FetchStream &stream) {
+BTBMGSC::prepareUpdateEntries(const FetchStream &stream)
+{
     auto all_entries = stream.updateBTBEntries;
 
     // Filter out non-conditional and always-taken branches
     auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-        [](const BTBEntry &e) { return !e.isCond && !e.alwaysTaken; });
+                                    [](const BTBEntry &e) { return !e.isCond && !e.alwaysTaken; });
     all_entries.erase(remove_it, all_entries.end());
 
     // Handle potential new BTB entry
     auto &potential_new_entry = stream.updateNewBTBEntry;
-    if (!stream.updateIsOldEntry && potential_new_entry.isCond &&
-        !potential_new_entry.alwaysTaken) {
+    if (!stream.updateIsOldEntry && potential_new_entry.isCond && !potential_new_entry.alwaysTaken) {
         all_entries.push_back(potential_new_entry);
     }
 
@@ -524,10 +524,9 @@ BTBMGSC::prepareUpdateEntries(const FetchStream &stream) {
  */
 void
 BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntry>>> &table,
-                                  const std::vector<Addr> &tableIndices,
-                                  unsigned numTables,
-                                  Addr pc,
-                                  bool actual_taken) {
+                                    const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
+                                    bool actual_taken)
+{
     for (unsigned int i = 0; i < numTables; ++i) {
         bool found_entry = false;
         // Search all ways in the set for a matching entry
@@ -570,11 +569,9 @@ BTBMGSC::updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntr
  * @param percsum_matches_actual Whether the raw percsum correctly predicted the outcome
  */
 void
-BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable,
-                                    Addr tableIndex,
-                                    Addr pc,
-                                    bool weight_scale_diff,
-                                    bool percsum_matches_actual) {
+BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc,
+                                      bool weight_scale_diff, bool percsum_matches_actual)
+{
     bool found_entry = false;
     // Search all ways in the set for a matching entry
     for (unsigned way = 0; way < numWays; way++) {
@@ -617,10 +614,8 @@ BTBMGSC::updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> 
  * @param update_direction Direction to update (true=increment, false=decrement)
  */
 void
-BTBMGSC::updatePCThresholdTable(Addr tableIndex,
-                                Addr pc,
-                                bool update_condition,
-                                bool update_direction) {
+BTBMGSC::updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition, bool update_direction)
+{
     bool found_entry = false;
     // Search all ways in the set for a matching entry
     for (unsigned way = 0; way < numWays; way++) {
@@ -660,9 +655,8 @@ BTBMGSC::updatePCThresholdTable(Addr tableIndex,
  * @param update_direction Direction to update (true=increment, false=decrement)
  */
 void
-BTBMGSC::updateGlobalThreshold(Addr pc,
-                             bool update_condition,
-                             bool update_direction) {
+BTBMGSC::updateGlobalThreshold(Addr pc, bool update_condition, bool update_direction)
+{
     bool found_entry = false;
     // Search all ways for a matching entry
     for (unsigned way = 0; way < numWays; way++) {
@@ -699,16 +693,15 @@ BTBMGSC::updateGlobalThreshold(Addr pc,
  * @param stream The fetch stream containing update information
  */
 void
-BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry,
-                             bool actual_taken,
-                             const MgscPrediction &pred,
-                             const FetchStream &stream) {
+BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
+                                          const FetchStream &stream)
+{
     // Extract prediction information
     auto total_sum = pred.total_sum;
     auto use_mgsc = pred.use_mgsc;
     auto total_thres = pred.total_thres;
     auto sc_pred_taken = total_sum >= 0;
-    auto tage_pred_taken = pred.taken_before_sc;    // tage predictions
+    auto tage_pred_taken = pred.taken_before_sc;  // tage predictions
 
     // Update statistics
     if (use_mgsc) {
@@ -733,57 +726,46 @@ BTBMGSC::updateAndAllocateSinglePredictor(const BTBEntry &entry,
 
         // Update BW tables
         updateAndAllocatePredTable(bwTable, pred.bwIndex, bwTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            bwWeightTable, weightTableIdx, entry.pc, pred.bw_weight_scale_diff,
-            (pred.bw_percsum >= 0) == actual_taken);
+        updateAndAllocateWeightTable(bwWeightTable, weightTableIdx, entry.pc, pred.bw_weight_scale_diff,
+                                     (pred.bw_percsum >= 0) == actual_taken);
 
         // Update L tables
-        updateAndAllocatePredTable(
-            lTable, pred.lIndex, lTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            lWeightTable, weightTableIdx, entry.pc, pred.l_weight_scale_diff,
-            (pred.l_percsum >= 0) == actual_taken);
+        updateAndAllocatePredTable(lTable, pred.lIndex, lTableNum, entry.pc, actual_taken);
+        updateAndAllocateWeightTable(lWeightTable, weightTableIdx, entry.pc, pred.l_weight_scale_diff,
+                                     (pred.l_percsum >= 0) == actual_taken);
 
         // Update I tables
-        updateAndAllocatePredTable(
-            iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
-            (pred.i_percsum >= 0) == actual_taken);
+        updateAndAllocatePredTable(iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
+        updateAndAllocateWeightTable(iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
+                                     (pred.i_percsum >= 0) == actual_taken);
 
         // Update G tables
-        updateAndAllocatePredTable(
-            gTable, pred.gIndex, gTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            gWeightTable, weightTableIdx, entry.pc, pred.g_weight_scale_diff,
-            (pred.g_percsum >= 0) == actual_taken);
+        updateAndAllocatePredTable(gTable, pred.gIndex, gTableNum, entry.pc, actual_taken);
+        updateAndAllocateWeightTable(gWeightTable, weightTableIdx, entry.pc, pred.g_weight_scale_diff,
+                                     (pred.g_percsum >= 0) == actual_taken);
 
         // Update P tables
-        updateAndAllocatePredTable(
-            pTable, pred.pIndex, pTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            pWeightTable, weightTableIdx, entry.pc, pred.p_weight_scale_diff,
-            (pred.p_percsum >= 0) == actual_taken);
+        updateAndAllocatePredTable(pTable, pred.pIndex, pTableNum, entry.pc, actual_taken);
+        updateAndAllocateWeightTable(pWeightTable, weightTableIdx, entry.pc, pred.p_weight_scale_diff,
+                                     (pred.p_percsum >= 0) == actual_taken);
 
         // Update bias tables
-        updateAndAllocatePredTable(
-            biasTable, pred.biasIndex, biasTableNum, entry.pc, actual_taken);
-        updateAndAllocateWeightTable(
-            biasWeightTable, weightTableIdx, entry.pc, pred.bias_weight_scale_diff,
-            (pred.bias_percsum >= 0) == actual_taken);
+        updateAndAllocatePredTable(biasTable, pred.biasIndex, biasTableNum, entry.pc, actual_taken);
+        updateAndAllocateWeightTable(biasWeightTable, weightTableIdx, entry.pc, pred.bias_weight_scale_diff,
+                                     (pred.bias_percsum >= 0) == actual_taken);
 
         // Update PC-indexed threshold table
-        updatePCThresholdTable(getPcIndex(stream.startPC, thresholdTablelogSize),
-            entry.pc, tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
+        updatePCThresholdTable(getPcIndex(stream.startPC, thresholdTablelogSize), entry.pc,
+                               tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
 
         // Update global threshold table
-        updateGlobalThreshold(entry.pc, tage_pred_taken != sc_pred_taken,
-                             sc_pred_taken != actual_taken);
+        updateGlobalThreshold(entry.pc, tage_pred_taken != sc_pred_taken, sc_pred_taken != actual_taken);
     }
 }
 
 void
-BTBMGSC::update(const FetchStream &stream) {
+BTBMGSC::update(const FetchStream &stream)
+{
     Addr startAddr = stream.getRealStartPC();
     DPRINTF(MGSC, "update startAddr: %#lx\n", startAddr);
 
@@ -812,9 +794,10 @@ BTBMGSC::update(const FetchStream &stream) {
 
 // Update signed counter with saturation
 void
-BTBMGSC::updateCounter(bool taken, unsigned width, short &counter) {
-    int max = (1 << (width-1)) - 1;
-    int min = -(1 << (width-1));
+BTBMGSC::updateCounter(bool taken, unsigned width, short &counter)
+{
+    int max = (1 << (width - 1)) - 1;
+    int min = -(1 << (width - 1));
     if (taken) {
         satIncrement(max, counter);
     } else {
@@ -824,7 +807,8 @@ BTBMGSC::updateCounter(bool taken, unsigned width, short &counter) {
 
 // Update unsigned counter with saturation
 void
-BTBMGSC::updateCounter(bool taken, unsigned width, unsigned &counter) {
+BTBMGSC::updateCounter(bool taken, unsigned width, unsigned &counter)
+{
     int max = (1 << width) - 1;
     int min = 0;
     if (taken) {
@@ -919,14 +903,13 @@ BTBMGSC::satDecrement(int min, unsigned &counter)
  * @param taken Whether the branch was taken
  */
 void
-BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
-                        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc, Addr target)
+BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool taken,
+                      std::vector<FoldedHist> &foldedHist, Addr pc, Addr target)
 {
     if (debugFlagOn) {
         std::string buf;
         boost::to_string(history, buf);
-        DPRINTF(MGSC, "in doUpdateHist, shamt %d, taken %d, history %s\n",
-                shamt, taken, buf.c_str());
+        DPRINTF(MGSC, "in doUpdateHist, shamt %d, taken %d, history %s\n", shamt, taken, buf.c_str());
     }
     if (shamt == 0) {
         DPRINTF(MGSC, "shamt is 0, returning\n");
@@ -957,7 +940,7 @@ BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPredictio
     int shamt;
     bool cond_taken;
     std::tie(shamt, cond_taken) = pred.getHistInfo();
-    doUpdateHist(history, shamt, cond_taken, indexGFoldedHist); // use global history to update G folded history
+    doUpdateHist(history, shamt, cond_taken, indexGFoldedHist);  // use global history to update G folded history
 }
 
 /**
@@ -976,7 +959,7 @@ void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto [pc, target, taken] = pred.getPHistInfo();
-    doUpdateHist(history, 2, taken, indexPFoldedHist, pc, target); // only path history needs pc!
+    doUpdateHist(history, 2, taken, indexPFoldedHist, pc, target);  // only path history needs pc!
 }
 
 
@@ -1040,8 +1023,7 @@ BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, Fu
     int shamt;
     bool cond_taken;
     std::tie(shamt, cond_taken) = pred.getHistInfo();
-    doUpdateHist(history[getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories))],
-                 shamt, cond_taken,
+    doUpdateHist(history[getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories))], shamt, cond_taken,
                  indexLFoldedHist[getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories))]);
 }
 
@@ -1059,8 +1041,7 @@ BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, Fu
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history,
-    const FetchStream &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < gTableNum; i++) {
@@ -1083,8 +1064,7 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history,
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchStream &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < pTableNum; i++) {
@@ -1107,8 +1087,7 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history,
-    const FetchStream &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < bwTableNum; i++) {
@@ -1131,8 +1110,7 @@ BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history,
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history,
-    const FetchStream &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < iTableNum; i++) {
@@ -1155,8 +1133,8 @@ BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history,
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history,
-    const FetchStream &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchStream &entry, int shamt,
+                      bool cond_taken)
 {
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
@@ -1165,23 +1143,26 @@ BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history,
         }
     }
     doUpdateHist(history[getPcIndex(entry.startPC, log2(numEntriesFirstLocalHistories))], shamt, cond_taken,
-                indexLFoldedHist[getPcIndex(entry.startPC, log2(numEntriesFirstLocalHistories))]);
+                 indexLFoldedHist[getPcIndex(entry.startPC, log2(numEntriesFirstLocalHistories))]);
 }
 
 // Constructor for TAGE statistics
-BTBMGSC::MgscStats::MgscStats(statistics::Group* parent):
-    statistics::Group(parent),
-     ADD_STAT(scCorrectTageWrong, statistics::units::Count::get(), "number of sc predict correct and tage predict wrong"),
-     ADD_STAT(scWrongTageCorrect, statistics::units::Count::get(), "number of sc predict wrong and tage predict correct"),
-     ADD_STAT(scCorrectTageCorrect, statistics::units::Count::get(), "number of sc predict correct and tage predict correct"),
-     ADD_STAT(scWrongTageWrong, statistics::units::Count::get(), "number of sc predict wrong and tage predict wrong"),
-     ADD_STAT(scUsed, statistics::units::Count::get(), "number of sc used"),
-     ADD_STAT(scNotUsed, statistics::units::Count::get(), "number of sc not used")
+BTBMGSC::MgscStats::MgscStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(scCorrectTageWrong, statistics::units::Count::get(),
+               "number of sc predict correct and tage predict wrong"),
+      ADD_STAT(scWrongTageCorrect, statistics::units::Count::get(),
+               "number of sc predict wrong and tage predict correct"),
+      ADD_STAT(scCorrectTageCorrect, statistics::units::Count::get(),
+               "number of sc predict correct and tage predict correct"),
+      ADD_STAT(scWrongTageWrong, statistics::units::Count::get(), "number of sc predict wrong and tage predict wrong"),
+      ADD_STAT(scUsed, statistics::units::Count::get(), "number of sc used"),
+      ADD_STAT(scNotUsed, statistics::units::Count::get(), "number of sc not used")
 {
 }
 
 // Update LRU counters for a set
-template <typename T>
+template<typename T>
 void
 BTBMGSC::updateLRU(std::vector<std::vector<T>> &table, Addr index, unsigned way)
 {
@@ -1195,7 +1176,7 @@ BTBMGSC::updateLRU(std::vector<std::vector<T>> &table, Addr index, unsigned way)
     table[index][way].lruCounter = 0;
 }
 
-template <typename T>
+template<typename T>
 void
 BTBMGSC::updateLRU(std::vector<T> &table, unsigned way)
 {
@@ -1210,7 +1191,7 @@ BTBMGSC::updateLRU(std::vector<T> &table, unsigned way)
 }
 
 // Find the LRU victim in a set
-template <typename T>
+template<typename T>
 unsigned
 BTBMGSC::getLRUVictim(std::vector<std::vector<T>> &table, Addr index)
 {
@@ -1220,7 +1201,7 @@ BTBMGSC::getLRUVictim(std::vector<std::vector<T>> &table, Addr index)
     // Find the entry with the highest LRU counter
     for (unsigned i = 0; i < numWays; i++) {
         if (!table[index][i].valid) {
-            return i; // Use invalid entry if available
+            return i;  // Use invalid entry if available
         }
         if (table[index][i].lruCounter > maxLRU) {
             maxLRU = table[index][i].lruCounter;
@@ -1230,7 +1211,7 @@ BTBMGSC::getLRUVictim(std::vector<std::vector<T>> &table, Addr index)
     return victim;
 }
 
-template <typename T>
+template<typename T>
 unsigned
 BTBMGSC::getLRUVictim(std::vector<T> &table)
 {
@@ -1240,7 +1221,7 @@ BTBMGSC::getLRUVictim(std::vector<T> &table)
     // Find the entry with the highest LRU counter
     for (unsigned i = 0; i < numWays; i++) {
         if (!table[i].valid) {
-            return i; // Use invalid entry if available
+            return i;  // Use invalid entry if available
         }
         if (table[i].lruCounter > maxLRU) {
             maxLRU = table[i].lruCounter;
@@ -1255,7 +1236,7 @@ BTBMGSC::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
 {
 }
 
-} // namespace btb_pred
+}  // namespace btb_pred
 
 }  // namespace branch_prediction
 

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -708,7 +708,7 @@ BTBMGSC::getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist)
     Addr mask = (1ULL << tableIndexBits) - 1;
 
     // Extract lower bits of PC and XOR with folded history directly
-    Addr pcBits = ((pc >> floorLog2(blockSize)) << numCtrsPerLineBits) & mask;
+    Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
     Addr foldedBits = foldedHist & mask;
 
     return pcBits ^ foldedBits;

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -60,7 +60,8 @@ BTBMGSC::BTBMGSC(const Params &p)
     assert(bwTableSize > numCtrsPerLine);
     for (unsigned int i = 0; i < bwTableNum; ++i) {
         bwTable[i].resize(bwTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexBwFoldedHist.push_back(FoldedHist(bwHistLen[i], bwTableIdxWidth, 16, HistoryType::GLOBALBW));
+        indexBwFoldedHist.push_back(
+            FoldedHist(bwHistLen[i], bwTableIdxWidth - numCtrsPerLineBits, 16, HistoryType::GLOBALBW));
     }
     bwIndex.resize(bwTableNum);
 
@@ -71,7 +72,8 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < lTableNum; ++i) {
         lTable[i].resize(lTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
         for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
-            indexLFoldedHist[k].push_back(FoldedHist(lHistLen[i], lTableIdxWidth, 16, HistoryType::LOCAL));
+            indexLFoldedHist[k].push_back(
+                FoldedHist(lHistLen[i], lTableIdxWidth - numCtrsPerLineBits, 16, HistoryType::LOCAL));
         }
     }
     lIndex.resize(lTableNum);
@@ -82,7 +84,8 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < iTableNum; ++i) {
         assert(std::pow(2, iHistLen[i]) <= iTableSize);
         iTable[i].resize(iTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexIFoldedHist.push_back(FoldedHist(iHistLen[i], iTableIdxWidth, 16, HistoryType::IMLI));
+        indexIFoldedHist.push_back(
+            FoldedHist(iHistLen[i], iTableIdxWidth - numCtrsPerLineBits, 16, HistoryType::IMLI));
     }
     iIndex.resize(iTableNum);
 
@@ -92,7 +95,8 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
         gTable[i].resize(gTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexGFoldedHist.push_back(FoldedHist(gHistLen[i], gTableIdxWidth, 16, HistoryType::GLOBAL));
+        indexGFoldedHist.push_back(
+            FoldedHist(gHistLen[i], gTableIdxWidth - numCtrsPerLineBits, 16, HistoryType::GLOBAL));
     }
     gIndex.resize(gTableNum);
 
@@ -102,7 +106,7 @@ BTBMGSC::BTBMGSC(const Params &p)
     for (unsigned int i = 0; i < pTableNum; ++i) {
         assert(pTable.size() >= pTableNum);
         pTable[i].resize(pTableSize / numCtrsPerLine, std::vector<int16_t>(numCtrsPerLine, 0));
-        indexPFoldedHist.push_back(FoldedHist(pHistLen[i], pTableIdxWidth, 2, HistoryType::PATH));
+        indexPFoldedHist.push_back(FoldedHist(pHistLen[i], pTableIdxWidth - numCtrsPerLineBits, 2, HistoryType::PATH));
     }
     pIndex.resize(pTableNum);
 
@@ -243,28 +247,28 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     // Calculate indices for all tables
     for (unsigned int i = 0; i < bwTableNum; ++i) {
-        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth, indexBwFoldedHist[i].get());
+        bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth - numCtrsPerLineBits, indexBwFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < lTableNum; ++i) {
-        lIndex[i] = getHistIndex(startPC, lTableIdxWidth,
+        lIndex[i] = getHistIndex(startPC, lTableIdxWidth - numCtrsPerLineBits,
                                  indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][i].get());
     }
 
     for (unsigned int i = 0; i < iTableNum; ++i) {
-        iIndex[i] = getHistIndex(startPC, iTableIdxWidth, indexIFoldedHist[i].get());
+        iIndex[i] = getHistIndex(startPC, iTableIdxWidth - numCtrsPerLineBits, indexIFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < gTableNum; ++i) {
-        gIndex[i] = getHistIndex(startPC, gTableIdxWidth, indexGFoldedHist[i].get());
+        gIndex[i] = getHistIndex(startPC, gTableIdxWidth - numCtrsPerLineBits, indexGFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < pTableNum; ++i) {
-        pIndex[i] = getHistIndex(startPC, pTableIdxWidth, indexPFoldedHist[i].get());
+        pIndex[i] = getHistIndex(startPC, pTableIdxWidth - numCtrsPerLineBits, indexPFoldedHist[i].get());
     }
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
-        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth, tage_info.tage_pred_taken,
+        biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - numCtrsPerLineBits, tage_info.tage_pred_taken,
                                     tage_info.tage_pred_conf_low && tage_info.tage_pred_alt_diff);
     }
 

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -245,7 +245,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
      */
     std::tuple<unsigned, unsigned> posHash(Addr pc, unsigned tableIdx)
     {
-        return {tableIdx >> numCtrsPerLineBits, ((pc >> (instShiftAmt + 1)) ^ tableIdx) & (numCtrsPerLine - 1)};
+        return {tableIdx, (pc >> (instShiftAmt + 1)) & (numCtrsPerLine - 1)};
     }
 
     // Helper method to generate prediction for a single BTB entry

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -192,8 +192,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Find threshold in a threshold table for a given PC
      */
-    int findThreshold(const std::vector<std::vector<int16_t>> &thresholdTable, Addr tableIndex, Addr pc,
-                      int defaultValue);
+    int findThreshold(const std::vector<uint16_t> &thresholdTable, Addr pc);
 
     /**
      * Calculate if weight scale causes prediction difference
@@ -216,7 +215,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Update a threshold table and allocate new entry if needed
      */
-    void updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition, bool update_direction);
+    void updatePCThresholdTable(Addr pc, bool update_direction);
 
     /**
      * Update the global threshold table and allocate new entry if needed
@@ -343,8 +342,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<std::vector<int16_t>> biasWeightTable;
 
     // thres table
-    std::vector<std::vector<int16_t>> pUpdateThreshold;  // pc-indexed threshold table
-    uint64_t updateThreshold;                             // global threshold table
+    std::vector<uint16_t> pUpdateThreshold;  // pc-indexed threshold table
+    uint16_t updateThreshold;                // global threshold table
 
 
     // Debug flag
@@ -353,19 +352,17 @@ class BTBMGSC : public TimedBaseBTBPredictor
     // Instruction shift amount
     unsigned instShiftAmt{1};
 
-    // Update signed counter with saturation
-    void updateCounter(bool taken, unsigned width, short &counter);
+    // Update counter with saturation (template for all integer types)
+    template<typename T>
+    void updateCounter(bool taken, unsigned width, T &counter);
 
-    // Update unsigned counter with saturation
-    void updateCounter(bool taken, unsigned width, uint64_t &counter);
+    // Increment counter with saturation (template for all integer types)
+    template<typename T>
+    bool satIncrement(T max, T &counter);
 
-    // Increment counter with saturation
-    bool satIncrement(int max, short &counter);
-    bool satIncrement(int max, uint64_t &counter);
-
-    // Decrement counter with saturation
-    bool satDecrement(int min, short &counter);
-    bool satDecrement(int min, uint64_t &counter);
+    // Decrement counter with saturation (template for all integer types)
+    template<typename T>
+    bool satDecrement(T min, T &counter);
 
     // Cache for MGSC indices
     std::vector<Addr> bwIndex;

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -8,15 +8,14 @@
 #include <utility>
 #include <vector>
 
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
+
 #include "base/sat_counter.hh"
 #include "base/types.hh"
-#include "cpu/inst_seq.hh"
 #include "cpu/pred/btb/folded_hist.hh"
 #include "cpu/pred/btb/stream_struct.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
-#include "debug/DecoupleBP.hh"
 #include "params/BTBMGSC.hh"
-#include "sim/sim_object.hh"
 
 namespace gem5
 {
@@ -29,9 +28,6 @@ namespace btb_pred
 
 class BTBMGSC : public TimedBaseBTBPredictor
 {
-    using defer = std::shared_ptr<void>;
-    using bitset = boost::dynamic_bitset<>;
-
   public:
     typedef BTBMGSCParams Params;
 
@@ -168,11 +164,12 @@ class BTBMGSC : public TimedBaseBTBPredictor
     void setTrace() override;
 
     // check folded hists after speculative update and recover
-    void checkFoldedHist(const bitset &history, const char *when);
+    void checkFoldedHist(const boost::dynamic_bitset<> &history, const char *when);
 
     // Calculate MGSC weight index
     Addr getPcIndex(Addr pc, unsigned tableIndexBits);
 
+  private:
     // Utility functions for reducing code duplication
     /**
      * Calculate percsum from a table for a given PC
@@ -203,15 +200,14 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Update a prediction table and allocate new entry if needed
      */
-    void updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
-                                    const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc,
-                                    bool actual_taken);
+    void updatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
+                         const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc, bool actual_taken);
 
     /**
      * Update a weight table and allocate new entry if needed
      */
-    void updateAndAllocateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc,
-                                      bool weight_scale_diff, bool percsum_matches_actual);
+    void updateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc, bool weight_scale_diff,
+                           bool percsum_matches_actual);
 
     /**
      * Update a threshold table and allocate new entry if needed
@@ -223,7 +219,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
      */
     void updateGlobalThreshold(Addr pc, bool update_direction);
 
-  private:
     // Look up predictions in MGSC tables for a stream of instructions
     void lookupHelper(const Addr &stream_start, const std::vector<BTBEntry> &btbEntries,
                       const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results);
@@ -241,10 +236,27 @@ class BTBMGSC : public TimedBaseBTBPredictor
     void doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool taken,
                       std::vector<FoldedHist> &foldedHist, Addr pc = 0, Addr target = 0);
 
+    /*
+     * Mix position and table index into two indexes,
+     * first index is used to access SRAM, second one is used to choose from the result
+     * @param pc the raw program counter
+     * @param tableIdx the table index
+     * @return a tuple of two unsigned integers representing the two indexes
+     */
     std::tuple<unsigned, unsigned> posHash(Addr pc, unsigned tableIdx)
     {
         return {tableIdx >> numCtrsPerLineBits, ((pc >> instShiftAmt) ^ tableIdx) & (numCtrsPerLine - 1)};
     }
+
+    // Helper method to generate prediction for a single BTB entry
+    MgscPrediction generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC,
+                                            const TageInfoForMGSC &tage_info);
+
+    // Helper method to prepare BTB entries for update
+    std::vector<BTBEntry> prepareUpdateEntries(const FetchStream &stream);
+
+    void updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
+                               const FetchStream &stream);
 
     /** global backward branch history indexed tables */
     // number of global backward branch history indexed tables
@@ -253,7 +265,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
     unsigned bwTableIdxWidth;
     // global backward branch history length
     std::vector<int> bwHistLen;
-    int bwWeightInitValue;
 
     /** First local history indexed tables param*/
     // number of entries for first local histories
@@ -264,25 +275,21 @@ class BTBMGSC : public TimedBaseBTBPredictor
     unsigned lTableIdxWidth;
     // local history lengths for all first local history indexed tables
     std::vector<int> lHistLen;
-    int lWeightInitValue;
 
     /** loop counter indexed tables param*/
     unsigned iTableNum;
     unsigned iTableIdxWidth;
     std::vector<int> iHistLen;
-    int iWeightInitValue;
 
     /** global history indexed table param*/
     unsigned gTableNum;
     unsigned gTableIdxWidth;
     std::vector<int> gHistLen;
-    int gWeightInitValue;
 
     /** path history indexed table param*/
     unsigned pTableNum;
     unsigned pTableIdxWidth;
     std::vector<int> pHistLen;
-    int pWeightInitValue;
 
     /** bias table param*/
     unsigned biasTableNum;
@@ -297,8 +304,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
     unsigned updateThresholdWidth;
     /*Number of bits for the pUpdate threshold counters*/
     unsigned pUpdateThresholdWidth;
-    /*Initial pUpdate threshold counter value*/
-    unsigned initialUpdateThresholdValue;
 
     /*Number of bits for the extra weights*/
     unsigned extraWeightsWidth;
@@ -352,10 +357,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<int16_t> pUpdateThreshold;  // pc-indexed threshold table
     int16_t updateThreshold;                // global threshold table
 
-
-    // Debug flag
-    bool debugFlagOn{false};
-
     // Instruction shift amount
     unsigned instShiftAmt{1};
 
@@ -398,10 +399,9 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
   public:
     // Recover folded history after misprediction
-    void recoverFoldedHist(const bitset &history);
+    void recoverFoldedHist(const boost::dynamic_bitset<> &history);
     unsigned getNumEntriesFirstLocalHistories() { return numEntriesFirstLocalHistories; };
 
-  public:
   private:
     // Metadata for MGSC predictions
     typedef struct MgscMeta
@@ -434,29 +434,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
             indexPFoldedHist = other.indexPFoldedHist;
         }
     } MgscMeta;
-
-  private:
-    // Helper method to generate prediction for a single BTB entry
-    bool tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits);
-    MgscPrediction generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC,
-                                            const TageInfoForMGSC &tage_info);
-
-    // Helper method to prepare BTB entries for update
-    std::vector<BTBEntry> prepareUpdateEntries(const FetchStream &stream);
-
-    void updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
-                                          const FetchStream &stream);
-    template<typename T>
-    void updateLRU(std::vector<std::vector<T>> &table, Addr index, unsigned way);
-
-    template<typename T>
-    void updateLRU(std::vector<T> &table, unsigned way);
-
-    template<typename T>
-    unsigned getLRUVictim(std::vector<std::vector<T>> &table, Addr index);
-
-    template<typename T>
-    unsigned getLRUVictim(std::vector<T> &table);
 
     std::shared_ptr<MgscMeta> meta;
 };

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -1,6 +1,7 @@
 #ifndef __CPU_PRED_BTB_MGSC_HH__
 #define __CPU_PRED_BTB_MGSC_HH__
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <utility>
@@ -32,57 +33,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
   public:
     typedef BTBMGSCParams Params;
-
-    // Represents a single entry in the MGSC prediction table
-    struct MgscEntry
-    {
-      public:
-        bool valid;
-        short counter;  // Prediction counter (-32 to 31), 6bits
-        Addr pc;        // branch pc, like branch position, for btb entry pc check
-        unsigned lruCounter;
-
-        MgscEntry() : valid(false), counter(0), pc(0), lruCounter(0) {}
-
-        MgscEntry(bool valid, short counter, Addr pc, unsigned lruCounter)
-            : valid(valid), counter(counter), pc(pc), lruCounter(lruCounter)
-        {
-        }
-        bool taken() const { return counter >= 0; }
-    };
-
-    // Represents a single entry in the MGSC weight table
-    struct MgscWeightEntry
-    {
-      public:
-        bool valid;
-        Addr pc;        // btb entry pc, same as mgsc entry pc
-        short counter;  // weight counter (-32 to 31), 6bits
-        unsigned lruCounter;
-
-        MgscWeightEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
-
-        MgscWeightEntry(bool valid, Addr pc, short counter, unsigned lruCounter)
-            : valid(valid), pc(pc), counter(counter), lruCounter(lruCounter)
-        {
-        }
-    };
-
-    struct MgscThresEntry
-    {
-      public:
-        bool valid;
-        Addr pc;           // btb entry pc, same as mgsc entry pc
-        unsigned counter;  // thres counter (0 to 255), 6bits
-        unsigned lruCounter;
-
-        MgscThresEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
-
-        MgscThresEntry(bool valid, Addr pc, unsigned counter, unsigned lruCounter)
-            : valid(valid), pc(pc), counter(counter), lruCounter(lruCounter)
-        {
-        }
-    };
 
     // Contains the complete prediction result
     struct MgscPrediction
@@ -226,13 +176,13 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Calculate percsum from a table for a given PC
      */
-    int calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>> &table,
+    int calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &table,
                          const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc);
 
     /**
      * Find weight in a weight table for a given PC
      */
-    int findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc);
+    int findWeight(const std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc);
 
     /**
      * Calculate scaled percsum using weight
@@ -242,7 +192,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Find threshold in a threshold table for a given PC
      */
-    int findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable, Addr tableIndex, Addr pc,
+    int findThreshold(const std::vector<std::vector<int16_t>> &thresholdTable, Addr tableIndex, Addr pc,
                       int defaultValue);
 
     /**
@@ -253,14 +203,14 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Update a prediction table and allocate new entry if needed
      */
-    void updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntry>>> &table,
+    void updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
                                     const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
                                     bool actual_taken);
 
     /**
      * Update a weight table and allocate new entry if needed
      */
-    void updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc,
+    void updateAndAllocateWeightTable(std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc,
                                       bool weight_scale_diff, bool percsum_matches_actual);
 
     /**
@@ -271,7 +221,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Update the global threshold table and allocate new entry if needed
      */
-    void updateGlobalThreshold(Addr pc, bool update_condition, bool update_direction);
+    void updateGlobalThreshold(Addr pc, bool update_direction);
 
   private:
     // Look up predictions in MGSC tables for a stream of instructions
@@ -350,8 +300,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /*weight table index width*/
     unsigned weightTableIdxWidth;
 
-    // Number of ways for set associative design
-    const unsigned numWays;
+    const unsigned numCtrsPerLine = 8;
 
     // Whether MGSC is enabled
     bool enableMGSC;
@@ -363,39 +312,39 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<FoldedHist> indexGFoldedHist;
     std::vector<FoldedHist> indexPFoldedHist;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> bwTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> bwWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> bwTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> bwWeightTable;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> lTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> lWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> lTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> lWeightTable;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> iTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> iWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> iTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> iWeightTable;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> gTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> gWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> gTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> gWeightTable;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> pTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> pWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> pTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> pWeightTable;
 
-    // The actual MGSC prediction tables (table x index x way)
-    std::vector<std::vector<std::vector<MgscEntry>>> biasTable;
-    // The actual MGSC prediction tables (index x way)
-    std::vector<std::vector<MgscWeightEntry>> biasWeightTable;
+    // The actual MGSC prediction tables (table x index x line)
+    std::vector<std::vector<std::vector<int16_t>>> biasTable;
+    // The actual MGSC prediction tables (index x line)
+    std::vector<std::vector<int16_t>> biasWeightTable;
 
     // thres table
-    std::vector<std::vector<MgscThresEntry>> pUpdateThreshold;  // pc-indexed threshold table
-    std::vector<MgscThresEntry> updateThreshold;                // global threshold table
+    std::vector<std::vector<int16_t>> pUpdateThreshold;  // pc-indexed threshold table
+    uint64_t updateThreshold;                             // global threshold table
 
 
     // Debug flag
@@ -408,15 +357,15 @@ class BTBMGSC : public TimedBaseBTBPredictor
     void updateCounter(bool taken, unsigned width, short &counter);
 
     // Update unsigned counter with saturation
-    void updateCounter(bool taken, unsigned width, unsigned &counter);
+    void updateCounter(bool taken, unsigned width, uint64_t &counter);
 
     // Increment counter with saturation
     bool satIncrement(int max, short &counter);
-    bool satIncrement(int max, unsigned &counter);
+    bool satIncrement(int max, uint64_t &counter);
 
     // Decrement counter with saturation
     bool satDecrement(int min, short &counter);
-    bool satDecrement(int min, unsigned &counter);
+    bool satDecrement(int min, uint64_t &counter);
 
     // Cache for MGSC indices
     std::vector<Addr> bwIndex;

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -42,7 +42,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         bool use_mgsc;                // Whether to use MGSC prediction
         bool taken;                   // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
         bool taken_before_sc;         // Tage prediction (before SC)
-        unsigned total_thres;         // Combined threshold
+        int16_t total_thres;         // Combined threshold
         std::vector<Addr> bwIndex;    // BW table indices
         std::vector<Addr> lIndex;     // L table indices
         std::vector<Addr> iIndex;     // I table indices
@@ -192,7 +192,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Find threshold in a threshold table for a given PC
      */
-    int findThreshold(const std::vector<uint16_t> &thresholdTable, Addr pc);
+    int findThreshold(const std::vector<int16_t> &thresholdTable, Addr pc);
 
     /**
      * Calculate if weight scale causes prediction difference
@@ -342,8 +342,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<std::vector<int16_t>> biasWeightTable;
 
     // thres table
-    std::vector<uint16_t> pUpdateThreshold;  // pc-indexed threshold table
-    uint16_t updateThreshold;                // global threshold table
+    std::vector<int16_t> pUpdateThreshold;  // pc-indexed threshold table
+    int16_t updateThreshold;                // global threshold table
 
 
     // Debug flag

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -245,7 +245,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
      */
     std::tuple<unsigned, unsigned> posHash(Addr pc, unsigned tableIdx)
     {
-        return {tableIdx >> numCtrsPerLineBits, ((pc >> instShiftAmt) ^ tableIdx) & (numCtrsPerLine - 1)};
+        return {tableIdx >> numCtrsPerLineBits, ((pc >> (instShiftAmt + 1)) ^ tableIdx) & (numCtrsPerLine - 1)};
     }
 
     // Helper method to generate prediction for a single BTB entry

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -3,8 +3,8 @@
 
 #include <deque>
 #include <map>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "base/sat_counter.hh"
 #include "base/types.hh"
@@ -29,123 +29,162 @@ class BTBMGSC : public TimedBaseBTBPredictor
 {
     using defer = std::shared_ptr<void>;
     using bitset = boost::dynamic_bitset<>;
+
   public:
     typedef BTBMGSCParams Params;
 
     // Represents a single entry in the MGSC prediction table
     struct MgscEntry
     {
-        public:
-            bool valid;
-            short counter;  // Prediction counter (-32 to 31), 6bits
-            Addr pc;        // branch pc, like branch position, for btb entry pc check
-            unsigned lruCounter;
+      public:
+        bool valid;
+        short counter;  // Prediction counter (-32 to 31), 6bits
+        Addr pc;        // branch pc, like branch position, for btb entry pc check
+        unsigned lruCounter;
 
-            MgscEntry() : valid(false), counter(0), pc(0), lruCounter(0) {}
+        MgscEntry() : valid(false), counter(0), pc(0), lruCounter(0) {}
 
-            MgscEntry(bool valid, short counter, Addr pc, unsigned lruCounter) :
-            valid(valid), counter(counter), pc(pc), lruCounter(lruCounter) {}
-            bool taken() const {
-                return counter >= 0;
-            }
+        MgscEntry(bool valid, short counter, Addr pc, unsigned lruCounter)
+            : valid(valid), counter(counter), pc(pc), lruCounter(lruCounter)
+        {
+        }
+        bool taken() const { return counter >= 0; }
     };
 
     // Represents a single entry in the MGSC weight table
     struct MgscWeightEntry
     {
-        public:
-            bool valid;
-            Addr pc;           // btb entry pc, same as mgsc entry pc
-            short counter;  // weight counter (-32 to 31), 6bits
-            unsigned lruCounter;
+      public:
+        bool valid;
+        Addr pc;        // btb entry pc, same as mgsc entry pc
+        short counter;  // weight counter (-32 to 31), 6bits
+        unsigned lruCounter;
 
-            MgscWeightEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
+        MgscWeightEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
 
-            MgscWeightEntry(bool valid, Addr pc, short counter, unsigned lruCounter) :
-                            valid(valid), pc(pc), counter(counter), lruCounter(lruCounter) {}
+        MgscWeightEntry(bool valid, Addr pc, short counter, unsigned lruCounter)
+            : valid(valid), pc(pc), counter(counter), lruCounter(lruCounter)
+        {
+        }
     };
 
     struct MgscThresEntry
     {
-        public:
-            bool valid;
-            Addr pc;           // btb entry pc, same as mgsc entry pc
-            unsigned counter;         // thres counter (0 to 255), 6bits
-            unsigned lruCounter;
+      public:
+        bool valid;
+        Addr pc;           // btb entry pc, same as mgsc entry pc
+        unsigned counter;  // thres counter (0 to 255), 6bits
+        unsigned lruCounter;
 
-            MgscThresEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
+        MgscThresEntry() : valid(false), pc(0), counter(0), lruCounter(0) {}
 
-            MgscThresEntry(bool valid, Addr pc, unsigned counter, unsigned lruCounter) :
-                            valid(valid), pc(pc), counter(counter), lruCounter(lruCounter) {}
+        MgscThresEntry(bool valid, Addr pc, unsigned counter, unsigned lruCounter)
+            : valid(valid), pc(pc), counter(counter), lruCounter(lruCounter)
+        {
+        }
     };
 
     // Contains the complete prediction result
     struct MgscPrediction
     {
-        Addr btb_pc;                    // BTB entry PC
-        int total_sum;                  // Total weighted sum
-        bool use_mgsc;                  // Whether to use MGSC prediction
-        bool taken;                     // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
-        bool taken_before_sc;           // Tage prediction (before SC)
-        unsigned total_thres;           // Combined threshold
-        std::vector<Addr> bwIndex;      // BW table indices
-        std::vector<Addr> lIndex;       // L table indices
-        std::vector<Addr> iIndex;       // I table indices
-        std::vector<Addr> gIndex;       // G table indices
-        std::vector<Addr> pIndex;       // P table indices
-        std::vector<Addr> biasIndex;    // Bias table indices
-        // Weight scale difference flags and percsum values
-            bool bw_weight_scale_diff;
-            bool l_weight_scale_diff;
-            bool i_weight_scale_diff;
-            bool g_weight_scale_diff;
-            bool p_weight_scale_diff;
-            bool bias_weight_scale_diff;
-            int bw_percsum;
-            int l_percsum;
-            int i_percsum;
-            int g_percsum;
-            int p_percsum;
-            int bias_percsum;
+        Addr btb_pc;                  // BTB entry PC
+        int total_sum;                // Total weighted sum
+        bool use_mgsc;                // Whether to use MGSC prediction
+        bool taken;                   // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
+        bool taken_before_sc;         // Tage prediction (before SC)
+        unsigned total_thres;         // Combined threshold
+        std::vector<Addr> bwIndex;    // BW table indices
+        std::vector<Addr> lIndex;     // L table indices
+        std::vector<Addr> iIndex;     // I table indices
+        std::vector<Addr> gIndex;     // G table indices
+        std::vector<Addr> pIndex;     // P table indices
+        std::vector<Addr> biasIndex;  // Bias table indices
+                                      // Weight scale difference flags and percsum values
+        bool bw_weight_scale_diff;
+        bool l_weight_scale_diff;
+        bool i_weight_scale_diff;
+        bool g_weight_scale_diff;
+        bool p_weight_scale_diff;
+        bool bias_weight_scale_diff;
+        int bw_percsum;
+        int l_percsum;
+        int i_percsum;
+        int g_percsum;
+        int p_percsum;
+        int bias_percsum;
 
-            MgscPrediction() : btb_pc(0), total_sum(0), use_mgsc(false), taken(false),
-                               taken_before_sc(false), total_thres(0), bwIndex(0),
-                               lIndex(0), iIndex(0), gIndex(0), pIndex(0), biasIndex(0), bw_weight_scale_diff(false),
-                               l_weight_scale_diff(false), i_weight_scale_diff(false),
-                               g_weight_scale_diff(false), p_weight_scale_diff(false), bias_weight_scale_diff(false),
-                               bw_percsum(0), l_percsum(0), i_percsum(0), g_percsum(0), p_percsum(0), bias_percsum(0){}
+        MgscPrediction()
+            : btb_pc(0),
+              total_sum(0),
+              use_mgsc(false),
+              taken(false),
+              taken_before_sc(false),
+              total_thres(0),
+              bwIndex(0),
+              lIndex(0),
+              iIndex(0),
+              gIndex(0),
+              pIndex(0),
+              biasIndex(0),
+              bw_weight_scale_diff(false),
+              l_weight_scale_diff(false),
+              i_weight_scale_diff(false),
+              g_weight_scale_diff(false),
+              p_weight_scale_diff(false),
+              bias_weight_scale_diff(false),
+              bw_percsum(0),
+              l_percsum(0),
+              i_percsum(0),
+              g_percsum(0),
+              p_percsum(0),
+              bias_percsum(0)
+        {
+        }
 
-            MgscPrediction(Addr btb_pc, int total_sum, bool use_mgsc, bool taken,
-                           bool taken_before_sc, unsigned total_thres,
-                           std::vector<Addr> bwIndex, std::vector<Addr> lIndex,
-                           std::vector<Addr> iIndex, std::vector<Addr> gIndex,
-                           std::vector<Addr> pIndex, std::vector<Addr> biasIndex,
-                           bool bw_weight_scale_diff, bool l_weight_scale_diff, bool i_weight_scale_diff,
-                           bool g_weight_scale_diff, bool p_weight_scale_diff,
-                           bool bias_weight_scale_diff, int bw_percsum,
-                           int l_percsum, int i_percsum, int g_percsum, int p_percsum, int bias_percsum) :
-                            btb_pc(btb_pc), total_sum(total_sum), use_mgsc(use_mgsc),
-                            taken(taken), taken_before_sc(taken_before_sc),
-                            total_thres(total_thres), bwIndex(bwIndex),
-                            lIndex(lIndex), iIndex(iIndex), gIndex(gIndex), pIndex(pIndex),
-                            biasIndex(biasIndex), bw_weight_scale_diff(bw_weight_scale_diff),
-                            l_weight_scale_diff(l_weight_scale_diff), i_weight_scale_diff(i_weight_scale_diff),
-                            g_weight_scale_diff(g_weight_scale_diff), p_weight_scale_diff(p_weight_scale_diff),
-                            bias_weight_scale_diff(bias_weight_scale_diff),
-                            bw_percsum(bw_percsum), l_percsum(l_percsum), i_percsum(i_percsum), g_percsum(g_percsum),
-                            p_percsum(p_percsum), bias_percsum(bias_percsum){}
+        MgscPrediction(Addr btb_pc, int total_sum, bool use_mgsc, bool taken, bool taken_before_sc,
+                       unsigned total_thres, std::vector<Addr> bwIndex, std::vector<Addr> lIndex,
+                       std::vector<Addr> iIndex, std::vector<Addr> gIndex, std::vector<Addr> pIndex,
+                       std::vector<Addr> biasIndex, bool bw_weight_scale_diff, bool l_weight_scale_diff,
+                       bool i_weight_scale_diff, bool g_weight_scale_diff, bool p_weight_scale_diff,
+                       bool bias_weight_scale_diff, int bw_percsum, int l_percsum, int i_percsum, int g_percsum,
+                       int p_percsum, int bias_percsum)
+            : btb_pc(btb_pc),
+              total_sum(total_sum),
+              use_mgsc(use_mgsc),
+              taken(taken),
+              taken_before_sc(taken_before_sc),
+              total_thres(total_thres),
+              bwIndex(bwIndex),
+              lIndex(lIndex),
+              iIndex(iIndex),
+              gIndex(gIndex),
+              pIndex(pIndex),
+              biasIndex(biasIndex),
+              bw_weight_scale_diff(bw_weight_scale_diff),
+              l_weight_scale_diff(l_weight_scale_diff),
+              i_weight_scale_diff(i_weight_scale_diff),
+              g_weight_scale_diff(g_weight_scale_diff),
+              p_weight_scale_diff(p_weight_scale_diff),
+              bias_weight_scale_diff(bias_weight_scale_diff),
+              bw_percsum(bw_percsum),
+              l_percsum(l_percsum),
+              i_percsum(i_percsum),
+              g_percsum(g_percsum),
+              p_percsum(p_percsum),
+              bias_percsum(bias_percsum)
+        {
+        }
     };
 
   public:
-    BTBMGSC(const Params& p);
+    BTBMGSC(const Params &p);
     ~BTBMGSC();
 
     void tickStart() override;
 
     void tick() override;
     // Make predictions for a stream of instructions and record in stage preds
-    void putPCHistory(Addr startAddr,
-                      const boost::dynamic_bitset<> &history,
+    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
 
     std::shared_ptr<void> getPredictionMeta() override;
@@ -157,12 +196,18 @@ class BTBMGSC : public TimedBaseBTBPredictor
     void specUpdateIHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
     void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) override;
 
-    // Recover all folded history after a misprediction, then update all folded history according to history and pred.taken
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
-    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
-    void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
-    void recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
-    void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchStream &entry, int shamt, bool cond_taken) override;
+    // Recover all folded history after a misprediction, then update all folded history according to history and
+    // pred.taken
+    void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt,
+                     bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt,
+                      bool cond_taken) override;
+    void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt,
+                       bool cond_taken) override;
+    void recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt,
+                      bool cond_taken) override;
+    void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchStream &entry, int shamt,
+                      bool cond_taken) override;
 
     // Update predictor state based on actual branch outcomes
     void update(const FetchStream &entry) override;
@@ -182,16 +227,12 @@ class BTBMGSC : public TimedBaseBTBPredictor
      * Calculate percsum from a table for a given PC
      */
     int calculatePercsum(const std::vector<std::vector<std::vector<MgscEntry>>> &table,
-                         const std::vector<Addr> &tableIndices,
-                         unsigned numTables,
-                         Addr pc);
+                         const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc);
 
     /**
      * Find weight in a weight table for a given PC
      */
-    int findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable,
-                   Addr tableIndex,
-                   Addr pc);
+    int findWeight(const std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc);
 
     /**
      * Calculate scaled percsum using weight
@@ -201,9 +242,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Find threshold in a threshold table for a given PC
      */
-    int findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable,
-                      Addr tableIndex,
-                      Addr pc,
+    int findThreshold(const std::vector<std::vector<MgscThresEntry>> &thresholdTable, Addr tableIndex, Addr pc,
                       int defaultValue);
 
     /**
@@ -215,40 +254,29 @@ class BTBMGSC : public TimedBaseBTBPredictor
      * Update a prediction table and allocate new entry if needed
      */
     void updateAndAllocatePredTable(std::vector<std::vector<std::vector<MgscEntry>>> &table,
-                                   const std::vector<Addr> &tableIndices,
-                                   unsigned numTables,
-                                   Addr pc,
-                                   bool actual_taken);
+                                    const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
+                                    bool actual_taken);
 
     /**
      * Update a weight table and allocate new entry if needed
      */
-    void updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable,
-                                    Addr tableIndex,
-                                    Addr pc,
-                                    bool weight_scale_diff,
-                                    bool percsum_matches_actual);
+    void updateAndAllocateWeightTable(std::vector<std::vector<MgscWeightEntry>> &weightTable, Addr tableIndex, Addr pc,
+                                      bool weight_scale_diff, bool percsum_matches_actual);
 
     /**
      * Update a threshold table and allocate new entry if needed
      */
-    void updatePCThresholdTable(Addr tableIndex,
-                                Addr pc,
-                                bool update_condition,
-                                bool update_direction);
+    void updatePCThresholdTable(Addr tableIndex, Addr pc, bool update_condition, bool update_direction);
 
     /**
      * Update the global threshold table and allocate new entry if needed
      */
-    void updateGlobalThreshold(Addr pc,
-                             bool update_condition,
-                             bool update_direction);
+    void updateGlobalThreshold(Addr pc, bool update_condition, bool update_direction);
 
   private:
-
     // Look up predictions in MGSC tables for a stream of instructions
     void lookupHelper(const Addr &stream_start, const std::vector<BTBEntry> &btbEntries,
-                                      const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results);
+                      const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results);
 
     // Calculate MGSC history index with folded history
     Addr getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist);
@@ -257,13 +285,11 @@ class BTBMGSC : public TimedBaseBTBPredictor
     Addr getBiasIndex(Addr pc, unsigned tableIndexBits, bool lowbit0, bool lowbit1);
 
     // Get offset within a block for a given PC
-    Addr getOffset(Addr pc) {
-        return (pc & (blockSize - 1)) >> 1;
-    }
+    Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }
 
     // Update branch history
-    void doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
-        bool taken, std::vector<FoldedHist> &foldedHist, Addr pc = 0, Addr target = 0);
+    void doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool taken,
+                      std::vector<FoldedHist> &foldedHist, Addr pc = 0, Addr target = 0);
 
     /** global backward branch history indexed tables */
     // number of global backward branch history indexed tables
@@ -369,14 +395,14 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
     // thres table
     std::vector<std::vector<MgscThresEntry>> pUpdateThreshold;  // pc-indexed threshold table
-    std::vector<MgscThresEntry> updateThreshold;  // global threshold table
+    std::vector<MgscThresEntry> updateThreshold;                // global threshold table
 
 
     // Debug flag
     bool debugFlagOn{false};
 
     // Instruction shift amount
-    unsigned instShiftAmt {1};
+    unsigned instShiftAmt{1};
 
     // Update signed counter with saturation
     void updateCounter(bool taken, unsigned width, short &counter);
@@ -401,7 +427,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<Addr> biasIndex;
 
     // Statistics for MGSC predictor
-    struct MgscStats : public statistics::Group {
+    struct MgscStats : public statistics::Group
+    {
         statistics::Scalar scCorrectTageWrong;
         statistics::Scalar scWrongTageCorrect;
         statistics::Scalar scCorrectTageCorrect;
@@ -409,26 +436,23 @@ class BTBMGSC : public TimedBaseBTBPredictor
         statistics::Scalar scUsed;
         statistics::Scalar scNotUsed;
 
-        MgscStats(statistics::Group* parent);
-    } ;
+        MgscStats(statistics::Group *parent);
+    };
 
     MgscStats mgscStats;
 
     TraceManager *mgscMissTrace;
 
-public:
-
+  public:
     // Recover folded history after misprediction
-    void recoverFoldedHist(const bitset& history);
-    unsigned getNumEntriesFirstLocalHistories(){
-        return numEntriesFirstLocalHistories;
-    };
+    void recoverFoldedHist(const bitset &history);
+    unsigned getNumEntriesFirstLocalHistories() { return numEntriesFirstLocalHistories; };
 
-public:
-
-private:
+  public:
+  private:
     // Metadata for MGSC predictions
-    typedef struct MgscMeta {
+    typedef struct MgscMeta
+    {
         std::unordered_map<Addr, MgscPrediction> preds;
         std::vector<FoldedHist> indexBwFoldedHist;
         std::vector<std::vector<FoldedHist>> indexLFoldedHist;
@@ -437,11 +461,18 @@ private:
         std::vector<FoldedHist> indexPFoldedHist;
         MgscMeta(std::unordered_map<Addr, MgscPrediction> preds, std::vector<FoldedHist> indexBwFoldedHist,
                  std::vector<std::vector<FoldedHist>> indexLFoldedHist, std::vector<FoldedHist> indexIFoldedHist,
-                 std::vector<FoldedHist> indexGFoldedHist, std::vector<FoldedHist> indexPFoldedHist) :
-            preds(preds), indexBwFoldedHist(indexBwFoldedHist), indexLFoldedHist(indexLFoldedHist),
-            indexIFoldedHist(indexIFoldedHist), indexGFoldedHist(indexGFoldedHist), indexPFoldedHist(indexPFoldedHist) {}
+                 std::vector<FoldedHist> indexGFoldedHist, std::vector<FoldedHist> indexPFoldedHist)
+            : preds(preds),
+              indexBwFoldedHist(indexBwFoldedHist),
+              indexLFoldedHist(indexLFoldedHist),
+              indexIFoldedHist(indexIFoldedHist),
+              indexGFoldedHist(indexGFoldedHist),
+              indexPFoldedHist(indexPFoldedHist)
+        {
+        }
         MgscMeta() {}
-        MgscMeta(const MgscMeta &other) {
+        MgscMeta(const MgscMeta &other)
+        {
             preds = other.preds;
             indexBwFoldedHist = other.indexBwFoldedHist;
             indexLFoldedHist = other.indexLFoldedHist;
@@ -451,30 +482,27 @@ private:
         }
     } MgscMeta;
 
-private:
+  private:
     // Helper method to generate prediction for a single BTB entry
     bool tagMatch(Addr pc_a, Addr pc_b, unsigned matchBits);
-    MgscPrediction generateSinglePrediction(const BTBEntry &btb_entry,
-                                           const Addr &startPC,
-                                           const TageInfoForMGSC &tage_info);
+    MgscPrediction generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC,
+                                            const TageInfoForMGSC &tage_info);
 
     // Helper method to prepare BTB entries for update
     std::vector<BTBEntry> prepareUpdateEntries(const FetchStream &stream);
 
-    void updateAndAllocateSinglePredictor(const BTBEntry &entry,
-                                          bool actual_taken,
-                                          const MgscPrediction &pred,
+    void updateAndAllocateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
                                           const FetchStream &stream);
-    template <typename T>
+    template<typename T>
     void updateLRU(std::vector<std::vector<T>> &table, Addr index, unsigned way);
 
-    template <typename T>
+    template<typename T>
     void updateLRU(std::vector<T> &table, unsigned way);
 
-    template <typename T>
+    template<typename T>
     unsigned getLRUVictim(std::vector<std::vector<T>> &table, Addr index);
 
-    template <typename T>
+    template<typename T>
     unsigned getLRUVictim(std::vector<T> &table);
 
     std::shared_ptr<MgscMeta> meta;

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -299,7 +299,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /*weight table index width*/
     unsigned weightTableIdxWidth;
 
-    const unsigned numCtrsPerLine = 8;
+    unsigned numCtrsPerLine;
+    unsigned numCtrsPerLineBits;
 
     // Whether MGSC is enabled
     bool enableMGSC;

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <deque>
 #include <map>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -37,19 +38,19 @@ class BTBMGSC : public TimedBaseBTBPredictor
     // Contains the complete prediction result
     struct MgscPrediction
     {
-        Addr btb_pc;                  // BTB entry PC
-        int total_sum;                // Total weighted sum
-        bool use_mgsc;                // Whether to use MGSC prediction
-        bool taken;                   // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
-        bool taken_before_sc;         // Tage prediction (before SC)
-        int16_t total_thres;          // Combined threshold
-        std::vector<Addr> bwIndex;    // BW table indices
-        std::vector<Addr> lIndex;     // L table indices
-        std::vector<Addr> iIndex;     // I table indices
-        std::vector<Addr> gIndex;     // G table indices
-        std::vector<Addr> pIndex;     // P table indices
-        std::vector<Addr> biasIndex;  // Bias table indices
-                                      // Weight scale difference flags and percsum values
+        Addr btb_pc;                      // BTB entry PC
+        int total_sum;                    // Total weighted sum
+        bool use_mgsc;                    // Whether to use MGSC prediction
+        bool taken;                       // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
+        bool taken_before_sc;             // Tage prediction (before SC)
+        int16_t total_thres;              // Combined threshold
+        std::vector<unsigned> bwIndex;    // BW table indices
+        std::vector<unsigned> lIndex;     // L table indices
+        std::vector<unsigned> iIndex;     // I table indices
+        std::vector<unsigned> gIndex;     // G table indices
+        std::vector<unsigned> pIndex;     // P table indices
+        std::vector<unsigned> biasIndex;  // Bias table indices
+                                          // Weight scale difference flags and percsum values
         bool bw_weight_scale_diff;
         bool l_weight_scale_diff;
         bool i_weight_scale_diff;
@@ -92,9 +93,9 @@ class BTBMGSC : public TimedBaseBTBPredictor
         }
 
         MgscPrediction(Addr btb_pc, int total_sum, bool use_mgsc, bool taken, bool taken_before_sc,
-                       unsigned total_thres, std::vector<Addr> bwIndex, std::vector<Addr> lIndex,
-                       std::vector<Addr> iIndex, std::vector<Addr> gIndex, std::vector<Addr> pIndex,
-                       std::vector<Addr> biasIndex, bool bw_weight_scale_diff, bool l_weight_scale_diff,
+                       unsigned total_thres, std::vector<unsigned> bwIndex, std::vector<unsigned> lIndex,
+                       std::vector<unsigned> iIndex, std::vector<unsigned> gIndex, std::vector<unsigned> pIndex,
+                       std::vector<unsigned> biasIndex, bool bw_weight_scale_diff, bool l_weight_scale_diff,
                        bool i_weight_scale_diff, bool g_weight_scale_diff, bool p_weight_scale_diff,
                        bool bias_weight_scale_diff, int bw_percsum, int l_percsum, int i_percsum, int g_percsum,
                        int p_percsum, int bias_percsum)
@@ -177,7 +178,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
      * Calculate percsum from a table for a given PC
      */
     int calculatePercsum(const std::vector<std::vector<std::vector<int16_t>>> &table,
-                         const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc);
+                         const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc);
 
     /**
      * Find weight in a weight table for a given PC
@@ -203,7 +204,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
      * Update a prediction table and allocate new entry if needed
      */
     void updateAndAllocatePredTable(std::vector<std::vector<std::vector<int16_t>>> &table,
-                                    const std::vector<Addr> &tableIndices, unsigned numTables, Addr pc,
+                                    const std::vector<unsigned> &tableIndices, unsigned numTables, Addr pc,
                                     bool actual_taken);
 
     /**
@@ -239,6 +240,11 @@ class BTBMGSC : public TimedBaseBTBPredictor
     // Update branch history
     void doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool taken,
                       std::vector<FoldedHist> &foldedHist, Addr pc = 0, Addr target = 0);
+
+    std::tuple<unsigned, unsigned> posHash(Addr pc, unsigned tableIdx)
+    {
+        return {tableIdx >> numCtrsPerLineBits, ((pc >> instShiftAmt) ^ tableIdx) & (numCtrsPerLine - 1)};
+    }
 
     /** global backward branch history indexed tables */
     // number of global backward branch history indexed tables
@@ -366,12 +372,12 @@ class BTBMGSC : public TimedBaseBTBPredictor
     bool satDecrement(T min, T &counter);
 
     // Cache for MGSC indices
-    std::vector<Addr> bwIndex;
-    std::vector<Addr> lIndex;
-    std::vector<Addr> iIndex;
-    std::vector<Addr> gIndex;
-    std::vector<Addr> pIndex;
-    std::vector<Addr> biasIndex;
+    std::vector<unsigned> bwIndex;
+    std::vector<unsigned> lIndex;
+    std::vector<unsigned> iIndex;
+    std::vector<unsigned> gIndex;
+    std::vector<unsigned> pIndex;
+    std::vector<unsigned> biasIndex;
 
     // Statistics for MGSC predictor
     struct MgscStats : public statistics::Group

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -89,7 +89,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         }
 
         MgscPrediction(Addr btb_pc, int total_sum, bool use_mgsc, bool taken, bool taken_before_sc,
-                       unsigned total_thres, std::vector<unsigned> bwIndex, std::vector<unsigned> lIndex,
+                       int16_t total_thres, std::vector<unsigned> bwIndex, std::vector<unsigned> lIndex,
                        std::vector<unsigned> iIndex, std::vector<unsigned> gIndex, std::vector<unsigned> pIndex,
                        std::vector<unsigned> biasIndex, bool bw_weight_scale_diff, bool l_weight_scale_diff,
                        bool i_weight_scale_diff, bool g_weight_scale_diff, bool p_weight_scale_diff,

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -42,7 +42,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         bool use_mgsc;                // Whether to use MGSC prediction
         bool taken;                   // Final prediction = (use sc pred) ? (total_sum >= 0) : tage prediction
         bool taken_before_sc;         // Tage prediction (before SC)
-        int16_t total_thres;         // Combined threshold
+        int16_t total_thres;          // Combined threshold
         std::vector<Addr> bwIndex;    // BW table indices
         std::vector<Addr> lIndex;     // L table indices
         std::vector<Addr> iIndex;     // I table indices
@@ -182,7 +182,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Find weight in a weight table for a given PC
      */
-    int findWeight(const std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc);
+    int findWeight(const std::vector<int16_t> &weightTable, Addr pc);
 
     /**
      * Calculate scaled percsum using weight
@@ -209,7 +209,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     /**
      * Update a weight table and allocate new entry if needed
      */
-    void updateAndAllocateWeightTable(std::vector<std::vector<int16_t>> &weightTable, Addr tableIndex, Addr pc,
+    void updateAndAllocateWeightTable(std::vector<int16_t> &weightTable, Addr tableIndex, Addr pc,
                                       bool weight_scale_diff, bool percsum_matches_actual);
 
     /**
@@ -314,32 +314,32 @@ class BTBMGSC : public TimedBaseBTBPredictor
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> bwTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> bwWeightTable;
+    std::vector<int16_t> bwWeightTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> lTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> lWeightTable;
+    std::vector<int16_t> lWeightTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> iTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> iWeightTable;
+    std::vector<int16_t> iWeightTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> gTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> gWeightTable;
+    std::vector<int16_t> gWeightTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> pTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> pWeightTable;
+    std::vector<int16_t> pWeightTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> biasTable;
     // The actual MGSC prediction tables (index x line)
-    std::vector<std::vector<int16_t>> biasWeightTable;
+    std::vector<int16_t> biasWeightTable;
 
     // thres table
     std::vector<int16_t> pUpdateThreshold;  // pc-indexed threshold table

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -304,7 +304,7 @@ BTBTAGE::lookupHelper(const Addr &alignedPC, const std::vector<BTBEntry> &btbEnt
             meta->preds[btb_entry.pc] = pred;
             tageStats.updateStatsWithTagePrediction(pred, true);
             results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
-            tageInfoForMgscs[btb_entry.pc].tage_pred_taken = pred.taken;
+            tageInfoForMgscs[btb_entry.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
             tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high = pred.mainInfo.found &&
                                          abs(pred.mainInfo.entry.counter*2 + 1) == 7; // counter saturated, -4 or 3
             tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid = pred.mainInfo.found &&

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -304,6 +304,7 @@ BTBTAGE::lookupHelper(const Addr &alignedPC, const std::vector<BTBEntry> &btbEnt
             meta->preds[btb_entry.pc] = pred;
             tageStats.updateStatsWithTagePrediction(pred, true);
             results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
+            tageInfoForMgscs[btb_entry.pc].tage_pred_taken = pred.taken;
             tageInfoForMgscs[btb_entry.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
             tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high = pred.mainInfo.found &&
                                          abs(pred.mainInfo.entry.counter*2 + 1) == 7; // counter saturated, -4 or 3

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -179,6 +179,7 @@ struct BTBEntry : BranchInfo
 struct TageInfoForMGSC
 {
     // tage info
+    bool tage_pred_taken;
     bool tage_main_taken;
     bool tage_pred_conf_high;
     bool tage_pred_conf_mid;
@@ -186,15 +187,25 @@ struct TageInfoForMGSC
     bool tage_pred_alt_diff;
 
     // Addr offset; // retrived from lowest bits of pc
-    TageInfoForMGSC() : tage_main_taken(false), tage_pred_conf_high(false),
-                        tage_pred_conf_mid(false), tage_pred_conf_low(false),
-                        tage_pred_alt_diff(false){}
-    TageInfoForMGSC(bool tage_pred_taken, bool tage_pred_conf_high, bool tage_pred_conf_mid,
-                    bool tage_pred_conf_low, bool tage_pred_alt_diff) :
-                    tage_main_taken(tage_pred_taken), tage_pred_conf_high(tage_pred_conf_high),
-                    tage_pred_conf_mid(tage_pred_conf_mid), tage_pred_conf_low(tage_pred_conf_low),
-                    tage_pred_alt_diff(tage_pred_alt_diff) {}
-
+    TageInfoForMGSC()
+        : tage_pred_taken(false),
+            tage_main_taken(false),
+            tage_pred_conf_high(false),
+            tage_pred_conf_mid(false),
+            tage_pred_conf_low(false),
+            tage_pred_alt_diff(false)
+    {
+    }
+    TageInfoForMGSC(bool tage_pred_taken, bool tage_main_taken, bool tage_pred_conf_high, bool tage_pred_conf_mid,
+                    bool tage_pred_conf_low, bool tage_pred_alt_diff)
+        : tage_pred_taken(tage_pred_taken),
+            tage_main_taken(tage_main_taken),
+            tage_pred_conf_high(tage_pred_conf_high),
+            tage_pred_conf_mid(tage_pred_conf_mid),
+            tage_pred_conf_low(tage_pred_conf_low),
+            tage_pred_alt_diff(tage_pred_alt_diff)
+    {
+    }
 };
 
 struct LFSR64

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -179,19 +179,19 @@ struct BTBEntry : BranchInfo
 struct TageInfoForMGSC
 {
     // tage info
-    bool tage_pred_taken;
+    bool tage_main_taken;
     bool tage_pred_conf_high;
     bool tage_pred_conf_mid;
     bool tage_pred_conf_low;
     bool tage_pred_alt_diff;
 
     // Addr offset; // retrived from lowest bits of pc
-    TageInfoForMGSC() : tage_pred_taken(false), tage_pred_conf_high(false),
+    TageInfoForMGSC() : tage_main_taken(false), tage_pred_conf_high(false),
                         tage_pred_conf_mid(false), tage_pred_conf_low(false),
                         tage_pred_alt_diff(false){}
     TageInfoForMGSC(bool tage_pred_taken, bool tage_pred_conf_high, bool tage_pred_conf_mid,
                     bool tage_pred_conf_low, bool tage_pred_alt_diff) :
-                    tage_pred_taken(tage_pred_taken), tage_pred_conf_high(tage_pred_conf_high),
+                    tage_main_taken(tage_pred_taken), tage_pred_conf_high(tage_pred_conf_high),
                     tage_pred_conf_mid(tage_pred_conf_mid), tage_pred_conf_low(tage_pred_conf_low),
                     tage_pred_alt_diff(tage_pred_alt_diff) {}
 
@@ -679,7 +679,7 @@ struct TageMissTrace : public Record {
         uint64_t mainFound, uint64_t mainCounter, uint64_t mainUseful, uint64_t mainTable, uint64_t mainIndex,
         uint64_t altFound, uint64_t altCounter, uint64_t altUseful, uint64_t altTable, uint64_t altIndex,
         uint64_t useAlt, uint64_t predTaken, uint64_t actualTaken, uint64_t allocSuccess,
-        uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay, 
+        uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay,
         std::string history, uint64_t indexFoldedHist)
     {
         _tick = curTick();


### PR DESCRIPTION
use signed int for update threshold and PupdateThreshold, this allows for a PC to use lower threshold then global threshold

removed tag cmp and alloc, just share counter between branches in the same line. For current config, 4:1 sharing seems good enough for performance.

remove fine grained weight, just use x1/x2 selection

remove extra information from TAGE, just use main provider info only.

use normally sized storage, ~ 16KB.

increase around 0.38 scores/GHz then using TAGE only. decrease around 0.15 scores/GHz from SC in xs-dev with 120KB storage.