### PR TITLE
cpu-o3: add load lifetime trace

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -372,12 +372,25 @@ def build_xiangshan_system(args):
     # config arch db
     if args.enable_arch_db:
         perfCCT_cmd = "CREATE TABLE LifeTimeCommitTrace(ID INTEGER PRIMARY KEY AUTOINCREMENT,"
-        perfCCT_cmd += PerfRecord.vals[0] + " INT NOT NULL"
+        perfCCT_cmd += PerfRecord.vals[0] + " bigint unsigned NOT NULL"
         for i in range(1, len(PerfRecord.vals)):
             name = PerfRecord.vals[i]
-            type_str = "INT" if name.lower().startswith(('at', 'pc')) else "CHAR(20)"
+            type_str = "bigint unsigned" if name.lower().startswith(('at', 'pc')) else "char(20)"
             perfCCT_cmd += "," + name + " " + type_str + " NOT NULL"
         perfCCT_cmd += ");"
+
+        perfCCT_cmd += """
+CREATE TABLE LoadLifeTimeCommitTrace(
+    ID int unsigned PRIMARY KEY,
+    VAddress bigint unsigned not null,
+    PAddress bigint unsigned not null,
+    LastReplay bigint unsigned not null,
+    ReplayStr char(10) not null,
+    constraint fk_id
+        foreign key (ID) references LifeTimeCommitTrace(ID)
+);
+
+"""
 
         test_sys.arch_db = ArchDBer(arch_db_file=args.arch_db_file)
         test_sys.arch_db.dump_from_start = args.arch_db_fromstart

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -69,11 +69,6 @@ class PerfRecord(ScopedEnum):
         'Disasm', 'PC'
     ]
 
-class PerfDetail(ScopedEnum):
-    vals = [
-        'pdst', 'psrcs', 'result', 'ldstAddr', 'cachemisslevel', 'arbfail'
-    ]
-
 class BaseO3CPU(BaseCPU):
     type = 'BaseO3CPU'
     cxx_class = 'gem5::o3::CPU'

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1225,6 +1225,9 @@ LSQUnit::loadDoTranslate(const DynInstPtr &inst)
 
     if (inst->savedRequest && inst->savedRequest->isTranslationComplete()) {
         inst->setNormalLd(inst->savedRequest->isNormalLd());
+
+        cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::VAddress, inst->effAddr);
+        cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::PAddress, inst->physEffAddr);
     }
 
     return load_fault;
@@ -1503,6 +1506,20 @@ LSQUnit::executeLoadPipeSx()
                 assert(inst->getReplayType());
                 stats.loadReplayEvents[*inst->getReplayType()]++;
 
+                if (inst->needCacheBlockedReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_DcacheStall);
+                }
+                else if (inst->needRARReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_RARReplay);
+                }
+                else if (inst->needRAWReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_RAWReplay);
+                }
+                else {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_OtherReplay);
+                }
+                cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::LastReplay, curTick());
+
                 iewStage->loadCancel(inst);
                 inst->endPipelining();
                 inst = nullptr;
@@ -1529,6 +1546,23 @@ LSQUnit::executeLoadPipeSx()
                     inst->issueQue->retryMem(inst);
                 }
                 else if (inst->needTLBMissReplay()) iewStage->deferMemInst(inst);
+
+
+                if (inst->needTLBMissReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_TLBMiss);
+                }
+                else if (inst->needCacheMissReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_CacheMiss);
+                }
+                else if (inst->needBankConflicyReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_BankConflict);
+                }
+                else if (inst->needNukeReplay()) {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_Nuke);
+                } else {
+                    cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_OtherReplay);
+                }
+                cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::LastReplay, curTick());
 
                 iewStage->loadCancel(inst);
                 inst->endPipelining();

--- a/src/cpu/o3/perfCCT.cc
+++ b/src/cpu/o3/perfCCT.cc
@@ -6,7 +6,6 @@ namespace gem5
 {
 namespace o3
 {
-
 void
 InstMeta::reset(const DynInstPtr inst)
 {
@@ -15,6 +14,12 @@ InstMeta::reset(const DynInstPtr inst)
     posTick.resize((int)PerfRecord::AtCommit + 1, 0);
     disasm = inst->staticInst->disassemble(inst->pcState().instAddr());
     pc = inst->pcState().instAddr();
+
+    isload = inst->isLoad();
+    vaddr = 0;
+    paddr = 0;
+    lastReplay = 0;
+    replayStr.str(std::string());
 }
 
 
@@ -31,6 +36,8 @@ PerfCCT::PerfCCT(bool enable, ArchDBer* db) : enableCCT(enable), archdb(db)
         ss << ") VALUES(";
         sql_insert_cmd = ss.str();
         ss.str(std::string());
+
+        ld_insert_cmd = "insert into LoadLifeTimeCommitTrace(ID, VAddress, PAddress, LastReplay, ReplayStr) Values (";
     }
 }
 
