### PR TITLE
mem: Add prefetch requests to the arbitration logic of MSHR.

### DIFF
--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -46,6 +46,7 @@
 #include "mem/cache/base.hh"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 
 #include "base/compiler.hh"
@@ -338,26 +339,41 @@ BaseCache::checkAndAllocateMSHRCycle(PacketPtr pkt)
     if (mshrAllocPerCycle < 0)
         return true;
 
-    uint64_t curCycle = ticksToCycles(curTick());
+    // Determine mode: nullptr = peek (check only), non-null = allocate
+    const bool allocate = (pkt != nullptr);
+
+    // Use floor-division to compute the cycle number, avoiding any rounding
+    // that could mistakenly promote mid-cycle ticks to the next cycle.
+    uint64_t curCycle = curTick() / clockPeriod();
 
     // New cycle: reset counter and grant.
     if (lastMSHRAllocCycle != curCycle) {
-        accessCounter = 1;
-        lastMSHRAllocCycle = curCycle;
+        // In peek mode, counter and cycle are not modified;
+        // in allocate mode, initialize counter for the new cycle.
+        if (allocate) {
+            accessCounter = 1;
+            lastMSHRAllocCycle = curCycle;
+        }
         return true;
     }
 
     // Same cycle: allow up to mshrAllocPerCycle grants.
     if (accessCounter < mshrAllocPerCycle) {
-        accessCounter++;
+        if (allocate)
+            accessCounter++;
         return true;
     }
 
     // Exceeded per-cycle limit: fail and account.
     stats.MSHRArbFails++;
-    pkt->setMshrArbFailed();
-    pkt->req->decAccessDepth();
-    stats.cmdStats(pkt).misses[pkt->req->requestorId()]--;
+
+    // Support nullptr for prefetch arbitration pre-check
+    if (pkt) {
+        pkt->setMshrArbFailed();
+        pkt->req->decAccessDepth();
+        stats.cmdStats(pkt).misses[pkt->req->requestorId()]--;
+    }
+
     return false;
 }
 
@@ -1307,6 +1323,26 @@ BaseCache::getNextQueueEntry()
     if (prefetcher && mshrQueue.canPrefetch() && !isBlocked()) {
         // If we have a miss queue slot, we can try a prefetch
         bool has_pending_pkt = prefetcher->hasPendingPacket();
+
+        // Cache the condition to avoid redundant checks
+        const bool enableMSHRArb = (cacheLevel == 1 && !isReadOnly);
+
+        // Perform non-allocating peek: check allocation availability without
+        // allocating arbitration quota.
+        if (has_pending_pkt && enableMSHRArb &&
+            !checkAndAllocateMSHRCycle(nullptr)) {
+            DPRINTF(HWPrefetch, "Prefetch MSHR arbitration failed, "
+                    "will retry next cycle\n");
+            // Record one prefetch-demand conflict in MSHR arbitration.
+            stats.pfMSHRArbConflicts++;
+            // Arbitration failed: don't get packet, it stays in queue
+            // Will automatically retry next cycle
+            return nullptr;
+        }
+        // Verify prefetch is issued at cycle end
+        if (enableMSHRArb && curTick() != cyclesToTicks(ticksToCycles(curTick())) - 1)
+            return nullptr;
+
         PacketPtr pkt = nullptr;
         if (cacheLevel == 1) {
             // load & prefetch share a limited number of cache tag read ports
@@ -1346,6 +1382,16 @@ BaseCache::getNextQueueEntry()
                 // free the request and packet
                 delete pkt;
             } else {
+                // Perform the actual allocation-stage arbitration before allocation.
+                // Prevents quota overrun due to race between peek and allocate.
+                if (enableMSHRArb) {
+                    // Since peek passed and no interruption occurs within this flow,
+                    // the second-stage allocation must succeed.
+                    if (!checkAndAllocateMSHRCycle(pkt)) {
+                        panic("Prefetch MSHR second-stage allocation failed unexpectedly "
+                              "after successful peek");
+                    }
+                }
                 // Update statistic on number of prefetches issued
                 // (hwpf_mshr_misses)
                 assert(pkt->req->requestorId() < system->maxRequestors());
@@ -2885,6 +2931,8 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
              "number of hits in write buffer when missing in cache"),
     ADD_STAT(prefetchTagReadFails, statistics::units::Count::get(),
              "number of prefetch req Tag read fail because of load"),
+    ADD_STAT(pfMSHRArbConflicts, statistics::units::Count::get(),
+             "number of prefetch-demand conflicts in MSHR arbitration"),
     ADD_STAT(dataExpansions, statistics::units::Count::get(),
              "number of data expansions"),
     ADD_STAT(dataContractions, statistics::units::Count::get(),
@@ -3366,12 +3414,22 @@ BaseCache::CacheReqPacketQueue::sendDeferredPacket()
         }
     }
 
