### PR TITLE
cpu-o3: fix bugs https://github.com/OpenXiangShan/GEM5/pull/595

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -76,7 +76,6 @@ def setKmhV3IdealParams(args, system):
 
         # branch predictor
         if args.bp_type == 'DecoupledBPUWithBTB':
-            cpu.branchPred.mgsc.enableMGSC = not args.disable_mgsc
             cpu.branchPred.ftq_size = 256
             cpu.branchPred.fsq_size = 256
 

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -92,7 +92,6 @@ def setKmhV3Params(args, system):
 
         # branch predictor
         if args.bp_type == 'DecoupledBPUWithBTB':
-            cpu.branchPred.mgsc.enableMGSC = not args.disable_mgsc
             cpu.branchPred.ftq_size = 256
             cpu.branchPred.fsq_size = 256
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1090,8 +1090,6 @@ class BTBMGSC(TimedBaseBTBPredictor):
     cxx_class = 'gem5::branch_prediction::btb_pred::BTBMGSC'
     cxx_header = "cpu/pred/btb/btb_mgsc.hh"
 
-    enableMGSC = Param.Bool(True, "Enable MGSC or not")
-
     needMoreHistories = Param.Bool(True, "MGSC needs more histories")
 
     bwTableNum = Param.Unsigned(2, "Num global backward branch GEHL tables")

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -47,7 +47,6 @@ BTBMGSC::BTBMGSC(const Params &p)
       extraWeightsWidth(p.extraWeightsWidth),
       weightTableIdxWidth(p.weightTableIdxWidth),
       numCtrsPerLine(p.numCtrsPerLine),
-      enableMGSC(p.enableMGSC),
       mgscStats(this)
 {
     DPRINTF(MGSC, "BTBMGSC constructor\n");
@@ -387,7 +386,7 @@ BTBMGSC::putPCHistory(Addr stream_start, const boost::dynamic_bitset<> &history,
     // btb entries should already be in stagePreds
     // get prediction and save it
 
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // Just return if MGSC is disabled
     }
 
@@ -624,7 +623,7 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
 void
 BTBMGSC::update(const FetchStream &stream)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No update if disabled
     }
     Addr startAddr = stream.getRealStartPC();
@@ -949,7 +948,7 @@ BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, Fu
 void
 BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
@@ -975,7 +974,7 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &
 void
 BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
@@ -1001,7 +1000,7 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchStream 
 void
 BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
@@ -1027,7 +1026,7 @@ BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchStream
 void
 BTBMGSC::recoverIHist(const boost::dynamic_bitset<> &history, const FetchStream &entry, int shamt, bool cond_taken)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
@@ -1054,7 +1053,7 @@ void
 BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchStream &entry, int shamt,
                       bool cond_taken)
 {
-    if (!enableMGSC) {
+    if (!isEnabled()) {
         return;  // No recover when disabled
     }
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -315,9 +315,6 @@ class BTBMGSC : public TimedBaseBTBPredictor
     unsigned numCtrsPerLine;
     unsigned numCtrsPerLineBits;
 
-    // Whether MGSC is enabled
-    bool enableMGSC;
-
     // Folded history for index calculation
     std::vector<GlobalBwFoldedHist> indexBwFoldedHist;
     std::vector<std::vector<LocalFoldedHist>> indexLFoldedHist;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -2036,14 +2036,6 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
     // Update path history
     pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);
 
-#ifndef NDEBUG
-    if (tage->isEnabled()) {
-        tage->checkFoldedHist(s0PHistory, "speculative update");
-    }
-    if (microtage->isEnabled()) {
-        microtage->checkFoldedHist(s0PHistory, "speculative update");
-    }
-#endif
     // Update imli history
     histShiftIn(bw_shamt, bw_taken, s0IHistory);  //s0IHistory is not used
 
@@ -2052,9 +2044,15 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
         s0LHistory[mgsc->getPcIndex(finalPred.bbStart, log2(mgsc->getNumEntriesFirstLocalHistories()))]);
 
 #ifndef NDEBUG
-    tage->checkFoldedHist(s0PHistory, "speculative update");
-    microtage->checkFoldedHist(s0PHistory, "speculative update");
-    mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, "specualtive update");
+    if (tage->isEnabled()) {
+        tage->checkFoldedHist(s0PHistory, "speculative update");
+    }
+    if (microtage->isEnabled()) {
+        microtage->checkFoldedHist(s0PHistory, "speculative update");
+    }
+    if (mgsc->isEnabled()) {
+        mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, "specualtive update");
+    }
 #endif
 }
 

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -2051,7 +2051,7 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchStream &entry)
         microtage->checkFoldedHist(s0PHistory, "speculative update");
     }
     if (mgsc->isEnabled()) {
-        mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, "specualtive update");
+        mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, "speculative update");
     }
 #endif
 }


### PR DESCRIPTION
since merge error, checkFoldedHist again.

Change-Id: I89b2d010223fa93fe5aee31292501bc1042338e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folded-history validation now runs under runtime-enabled guards so checks execute consistently when prediction components are active (works in both debug and release builds).

* **Chores**
  * Removed an explicit per-branch override for MGSC enablement and the public enableMGSC configuration flag; MGSC is now controlled by its runtime-enabled setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->