### PR TITLE
cpu-o3:Add S3 prediction statistics to UBTB

### DIFF
--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -200,14 +200,20 @@ UBTB::replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry, Addr
 void
 UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
 {
-    if (usingS3Pred) {
-        auto takenEntry = s3Pred.getTakenEntry();
-        auto startAddr = s3Pred.bbStart;
-        UBTBIter oldEntryIter = lastPred.hit_entry;
-        updateNewEntry(oldEntryIter, takenEntry, startAddr);
-    } else {
-        //using commit result to update ubtb
+    if (!usingS3Pred) {
+        return;
     }
+
+    auto takenEntry = s3Pred.getTakenEntry();
+    if (takenEntry.valid) {
+        ubtbStats.s3Hits++;
+    }else {
+        ubtbStats.s3Misses++;
+    }
+    auto startAddr = s3Pred.bbStart;
+    UBTBIter oldEntryIter = lastPred.hit_entry;
+    updateNewEntry(oldEntryIter, takenEntry, startAddr);
+
 }
 
 
@@ -300,6 +306,8 @@ UBTB::update(const FetchStream &stream)
         if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
             DPRINTF(UBTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
             ubtbStats.updateMiss++;
+        }else {
+            ubtbStats.updateHit++;
         }
     }
 
@@ -407,6 +415,9 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
       ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
       ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
+       ADD_STAT(updateHit, statistics::units::Count::get(), "hits encountered on update"),
+      ADD_STAT(s3Hits, statistics::units::Count::get(), "number of s3 predictions that are taken"),
+      ADD_STAT(s3Misses, statistics::units::Count::get(), "number of s3 predictions that are not taken"),
 
 
       ADD_STAT(allBranchHits, statistics::units::Count::get(),

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -206,9 +206,9 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
 
     auto takenEntry = s3Pred.getTakenEntry();
     if (takenEntry.valid) {
-        ubtbStats.s3Hits++;
+        ubtbStats.s3UpdateHits++;
     }else {
-        ubtbStats.s3Misses++;
+        ubtbStats.s3UpdateMisses++;
     }
     auto startAddr = s3Pred.bbStart;
     UBTBIter oldEntryIter = lastPred.hit_entry;
@@ -416,9 +416,8 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
       ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
       ADD_STAT(updateHit, statistics::units::Count::get(), "hits encountered on update"),
-      ADD_STAT(s3Hits, statistics::units::Count::get(), "number of s3 predictions that are taken"),
-      ADD_STAT(s3Misses, statistics::units::Count::get(), "number of s3 predictions that are not taken"),
-
+      ADD_STAT(s3UpdateHits, statistics::units::Count::get(), "hits encountered on S3 update"),
+      ADD_STAT(s3UpdateMisses, statistics::units::Count::get(), "misses encountered on S3 update"),
 
       ADD_STAT(allBranchHits, statistics::units::Count::get(),
                "all types of branches committed that was predicted hit"),

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -415,7 +415,7 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
       ADD_STAT(predHit, statistics::units::Count::get(), "hits encountered on prediction"),
       ADD_STAT(updateMiss, statistics::units::Count::get(), "misses encountered on update"),
-       ADD_STAT(updateHit, statistics::units::Count::get(), "hits encountered on update"),
+      ADD_STAT(updateHit, statistics::units::Count::get(), "hits encountered on update"),
       ADD_STAT(s3Hits, statistics::units::Count::get(), "number of s3 predictions that are taken"),
       ADD_STAT(s3Misses, statistics::units::Count::get(), "number of s3 predictions that are not taken"),
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -287,8 +287,8 @@ class UBTB : public TimedBaseBTBPredictor
         statistics::Scalar predHit;
         statistics::Scalar updateMiss;
         statistics::Scalar updateHit;
-        statistics::Scalar s3Hits;
-        statistics::Scalar s3Misses;
+        statistics::Scalar s3UpdateHits;
+        statistics::Scalar s3UpdateMisses;
 
         // per branch statistics
         statistics::Scalar allBranchHits;

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -286,6 +286,9 @@ class UBTB : public TimedBaseBTBPredictor
         statistics::Scalar predMiss;
         statistics::Scalar predHit;
         statistics::Scalar updateMiss;
+        statistics::Scalar updateHit;
+        statistics::Scalar s3Hits;
+        statistics::Scalar s3Misses;
 
         // per branch statistics
         statistics::Scalar allBranchHits;

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -688,7 +688,7 @@ MBTB::update(const FetchStream &stream)
         std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get());
 
     // only update btb entry for control squash T-> NT or NT -> T
-    if (stream.squashType == SQUASH_CTRL && stream.exeTaken) {
+    if (stream.squashType == SQUASH_CTRL) {
         warn_if(stream.exeBranchInfo.pc > stream.updateEndInstPC, "exeBranchInfo.pc > updateEndInstPC");
         updateBTBEntry(stream.exeBranchInfo, stream);
     }

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -688,7 +688,7 @@ MBTB::update(const FetchStream &stream)
         std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get());
 
     // only update btb entry for control squash T-> NT or NT -> T
-    if (stream.squashType == SQUASH_CTRL) {
+    if (stream.squashType == SQUASH_CTRL && stream.exeTaken) {
         warn_if(stream.exeBranchInfo.pc > stream.updateEndInstPC, "exeBranchInfo.pc > updateEndInstPC");
         updateBTBEntry(stream.exeBranchInfo, stream);
     }


### PR DESCRIPTION
Change-Id: Ie0a9a32f0ffc5e41a8555954392a08f62b746dc2
add counter for ubtb in S3update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three performance counters for the micro BTB: update-success, S3 prediction hits, and S3 prediction misses for better visibility.

* **Behavioral Changes**
  * S3-driven updates now record hit/miss metrics and apply S3-provided predictions consistently.
  * BTB update logic tightened to only update on confirmed taken control branches, reducing spurious updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->