### PR TITLE
cpu-o3: Remove unused L0 BTB checks and related statistics from abtb mbtb

### DIFF
--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -225,15 +225,6 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
                   return a.pc == b.pc;
               }),
               mixed_entries.end());
-        // Fill all later stages with the mix prediction from uBTB and aBTB
-        // for (int s = getDelay(); s < stagePreds.size(); ++s) {
-        //     stagePreds[s].btbEntries.clear();
-        //     for (auto e: mixed_entries) {
-        //         stagePreds[s].btbEntries.push_back(BTBEntry(e));
-        //     }
-        //     checkAscending(stagePreds[s].btbEntries);
-        //     dumpBTBEntries(stagePreds[s].btbEntries);
-        // }
         // return;
     } else {// no uBTB prediction, only use aBTB prediction
         mixed_entries = entries;
@@ -245,11 +236,6 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
     }
 
     FillStageLoop(s) {
-        // if (!isL0() && !hit && stagePreds[s].valid) {
-        //     DPRINTF(ABTB, "BTB: ubtb hit and btb miss, use ubtb result");
-        //     incNonL0Stat(btbStats.predUseL0OnL1Miss);
-        //     break;
-        // }
         DPRINTF(ABTB, "BTB: assigning prediction for stage %d\n", s);
         // Copy BTB entries to stage prediction
         stagePreds[s].btbEntries.clear();
@@ -297,16 +283,12 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
 /**
  * Update metadata for later stages:
  * 1. Clear old metadata
- * 2. Save L0 BTB entries for L1 BTB's reference
- * 3. Save current BTB entries
+ * 2. Save current BTB entries
  */
 void
 AheadBTB::updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
                                    std::vector<FullBTBPrediction>& stagePreds)
 {
-
-
-
     // Save current BTB entries
     for (auto e: entries) {
         meta->hit_entries.push_back(BTBEntry(e));
@@ -456,7 +438,6 @@ AheadBTB::processOldEntries(const std::vector<BTBEntry>& hit_entries,
 
 /**
  * Check if the branch was predicted correctly
- * Also check L0 BTB prediction status
  */
 void
 AheadBTB::checkPredictionHit(const FetchStream &stream, const BTBMeta* meta)
@@ -538,11 +519,9 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
         }
-        // if (isL0()) {  // only L0 BTB has saturating counter
-        if(!entry_to_write.alwaysTaken) {
+        if (!entry_to_write.alwaysTaken) {
             updateCtr(entry_to_write.ctr, this_cond_taken);
         }
-        // }
     }
     // update indirect target if necessary
     if (entry_to_write.isIndirect && isTaken && takenbranchinfo.pc == entry_to_write.pc) {
@@ -766,14 +745,12 @@ AheadBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
             } else {
                 btbStats.condHitNotTakens++;
             }
-            // if (isL0()) {
                 bool pred_taken = entry.ctr >= 0;
                 if (pred_taken == this_branch_taken) {
                     btbStats.condPredCorrect++;
                 } else {
                     btbStats.condPredWrong++;
                 }
-            // }
         }
         if (inst->isUncondCtrl()) {
             btbStats.uncondHits++;
@@ -807,18 +784,11 @@ AheadBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
             btbStats.condMisses++;
             if (this_branch_taken) {
                 btbStats.condMissTakens++;
-                // if (isL0()) {
-                    // only L0 BTB has saturating counters to predict conditional branches
-                    // taken branches that is missed in btb must have been mispredicted
-                    btbStats.condPredWrong++;
-                // }
+                btbStats.condPredWrong++;
             } else {
                 btbStats.condMissNotTakens++;
-                // if (isL0()) {
-                    // only L0 BTB has saturating counters to predict conditional branches
-                    // taken branches that is missed in btb must have been mispredicted
-                    btbStats.condPredCorrect++;
-                // }
+
+                btbStats.condPredCorrect++;
             }
         }
         if (inst->isUncondCtrl()) {
@@ -844,13 +814,7 @@ AheadBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
 #ifndef UNIT_TEST
 AheadBTB::BTBStats::BTBStats(statistics::Group* parent) :
     statistics::Group(parent),
-    ADD_STAT(newEntry, statistics::units::Count::get(), "number of new btb entries generated"),
-    ADD_STAT(newEntryWithCond, statistics::units::Count::get(), "number of new btb entries generated with conditional branch"),
-    ADD_STAT(newEntryWithUncond, statistics::units::Count::get(), "number of new btb entries generated with unconditional branch"),
-    ADD_STAT(oldEntry, statistics::units::Count::get(), "number of old btb entries updated"),
-    ADD_STAT(oldEntryIndirectTargetModified, statistics::units::Count::get(), "number of old btb entries with indirect target modified"),
-    ADD_STAT(oldEntryWithNewCond, statistics::units::Count::get(), "number of old btb entries with new conditional branches"),
-    ADD_STAT(oldEntryWithNewUncond, statistics::units::Count::get(), "number of old btb entries with new unconditional branches"),
+
     ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
     ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
     ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
@@ -858,9 +822,7 @@ AheadBTB::BTBStats::BTBStats(statistics::Group* parent) :
     ADD_STAT(updateExisting, statistics::units::Count::get(), "existing entries updated"),
     ADD_STAT(updateReplace, statistics::units::Count::get(), "entries replaced"),
     ADD_STAT(updateReplaceValidOne, statistics::units::Count::get(), "entries replaced with valid entry"),
-    ADD_STAT(eraseSlotBehindUncond, statistics::units::Count::get(), "erase slots behind unconditional slot"),
-    ADD_STAT(predUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when pred"),
-    ADD_STAT(updateUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when update"),
+
     ADD_STAT(S0Predmiss, statistics::units::Count::get(), "misses encountered on S0 prediction, i.e. uBTB and ABTB miss"),
     ADD_STAT(S0PredUseUBTB, statistics::units::Count::get(), "uBTB prediction used, i.e. uBTB hit"),
     ADD_STAT(S0PredUseABTB, statistics::units::Count::get(), "aBTB prediction used, i.e. uBTB miss and ABTB hit"),
@@ -891,20 +853,6 @@ AheadBTB::BTBStats::BTBStats(statistics::Group* parent) :
     ADD_STAT(returnMisses, statistics::units::Count::get(), "returns committed that was predicted miss")
 
 {
-    auto btb = dynamic_cast<branch_prediction::btb_pred::AheadBTB*>(parent);
-    // do not need counter below in L0 btb
-    if (btb->isL0()) {
-        predUseL0OnL1Miss.prereq(predUseL0OnL1Miss);
-        updateUseL0OnL1Miss.prereq(updateUseL0OnL1Miss);
-        newEntry.prereq(newEntry);
-        newEntryWithCond.prereq(newEntryWithCond);
-        newEntryWithUncond.prereq(newEntryWithUncond);
-        oldEntry.prereq(oldEntry);
-        oldEntryIndirectTargetModified.prereq(oldEntryIndirectTargetModified);
-        oldEntryWithNewCond.prereq(oldEntryWithNewCond);
-        oldEntryWithNewUncond.prereq(oldEntryWithNewUncond);
-        eraseSlotBehindUncond.prereq(eraseSlotBehindUncond);
-    }
 }
 #endif
 

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -238,10 +238,6 @@ class AheadBTB : public TimedBaseBTBPredictor
         return (instPC >> tagShiftAmt) & tagMask;
     }
 
-    /** Helper function to check if this is L0 BTB
-     *  L0 BTB has zero delay (getDelay() == 0)
-     */
-    bool isL0() { return getDelay() == 0; }
 
     /** Update the 2-bit saturating counter for conditional branches
      *  Counter range: [-2, 1]
@@ -255,12 +251,10 @@ class AheadBTB : public TimedBaseBTBPredictor
 
         typedef struct BTBMeta
     {
-        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
-        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
+        std::vector<BTBEntry> hit_entries;
         BTBMeta() {
             std::vector<BTBEntry> es;
             hit_entries = es;
-            l0_hit_entries = es;
         }
     }BTBMeta;
 
@@ -433,13 +427,6 @@ class AheadBTB : public TimedBaseBTBPredictor
 #else
     struct BTBStats : public statistics::Group {
 #endif
-        Scalar newEntry;
-        Scalar newEntryWithCond;
-        Scalar newEntryWithUncond;
-        Scalar oldEntry;
-        Scalar oldEntryIndirectTargetModified;
-        Scalar oldEntryWithNewCond;
-        Scalar oldEntryWithNewUncond;
 
         Scalar predMiss;
         Scalar predHit;
@@ -448,11 +435,6 @@ class AheadBTB : public TimedBaseBTBPredictor
         Scalar updateExisting;
         Scalar updateReplace;
         Scalar updateReplaceValidOne;
-
-        Scalar eraseSlotBehindUncond;
-
-        Scalar predUseL0OnL1Miss;
-        Scalar updateUseL0OnL1Miss;
 
         Scalar S0Predmiss;
         Scalar S0PredUseUBTB;
@@ -494,11 +476,6 @@ class AheadBTB : public TimedBaseBTBPredictor
 #endif
     } btbStats;
 
-    void incNonL0Stat(Scalar &stat) {
-        if (!isL0()) {
-            stat++;
-        }
-    }
 };
 
 // Close conditional namespace wrapper for testing

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -262,13 +262,9 @@ MBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
         assert(e.valid);
         if (e.isCond) {
             // TODO: a performance bug here, mbtb should not update condTakens!
-            // if (isL0()) {  // only L0 BTB has saturating counter
-            // use saturating counter of L0 BTB
 
             FillStageLoop(s) stagePreds[s].condTakens.push_back({e.pc, e.alwaysTaken || (e.ctr >= 0)});
 
-            // } else {  // L1 BTB condTakens depends on the TAGE predictor
-            // }
         } else if (e.isIndirect) {
             // Set predicted target for indirect branches
             DPRINTF(BTB, "setting indirect target for pc %#lx to %#lx\n", e.pc, e.target);
@@ -286,20 +282,12 @@ MBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
 /**
  * Update metadata for later stages:
  * 1. Clear old metadata
- * 2. Save L0 BTB entries for L1 BTB's reference
- * 3. Save current BTB entries
+ * 2. Save current BTB entries
  */
 void
 MBTB::updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
                                    std::vector<FullBTBPrediction>& stagePreds)
 {
-
-    // Save L0 BTB entries for L1 BTB's reference
-    if (getDelay() >= 1) {
-        // L0 should be zero-bubble
-        meta->l0_hit_entries = stagePreds[0].btbEntries;
-    }
-
     // Save current BTB entries
     for (auto e: entries) {
         meta->hit_entries.push_back(BTBEntry(e));
@@ -399,7 +387,7 @@ MBTB::lookup(Addr block_pc, std::shared_ptr<BTBMeta> meta)
         auto victimResults = lookupVictimCache(block_pc);
         if (!victimResults.empty()) {
             DPRINTF(BTB, "Victim cache hit for lookup at %#lx\n", block_pc);
-            incNonL0Stat(btbStats.victimCacheHit);
+            btbStats.victimCacheHit++;
             res.insert(res.end(), victimResults.begin(), victimResults.end()); // merge victim results
         }
     }
@@ -457,11 +445,11 @@ MBTB::getAndSetNewBTBEntry(FetchStream &stream)
         if (new_entry.isCond) {
             new_entry.alwaysTaken = true;
             new_entry.ctr = 0;  // Start with positive prediction
-            incNonL0Stat(btbStats.newEntryWithCond);
+            btbStats.newEntryWithCond++;
         } else {
-            incNonL0Stat(btbStats.newEntryWithUncond);
+            btbStats.newEntryWithUncond++;
         }
-        incNonL0Stat(btbStats.newEntry);
+        btbStats.newEntry++;
         entry_to_write = new_entry;
         is_old_entry = false;
     } else {
@@ -478,7 +466,7 @@ MBTB::getAndSetNewBTBEntry(FetchStream &stream)
 
 /**
  * Check if the branch was predicted correctly
- * Also check L0 BTB prediction status
+ * Also check BTB prediction status
  */
 void
 MBTB::checkPredictionHit(const FetchStream &stream, const BTBMeta* meta)
@@ -497,19 +485,6 @@ MBTB::checkPredictionHit(const FetchStream &stream, const BTBMeta* meta)
         btbStats.updateHit++;
     }
 
-    // Check if L0 BTB had a hit but L1 BTB missed
-    bool pred_l0_branch_hit = false;
-    for (auto &e : meta->l0_hit_entries) {
-        if (stream.exeBranchInfo == e) {
-            pred_l0_branch_hit = true;
-            break;
-        }
-    }
-    bool l0_hit_l1_miss = pred_l0_branch_hit && !pred_branch_hit;
-    if (l0_hit_l1_miss) {
-        DPRINTF(BTB, "BTB: skipping entry write because of l0 hit\n");
-        incNonL0Stat(btbStats.updateUseL0OnL1Miss);
-    }
 }
 
 
@@ -835,14 +810,14 @@ MBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
             } else {
                 btbStats.condHitNotTakens++;
             }
