### PR TITLE
cpu-o3: enlarge kmhv3 phyregReleaseWidth->8

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -51,6 +51,7 @@ def setKmhV3IdealParams(args, system):
         # rob
         cpu.commitWidth = 12
         cpu.squashWidth = 12
+        cpu.phyregReleaseWidth = 8
         cpu.RobCompressPolicy = 'kmhv3'
         cpu.numROBEntries = 160
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -65,6 +65,7 @@ def setKmhV3Params(args, system):
         # rob
         cpu.commitWidth = 8
         cpu.squashWidth = 8
+        cpu.phyregReleaseWidth = 8
         cpu.RobCompressPolicy = 'none'
         cpu.numROBEntries = 352
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression


### PR DESCRIPTION
Change-Id: I34feca15b62de9a94357d94a375183622f01f444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example CPU configurations to include a new physical register release width parameter set to 8. This affects the reorder buffer configuration in both ideal and standard example setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->