### PR TITLE
cpu-o3: add fine-grained branch type stats to BPU

### DIFF
--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1,5 +1,7 @@
 #include "cpu/pred/btb/decoupled_bpred.hh"
 
+#include <array>
+
 #include "base/debug_helper.hh"
 #include "base/output.hh"
 #include "cpu/o3/cpu.hh"
@@ -478,7 +480,57 @@ DecoupledBPUWithBTB::dumpStats()
     }
 }
 
-DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum):
+namespace {
+
+constexpr std::array<const char*, DecoupledBPUWithBTB::NumBranchClasses>
+    BranchClassLabels = {
+        "cond_branch",
+        "direct_call",
+        "indirect_call",
+        "return",
+        "direct_jump",
+        "indirect_jump",
+        "unknown"
+    };
+
+template <typename InstPtr>
+DecoupledBPUWithBTB::BranchClass
+classifyBranchImpl(const InstPtr &inst)
+{
+    using BranchClass = DecoupledBPUWithBTB::BranchClass;
+
+    if (!inst || !inst->isControl()) {
+        return BranchClass::Unknown;
+    }
+
+    if (inst->isReturn()) {
+        return BranchClass::Return;
+    }
+
+    if (inst->isCall()) {
+        return inst->isIndirectCtrl() ? BranchClass::IndirectCall
+                                      : BranchClass::DirectCall;
+    }
+
+    if (inst->isCondCtrl()) {
+        return BranchClass::CondBranch;
+    }
+
+    if (inst->isIndirectCtrl()) {
+        return BranchClass::IndirectJump;
+    }
+
+    if (inst->isDirectCtrl() || inst->isUncondCtrl()) {
+        return BranchClass::DirectJump;
+    }
+
+    return BranchClass::Unknown;
+}
+
+} // anonymous namespace
+
+DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
+    statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum):
     statistics::Group(parent),
     ADD_STAT(condNum, statistics::units::Count::get(), "the number of cond branches"),
     ADD_STAT(uncondNum, statistics::units::Count::get(), "the number of uncond branches"),
@@ -488,6 +540,9 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group* parent, unsigne
     ADD_STAT(uncondMiss, statistics::units::Count::get(), "the number of uncond branch misses"),
     ADD_STAT(returnMiss, statistics::units::Count::get(), "the number of return branch misses"),
     ADD_STAT(otherMiss, statistics::units::Count::get(), "the number of other branch misses"),
+    ADD_STAT(branchClassCounts, statistics::units::Count::get(), "branch counts by fine-grained class"),
+    ADD_STAT(branchClassMisses, statistics::units::Count::get(), "branch mispredictions by fine-grained class"),
+    ADD_STAT(controlSquashByClass, statistics::units::Count::get(), "commit/resolve-path squashes by branch class"),
     ADD_STAT(staticBranchNum, statistics::units::Count::get(), "the number of all (different) static branches"),
     ADD_STAT(staticBranchNumEverTaken, statistics::units::Count::get(), "the number of all (different) static branches that are once taken"),
     ADD_STAT(predsOfEachStage, statistics::units::Count::get(), "the number of preds of each stage that account for final pred"),
@@ -538,6 +593,14 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group* parent, unsigne
     fsqEntryDist.init(0, fsqSize, 20).flags(statistics::total);
     commitFsqEntryHasInsts.init(0, maxInstsNum >> 1, 1);
     commitFsqEntryFetchedInsts.init(0, maxInstsNum >> 1, 1);
+    branchClassCounts.init(NumBranchClasses);
+    branchClassMisses.init(NumBranchClasses);
+    controlSquashByClass.init(NumBranchClasses);
+    for (size_t i = 0; i < NumBranchClasses; ++i) {
+        branchClassCounts.subname(i, BranchClassLabels[i]);
+        branchClassMisses.subname(i, BranchClassLabels[i]);
+        controlSquashByClass.subname(i, BranchClassLabels[i]);
+    }
 }
 
 DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchStream &stream, const DynInstPtr &inst, bool mispred)