-            // if (isL0()) {
-                bool pred_taken = entry.ctr >= 0;
-                if (pred_taken == this_branch_taken) {
-                    btbStats.condPredCorrect++;
-                } else {
-                    btbStats.condPredWrong++;
-                }
-            // }
+
+            bool pred_taken = entry.ctr >= 0;
+            if (pred_taken == this_branch_taken) {
+                btbStats.condPredCorrect++;
+            } else {
+                btbStats.condPredWrong++;
+            }
+
         }
         if (inst->isUncondCtrl()) {
             btbStats.uncondHits++;
@@ -876,18 +851,11 @@ MBTB::commitBranch(const FetchStream &stream, const DynInstPtr &inst)
             btbStats.condMisses++;
             if (this_branch_taken) {
                 btbStats.condMissTakens++;
-                // if (isL0()) {
-                    // only L0 BTB has saturating counters to predict conditional branches
-                    // taken branches that is missed in btb must have been mispredicted
-                    btbStats.condPredWrong++;
-                // }
+                btbStats.condPredWrong++;
+
             } else {
                 btbStats.condMissNotTakens++;
-                // if (isL0()) {
-                    // only L0 BTB has saturating counters to predict conditional branches
-                    // taken branches that is missed in btb must have been mispredicted
-                    btbStats.condPredCorrect++;
-                // }
+                btbStats.condPredCorrect++;
             }
         }
         if (inst->isUncondCtrl()) {
@@ -926,11 +894,6 @@ MBTB::BTBStats::BTBStats(statistics::Group* parent, int numWays) :
     ADD_STAT(updateReplaceValidOne, statistics::units::Count::get(), "entries replaced with valid entry"),
     ADD_STAT(updateInVC, statistics::units::Count::get(), "entries updated in victim cache"),
     ADD_STAT(updateTotal, statistics::units::Count::get(), "total number of entries updated"),
-    ADD_STAT(predUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when pred"),
-    ADD_STAT(updateUseL0OnL1Miss, statistics::units::Count::get(), "use l0 result on l1 miss when update"),
-    ADD_STAT(S0Predmiss, statistics::units::Count::get(), "misses encountered on S0 prediction, i.e. uBTB and ABTB miss"),
-    ADD_STAT(S0PredUseUBTB, statistics::units::Count::get(), "uBTB prediction used, i.e. uBTB hit"),
-    ADD_STAT(S0PredUseABTB, statistics::units::Count::get(), "aBTB prediction used, i.e. uBTB miss and ABTB hit"),
 
     ADD_STAT(allBranchHits, statistics::units::Count::get(), "all types of branches committed that was predicted hit"),
     ADD_STAT(allBranchHitTakens, statistics::units::Count::get(), "all types of taken branches committed was that predicted hit"),

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -226,11 +226,6 @@ class MBTB : public TimedBaseBTBPredictor
         return (instPC >> tagShiftAmt) & tagMask;
     }
 
-    /** Helper function to check if this is L0 BTB
-     *  L0 BTB has zero delay (getDelay() == 0)
-     */
-    bool isL0() { return getDelay() == 0; }
-
     /** Update the 2-bit saturating counter for conditional branches
      *  Counter range: [-2, 1]
      *  - Increment on taken (max 1)
@@ -242,12 +237,10 @@ class MBTB : public TimedBaseBTBPredictor
     }
 
     typedef struct BTBMeta {
-        std::vector<BTBEntry> hit_entries;  // hit entries in L1 BTB
-        std::vector<BTBEntry> l0_hit_entries; // hit entries in L0 BTB
+        std::vector<BTBEntry> hit_entries;
         BTBMeta() {
             std::vector<BTBEntry> es;
             hit_entries = es;
-            l0_hit_entries = es;
         }
     }BTBMeta;
 
@@ -438,13 +431,6 @@ public:
         Scalar updateInVC;
         Scalar updateTotal;
 
-        Scalar predUseL0OnL1Miss;
-        Scalar updateUseL0OnL1Miss;
-
-        Scalar S0Predmiss;
-        Scalar S0PredUseUBTB;
-        Scalar S0PredUseABTB;
-
         // per branch statistics
         Scalar allBranchHits;
         Scalar allBranchHitTakens;
@@ -485,11 +471,6 @@ public:
 #endif
     } btbStats;
 
-    void incNonL0Stat(Scalar &stat) {
-        if (!isL0()) {
-            stat++;
-        }
-    }
 };
 
 // Close conditional namespace wrapper for testing


### PR DESCRIPTION
cpu-o3: Remove unused L0 BTB checks and related statistics from abtb mbtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal branch prediction logic by removing dual-layer BTB tracking paths and consolidating prediction behavior across all prediction stages.
  * Removed redundant L0 BTB-specific code paths and helper functions to streamline the branch prediction mechanism.

* **Chores**
  * Removed unused internal statistics counters related to branch prediction tracking and layer-specific metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->