### PR TITLE
cpu-o3: move resolve queue merging from iew to fetch stage

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -97,7 +97,6 @@ def setKmhV3Params(args, system):
 
             cpu.branchPred.mbtb.resolvedUpdate = True
             cpu.branchPred.tage.resolvedUpdate = True
-            cpu.branchPred.tage.enableBankConflict = False
 
             cpu.branchPred.ubtb.enabled = True
             cpu.branchPred.abtb.enabled = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -97,6 +97,7 @@ def setKmhV3Params(args, system):
 
             cpu.branchPred.mbtb.resolvedUpdate = True
             cpu.branchPred.tage.resolvedUpdate = True
+            cpu.branchPred.tage.enableBankConflict = False
 
             cpu.branchPred.ubtb.enabled = True
             cpu.branchPred.abtb.enabled = False

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -248,7 +248,13 @@ struct TimeStruct
         StallReason lqHeadStallReason;
         StallReason sqHeadStallReason;
 
-        std::vector<ResolveQueueEntry> resolveQueue;  // *F
+        struct ResolvedCFIEntry
+        {
+            uint64_t fsqId;
+            uint64_t pc;
+        };
+        /** Resolved control-flow PCs produced this cycle (fetch buffers/merges). */
+        std::vector<ResolvedCFIEntry> resolvedCFIs;  // *F
     };
 
     IewComm iewInfo[MaxThreads];

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -91,6 +91,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
     : fetchPolicy(params.smtFetchPolicy),
       cpu(_cpu),
       branchPred(nullptr),
+      resolveQueueSize(params.resolveQueueSize),
       decodeToFetchDelay(params.decodeToFetchDelay),
       renameToFetchDelay(params.renameToFetchDelay),
       iewToFetchDelay(params.iewToFetchDelay),
@@ -249,7 +250,13 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
     ADD_STAT(frontendBandwidthBound, statistics::units::Rate<
                     statistics::units::Count, statistics::units::Cycle>::get(),
              "Frontend Bandwidth Bound",
-             frontendBound - frontendLatencyBound)
+             frontendBound - frontendLatencyBound),
+    ADD_STAT(resolveQueueFullCycles, statistics::units::Count::get(),
+             "Number of cycles the resolve queue is full"),
+    ADD_STAT(resolveQueueFullEvents, statistics::units::Count::get(),
+             "Number of events the resolve queue becomes full"),
+    ADD_STAT(resolveEnqueueFailEvent, statistics::units::Count::get(),
+             "Number of times an entry could not be enqueued to the resolve queue")
 {
         icacheStallCycles
             .prereq(icacheStallCycles);
@@ -1494,17 +1501,43 @@ Fetch::handleIEWSignals()
         return;
     }
 
-    // iterate resolved stream_id and PC value from ResolveQueue
-    for (auto entry : fromIEW->iewInfo->resolveQueue) {
+    auto &incoming = fromIEW->iewInfo->resolvedCFIs;
+
+    for (const auto &resolved : incoming) {
+        bool merged = false;
+        for (auto &queued : resolveQueue) {
+            if (queued.resolvedFSQId == resolved.fsqId) {
+                queued.resolvedInstPC.push_back(resolved.pc);
+                merged = true;
+                break;
+            }
+        }
+
+        if (merged) {
+            continue;
+        }
+
+        if (resolveQueueSize && resolveQueue.size() >= resolveQueueSize) {
+            fetchStats.resolveQueueFullEvents++;
+            continue;
+        }
+
+        ResolveQueueEntry new_entry;
+        new_entry.resolvedFSQId = resolved.fsqId;
+        new_entry.resolvedInstPC.push_back(resolved.pc);
+        resolveQueue.push_back(std::move(new_entry));
+    }
+
+    if (!resolveQueue.empty()) {
+        auto &entry = resolveQueue.front();
         unsigned int stream_id = entry.resolvedFSQId;
         dbpbtb->prepareResolveUpdateEntries(stream_id);
-        for (uint64_t &resolvedInstPC : entry.resolvedInstPC) {
+        for (const auto resolvedInstPC : entry.resolvedInstPC) {
             dbpbtb->markCFIResolved(stream_id, resolvedInstPC);
         }
         dbpbtb->resolveUpdate(stream_id);
+        resolveQueue.pop_front();
     }
-
-    return;
 }
 
 bool

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -42,6 +42,7 @@
 #define __CPU_O3_FETCH_HH__
 
 #include <cstring>
+#include <deque>
 #include <utility>
 
 #include "arch/generic/decoder.hh"
@@ -612,6 +613,12 @@ class Fetch
 
     branch_prediction::btb_pred::DecoupledBPUWithBTB *dbpbtb;
 
+    /** Maximum number of resolve entries buffered in fetch before training. */
+    const unsigned resolveQueueSize;
+
+    /** FIFO storing resolve entries waiting for BPU training. */
+    std::deque<ResolveQueueEntry> resolveQueue;
+
     /** PC of each thread. */
     std::unique_ptr<PCStateBase> pc[MaxThreads];
 
@@ -1095,6 +1102,12 @@ class Fetch
         statistics::Formula frontendLatencyBound;
         /** Frontend Bandwidth Bound */
         statistics::Formula frontendBandwidthBound;
+        /** Stat for total cycles the resolve queue is full. */
+        statistics::Scalar resolveQueueFullCycles;
+        /** Stat for total events of the resolve queue becomes full. */
+        statistics::Scalar resolveQueueFullEvents;
+        /** Stat for total number of resolve enqueue fail events. */
+        statistics::Scalar resolveEnqueueFailEvent;
     } fetchStats;
 
     SquashVersion localSquashVer;

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -93,7 +93,6 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       wbWidth(params.wbWidth),
       enableStoreSetTrain(params.enable_storeSet_train),
       numThreads(params.numThreads),
