### PR TITLE
Mem: calibrate xs-stride config

### DIFF
--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -204,7 +204,7 @@ class XSStridePrefetcher(QueuedPrefetcher):
     fuzzy_stride_matching = Param.Bool(False, "Match stride with fuzzy condition")
     short_stride_thres = Param.Unsigned(512, "Ignore short strides when there are long strides (Bytes)")
     stride_dyn_depth = Param.Bool(False, "Dynamic depth of stride table")
-    stride_entries = Param.MemorySize("32", "Stride Entries")
+    stride_entries = Param.MemorySize("10", "Stride Entries")
     stride_indexing_policy = Param.BaseIndexingPolicy(
         SetAssociative(
             entry_size=1,
@@ -213,7 +213,7 @@ class XSStridePrefetcher(QueuedPrefetcher):
         "Indexing policy of stride table"
     )
     stride_replacement_policy = Param.BaseReplacementPolicy(
-        LRURP(),
+        TreePLRURP(num_leaves=Parent.stride_entries),
         "Replacement policy of stride table"
     )
     fuzzy_stride_matching = Param.Bool(False, "Match stride with fuzzy condition")

--- a/src/mem/cache/prefetch/associative_set_impl.hh
+++ b/src/mem/cache/prefetch/associative_set_impl.hh
@@ -42,9 +42,9 @@ AssociativeSet<Entry>::AssociativeSet(int assoc, int num_entries,
   : associativity(assoc), numEntries(num_entries), indexingPolicy(idx_policy),
     replacementPolicy(rpl_policy), entries(numEntries, init_value)
 {
-    fatal_if(!isPowerOf2(num_entries), "The number of entries of an "
+    warn_if(!isPowerOf2(num_entries), "The number of entries of an "
              "AssociativeSet<> must be a power of 2");
-    fatal_if(!isPowerOf2(assoc), "The associativity of an AssociativeSet<> "
+    warn_if(!isPowerOf2(assoc), "The associativity of an AssociativeSet<> "
              "must be a power of 2");
     for (unsigned int entry_idx = 0; entry_idx < numEntries; entry_idx += 1) {
         Entry* entry = &entries[entry_idx];

--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -105,7 +105,7 @@ TreePLRU::TreePLRUReplData::TreePLRUReplData(
 TreePLRU::TreePLRU(const Params &p)
   : Base(p), numLeaves(p.num_leaves), count(0), treeInstance(nullptr)
 {
-    fatal_if(!isPowerOf2(numLeaves),
+    warn_if(!isPowerOf2(numLeaves),
              "Number of leaves must be non-zero and a power of 2");
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced the default stride size used by the cache prefetcher and updated its replacement policy to better align with current configurations.
* **Bug Fix**
  * Relaxed validation in tree-based replacement and associative set logic: invalid sizes now emit warnings instead of aborting execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->