@@ -58,8 +65,35 @@ PerfCCT::updateInstPos(InstSeqNum sn, const PerfRecord pos)
         return;
     }
     auto meta = getMeta(sn);
-    if (meta->posTick.at((int)pos)) return;
     meta->posTick.at((int)pos) = curTick();
+}
+
+void
+PerfCCT::updateInstMeta(InstSeqNum sn, const InstDetail detail, const uint64_t val)
+{
+    if (!enableCCT) [[likely]] {
+        return;
+    }
+    auto meta = getMeta(sn);
+    switch (detail) {
+    case InstDetail::VAddress: {
+        meta->vaddr = val;
+        break;
+    }
+    case InstDetail::PAddress: {
+        meta->paddr = val;
+        break;
+    }
+    case InstDetail::LastReplay:{
+        meta->lastReplay = val;
+        break;
+    }
+    case InstDetail::ReplayStr:{
+        assert(val < TT_NumReplay);
+        meta->replayStr << ReplayReasonStr[val];
+        break;
+    }
+    }
 }
 
 void
@@ -75,16 +109,24 @@ PerfCCT::commitMeta(InstSeqNum sn)
     for (auto it = meta->posTick.begin() + 1; it != meta->posTick.end(); it++) {
         ss << "," << *it;
     }
-    // dump string last
     ss << ",\'" << meta->disasm << "\'";
-    // pc is unsigned, but sqlite3 only supports signed integer [-2^63, 2^63-1]
-    // if real pc > 2^63-1, it will be stored as negative number
-    // (negtive pc = real pc - 2^64)
-    // when read a negtive pc, real pc = negtive pc + 2^64
-    ss << "," << int64_t(meta->pc);
+    ss << "," << meta->pc;
     ss << ");";
     archdb->execmd(ss.str());
     ss.str(std::string());
+
+    id++;
+    if (meta->isload) {
+        ss << ld_insert_cmd;
+        ss << id << ',';
+        ss << meta->vaddr << ',';
+        ss << meta->paddr << ',';
+        ss << meta->lastReplay << ',';
+        ss << '\'' << meta->replayStr.str() << '\'';
+        ss << ");";
+        archdb->execmd(ss.str());
+        ss.str(std::string());
+    }
 }
 
 }

--- a/src/cpu/o3/perfCCT.hh
+++ b/src/cpu/o3/perfCCT.hh
@@ -13,14 +13,52 @@ namespace gem5
 namespace o3
 {
 
+enum class InstDetail
+{
+    VAddress,
+    PAddress,
+    LastReplay,
+    ReplayStr,
+};
+
+enum ReplayReason
+{
+    TT_CacheMiss,
+    TT_TLBMiss,
+    TT_BankConflict,
+    TT_Nuke,
+    TT_DcacheStall,
+    TT_RARReplay,
+    TT_RAWReplay,
+    TT_OtherReplay,
+    TT_NumReplay
+};
+
+static char ReplayReasonStr[] = {
+    'C',
+    'T',
+    'B',
+    'N',
+    'S',
+    'R',
+    'W',
+    'O'
+};
 
 class InstMeta
 {
+
     friend class PerfCCT;
     InstSeqNum sn;
-    std::vector<uint64_t> posTick;
+    std::vector<Tick> posTick;
     std::string disasm;
     Addr pc;
+
+    bool isload;
+    Addr vaddr;
+    Addr paddr;
+    Tick lastReplay;
+    std::stringstream replayStr;
   public:
 
     void reset(const DynInstPtr inst);
@@ -33,7 +71,9 @@ class PerfCCT
     bool enableCCT;
     ArchDBer* archdb;
     std::string sql_insert_cmd;
+    std::string ld_insert_cmd;
 
+    uint64_t id = 0;
     std::vector<InstMeta> metas;
 
     std::stringstream ss;
@@ -47,7 +87,7 @@ class PerfCCT
 
     void updateInstPos(InstSeqNum sn, const PerfRecord pos);
 
-    // void updateInstMeta
+    void updateInstMeta(InstSeqNum sn, const InstDetail detail, const uint64_t val);
 
     void commitMeta(InstSeqNum sn);
 };

--- a/util/perfcct.py
+++ b/util/perfcct.py
@@ -151,8 +151,6 @@ if __name__ == '__main__':
                     if col_name[i].startswith('at'):
                         pos.append(val // tick_per_cycle)
                     elif col_name[i].startswith('pc'):
-                        if val < 0:
-                            val = val + (1 << 64)
                         records.append(hex(val))
                     else:
                         records.append(val)


### PR DESCRIPTION
Change-Id: Idc52d13ed61df006b1b9b46e0882f8a02fd61b02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated load-lifetime trace recording virtual/physical addresses, replay timestamps, and replay reasons per memory operation.

* **Chores**
  * Extended performance telemetry to capture detailed replay types (cache/TLB/bank/nuke/other) and timestamps.
  * Updated persistent trace storage to include load-specific records.

* **Bug Fixes**
  * Preserved sign when formatting negative program-counter values so they appear as signed hex.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->