### PR TITLE
Fix mbtb vc perf

### DIFF
--- a/configs/example/xiangshan.py
+++ b/configs/example/xiangshan.py
@@ -403,13 +403,6 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.tage.TTagPcShifts = [1] * 8
             cpu.branchPred.tage.histLengths = [4, 9, 17, 29, 56, 109, 211, 397]
 
-            # cpu.branchPred.microtage.enableSC = False
-
-            cpu.branchPred.microtage.numPredictors = 1
-            cpu.branchPred.microtage.TTagBitSizes = [13]
-            cpu.branchPred.microtage.TTagPcShifts = [1]
-            cpu.branchPred.microtage.histLengths = [16]
-
         # ideal l1 caches
         if args.caches:
             cpu.icache.size = '64kB'

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1057,15 +1057,12 @@ class BTBTAGE(TimedBaseBTBPredictor):
 class MicroTAGE(BTBTAGE):
     """A smaller TAGE predictor configuration to assist uBTB"""
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
-    numPredictors = Param.Unsigned(1, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([512]*1, "the ITTAGE T0~Tn length")
-    TTagBitSizes = VectorParam.Unsigned([6]*1, "the T0~Tn entry's tag bit size")
-    TTagPcShifts = VectorParam.Unsigned([1]*1, "when the T0~Tn entry's tag generating, PC right shift")
+    numPredictors = 1
+    tableSizes = [512]
+    TTagBitSizes = [16]
+    TTagPcShifts = [1]
 
-    histLengths = VectorParam.Unsigned([16], "the FTB TAGE T0~Tn history length")
-    maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
-    numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = Param.Unsigned(2, "Number of ways per set")
+    histLengths = [16]
     numDelay = 0
 
 class BTBITTAGE(TimedBaseBTBPredictor):

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -982,6 +982,7 @@ class MBTB(TimedBaseBTBPredictor):
     numDelay = 2
     blockSize = 32  # max 64 byte block, 32 byte aligned
     # MBTB is always half-aligned - no parameter needed
+    victimCacheSize = Param.Unsigned(16, "Number of entries in the victim cache")
 
 class AheadBTB(TimedBaseBTBPredictor):
     type = 'AheadBTB'

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -205,11 +205,14 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
     auto s3TakenEntry = s3Pred.getTakenEntry();
     if (s0EntryIter != ubtb.end() && !s3TakenEntry.valid) {
         // S0 has a hit entry, but S3 predicts fall through
+        ubtbStats.s1Hits3FallThrough++;
         updateUCtr(s0EntryIter->uctr, false);
         if (s0EntryIter->uctr == 0) {
+            ubtbStats.s1InvalidatedEntries++;
             s0EntryIter->valid = false;
         }
     } else if (s0EntryIter == ubtb.end() && s3TakenEntry.valid) {
+        ubtbStats.s1Misses3Taken++;
         /* S0 misses, but S3 predicts taken,
          * generate new entry and replace another using LRU
          */
@@ -237,6 +240,7 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
         replaceOldEntry(toBeReplacedIter, s3Pred);
 
     } else if (s0EntryIter != ubtb.end() && s3TakenEntry.valid) {
+        ubtbStats.s1Hits3Taken++;
         // both S0 and S3 predict taken
         if (s0EntryIter->pc != s3Pred.controlAddr() || s0EntryIter->target != s3Pred.getTarget(predictWidth)) {
             // S0 and S3 predict different branch instruction
@@ -250,6 +254,7 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
             updateUCtr(s0EntryIter->uctr, true);
         }
     } else {
+        ubtbStats.s1Misses3FallThrough++;
         // both S0 and S3 predict fall through, do nothing
     }
 }
@@ -412,7 +417,12 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(callHits, statistics::units::Count::get(), "calls committed that was predicted hit"),
       ADD_STAT(callMisses, statistics::units::Count::get(), "calls committed that was predicted miss"),
       ADD_STAT(returnHits, statistics::units::Count::get(), "returns committed that was predicted hit"),
