### PR TITLE
Refill bank confict perf

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -304,6 +304,7 @@ def config_cache(options, system):
                 dcache.response_latency = 0
 
             dcache.do_fast_writeline = not options.kmh_align
+            dcache.pipe_latency = 3 if options.kmh_align else 0
             l2_prefetcher = system.l2_caches[i].prefetcher if options.classic_l2 else system.l2_wrappers[i].prefetcher
             if (not options.no_pf) and options.l1_to_l2_pf_hint:
                 assert dcache.prefetcher != NULL and \

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -115,6 +115,7 @@ def setKmhV3Params(args, system):
             cpu.dcache.tag_load_read_ports = 3
             cpu.dcache.mshrs = 16
             cpu.dcache.do_fast_writeline = False
+            cpu.dcache.simulate_dcache_refill = True
 
     # l2 caches
     if args.l2cache:

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -165,6 +165,7 @@ IssueQue::IssueQueStats::IssueQueStats(statistics::Group* parent, IssueQue* que,
       ADD_STAT(canceledInst, statistics::units::Count::get(), "count of canceled insts"),
       ADD_STAT(loadmiss, statistics::units::Count::get(), "count of load miss"),
       ADD_STAT(arbFailed, statistics::units::Count::get(), "count of arbitration failed"),
+      ADD_STAT(tagRefillBlock, statistics::units::Count::get(), "count of blocked due to tag refill"),
       ADD_STAT(issueOccupy, statistics::units::Count::get(), "count of replayQ blocked"),
       ADD_STAT(insertDist, statistics::units::Count::get(), "distruibution of insert"),
       ADD_STAT(issueDist, statistics::units::Count::get(), "distruibution of issue"),
@@ -356,11 +357,19 @@ IssueQue::issueToFu()
     int issuedLoad = 0;
     int issuedStore = 0;
 
+    bool incTagRefillBlockStats = false;
+
     // replay first
     for (; !replayQ.empty() && replayed < outports; replayed++) {
         auto& inst = replayQ.front();
 
         if (inst->isLoad()) {
+            // Check if tag write is happening in the next cycle
+            // if so, load cannot be issued to load pipeline
+            if (scheduler->lsq->isDcacheRefillTagWrite()) {
+                incTagRefillBlockStats = true;
+                break;
+            }
             if (issuedLoad >= numLoadPipe) {
                 break;
             }
@@ -384,8 +393,15 @@ IssueQue::issueToFu()
         if (!inst) {
             continue;
         }
+        // Check if tag write is happening in the next cycle
+        // if so, load cannot be issued to load pipeline
+        bool blockLoad = inst->isLoad() && scheduler->lsq->isDcacheRefillTagWrite();
+        if (blockLoad) {
+            incTagRefillBlockStats = true;
+        }
+
         if ((i + replayed >= outports) || (inst->isLoad() && (issuedLoad >= numLoadPipe)) ||
-            (inst->isStore() && (issuedStore >= numStorePipe))) {
+            (inst->isStore() && (issuedStore >= numStorePipe)) || blockLoad) {
             inst->clearScheduled();
             // only for load/store
             READYQ_PUSH(inst);
@@ -412,6 +428,9 @@ IssueQue::issueToFu()
     }
     if (replayed) {
         iqstats->issueOccupy += replayed;
+    }
+    if (incTagRefillBlockStats) {
+        iqstats->tagRefillBlock++;
     }
 }
 

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -176,6 +176,7 @@ class IssueQue : public SimObject
         statistics::Scalar canceledInst;
         statistics::Scalar loadmiss;
         statistics::Scalar arbFailed;
+        statistics::Scalar tagRefillBlock;
         statistics::Scalar issueOccupy;
         statistics::Vector insertDist;
         statistics::Vector issueDist;

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -89,10 +89,10 @@ std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;
 
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     : cpu(cpu_ptr), iewStage(iew_ptr),
+      recentlyloadAddr(8),
       _cacheBlocked(false),
       cacheStorePorts(params.cacheStorePorts), usedStorePorts(0),
       cacheLoadPorts(params.cacheLoadPorts), usedLoadPorts(0),
-      recentlyloadAddr(8),
       enableBankConflictCheck(params.BankConflictCheck),
       sbufferBankWriteAccurately(params.sbufferBankWriteAccurately),
       _enableLdMissReplay(params.EnableLdMissReplay),
@@ -230,7 +230,36 @@ LSQ::tick()
 void
 LSQ::clearAddresses()
 {
-    std::fill(bankOccupied.begin(), bankOccupied.end(), false);
+    // Check if the current cycle is already occupied by previous operations (e.g. delayed writeback)
+    bool currentCycleBusy = (dcacheRefillDataRead | dcacheRefillDataWrite) & 0x1;
+
+    if (pendingDcacheRefill) {
+        // If current cycle is busy, we stall the new request (keep pendingDcacheRefill = true)
+        // If free, we issue the new request
+        if (!currentCycleBusy) {
+            pendingDcacheRefill = false;
+            // Data Read at current cycle (Bit 0)
+            dcacheRefillDataRead |= 0x1;
+            // Tag Write at 3 cycles later (Bit 3)
+            dcacheRefillTagWrite |= (1 << 3);
+            // Data Write at 4 cycles later (Bit 4)
+            dcacheRefillDataWrite |= (1 << 4);
+
+            // We just occupied the current cycle
+            currentCycleBusy = true;
+        }
+    }
+
+    // Advance the pipeline for the next cycle
+    dcacheRefillDataRead >>= 1;
+    dcacheRefillTagWrite >>= 1;
+    dcacheRefillDataWrite >>= 1;
+
+    if (currentCycleBusy) {
+        std::fill(bankOccupied.begin(), bankOccupied.end(), true);
+    } else {
+        std::fill(bankOccupied.begin(), bankOccupied.end(), false);
+    }
     recentlyloadAddr.clear();
 }
 
@@ -238,9 +267,9 @@ bool
 LSQ::loadBankConflictedCheck(Addr vaddr)
 {
     bool now_bank_conflict = false;
-    // [12:6]   [5:3]     [2:0]
+    // [13:6]   [5:3]     [2:0]
     // setIndex bankIndex dataOffset
-    const uint64_t cacheBankmask = 0b1111111111000;
+    const uint64_t cacheBankmask = 0b11111111111000;
     const int bankIndex = bankNum(vaddr);
 
     if (enableBankConflictCheck) {
@@ -1814,6 +1843,7 @@ LSQ::SbufferRequest::sendPacketToCache()
     bool success = _port.sbufferSendPacket(_packets.at(0));
     DPRINTF(StoreBuffer, "Sbuffer Req::sendPacketToCache: entry[%#x]\n", _packets[0]->getAddr());
     if (success) {
+        _packets[0]->setLSQPtr(lsqUnit()->getLsq());
         _numOutstandingPackets = 1;
     }
 
@@ -1832,6 +1862,7 @@ LSQ::SingleDataRequest::sendPacketToCache()
     bool success = lsqUnit()->trySendPacket(isLoad(), _packets.at(0), bank_conflict,
                                             tag_read_fail, mshr_used, mshr_alias_fail, hit_in_write_buffer);
     if (success) {
+        _packets[0]->setLSQPtr(lsqUnit()->getLsq());
         if (isLoad()) {
             assert(lsqUnit()->inflightLoads.size() < lsqUnit()->numLoads() + 4);
             lsqUnit()->inflightLoads.emplace_back(this);
@@ -1886,6 +1917,7 @@ LSQ::SplitDataRequest::sendPacketToCache()
                                                 bank_conflict, tag_read_fail, mshr_used,
                                                 mshr_alias_fail, hit_in_write_buffer);
         if (success) {
+            _packets[numReceivedPackets + _numOutstandingPackets]->setLSQPtr(lsqUnit()->getLsq());
             _numOutstandingPackets++;
         } else {
             break;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1007,6 +1007,18 @@ class LSQ
     bool enablePipeNukeCheck() const { return _enablePipeNukeCheck; }
     int storeWbStage() const { return _storeWbStage; }
 
+  public:
+    struct NullStruct {};
+    boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
+    std::vector<bool> bankOccupied;
+
+    bool pendingDcacheRefill = false;
+    uint32_t dcacheRefillDataRead = 0;
+    uint32_t dcacheRefillDataWrite = 0;
+    uint32_t dcacheRefillTagWrite = 0;
+
+    bool isDcacheRefillTagWrite() const { return dcacheRefillTagWrite & 0b1; }
+
   protected:
     /** D-cache is blocked */
     bool _cacheBlocked;
@@ -1021,10 +1033,6 @@ class LSQ
 
     const int numBank = 8;
     bool dcacheWriteStall = false;
-    std::vector<bool> bankOccupied;
-
-    struct NullStruct {};
-    boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
 
     bool enableBankConflictCheck;
     bool sbufferBankWriteAccurately;

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -182,6 +182,11 @@ class BaseCache(ClockedObject):
         "Replacement policy of active generation table"
     )
 
+    simulate_dcache_refill = Param.Bool(
+        False,
+        "If true, simulate Dcache refill behavior (LSQ pending flag/stats) on L1 fills",
+    )
+
 class Cache(BaseCache):
     type = 'Cache'
     cxx_header = 'mem/cache/cache.hh'

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -163,6 +163,8 @@ class BaseCache(ClockedObject):
 
     num_slices = Param.Int(-1, "slice number (-1 is disable)")
 
+    pipe_latency = Param.Cycles(0, "pipeline latency")
+
     force_hit = Param.Bool(False, "Force some PC to hit in L1")
     way_entries = Param.MemorySize(
         "64",

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -57,6 +57,7 @@
 #include "base/trace.hh"
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
+#include "cpu/o3/lsq.hh"
 #include "debug/ArchDB.hh"
 #include "debug/Cache.hh"
 #include "debug/CacheComp.hh"
@@ -184,6 +185,7 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       stats(*this),
       cacheLevel(p.cache_level),
       forceHit(p.force_hit),
+      simulateDcacheRefill(p.simulate_dcache_refill),
       doFastWriteline(p.do_fast_writeline)
 {
     // the MSHR queue has no reserve entries as we check the MSHR
@@ -918,6 +920,12 @@ BaseCache::recvTimingResp(PacketPtr pkt)
 
         const bool allocate = (writeAllocator && mshr->wasWholeLineWrite) ?
             writeAllocator->allocate() : mshr->allocOnFill();
+        // Optionally indicate that the Dcache received a refill request
+        // to drive LSQ-side modelling.
+        if (simulateDcacheRefill && cacheLevel == 1 && pkt->getLSQPtr()) {
+            pkt->getLSQPtr()->pendingDcacheRefill = true;
+            stats.DcacheRefillTimes++;
+        }
         blk = handleFill(pkt, blk, writebacks, allocate);
         assert(blk != nullptr);
         ppFill->notify(pkt);
@@ -2880,6 +2888,8 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
              "number of load Tag read fail because of prefetcher"),
     ADD_STAT(MSHRArbFails,statistics::units::Count::get(),
              "number of MSHR arbitration fails (one miss per cycle)"),
+    ADD_STAT(DcacheRefillTimes, statistics::units::Count::get(),
+             "number of Dcache refill events"),
     ADD_STAT(MSHRAliasFails, statistics::units::Count::get(),
              "number of MSHR Alias fails (VA diff)"),
     ADD_STAT(FindHitInWriteBuffer, statistics::units::Count::get(),

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -165,6 +165,7 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       dataLatency(p.data_latency),
       forwardLatency(p.tag_latency),
       fillLatency(p.data_latency),
+      pipeLatency(p.pipe_latency),
       responseLatency(p.response_latency),
       sequentialAccess(p.sequential_access),
       numTarget(p.tgts_per_mshr),
@@ -2128,7 +2129,7 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
         updateBlockData(blk, pkt, has_old_data);
     }
     // The block will be ready when the payload arrives and the fill is done
-    blk->setWhenReady(clockEdge(fillLatency) + pkt->headerDelay +
+    blk->setWhenReady(clockEdge(dataLatency + pipeLatency) + pkt->headerDelay +
                       pkt->payloadDelay);
 
     // NOTE: Dcache sends the block address back to lsu
@@ -2139,7 +2140,7 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
         customPkt->setAddr(addr);
         // set `deletePkt` as true to ensure that the customPkt will be deleted finally.
         SendCustomEvent* clearEvent = new SendCustomEvent(this, customPkt, DcacheRespType::Bus_Clear, true);
-        schedule(clearEvent, clockEdge(fillLatency) + pkt->headerDelay +
+        schedule(clearEvent, clockEdge(dataLatency + pipeLatency) + pkt->headerDelay +
                         pkt->payloadDelay);
     }
 

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1325,6 +1325,8 @@ class BaseCache : public ClockedObject, public CacheAccessor
          */
         statistics::Scalar MSHRArbFails;
 
+        statistics::Scalar DcacheRefillTimes;
+
         /** Number of MSHR Alias fails (VA diff) . */
         statistics::Scalar MSHRAliasFails;
 
@@ -1617,6 +1619,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
     std::set<Addr> forceHitPCs{};
 
     const bool forceHit;
+    const bool simulateDcacheRefill;
 
 public:
     /**

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1035,6 +1035,8 @@ class BaseCache : public ClockedObject, public CacheAccessor
     /** The latency to fill a cache block */
     const Cycles fillLatency;
 
+    const Cycles pipeLatency;
+
     /**
      * The latency of sending reponse to its upper level cache/core on
      * a linefill. The responseLatency parameter captures this

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -591,6 +591,7 @@ Cache::createMissPacket(PacketPtr cpu_pkt, CacheBlk *blk,
             (force_clean_rsp ? MemCmd::ReadCleanReq : MemCmd::ReadSharedReq);
     }
     PacketPtr pkt = new Packet(cpu_pkt->req, cmd, blkSize);
+    pkt->setLSQPtr(cpu_pkt->getLSQPtr());
 
     // if there are upstream caches that have already marked the
     // packet as having sharers (not passing writable), pass that info

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -66,6 +66,10 @@
 namespace gem5
 {
 
+namespace o3 {
+    class LSQ;
+}
+
 class Packet;
 typedef Packet *PacketPtr;
 typedef uint8_t* PacketDataPtr;
@@ -562,6 +566,8 @@ class Packet : public Printable
      */
     SenderState *senderState;
 
+    o3::LSQ *lsqPtr = nullptr;
+
     /**
      * Push a new sender state to the packet and make the current
      * sender state the predecessor of the new one. This should be
@@ -804,6 +810,9 @@ class Packet : public Printable
     void setHitInWriteBuffer() { flags.set(HIT_IN_WRITE_BUFFER); }
     bool isHitInWriteBuffer() const { return flags.isSet(HIT_IN_WRITE_BUFFER); }
     void clearHitInWriteBuffer() { flags.clear(HIT_IN_WRITE_BUFFER); }
+
+    void setLSQPtr(o3::LSQ *lsq) { lsqPtr = lsq; }
+    o3::LSQ *getLSQPtr() const { return lsqPtr; }
 
     /**
      * QoS Value getter


### PR DESCRIPTION
Key changes:
1.  **Refill mechanism of Dcache**: use three independent pipelines to model precise resource occupancy:
    *   `dcacheRefillDataRead`: Tracks data read occupancy (Cycle 0).
    *   `dcacheRefillTagWrite`: Tracks tag write occupancy (Cycle 3).
    *   `dcacheRefillDataWrite`: Tracks data write occupancy (Cycle 4).
    This separation allows for fine-grained control over when specific resources are busy during a refill.

2.  **Tag Refill Blocking**: In `IssueQue::issueToFu`, load instructions are now blocked from issuing or replaying if a conflict is detected with `dcacheRefillTagWrite` (specifically when `dcacheRefillTagWrite & 0b1` is set).
    This prevents loads from accessing the cache while tags are being updated.

3.  **Statistics**: Added a `tagRefillBlock` statistic to `IssueQue` to quantify the performance impact of blocking loads due to tag refill conflicts.

These changes ensure that the simulation accurately reflects the hardware constraints where tag updates during cache refills prevent concurrent load accesses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added D-cache refill simulation capability for L1 cache fills with pending flag tracking
  * Introduced configurable cache pipeline latency parameter
  * Added D-cache refill statistics tracking, including refill event counts and tag refill blocking metrics
  * Enabled detailed load queue blockage analysis due to cache refill operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->