-    // if we succeeded and are not waiting for a retry, schedule the
-    // next send considering when the next queue is ready, note that
-    // snoop responses have their own packet queue and thus schedule
-    // their own events
+    // If we succeeded and are not waiting for a retry, schedule the next send.
+    // If there's no earlier specific time:
+    // - For prefetch requests, align to the end of the next cycle.
+    // - Otherwise, use nextQueueReadyTime() as-is.
     if (!waitingOnRetry) {
         to_schedule = to_schedule ? to_schedule : cache.nextQueueReadyTime();
+        // When both MSHR and WriteBuffer are empty,
+        // the next cycle will allocate MSHR for pf requests.
+        const bool enableMSHRArb = cache.cacheLevel == 1 && !cache.isReadOnly;
+        bool isPrefetch = (cache.prefetcher && to_schedule == cache.nextPrefetchReadyTime()) &&
+                          (to_schedule != cache.mshrQueue.nextReadyTime()) &&
+                          (to_schedule != cache.writeBuffer.nextReadyTime());
+        if (isPrefetch && enableMSHRArb) {
+            assert(to_schedule == cache.nextQueueReadyTime());
+            to_schedule = cache.endOfCycle(std::max(to_schedule, curTick()));
+        }
         schedSendEvent(to_schedule);
     }
 }

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -583,10 +583,30 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * arbitration failure flag on the packet, corrects statistics, and
      * returns false.
      *
+     * Supports two modes based on the pkt parameter:
+     * - pkt == nullptr: peek mode, only checks availability without allocation
+     * - pkt != nullptr: allocate mode, checks and allocates arbitration quota
+     *
      * @param pkt The memory request packet that requires an MSHR.
+     *            Pass nullptr for peek-only checks.
      * @return True if arbitration succeeds, false otherwise.
      */
     bool checkAndAllocateMSHRCycle(PacketPtr pkt);
+
+    /**
+     * @brief Helper function to compute the last tick of the cycle containing
+     * the given tick. Eliminates code duplication for cycle-end alignment.
+     *
+     * @param t The tick to query.
+     * @return The last tick of the cycle containing t.
+     */
+    Tick endOfCycle(Tick tick) const
+    {
+        // When the input is at the clock edge, align to the last tick of the current cycle.
+        if (tick % clockPeriod() == 0)
+            return tick + clockPeriod() - 1;
+        return cyclesToTicks(ticksToCycles(tick)) - 1;
+    }
 
     /*
      * Handle a timing request that hit in the cache
@@ -1327,6 +1347,13 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
         /** Number of prefetch req Tag read fail because of load. */
         mutable statistics::Scalar prefetchTagReadFails;
+
+        /**
+         * Number of prefetch-demand conflicts in MSHR arbitration.
+         * This counter measures how often prefetches are deferred due to
+         * the "demand-priority + prefetch-deferral" policy.
+         */
+        statistics::Scalar pfMSHRArbConflicts;
 
         /** Number of data expansions. */
         statistics::Scalar dataExpansions;


### PR DESCRIPTION
Change-Id: I45c4b62c0c4c77b574a8f06da7b7b27104027320

1. At the last 1 tick of each cycle, process the prefetch requests to ensure the prefetch has the lowest priority.
2. The prefetch request enters the mshr to participate in arbitration.