@@ -961,6 +1024,8 @@ DecoupledBPUWithBTB::controlSquash(unsigned target_id, unsigned stream_id,
 {
     if (fromCommit) {
         dbpBtbStats.controlSquashFromCommit++;
+        auto branchClass = classifyBranch(static_inst);
+        addControlSquashCommitStat(branchClass);
     } else {
         dbpBtbStats.controlSquashFromDecode++;
     }
@@ -1350,6 +1415,63 @@ DecoupledBPUWithBTB::trackTakenBranch(Addr branchAddr)
     updateBranchMap(currentSubPhaseTakenBranches);
 }
 
+DecoupledBPUWithBTB::BranchClass
+DecoupledBPUWithBTB::classifyBranch(const DynInstPtr &inst) const
+{
+    return classifyBranchImpl(inst);
+}
+
+DecoupledBPUWithBTB::BranchClass
+DecoupledBPUWithBTB::classifyBranch(const StaticInstPtr &inst) const
+{
+    return classifyBranchImpl(inst);
+}
+
+const char *
+DecoupledBPUWithBTB::branchClassName(BranchClass cls)
+{
+    auto idx = static_cast<size_t>(cls);
+    if (idx < BranchClassLabels.size()) {
+        return BranchClassLabels[idx];
+    }
+    return "invalid";
+}
+
+void
+DecoupledBPUWithBTB::addBranchClassStat(BranchClass cls, bool mispred)
+{
+    auto idx = static_cast<size_t>(cls);
+    if (idx >= NumBranchClasses) {
+        DPRINTF(DBPBTBStats, "Skip invalid branch class stats update %d\n",
+                static_cast<int>(cls));
+        return;
+    }
+
+    dbpBtbStats.branchClassCounts[idx]++;
+    if (mispred) {
+        dbpBtbStats.branchClassMisses[idx]++;
+    }
+
+    DPRINTF(DBPBTBStats, "Branch classified as %s, mispred=%d\n",
+            branchClassName(cls), mispred);
+}
+
+void
+DecoupledBPUWithBTB::addControlSquashCommitStat(BranchClass cls)
+{
+    auto idx = static_cast<size_t>(cls);
+    if (idx >= NumBranchClasses) {
+        DPRINTF(DBPBTBStats,
+                "Skip invalid commit squash class stats update %d\n",
+                static_cast<int>(cls));
+        return;
+    }
+
+    dbpBtbStats.controlSquashByClass[idx]++;
+    DPRINTF(DBPBTBStats, "Commit squash classified as %s\n",
+            branchClassName(cls));
+}
+
 void
 DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
 {
@@ -1365,6 +1487,9 @@ DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
     } else if (inst->isIndirectCtrl()) {
         addCfi(OTHER, mispred);
     }
+
+    auto branchClass = classifyBranch(inst);
+    addBranchClassStat(branchClass, mispred);
 
     // ---------- Find corresponding fetch stream entry ----------
     auto streamIt = fetchStreamQueue.find(inst->fsqId);

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -2,6 +2,7 @@
 #define __CPU_PRED_BTB_DECOUPLED_BPRED_HH__
 
 #include <array>
+#include <cstdint>
 #include <queue>
 #include <stack>
 #include <utility>
@@ -308,6 +309,11 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar uncondMiss;   ///< Unconditional branch mispredictions
         statistics::Scalar returnMiss;   ///< Return mispredictions
         statistics::Scalar otherMiss;    ///< Other control mispredictions
+
+        // Fine-grained branch classification statistics
+        statistics::Vector branchClassCounts; ///< Classified branch occurrences
+        statistics::Vector branchClassMisses; ///< Mispredictions per class
+        statistics::Vector controlSquashByClass; ///< Commit/Resolve-path squashes per class
 
         // Branch coverage statistics
         statistics::Scalar staticBranchNum;           ///< Total static branches seen
@@ -829,6 +835,24 @@ class DecoupledBPUWithBTB : public BPredUnit
         OTHER     ///< Other control flow instruction
     };
 
+    /**
+     * @brief Fine-grained branch classes used to tie stats to predictors
+     */
+    enum class BranchClass : uint8_t
+    {
+        CondBranch = 0,   ///< Conditional direct branches (TAGE focus)
+        DirectCall,       ///< Direct call instructions (RAS + BTB)
+        IndirectCall,     ///< Indirect call instructions (ITTAGE + RAS)
+        Return,           ///< Return instructions (RAS)
+        DirectJump,       ///< Direct, non-call control transfers (BTB)
+        IndirectJump,     ///< Indirect jumps that are not calls/returns (ITTAGE)
+        Unknown,          ///< Fallback for unexpected classifications
+        NumClasses        ///< Sentinel used for sizing stat containers
+    };
+
+    static constexpr size_t NumBranchClasses =
+        static_cast<size_t>(BranchClass::NumClasses);
+
     void addCfi(CfiType type, bool mispred) {
         switch (type) {
             case COND:
@@ -854,6 +878,12 @@ class DecoupledBPUWithBTB : public BPredUnit
         }
         DPRINTF(DBPBTBStats, "Miss type: %d\n", type);
     }
+
+    BranchClass classifyBranch(const DynInstPtr &inst) const;
+    BranchClass classifyBranch(const StaticInstPtr &inst) const;
+    static const char *branchClassName(BranchClass cls);
+    void addBranchClassStat(BranchClass cls, bool mispred);
+    void addControlSquashCommitStat(BranchClass cls);
 
     void addFtqNotValid() {
         dbpBtbStats.ftqNotValid++;


### PR DESCRIPTION
Implement fine-grained RISC-V branch classification stats in the decoupled BPU so we can track per-class resolve squashes and commit mispredictions (e.g., cond, direct/indirect call, return, direct/indirect jump) via DBPBTBStats.

Change-Id: Ie0b99fa76844505dc8688b99b5760fa48a15d8c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced branch prediction statistics with fine-grained classification by branch type (conditional, calls, returns, jumps).
  * Added per-class tracking of branch prediction accuracy and control flow squash events for improved performance visibility and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->