### PR TITLE
cpu-o3: add enabled parameter to predictor components

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -969,6 +969,7 @@ class TimedBaseBTBPredictor(SimObject):
     predictWidth = Param.Unsigned(Parent.predictWidth, "Maximum range in bytes that a single prediction can cover")
     numDelay = Param.Unsigned(1000, "Number of bubbles to put on a prediction")
     resolvedUpdate = Param.Bool(False, "Enable resolved update, no need to wait until commit")
+    enabled = Param.Bool(True, "Enable this predictor component")
 
 class MBTB(TimedBaseBTBPredictor):
     type = 'MBTB'

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -49,17 +49,15 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
         initDB();
     }
     bpType = DecoupledBTBType;
-    // TODO: better impl (use vector to assign in python)
-    // problem: btb->getAndSetNewBTBEntry
-    components.push_back(ubtb);
-    components.push_back(abtb);
-    components.push_back(microtage);
-    // components.push_back(uras);
-    components.push_back(mbtb);
-    components.push_back(tage);
-    components.push_back(ras);
-    components.push_back(ittage);
-    components.push_back(mgsc);
+    // Only add enabled components to the list
+    if (ubtb->isEnabled()) components.push_back(ubtb);
+    if (abtb->isEnabled()) components.push_back(abtb);
+    if (microtage->isEnabled()) components.push_back(microtage);
+    if (mbtb->isEnabled()) components.push_back(mbtb);
+    if (tage->isEnabled()) components.push_back(tage);
+    if (ras->isEnabled()) components.push_back(ras);
+    if (ittage->isEnabled()) components.push_back(ittage);
+    if (mgsc->isEnabled()) components.push_back(mgsc);
     numComponents = components.size();
     for (int i = 0; i < numComponents; i++) {
         components[i]->setComponentIdx(i);
@@ -1193,7 +1191,9 @@ DecoupledBPUWithBTB::prepareResolveUpdateEntries(unsigned &stream_id)
         stream.setUpdateBTBEntries();
 
         // only mbtb can generate new entry
-        mbtb->getAndSetNewBTBEntry(stream);
+        if (mbtb->isEnabled()) {
+            mbtb->getAndSetNewBTBEntry(stream);
+        }
     }
 }
 
@@ -1221,7 +1221,9 @@ DecoupledBPUWithBTB::updatePredictorComponents(FetchStream &stream)
         stream.setUpdateBTBEntries();
 
         // only mbtb can generate new entry
-        mbtb->getAndSetNewBTBEntry(stream);
+        if (mbtb->isEnabled()) {
+            mbtb->getAndSetNewBTBEntry(stream);
+        }
 
         // Update predictor components
         for (int i = 0; i < numComponents; ++i) {
@@ -2034,8 +2036,12 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     // Update path history
     pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);
 #ifndef NDEBUG
-    tage->checkFoldedHist(s0PHistory, "speculative update");
-    microtage->checkFoldedHist(s0PHistory, "speculative update");
+    if (tage->isEnabled()) {
+        tage->checkFoldedHist(s0PHistory, "speculative update");
+    }
+    if (microtage->isEnabled()) {
+        microtage->checkFoldedHist(s0PHistory, "speculative update");
+    }
 #endif
     // Update imli history
     histShiftIn(bw_shamt, bw_taken, s0IHistory);  //s0IHistory is not used
@@ -2122,12 +2128,16 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     // Perform history consistency checks when not a fast build variant
 #ifndef NDEBUG
     checkHistory(s0History);
-    tage->checkFoldedHist(s0PHistory,
-        squash_type == SQUASH_CTRL ? "control squash" :
-        squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
-    microtage->checkFoldedHist(s0PHistory,
-        squash_type == SQUASH_CTRL ? "control squash" :
-        squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+    if (tage->isEnabled()) {
+        tage->checkFoldedHist(s0PHistory,
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+    }
+    if (microtage->isEnabled()) {
+        microtage->checkFoldedHist(s0PHistory,
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+    }
 #endif
 }
 

--- a/src/cpu/pred/btb/timed_base_pred.cc
+++ b/src/cpu/pred/btb/timed_base_pred.cc
@@ -20,7 +20,8 @@ TimedBaseBTBPredictor::TimedBaseBTBPredictor(const Params &p)
       blockSize(p.blockSize),
       predictWidth(p.predictWidth),
       numDelay(p.numDelay),
-      resolvedUpdate(p.resolvedUpdate)
+      resolvedUpdate(p.resolvedUpdate),
+      enabled(p.enabled)
 {
 }
 #endif

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -100,9 +100,13 @@ class TimedBaseBTBPredictor: public SimObject
 #endif
     virtual void setTrace() {}
 
+    // Check if this component is enabled
+    bool isEnabled() const { return enabled; }
+
 private:
     unsigned numDelay;
     bool resolvedUpdate;
+    bool enabled;
 };
 
 // Close conditional namespace wrapper for testing


### PR DESCRIPTION
Add a unified 'enabled' parameter to TimedBaseBTBPredictor base class to allow runtime enabling/disabling of predictor components without recompilation.

Key changes:
- Add 'enabled' parameter (default=True) to TimedBaseBTBPredictor in Python configuration and C++ implementation
- Add isEnabled() method to check component status
- Conditionally add components to DecoupledBPUWithBTB based on enabled status during construction
- Add enabled checks before calling component-specific methods:
  * mbtb->getAndSetNewBTBEntry() in prepareUpdate and updatePredictorComponents
  * tage/microtage->checkFoldedHist() in speculativeHistUpdate and recoverHistoryForSquash

Usage:
add in idealkmhv3.py:
cpu.branchPred.mbtb.enabled = False
cpu.branchPred.tage.enabled = False
cpu.branchPred.microtage.enabled = False
cpu.branchPred.mgsc.enabled = False

Change-Id: Idcdf6a70a272eff60062c9e3cc33d836f11496ab