### PR TITLE
mem: fix wrong raw violation

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -188,6 +188,7 @@ class DynInst : public ExecContext, public RefCounted
         FullForward,
         LocalAccess,
         NeedReplay,
+        SkipRawCheck,
         SkipFollowingPipe,
 
         // load/store pipe state end
@@ -1020,6 +1021,10 @@ class DynInst : public ExecContext, public RefCounted
 
     void setSkipFollowingPipe() { status.set(SkipFollowingPipe); }
     bool replayOrSkipFollowingPipe() const { return status[SkipFollowingPipe] || status[NeedReplay]; }
+
+    void setSkipRawCheck() { status.set(SkipRawCheck); }
+    void clearSkipRawCheck() { status.reset(SkipRawCheck); }
+    bool skipRawCheck() const { return status[SkipRawCheck]; }
 
     /** True if inst is waiting for Dcache refill. */
     bool waitingCacheRefill() const { return instFlags[WaitingCacheRefill]; }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -761,6 +761,7 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(nonUnitStrideCross16Byte, "Number of vector non unitStride cross 16-byte boundary"),
       ADD_STAT(unitStrideCross16Byte, "Number of vector unitStride cross 16-byte boundary"),
       ADD_STAT(unitStrideAligned, "Number of vector unitStride 16-byte aligned"),
+      ADD_STAT(skipRawWhenLoadAtS0, "Number of times RAW check skipped because load is at S0"),
       ADD_STAT(RARQueueFull, "Number of times RAR queue was full"),
       ADD_STAT(RARQueueReplay, "Number of instructions replayed from RAR queue"),
       ADD_STAT(RARQueueLatency, statistics::units::Cycle::get(), "RAR queue latency distribution"),
@@ -1133,6 +1134,13 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                             break;
                         }
 
+                        // If load is at stage 0 while store is at stage 1, no RAW violation
+                        // should occur since the load can forward data from store later
+                        if (ld_inst->skipRawCheck()) {
+                            ++stats.skipRawWhenLoadAtS0;
+                            break;
+                        }
+
                         DPRINTF(LSQUnit,
                                 "ld_eff_addr1: %#x, ld_eff_addr2: %#x, "
                                 "inst_eff_addr1: %#x, inst_eff_addr2: %#x\n",
@@ -1185,6 +1193,7 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
     assert(loadPipeSx[0]->size < MaxPipeWidth);
     panic_if(inst->inPipe(), "load [sn:%llu] is already in pipeline", inst->seqNum);
     inst->beginPipelining();
+    inst->setSkipRawCheck();
 
     int idx = loadPipeSx[0]->size;
     loadPipeSx[0]->insts[idx] = inst;
@@ -1453,7 +1462,6 @@ LSQUnit::loadDoWriteback(const DynInstPtr &inst)
 void
 LSQUnit::executeLoadPipeSx()
 {
-    // TODO: execute operations in each load pipelines
     Fault fault = NoFault;
     for (int i = 0; i < loadPipeSx.size(); i++) {
         auto& stage = loadPipeSx[i];
@@ -1461,6 +1469,9 @@ LSQUnit::executeLoadPipeSx()
             auto& inst = stage->insts[j];
             if (!inst) {
                 continue;
+            }
+            if (i > 0 && inst->skipRawCheck()) {
+                inst->clearSkipRawCheck();
             }
             if (inst->isSquashed()) {
                 DPRINTF(LoadPipeline, "Instruction was squashed. PC: %s, [tid:%i]"
@@ -1690,7 +1701,6 @@ LSQUnit::emptyStorePipeSx(const DynInstPtr &inst, uint64_t stage)
 void
 LSQUnit::executeStorePipeSx()
 {
-    // TODO: execute operations in each store pipelines
     Fault fault = NoFault;
     for (int i = 0; i < storePipeSx.size(); i++) {
         auto& stage = storePipeSx[i];

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -898,6 +898,8 @@ class LSQUnit
         statistics::Scalar unitStrideCross16Byte;
         statistics::Scalar unitStrideAligned;
 
+        statistics::Scalar skipRawWhenLoadAtS0;
+
         /** RAR replay queue related stats */
         statistics::Scalar RARQueueFull;
         statistics::Scalar RARQueueReplay;


### PR DESCRIPTION
When load is at s0 and store is at s1, wrong raw violation will occur. However, load can forward data from store when it goes into s1, so no need to do raw violation.

Change-Id: I2c68663288b2009e722516589dd34b9743e49bd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loads can conditionally skip raw-dependence checks in early pipeline stages to reduce false RAW violations.
  * Added per-stage metric tracking for skipped RAW checks to improve memory-access analysis and reporting.
  * Pipeline logic now clears the skip condition as instructions advance, improving simulation accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->