### PR TITLE
cpu-o3: mark override functions in tage test to reduce warning

### DIFF
--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -136,11 +136,14 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
 #ifdef UNIT_TEST
     // API compatibility wrappers for testing
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {
+    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override
+    {
         specUpdatePHist(history, pred);
     }
 
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken) {
+    void recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt,
+                     bool cond_taken) override
+    {
         recoverPHist(history, entry, shamt, cond_taken);
     }
 #endif


### PR DESCRIPTION
Change-Id: Ib60f6e0e1c2ab895d57ee94ab7c493f1e8d680ae