-      ADD_STAT(returnMisses, statistics::units::Count::get(), "returns committed that was predicted miss")
+      ADD_STAT(returnMisses, statistics::units::Count::get(), "returns committed that was predicted miss"),
+      ADD_STAT(s1Hits3FallThrough, statistics::units::Count::get(), "s1 hits s3 predicted fall through"),
+      ADD_STAT(s1Misses3Taken, statistics::units::Count::get(), "s1 misses s3 predicted taken"),
+      ADD_STAT(s1Hits3Taken, statistics::units::Count::get(), "s1 hits s3 predicted taken"),
+      ADD_STAT(s1Misses3FallThrough, statistics::units::Count::get(), "s1 misses s3 predicted fall through"),
+      ADD_STAT(s1InvalidatedEntries, statistics::units::Count::get(), "s1 invalidated entries")
 {
 }
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -314,6 +314,12 @@ class UBTB : public TimedBaseBTBPredictor
         statistics::Scalar returnHits;
         statistics::Scalar returnMisses;
 
+        statistics::Scalar s1Hits3FallThrough;
+        statistics::Scalar s1Misses3Taken;
+        statistics::Scalar s1Hits3Taken;
+        statistics::Scalar s1Misses3FallThrough;
+        statistics::Scalar s1InvalidatedEntries;
+
         UBTBStats(statistics::Group* parent);
     } ubtbStats;
 

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -671,6 +671,11 @@ MBTB::updateExistingInSRAMSet(Addr btb_idx,
 #endif
     btbStats.updateExisting++;
     std::make_heap(heap.begin(), heap.end(), older());
+
+    // Ensure single source of truth: remove duplicate from victim cache if any
+    if (eraseFromVictimCacheByPC(ticked_entry.pc)) {
+        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM update, pc %#lx\n", ticked_entry.pc);
+    }
 }
 
 void
@@ -713,6 +718,11 @@ MBTB::replaceOldestInSRAMSet(int sram_id,
     }
 #endif
     std::make_heap(heap.begin(), heap.end(), older());
+
+    // Ensure single source of truth: remove duplicate from victim cache if any
+    if (eraseFromVictimCacheByPC(ticked_entry.pc)) {
+        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM replace, pc %#lx\n", ticked_entry.pc);
+    }
 }
 
 void

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -77,7 +77,7 @@ MBTB::MBTB(unsigned numEntries, unsigned tagBits, unsigned numWays, unsigned num
 // Production constructor
 MBTB::MBTB(const Params &p)
     : TimedBaseBTBPredictor(p),
-    victimCacheSize(16), // Default size, will be configurable later
+    victimCacheSize(p.victimCacheSize),
     numEntries(p.numEntries),
     numWays(p.numWays),
     tagBits(p.tagBits),
@@ -596,76 +596,132 @@ MBTB::updateBTBEntry(const BTBEntry& entry, const FetchStream &stream)
             break;
         }
     }