-      resolveQueueSize(params.resolveQueueSize),
       iewStats(cpu)
 {
     if (wbWidth > MaxWidth)
@@ -181,13 +180,6 @@ IEW::IEWStats::IEWStats(CPU *cpu)
              "Number of branches that were predicted taken incorrectly"),
     ADD_STAT(predictedNotTakenIncorrect, statistics::units::Count::get(),
              "Number of branches that were predicted not taken incorrectly"),
-    ADD_STAT(resolveQueueFullCycles, statistics::units::Count::get(),
-             "Number of cycles the resolve queue is full"),
-    ADD_STAT(resolveQueueFullEvents, statistics::units::Count::get(),
-             "Number of events the resolve queue becomes full"),
-    ADD_STAT(resolveEnqueueFailEvent, statistics::units::Count::get(),
-             "Number of times an instruction could not be enqueued to the "
-             "resolve queue"),
     ADD_STAT(branchMispredicts, statistics::units::Count::get(),
              "Number of branch mispredicts detected at execute",
              predictedTakenIncorrect + predictedNotTakenIncorrect),
@@ -1572,32 +1564,13 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
 {
     ThreadID tid = inst->threadNumber;
 
-    uint64_t fsqId = inst->getFsqId();
-    uint64_t pc = inst->getPC();
-    bool found = false;
-    for (auto &entry : resolveQueue) {
-        if (entry.resolvedFSQId == fsqId) {
-            entry.resolvedInstPC.push_back(pc);
-            found = true;
-        }
-    }
-
-    if (!found && resolveQueue.size() < resolveQueueSize) {
-        ResolveQueueEntry newEntry;
-        newEntry.resolvedFSQId = fsqId;
-        newEntry.resolvedInstPC.push_back(pc);
-        resolveQueue.push_back(newEntry);
-        if (resolveQueue.size() == resolveQueueSize) {
-            iewStats.resolveQueueFullEvents++;
-        }
-    }
-
-    if (resolveQueue.size() >= resolveQueueSize) {
-        if (!found) {
-            iewStats.resolveEnqueueFailEvent++;
-        }
-        iewStats.resolveQueueFullCycles++;
-    }
+    // if (inst->isControl()) {
+        auto &resolved_cfis = toFetch->iewInfo[tid].resolvedCFIs;
+        TimeStruct::IewComm::ResolvedCFIEntry entry;
+        entry.fsqId = inst->getFsqId();
+        entry.pc = inst->getPC();
+        resolved_cfis.push_back(entry);
+    // }
 
     if (!fetchRedirect[tid] ||
         !execWB->squash[tid] ||
@@ -1694,7 +1667,7 @@ IEW::executeInsts()
 
     // Clear resolvedFSQId and resolvedInstPC since they are already handled in frontend
     ThreadID tid = *activeThreads->begin();
-    toFetch->iewInfo[tid].resolveQueue.clear();
+    toFetch->iewInfo[tid].resolvedCFIs.clear();
 
     // Execute/writeback any instructions that are available.
     int insts_to_execute = fromIssue->size;
@@ -1810,12 +1783,6 @@ IEW::executeInsts()
             // call this in `lsq_unit.cc` after execution
             SquashCheckAfterExe(inst);
         }
-    }
-
-    if (!resolveQueue.empty()) {
-        ResolveQueueEntry entry = resolveQueue.front();
-        resolveQueue.erase(resolveQueue.begin());
-        toFetch->iewInfo[tid].resolveQueue.push_back(entry);
     }
 
     ldstQueue.executePipeSx();

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1564,13 +1564,13 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
 {
     ThreadID tid = inst->threadNumber;
 
-    // if (inst->isControl()) {
+    if (inst->isControl()) {
         auto &resolved_cfis = toFetch->iewInfo[tid].resolvedCFIs;
         TimeStruct::IewComm::ResolvedCFIEntry entry;
         entry.fsqId = inst->getFsqId();
         entry.pc = inst->getPC();
         resolved_cfis.push_back(entry);
-    // }
+    }
 
     if (!fetchRedirect[tid] ||
         !execWB->squash[tid] ||

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -495,9 +495,6 @@ class IEW
     /** Maximum size of the skid buffer. */
     unsigned skidBufferMax;
 
-    unsigned resolveQueueSize;
-    std::vector<ResolveQueueEntry> resolveQueue;
-
     struct IEWStats : public statistics::Group
     {
         IEWStats(CPU *cpu);
@@ -530,12 +527,6 @@ class IEW
         statistics::Scalar predictedTakenIncorrect;
         /** Stat for total number of incorrect predicted not taken branches. */
         statistics::Scalar predictedNotTakenIncorrect;
-        /** Stat for total cycles the resolve queue is full. */
-        statistics::Scalar resolveQueueFullCycles;
-        /** Stat for total events of the resolve queue becomes full. */
-        statistics::Scalar resolveQueueFullEvents;
-        /** Stat for total number of enqueue fail events. */
-        statistics::Scalar resolveEnqueueFailEvent;
         /** Stat for total number of mispredicted branches detected at
          *  execute. */
         statistics::Formula branchMispredicts;


### PR DESCRIPTION
Change-Id: Iaba29431fecd59d250c48cc566cb9b18140c5098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured how resolved control‑flow information is communicated between execution and fetch stages; the fetch stage now manages a buffered resolve queue with merging and capacity handling.

* **Monitoring**
  * Added frontend metrics to track resolve‑queue fullness and enqueue events for performance analysis.

* **Chores**
  * Default config: disabled bank‑conflict handling for a specific branch predictor setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->