### PR TITLE
cpu-o3: add method for microtage misprediction counting

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -536,6 +536,8 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
 #endif
             }
         }
+    }else{
+        checkUtageUpdateMisspred(stream);
     }
 
     // No allocation if no misprediction
@@ -759,33 +761,37 @@ BTBTAGE::update(const FetchStream &stream) {
         }
 #endif
     }
-    if (getDelay() != 2){// use for microtage updatemispred counting
-        // sort microtage predictions by pc to find the first taken branch
-        std::vector<std::pair<Addr, TagePrediction>> lastPreds;
-        lastPreds.reserve(predMeta->preds.size());
-        for (auto &kv : predMeta->preds) {
-            lastPreds.emplace_back(kv.first, kv.second);
-        }
-        std::sort(lastPreds.begin(), lastPreds.end(),
-                [](const std::pair<Addr, TagePrediction> &a,
-                    const std::pair<Addr, TagePrediction> &b) {
-                    return a.first < b.first;
-                });
-        Addr first_taken_pc = 0;
-        for (auto &entry_info : lastPreds) {
-            if (entry_info.second.taken) {
-                first_taken_pc = entry_info.first;
-                break;
-            }
-        }
-        bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) ||
-                                    (first_taken_pc != 0 && !stream.exeTaken);
-        bool branch_mispred = stream.exeTaken && first_taken_pc != stream.exeBranchInfo.pc;
-        if (fallthrough_mispred || branch_mispred) {
-            tageStats.updateMispred++;
+    DPRINTF(TAGE, "end update\n");
+}
+
+void
+BTBTAGE::checkUtageUpdateMisspred(const FetchStream &stream) {
+    auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
+    // use for microtage updatemispred counting
+    // sort microtage predictions by pc to find the first taken branch
+    std::vector<std::pair<Addr, TagePrediction>> lastPreds;
+    lastPreds.reserve(predMeta->preds.size());
+    for (auto &kv : predMeta->preds) {
+        lastPreds.emplace_back(kv.first, kv.second);
+    }
+    std::sort(lastPreds.begin(), lastPreds.end(),
+            [](const std::pair<Addr, TagePrediction> &a,
+                const std::pair<Addr, TagePrediction> &b) {
+                return a.first < b.first;
+            });
+    Addr first_taken_pc = 0;
+    for (auto &entry_info : lastPreds) {
+        if (entry_info.second.taken) {
+            first_taken_pc = entry_info.first;
+            break;
         }
     }
-    DPRINTF(TAGE, "end update\n");
+    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) ||
+                                (first_taken_pc != 0 && !stream.exeTaken);
+    bool branch_mispred = stream.exeTaken && first_taken_pc != stream.exeBranchInfo.pc;
+    if (fallthrough_mispred || branch_mispred) {
+        tageStats.updateMispred++;
+    }
 }
 
 // Update prediction counter with saturation

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -274,6 +274,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Instruction shift amount
     unsigned instShiftAmt {1};
 
+    // use for microtage updatemispred counting
+    void checkUtageUpdateMisspred(const FetchStream &stream);
+
     // Update prediction counter with saturation
     void updateCounter(bool taken, unsigned width, short &counter);
 


### PR DESCRIPTION
Change-Id: I1fca6a50ccf36fc0186e6799e35b87cc8480029f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured branch prediction misprediction counting by consolidating related logic into a dedicated helper function for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->