-    // Simplify: if not found in MBTB but found in VC, do nothing and return
-    if (!found && found_in_vc) {
-        return;
+    // Build updated entry using existing state (MBTB hit or VC hit) when applicable
+    const BTBEntry* existing_ptr = nullptr;
+    if (found) {
+        existing_ptr = static_cast<const BTBEntry*>(&(*it));
+    } else if (found_in_vc) {
+        existing_ptr = static_cast<const BTBEntry*>(&victimCache[vc_idx]);
     }
 
-    auto entry_to_write = entry.isCond && found ? BTBEntry(*it) : entry;
-    entry_to_write.tag = btb_tag;   // update tag after found it!
-    // update saturating counter if necessary
+    auto entry_to_write = buildUpdatedEntry(entry, existing_ptr, stream, btb_tag);
+    auto ticked_entry = TickedBTBEntry(entry_to_write, curTick());
+
+    if (found) {
+        // Update in-place in SRAM set
+        updateExistingInSRAMSet(btb_idx, target_mru[btb_idx], it, ticked_entry);
+    } else if (found_in_vc) {
+        // In-place update in victim cache to avoid ping-ponging between MBTB and VC
+        commitToVictimCache(vc_idx, ticked_entry);
+        return;
+    } else {
+        // Not found anywhere, replace oldest in SRAM set
+        replaceOldestInSRAMSet(sram_id, btb_idx, target_mru[btb_idx], ticked_entry);
+    }
+}
+
+BTBEntry
+MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
+                        const BTBEntry* existing_entry,
+                        const FetchStream &stream,
+                        Addr btb_tag)
+{
+    // For conditional branches, prefer the existing entry to preserve up-to-date ctr
+    auto entry_to_write = (req_entry.isCond && existing_entry)
+                              ? BTBEntry(*existing_entry)
+                              : req_entry;
+    entry_to_write.tag = btb_tag;   // update tag
+
+    // Update saturating counter and alwaysTaken
     if (entry_to_write.isCond) {
         bool this_cond_taken = stream.exeTaken && stream.getControlPC() == entry_to_write.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
+            DPRINTF(BTB, "BTB: unset alwaysTaken, pc %#lx, alwaysTaken %d\n",
+                    entry_to_write.pc, entry_to_write.alwaysTaken);
         }
-        if(!entry_to_write.alwaysTaken) {
+        if (!entry_to_write.alwaysTaken) {
             updateCtr(entry_to_write.ctr, this_cond_taken);
         }
     }
-    // update indirect target if necessary
+
+    // Update indirect target if necessary
     if (entry_to_write.isIndirect && stream.exeTaken && stream.getControlPC() == entry_to_write.pc) {
         entry_to_write.target = stream.exeBranchInfo.target;
     }
-    auto ticked_entry = TickedBTBEntry(entry_to_write, curTick());
-    if (found) {
-        // Update existing entry
-        *it = ticked_entry;
-#ifndef UNIT_TEST
-        if (enableDB) {
-            BTBTrace rec;
-            rec.set(ticked_entry.pc, ticked_entry.getType(),
-                ticked_entry.target, btb_idx, Mode::WRITE, 1);
-            btbTrace->write_record(rec);
-        }
-#endif
-        btbStats.updateExisting++;
-    } else {
-        // Replace oldest entry in the set
-        DPRINTF(BTB, "trying to replace entry in SRAM%d set %#lx\n", sram_id, btb_idx);
-        // put the oldest entry in this set to the back of heap
-        std::pop_heap(target_mru[btb_idx].begin(), target_mru[btb_idx].end(), older());
-        const auto& entry_in_btb_now = target_mru[btb_idx].back();
-#ifndef UNIT_TEST
-        if (enableDB) {
-            BTBTrace rec;
-            rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                    entry_in_btb_now->target, btb_idx, Mode::EVICT, 0);
-                btbTrace->write_record(rec);
-        }
-#endif
-        if (entry_in_btb_now->valid) {
-            // if all ways are really occupied, we need to replace valid entry
-            // means 32B block is more than 4ways/ 4 branches
-            btbStats.updateReplaceValidOne++;
 
-            // Insert evicted entry into victim cache
-            insertVictimCache(*entry_in_btb_now);
-        }
-        btbStats.updateReplace++;
-        DPRINTF(BTB, "BTB: Replacing entry with tag %#lx, pc %#lx in set %#lx\n",
-                entry_in_btb_now->tag, entry_in_btb_now->pc, btb_idx);
-        *entry_in_btb_now = ticked_entry;
+    return entry_to_write;
+}
+
+void
+MBTB::updateExistingInSRAMSet(Addr btb_idx,
+                              BTBHeap &heap,
+                              BTBSetIter it_found,
+                              const TickedBTBEntry &ticked_entry)
+{
+    // Update existing entry
+    *it_found = ticked_entry;
 #ifndef UNIT_TEST
-        if (enableDB) {
-            BTBTrace rec;
-            rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                entry_in_btb_now->target, btb_idx, Mode::WRITE, 0);
-            btbTrace->write_record(rec);
-        }
-#endif
+    if (enableDB) {
+        BTBTrace rec;
+        rec.set(ticked_entry.pc, ticked_entry.getType(),
+                ticked_entry.target, btb_idx, Mode::WRITE, 1);
+        btbTrace->write_record(rec);
     }
