### PR TITLE
Train potential entry correctly in resolve update (#637)

### DIFF
--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -502,6 +502,7 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
     // if cond entry in btb now, use the one in btb, since we need the up-to-date counter
     // else use the recorded entry
     auto entry_to_write = entry.isCond && found ? BTBEntry(*it) : entry;
+    entry_to_write.resolved = false; // reset resolved bit on update
     entry_to_write.tag = btb_tag;   // update tag after found it!
     // update saturating counter if necessary
     if (entry_to_write.isCond) {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -675,6 +675,10 @@ DecoupledBPUWithBTB::markCFIResolved(unsigned &stream_id, uint64_t resolvedInstP
     }
     auto &stream = stream_it->second;
 
+    if (stream.updateNewBTBEntry.pc == resolvedInstPC) {
+        stream.updateNewBTBEntry.resolved = true;
+    }
+
     stream.markBTBEntryResolved(resolvedInstPC);
 }
 

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -422,7 +422,7 @@ MBTB::getAndSetNewBTBEntry(FetchStream &stream)
     // Get prediction metadata from previous stages
     auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
     auto &predBTBEntries = meta->hit_entries;
-    
+
     // Check if this branch was predicted (exists in BTB)
     bool pred_branch_hit = false;
     BTBEntry entry_to_write = BTBEntry();
@@ -450,6 +450,7 @@ MBTB::getAndSetNewBTBEntry(FetchStream &stream)
         }
         btbStats.newEntry++;
         entry_to_write = new_entry;
+        entry_to_write.resolved = stream.exeBranchInfo.resolved;
         is_old_entry = false;
     } else {
         DPRINTF(BTB, "Not creating new entry: pred_branch_hit=%d, stream.exeTaken=%d\n",
@@ -564,6 +565,7 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
                               ? BTBEntry(*existing_entry)
                               : req_entry;
     entry_to_write.tag = btb_tag;   // update tag
+    entry_to_write.resolved = false; // reset resolved status
 
     // Update saturating counter and alwaysTaken
     if (entry_to_write.isCond) {

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -71,6 +71,7 @@ enum class HistoryType
  *
  * Stores essential information about a branch instruction including:
  * - PC and target address
+ * - Resolved bit
  * - Branch type (conditional, indirect, call, return)
  * - Instruction size
  */
@@ -78,6 +79,11 @@ struct BranchInfo
 {
     Addr pc;
     Addr target;
+    // An independent resolved bit to indicate whether CFI is resolved
+    // or not for training, which is trained in resolve stage so
+    // it's necessary to know whether the branch is resolved and skip
+    // the BTB entry or not.
+    bool resolved;
     bool isCond;
     bool isIndirect;
     bool isCall;
@@ -85,20 +91,23 @@ struct BranchInfo
     uint8_t size;
     bool isUncond() const { return !this->isCond; }
     Addr getEnd() { return this->pc + this->size; }
-    BranchInfo() : pc(0), target(0), isCond(false), isIndirect(false), isCall(false), isReturn(false), size(0) {}
+    BranchInfo()
+        : pc(0), target(0), resolved(false), isCond(false), isIndirect(false), isCall(false), isReturn(false), size(0)
+    {
+    }
     // BranchInfo(const Addr &pc, const Addr &target_pc, bool is_cond) :
     // pc(pc), target(target_pc), isCond(is_cond), isIndirect(false), isCall(false), isReturn(false), size(0) {}
-    BranchInfo (const Addr &control_pc,
-                const Addr &target_pc,
-                const StaticInstPtr &static_inst,
-                unsigned size) :
-        pc(control_pc),
-        target(target_pc),
-        isCond(static_inst->isCondCtrl()),
-        isIndirect(static_inst->isIndirectCtrl()),
-        isCall(static_inst->isCall()),
-        isReturn(static_inst->isReturn() && !static_inst->isNonSpeculative() && !static_inst->isDirectCtrl()),
-        size(size) {}
+    BranchInfo(const Addr &control_pc, const Addr &target_pc, const StaticInstPtr &static_inst, unsigned size)
+        : pc(control_pc),
+          target(target_pc),
+          resolved(false),
+          isCond(static_inst->isCondCtrl()),
+          isIndirect(static_inst->isIndirectCtrl()),
+          isCall(static_inst->isCall()),
+          isReturn(static_inst->isReturn() && !static_inst->isNonSpeculative() && !static_inst->isDirectCtrl()),
+          size(size)
+    {
+    }
     int getType() const {
         if (isCond) {
             return BR_COND;
@@ -157,7 +166,6 @@ struct BranchInfo
  * Contains branch information plus prediction state:
  * - Valid bit
  * - Always taken bit
- * - Resolved bit
  * - Counter for prediction
  * - Tag for BTB lookup
  */
@@ -165,16 +173,11 @@ struct BTBEntry : BranchInfo
 {
     bool valid;
     bool alwaysTaken;
-    // An independent resolved bit to indicate whether CFI is resolved
-    // or not for TAGE training, which is trained in resolve stage so
-    // it's necessary to know whether the branch is resolved and skip
-    // the BTB entry or not.
-    bool resolved;
     int ctr;
     Addr tag;
     // Addr offset; // retrived from lowest bits of pc
-    BTBEntry() : valid(false), alwaysTaken(false), resolved(false), ctr(0), tag(0) {}
-    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), resolved(false), ctr(0) {}
+    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0) {}
+    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0) {}
     BranchInfo getBranchInfo() { return BranchInfo(*this); }
 };
 


### PR DESCRIPTION
* cpu-o3: mark resolved info in potential new entries correctly

Change-Id: I95daed85988b0751001fabafe8f30716e82fa3ba

* cpu-o3: train exeBranchInfo when it resolved without squash

Change-Id: I09c87f5ec47482c70e161cfe83f99523fcfa498b

* cpu-o3: reduce redundant train of potential new entry

Change-Id: I41617fb01b9fd5b7a781f2426685dd46c5324d3a

* cpu-o3: set update new btb entry resolved to true directly

Change-Id: I799acfe52c876b54aee34345cca12cb2c1d76233