### PR TITLE
cpu-o3:Add S3 prediction update AheadBTB

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1000,6 +1000,7 @@ class AheadBTB(TimedBaseBTBPredictor):
     entryHalfAligned = Param.Bool(False, "Whether the entries are half-aligned")
     blockSize = 64
     numDelay = 0
+    usingS3Pred = Param.Bool(True, "Whether using S3 predictor to update AheadBTB")
 
 class UBTB(TimedBaseBTBPredictor):
     type = 'UBTB'

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -81,6 +81,7 @@ AheadBTB::AheadBTB(const Params &p)
     numEntries(p.numEntries),
     numWays(p.numWays),
     tagBits(p.tagBits),
+    usingS3Pred(p.usingS3Pred),
     btbStats(this)
 {
     // AheadBTB supports configurable ahead-pipelined stages, but must be > 0
@@ -424,14 +425,14 @@ AheadBTB::lookup(Addr block_pc)
  * 2. Remove entries that were not executed
  */
 std::vector<BTBEntry>
-AheadBTB::processOldEntries(const FetchStream &stream)
+AheadBTB::processOldEntries(const BTBMeta& meta, Addr end_inst_pc)
 {
-    auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
-    // hit entries whose corresponding insts are acutally executed
-    Addr end_inst_pc = stream.updateEndInstPC;
+    // auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
+    // // hit entries whose corresponding insts are acutally executed
+    // Addr end_inst_pc = stream.updateEndInstPC;
     DPRINTF(ABTB, "end_inst_pc: %#lx\n", end_inst_pc);
     // remove not executed btb entries, pc > end_inst_pc
-    auto old_entries = meta->hit_entries;
+    auto old_entries = meta.hit_entries;
     DPRINTF(ABTB, "old_entries.size(): %lu\n", old_entries.size());
     dumpBTBEntries(old_entries);
     auto remove_it = std::remove_if(old_entries.begin(), old_entries.end(),
@@ -506,7 +507,8 @@ AheadBTB::collectEntriesToUpdate(const std::vector<BTBEntry>& old_entries,
  * 5. Update MRU information
  */
 void
-AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, const FetchStream &stream)
+AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
+                                        const BranchInfo takenbranchinfo,const bool isTaken)
 {
 
     // Look for matching entry
@@ -524,7 +526,7 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, cons
     entry_to_write.tag = btb_tag;   // update tag after found it!
     // update saturating counter if necessary
     if (entry_to_write.isCond) {
-        bool this_cond_taken = stream.exeTaken && stream.getControlPC() == entry_to_write.pc;
+        bool this_cond_taken = isTaken && takenbranchinfo.pc == entry_to_write.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
         }
@@ -535,8 +537,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, cons
         // }
     }
     // update indirect target if necessary
-    if (entry_to_write.isIndirect && stream.exeTaken && stream.getControlPC() == entry_to_write.pc) {
-        entry_to_write.target = stream.exeBranchInfo.target;
+    if (entry_to_write.isIndirect && isTaken && takenbranchinfo.pc == entry_to_write.pc) {
+        entry_to_write.target = takenbranchinfo.target;
     }
     auto ticked_entry = TickedBTBEntry(entry_to_write, curTick());
     if (found) {
@@ -588,6 +590,73 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, cons
     std::make_heap(mruList[btb_idx].begin(), mruList[btb_idx].end(), older());
 }
 
+
+void
+AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const Addr previousPC)
+{
+    if (!usingS3Pred) {
+        DPRINTF(ABTB, "AheadBTB: not using S3 prediction for update, skipping\n");
+        return;
+    }
+    auto meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
+    Addr end_inst_pc =mbtb_pred.isTaken() ? mbtb_pred.getTakenEntry().pc :
+                            (mbtb_pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
+
+    // AheadBTB use S3 prediction for update
+    auto old_entries= processOldEntries(*meta, end_inst_pc);
+
+    // checkPredictionHit(stream, meta);//todo
+    //auto entries_to_update = collectEntriesToUpdate(old_entries, stream);
+    //can't use this function the new entry is from stream and it update when we get resvol
+
+    auto entries_to_update = collectEntriesToUpdateFromS3Pred(old_entries,mbtb_pred);
+
+    for (auto &entry : entries_to_update) {
+        Addr startPC = mbtb_pred.bbStart;
+        Addr btb_tag = getTag(startPC);  // use last pc to get tag
+        if (previousPC == 0) {
+            DPRINTF(ABTB, "AheadBTB: no previous PC, skipping update\n");
+            return;
+        }
+        Addr btb_idx = getIndex(previousPC);  // use last pc to get idx
+        BranchInfo takenbranchinfo;
+        takenbranchinfo.pc = mbtb_pred.getTakenEntry().pc;
+        takenbranchinfo.target = mbtb_pred.getTakenEntry().target;
+
+        updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo, mbtb_pred.isTaken());
+    }
+}
+
+std::vector<BTBEntry>
+AheadBTB::collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entries,
+                                     FullBTBPrediction &mbtb_pred)
+{
+    auto all_entries = old_entries;
+    BTBEntry new_entry = BTBEntry();
+    // which causes its counter to update twice unintentionally
+    // we need to check if the new entry already exists in uBTB
+    bool pred_branch_hit = false;
+    for (auto &e: old_entries) {
+        if (mbtb_pred.getTakenEntry() == e) {
+            pred_branch_hit = true;
+            break;
+        }
+    }
+    if (!pred_branch_hit&& mbtb_pred.isTaken()) {
+        new_entry = mbtb_pred.getTakenEntry();
+        new_entry.valid = true;
+
+        if (new_entry.isCond) {
+            new_entry.alwaysTaken = true;
+            new_entry.ctr = 0;
+        }
+        all_entries.push_back(new_entry);
+    }
+
+    DPRINTF(ABTB, "all_entries_to_update.size(): %lu\n", all_entries.size());
+    return all_entries;
+}
+
 /*
  * Update BTB with execution results
  * Steps:
@@ -600,9 +669,16 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, cons
 void
 AheadBTB::update(const FetchStream &stream)
 {
+    if (usingS3Pred) {
+        DPRINTF(ABTB, "AheadBTB: using S3 prediction for update, skipping AheadBTB update\n");
+        return;
+    }
+    auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get();
+    Addr end_inst_pc = stream.updateEndInstPC;
+
     // 1. Process old entries
-    auto old_entries = processOldEntries(stream);
-    
+    auto old_entries = processOldEntries(*meta, end_inst_pc);
+
     // 2. Check prediction hit status, for stats recording
     checkPredictionHit(stream,
         std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get());
@@ -622,7 +698,7 @@ AheadBTB::update(const FetchStream &stream)
             return;
         }
         Addr btb_idx = getIndex(previousPC);  // use last pc to get idx
-        updateBTBEntry(btb_idx, btb_tag, entry, stream);
+        updateBTBEntry(btb_idx, btb_tag, entry, stream.exeBranchInfo, stream.exeTaken);
     }
 }
 

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -311,6 +311,8 @@ AheadBTB::updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
     for (auto e: entries) {
         meta->hit_entries.push_back(BTBEntry(e));
     }
+
+    lastPredEntries = meta->hit_entries;
 }
 
 void
@@ -430,14 +432,15 @@ AheadBTB::lookup(Addr block_pc)
  * 2. Remove entries that were not executed
  */
 std::vector<BTBEntry>
-AheadBTB::processOldEntries(const BTBMeta* meta, Addr end_inst_pc)
+AheadBTB::processOldEntries(const std::vector<BTBEntry>& hit_entries,
+                            Addr end_inst_pc)
 {
     // auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
     // // hit entries whose corresponding insts are acutally executed
     // Addr end_inst_pc = stream.updateEndInstPC;
     DPRINTF(ABTB, "end_inst_pc: %#lx\n", end_inst_pc);
     // remove not executed btb entries, pc > end_inst_pc
-    auto old_entries = meta->hit_entries;
+    auto old_entries = hit_entries;
     DPRINTF(ABTB, "old_entries.size(): %lu\n", old_entries.size());
     //dumpBTBEntries(old_entries);
     auto remove_it = std::remove_if(old_entries.begin(), old_entries.end(),
@@ -597,27 +600,28 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 
 
 void
-AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const BTBMeta* meta,const Addr previousPC)
+AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
 {
     if (!usingS3Pred) {
         DPRINTF(ABTB, "AheadBTB: not using S3 prediction for update, skipping\n");
         return;
     }
-    meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
-    Addr end_inst_pc =mbtb_pred.isTaken() ? mbtb_pred.getTakenEntry().pc :
-                            (mbtb_pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
+
+    if (lastPredEntries.empty()) {
+        DPRINTF(ABTB, "AheadBTB: no cached entries for fast-train update\n");
+        return;
+    }
+
+    Addr end_inst_pc = s3Pred.isTaken() ? s3Pred.getTakenEntry().pc :
+                            (s3Pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 
     // AheadBTB use S3 prediction for update
-    auto old_entries= processOldEntries(meta, end_inst_pc);
+    auto old_entries= processOldEntries(lastPredEntries, end_inst_pc);
 
-    // checkPredictionHit(stream, meta);//todo
-    //auto entries_to_update = collectEntriesToUpdate(old_entries, stream);
-    //can't use this function the new entry is from stream and it update when we get resvol
-
-    auto entries_to_update = collectEntriesToUpdateFromS3Pred(old_entries,mbtb_pred);
+    auto entries_to_update = collectEntriesToUpdateFromS3Pred(old_entries,s3Pred);
 
     for (auto &entry : entries_to_update) {
-        Addr startPC = mbtb_pred.bbStart;
+        Addr startPC = s3Pred.bbStart;
         Addr btb_tag = getTag(startPC);  // use last pc to get tag
         if (previousPC == 0) {
             DPRINTF(ABTB, "AheadBTB: no previous PC, skipping update\n");
@@ -625,16 +629,15 @@ AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const BTBMeta* meta,co
         }
         Addr btb_idx = getIndex(previousPC);  // use last pc to get idx
         BranchInfo takenbranchinfo;
-        takenbranchinfo.pc = mbtb_pred.getTakenEntry().pc;
-        takenbranchinfo.target = mbtb_pred.getTakenEntry().target;
+        takenbranchinfo.pc = s3Pred.getTakenEntry().pc;
+        takenbranchinfo.target = s3Pred.getTakenEntry().target;
 
-        updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo, mbtb_pred.isTaken());
+        updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo, s3Pred.isTaken());
     }
 }
-
 std::vector<BTBEntry>
 AheadBTB::collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entries,
-                                     FullBTBPrediction &mbtb_pred)
+                                     FullBTBPrediction &s3Pred)
 {
     auto all_entries = old_entries;
     BTBEntry new_entry = BTBEntry();
@@ -642,13 +645,13 @@ AheadBTB::collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entr
     // we need to check if the new entry already exists in uBTB
     bool pred_branch_hit = false;
     for (auto &e: old_entries) {
-        if (mbtb_pred.getTakenEntry() == e) {
+        if (s3Pred.getTakenEntry() == e) {
             pred_branch_hit = true;
             break;
         }
     }
-    if (!pred_branch_hit&& mbtb_pred.isTaken()) {
-        new_entry = mbtb_pred.getTakenEntry();
+    if (!pred_branch_hit&& s3Pred.isTaken()) {
+        new_entry = s3Pred.getTakenEntry();
         new_entry.valid = true;
 
         if (new_entry.isCond) {
@@ -682,7 +685,7 @@ AheadBTB::update(const FetchStream &stream)
     Addr end_inst_pc = stream.updateEndInstPC;
 
     // 1. Process old entries
-    auto old_entries = processOldEntries(meta, end_inst_pc);
+    auto old_entries = processOldEntries(meta->hit_entries, end_inst_pc);
 
     // 2. Check prediction hit status, for stats recording
     checkPredictionHit(stream,

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -603,7 +603,7 @@ AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const BTBMeta* meta,co
         DPRINTF(ABTB, "AheadBTB: not using S3 prediction for update, skipping\n");
         return;
     }
-    meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
+
     Addr end_inst_pc =mbtb_pred.isTaken() ? mbtb_pred.getTakenEntry().pc :
                             (mbtb_pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -425,14 +425,14 @@ AheadBTB::lookup(Addr block_pc)
  * 2. Remove entries that were not executed
  */
 std::vector<BTBEntry>
-AheadBTB::processOldEntries(const BTBMeta& meta, Addr end_inst_pc)
+AheadBTB::processOldEntries(const BTBMeta* meta, Addr end_inst_pc)
 {
     // auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
     // // hit entries whose corresponding insts are acutally executed
     // Addr end_inst_pc = stream.updateEndInstPC;
     DPRINTF(ABTB, "end_inst_pc: %#lx\n", end_inst_pc);
     // remove not executed btb entries, pc > end_inst_pc
-    auto old_entries = meta.hit_entries;
+    auto old_entries = meta->hit_entries;
     DPRINTF(ABTB, "old_entries.size(): %lu\n", old_entries.size());
     dumpBTBEntries(old_entries);
     auto remove_it = std::remove_if(old_entries.begin(), old_entries.end(),
@@ -592,18 +592,18 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 
 
 void
-AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const Addr previousPC)
+AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const BTBMeta* meta,const Addr previousPC)
 {
     if (!usingS3Pred) {
         DPRINTF(ABTB, "AheadBTB: not using S3 prediction for update, skipping\n");
         return;
     }
-    auto meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
+    // auto meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
     Addr end_inst_pc =mbtb_pred.isTaken() ? mbtb_pred.getTakenEntry().pc :
                             (mbtb_pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 
     // AheadBTB use S3 prediction for update
-    auto old_entries= processOldEntries(*meta, end_inst_pc);
+    auto old_entries= processOldEntries(meta, end_inst_pc);
 
     // checkPredictionHit(stream, meta);//todo
     //auto entries_to_update = collectEntriesToUpdate(old_entries, stream);
@@ -677,7 +677,7 @@ AheadBTB::update(const FetchStream &stream)
     Addr end_inst_pc = stream.updateEndInstPC;
 
     // 1. Process old entries
-    auto old_entries = processOldEntries(*meta, end_inst_pc);
+    auto old_entries = processOldEntries(meta, end_inst_pc);
 
     // 2. Check prediction hit status, for stats recording
     checkPredictionHit(stream,

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -607,11 +607,6 @@ AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
         return;
     }
 
-    if (lastPredEntries.empty()) {
-        DPRINTF(ABTB, "AheadBTB: no cached entries for fast-train update\n");
-        return;
-    }
-
     Addr end_inst_pc = s3Pred.isTaken() ? s3Pred.getTakenEntry().pc :
                             (s3Pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -335,6 +335,11 @@ AheadBTB::putPCHistory(Addr startAddr,
 std::shared_ptr<void>
 AheadBTB::getPredictionMeta()
 {
+    // Lazy-initialize meta so callers never observe a null pointer
+    // This avoids early-cycle crashes when prediction hasn't populated meta yet
+    if (!meta) {
+        meta = std::make_shared<BTBMeta>();
+    }
     return meta;
 }
 
@@ -434,12 +439,12 @@ AheadBTB::processOldEntries(const BTBMeta* meta, Addr end_inst_pc)
     // remove not executed btb entries, pc > end_inst_pc
     auto old_entries = meta->hit_entries;
     DPRINTF(ABTB, "old_entries.size(): %lu\n", old_entries.size());
-    dumpBTBEntries(old_entries);
+    //dumpBTBEntries(old_entries);
     auto remove_it = std::remove_if(old_entries.begin(), old_entries.end(),
         [end_inst_pc](const BTBEntry &e) { return e.pc > end_inst_pc; });
     old_entries.erase(remove_it, old_entries.end());
     DPRINTF(ABTB, "after removing not executed insts, old_entries.size(): %lu\n", old_entries.size());
-    dumpBTBEntries(old_entries);
+    //dumpBTBEntries(old_entries);
 
     btbStats.updateHit += old_entries.size();
     
@@ -598,7 +603,7 @@ AheadBTB::updateUsingS3Pred( FullBTBPrediction &mbtb_pred,const BTBMeta* meta,co
         DPRINTF(ABTB, "AheadBTB: not using S3 prediction for update, skipping\n");
         return;
     }
-    // auto meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
+    meta = static_cast<const BTBMeta*>(getPredictionMeta().get());
     Addr end_inst_pc =mbtb_pred.isTaken() ? mbtb_pred.getTakenEntry().pc :
                             (mbtb_pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -175,12 +175,16 @@ class AheadBTB : public TimedBaseBTBPredictor
      */
     void update(const FetchStream &stream) override;
 
+    void updateUsingS3Pred(FullBTBPrediction &mbtb_pred,const Addr previousPC);
 
     void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
             e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
     }
+
+    std::vector<BTBEntry>collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entries,
+                                        FullBTBPrediction &mbtb_pred);
 
     void printTickedBTBEntry(const TickedBTBEntry &e) {
         printBTBEntry(e, e.tick);
@@ -281,10 +285,11 @@ class AheadBTB : public TimedBaseBTBPredictor
                                std::vector<FullBTBPrediction>& stagePreds);
 
     /** Process prediction metadata and old entries
-     *  @param stream Fetch stream containing prediction info
+     *  @param meta BTB metadata from prediction
+     *  @param end_inst_pc End PC of the executed instructions
      *  @return Processed old BTB entries
      */
-    std::vector<BTBEntry> processOldEntries(const FetchStream &stream);
+    std::vector<BTBEntry> processOldEntries(const BTBMeta& meta, Addr end_inst_pc);
 
     /** Get the previous PC from the fetch stream
      *  @param stream Fetch stream containing prediction info
@@ -314,7 +319,8 @@ class AheadBTB : public TimedBaseBTBPredictor
      *  @param entry Entry to update/replace
      *  @param stream Fetch stream with update info
      */
-    void updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry, const FetchStream &stream);
+    void updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
+                                    const BranchInfo takenbranchinfo,const bool isTaken);
 
     /*
      * Comparator for MRU heap
@@ -392,6 +398,7 @@ class AheadBTB : public TimedBaseBTBPredictor
     /** Address calculation masks and shifts */
     Addr idxMask;          // Mask for extracting index bits
     unsigned tagBits;      // Number of tag bits
+    bool usingS3Pred;   // Whether to use S3 prediction for update
     Addr tagMask;          // Mask for extracting tag bits
     unsigned idxShiftAmt;  // Amount to shift PC for index
     unsigned tagShiftAmt;  // Amount to shift PC for tag

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -212,16 +212,6 @@ class AheadBTB : public TimedBaseBTBPredictor
         }
     }
 
-    typedef struct BTBMeta
-    {
-        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
-        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
-        BTBMeta() {
-            std::vector<BTBEntry> es;
-            hit_entries = es;
-            l0_hit_entries = es;
-        }
-    }BTBMeta;
 
     void updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC);
 
@@ -263,8 +253,25 @@ class AheadBTB : public TimedBaseBTBPredictor
         if (!taken && ctr > -2) {ctr--;}
     }
 
+        typedef struct BTBMeta
+    {
+        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
+        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
+        BTBMeta() {
+            std::vector<BTBEntry> es;
+            hit_entries = es;
+            l0_hit_entries = es;
+        }
+    }BTBMeta;
 
     std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
+
+    /**
+    * lastPredEntries is using in updateusingS3pred() to store the hit entries during prediction
+    * it is using to hold the hit entries for later use in S3 update
+    * because in gem5 generat pred and updateusingS3pred finish in the same cycle
+    * so we can use this instead of using BTBMeta
+    */
     std::vector<BTBEntry> lastPredEntries; // cached hit entries for the latest prediction
 
     /** Process BTB entries for prediction

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -175,7 +175,7 @@ class AheadBTB : public TimedBaseBTBPredictor
      */
     void update(const FetchStream &stream) override;
 
-    void updateUsingS3Pred(FullBTBPrediction &mbtb_pred,const Addr previousPC);
+
 
     void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
@@ -211,7 +211,18 @@ class AheadBTB : public TimedBaseBTBPredictor
         }
     }
 
+    typedef struct BTBMeta
+    {
+        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
+        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
+        BTBMeta() {
+            std::vector<BTBEntry> es;
+            hit_entries = es;
+            l0_hit_entries = es;
+        }
+    }BTBMeta;
 
+    void updateUsingS3Pred(FullBTBPrediction &mbtb_pred,const BTBMeta* meta,const Addr previousPC);
 
   private:
     /** Returns the index into the BTB, based on the branch's PC.
@@ -251,15 +262,6 @@ class AheadBTB : public TimedBaseBTBPredictor
         if (!taken && ctr > -2) {ctr--;}
     }
 
-    typedef struct BTBMeta {
-        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
-        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
-        BTBMeta() {
-            std::vector<BTBEntry> es;
-            hit_entries = es;
-            l0_hit_entries = es;
-        }
-    }BTBMeta;
 
     std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
 
@@ -289,7 +291,7 @@ class AheadBTB : public TimedBaseBTBPredictor
      *  @param end_inst_pc End PC of the executed instructions
      *  @return Processed old BTB entries
      */
-    std::vector<BTBEntry> processOldEntries(const BTBMeta& meta, Addr end_inst_pc);
+    std::vector<BTBEntry> processOldEntries(const BTBMeta* meta, Addr end_inst_pc);
 
     /** Get the previous PC from the fetch stream
      *  @param stream Fetch stream containing prediction info

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -183,8 +183,9 @@ class AheadBTB : public TimedBaseBTBPredictor
             e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
     }
 
-    std::vector<BTBEntry>collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entries,
-                                        FullBTBPrediction &mbtb_pred);
+    std::vector<BTBEntry> collectEntriesToUpdateFromS3Pred(
+        const std::vector<BTBEntry>& old_entries,
+        FullBTBPrediction &s3Pred);
 
     void printTickedBTBEntry(const TickedBTBEntry &e) {
         printBTBEntry(e, e.tick);
@@ -222,7 +223,7 @@ class AheadBTB : public TimedBaseBTBPredictor
         }
     }BTBMeta;
 
-    void updateUsingS3Pred(FullBTBPrediction &mbtb_pred,const BTBMeta* meta,const Addr previousPC);
+    void updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC);
 
   private:
     /** Returns the index into the BTB, based on the branch's PC.
@@ -264,6 +265,7 @@ class AheadBTB : public TimedBaseBTBPredictor
 
 
     std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
+    std::vector<BTBEntry> lastPredEntries; // cached hit entries for the latest prediction
 
     /** Process BTB entries for prediction
      *  @param entries Vector of BTB entries to process
@@ -291,7 +293,8 @@ class AheadBTB : public TimedBaseBTBPredictor
      *  @param end_inst_pc End PC of the executed instructions
      *  @return Processed old BTB entries
      */
-    std::vector<BTBEntry> processOldEntries(const BTBMeta* meta, Addr end_inst_pc);
+    std::vector<BTBEntry> processOldEntries(const std::vector<BTBEntry>& hit_entries,
+                                            Addr end_inst_pc);
 
     /** Get the previous PC from the fetch stream
      *  @param stream Fetch stream containing prediction info

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -771,6 +771,13 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
     // update ubtb using mbtb prediction
     if (predsOfEachStage[numStages - 1].btbEntries.size() > 0) {
         ubtb->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
+        auto it = fetchStreamQueue.find(fsqId-1);
+        if (it != fetchStreamQueue.end()) {
+            auto previous_block_startpc = it->second.startPC;
+            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], previous_block_startpc);
+        } else {
+             abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], 0);
+        }
     }
 
     // 4. Record override bubbles and update statistics

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -768,16 +768,15 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
         overrideReason = reason;
     }
 
-    // update ubtb using mbtb prediction
+    // update ubtb/abtb using final S3 prediction
     if (predsOfEachStage[numStages - 1].btbEntries.size() > 0) {
         ubtb->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
-        const AheadBTB::BTBMeta* meta = static_cast<const AheadBTB::BTBMeta*>(abtb->getPredictionMeta().get());
         auto it = fetchStreamQueue.find(fsqId-1);
         if (it != fetchStreamQueue.end()) {
             auto previous_block_startpc = it->second.startPC;
-            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], meta,previous_block_startpc);
+            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], previous_block_startpc);
         } else {
-            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], meta, 0);
+            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], 0);
         }
 
     }

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -771,13 +771,15 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles()
     // update ubtb using mbtb prediction
     if (predsOfEachStage[numStages - 1].btbEntries.size() > 0) {
         ubtb->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
+        const AheadBTB::BTBMeta* meta = static_cast<const AheadBTB::BTBMeta*>(abtb->getPredictionMeta().get());
         auto it = fetchStreamQueue.find(fsqId-1);
         if (it != fetchStreamQueue.end()) {
             auto previous_block_startpc = it->second.startPC;
-            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], previous_block_startpc);
+            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], meta,previous_block_startpc);
         } else {
-             abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], 0);
+            abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], meta, 0);
         }
+
     }
 
     // 4. Record override bubbles and update statistics


### PR DESCRIPTION
add abtb update using S3Pred and add a switch to change abtb update from commit/resolve or S3Pred

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable S3-based prediction integration for branch-target updates, enabled by default.
  * BTB update flow now uses prior fetch-block context when available to improve update accuracy.

* **Behavior**
  * When S3 mode is active, BTB updates follow the S3-driven path to avoid conflicting with the original update flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->