-    std::make_heap(target_mru[btb_idx].begin(), target_mru[btb_idx].end(), older());
+#endif
+    btbStats.updateExisting++;
+    std::make_heap(heap.begin(), heap.end(), older());
+}
+
+void
+MBTB::replaceOldestInSRAMSet(int sram_id,
+                             Addr btb_idx,
+                             BTBHeap &heap,
+                             const TickedBTBEntry &ticked_entry)
+{
+    // Replace oldest entry in the set
+    DPRINTF(BTB, "trying to replace entry in SRAM%d set %#lx\n", sram_id, btb_idx);
+    // put the oldest entry in this set to the back of heap
+    std::pop_heap(heap.begin(), heap.end(), older());
+    const auto& entry_in_btb_now = heap.back();
+#ifndef UNIT_TEST
+    if (enableDB) {
+        BTBTrace rec;
+        rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
+                entry_in_btb_now->target, btb_idx, Mode::EVICT, 0);
+        btbTrace->write_record(rec);
+    }
+#endif
+    if (entry_in_btb_now->valid) {
+        // if all ways are really occupied, we need to replace valid entry
+        // means 32B block is more than 4ways/ 4 branches
+        btbStats.updateReplaceValidOne++;
+
+        // Insert evicted entry into victim cache
+        insertVictimCache(*entry_in_btb_now);
+    }
+    btbStats.updateReplace++;
+    DPRINTF(BTB, "BTB: Replacing entry with tag %#lx, pc %#lx in set %#lx\n",
+            entry_in_btb_now->tag, entry_in_btb_now->pc, btb_idx);
+    *entry_in_btb_now = ticked_entry;
+#ifndef UNIT_TEST
+    if (enableDB) {
+        BTBTrace rec;
+        rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
+                entry_in_btb_now->target, btb_idx, Mode::WRITE, 0);
+        btbTrace->write_record(rec);
+    }
+#endif
+    std::make_heap(heap.begin(), heap.end(), older());
+}
+
+void
+MBTB::commitToVictimCache(int vc_idx, const TickedBTBEntry &ticked_entry)
+{
+    if (vc_idx >= 0 && (size_t)vc_idx < victimCache.size()) {
+        victimCache[vc_idx] = ticked_entry;
+        victimCache[vc_idx].valid = true;
+    }
 }
 
 /*
@@ -680,7 +736,7 @@ MBTB::updateBTBEntry(const BTBEntry& entry, const FetchStream &stream)
 void
 MBTB::update(const FetchStream &stream)
 {
-
+    DPRINTF(BTB, "BTB: update called for pc %#lx\n", stream.startPC);
     // 1. Process old entries
     auto old_entries = processOldEntries(stream);
     
@@ -895,10 +951,6 @@ MBTB::BTBStats::BTBStats(statistics::Group* parent) :
     ADD_STAT(newEntry, statistics::units::Count::get(), "number of new btb entries generated"),
     ADD_STAT(newEntryWithCond, statistics::units::Count::get(), "number of new btb entries generated with conditional branch"),
     ADD_STAT(newEntryWithUncond, statistics::units::Count::get(), "number of new btb entries generated with unconditional branch"),
-    ADD_STAT(oldEntry, statistics::units::Count::get(), "number of old btb entries updated"),
-    ADD_STAT(oldEntryIndirectTargetModified, statistics::units::Count::get(), "number of old btb entries with indirect target modified"),
-    ADD_STAT(oldEntryWithNewCond, statistics::units::Count::get(), "number of old btb entries with new conditional branches"),
-    ADD_STAT(oldEntryWithNewUncond, statistics::units::Count::get(), "number of old btb entries with new unconditional branches"),
     ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
     ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
     ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
@@ -906,7 +958,6 @@ MBTB::BTBStats::BTBStats(statistics::Group* parent) :
     ADD_STAT(updateExisting, statistics::units::Count::get(), "existing entries updated"),
     ADD_STAT(updateReplace, statistics::units::Count::get(), "entries replaced"),
     ADD_STAT(updateReplaceValidOne, statistics::units::Count::get(), "entries replaced with valid entry"),
-    ADD_STAT(eraseSlotBehindUncond, statistics::units::Count::get(), "erase slots behind unconditional slot"),
     ADD_STAT(predUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when pred"),
     ADD_STAT(updateUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when update"),
     ADD_STAT(S0Predmiss, statistics::units::Count::get(), "misses encountered on S0 prediction, i.e. uBTB and ABTB miss"),

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -304,6 +304,27 @@ class MBTB : public TimedBaseBTBPredictor
      */
     void updateBTBEntry(const BTBEntry& entry, const FetchStream &stream);
 
