### PR TITLE
misc: createStoreDataUop adds pc

### DIFF
--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -460,7 +460,7 @@ DynInstPtr DynInst::createStoreDataUop()
     arrays.numSrcs = 1;
     arrays.numDests = 0;
     StaticInstPtr stdinst = new RiscvISA::StoreData(this->staticInst);
-    DynInstPtr stduop = new (arrays) DynInst(arrays, stdinst, macroop, this->seqNum, cpu);
+    DynInstPtr stduop = new (arrays) DynInst(arrays, stdinst, macroop, *this->pc, *this->predPC, this->seqNum, cpu);
 
     stduop->thread = this->thread;
     stduop->renameSrcReg(0, this->extRenamedSrcIdx(1));


### PR DESCRIPTION
Change-Id: I322cc94179da5fc05a4c9e5bedd6faca752573b7

When using debug-flags=IEW, a segmentation fault occurs during print PC because `createStoreDataUop` here does not add the PC.