+    // Helper: build updated entry (ctr/alwaysTaken/indirect target/tag)
+    BTBEntry buildUpdatedEntry(const BTBEntry& req_entry,
+                               const BTBEntry* existing_entry,
+                               const FetchStream &stream,
+                               Addr btb_tag);
+
+    // Helper: update an existing entry in SRAM set
+    void updateExistingInSRAMSet(Addr btb_idx,
+                                 BTBHeap &heap,
+                                 BTBSetIter it_found,
+                                 const TickedBTBEntry &ticked_entry);
+
+    // Helper: replace the oldest entry in SRAM set
+    void replaceOldestInSRAMSet(int sram_id,
+                                Addr btb_idx,
+                                BTBHeap &heap,
+                                const TickedBTBEntry &ticked_entry);
+
+    // Helper: commit/update an entry in victim cache at given index
+    void commitToVictimCache(int vc_idx, const TickedBTBEntry &ticked_entry);
+
     /*
      * Comparator for MRU heap
      * Returns true if a's timestamp is larger than b's
@@ -422,10 +443,6 @@ public:
         Scalar newEntry;
         Scalar newEntryWithCond;
         Scalar newEntryWithUncond;
-        Scalar oldEntry;
-        Scalar oldEntryIndirectTargetModified;
-        Scalar oldEntryWithNewCond;
-        Scalar oldEntryWithNewUncond;
 
         Scalar predMiss;
         Scalar predHit;
@@ -434,8 +451,6 @@ public:
         Scalar updateExisting;
         Scalar updateReplace;
         Scalar updateReplaceValidOne;
-
-        Scalar eraseSlotBehindUncond;
 
         Scalar predUseL0OnL1Miss;
         Scalar updateUseL0OnL1Miss;


### PR DESCRIPTION
cpu-o3: Update VC entries in-place to fix alwaysTaken stale state
  Problem:

  - updateBTBEntry returned early when an entry was only in victim cache
  - This blocked clearing alwaysTaken=0 and ctr updates for VC-resident
    branches, leaving stale state that polluted predictions
  - The early return was originally meant to avoid MBTB-VC ping-pong

  Solution:

  - Replace the early return with an in-place update of the VC entry
  - Share the update logic via buildUpdatedEntry (alwaysTaken/ctr/target/tag)
  - Do not refill MBTB from VC on update, avoiding ping-pong by design
  - Keep tag/tick consistent so VC lookups see up-to-date entries

  Refactor:

  - Split commitToSRAMSet into:
      - updateExistingInSRAMSet (in-place update + MRU rebuild)
      - replaceOldestInSRAMSet (evict to VC, replace, DB/stats/MRU)
  - Add commitToVictimCache for VC in-place updates
  - Simplify updateBTBEntry to a clear 3-way flow (MBTB hit / VC hit / miss)
  - Preserve DB traces and statistics; maintain MRU heaps
  - Avoid double bumping tick on VC writes

  Files:

  - src/cpu/pred/btb/mbtb.cc
  - src/cpu/pred/btb/mbtb.hh

  Validation:

  - MBTB miss + VC hit + not-taken now clears alwaysTaken and updates ctr
  - Check BTB DPRINTF for "unset alwaysTaken" and victim cache stats