### PR TITLE
cpu-o3: align to RTL, disable mbtb victimCache now

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -984,7 +984,7 @@ class MBTB(TimedBaseBTBPredictor):
     numDelay = 2
     blockSize = 32  # max 64 byte block, 32 byte aligned
     # MBTB is always half-aligned - no parameter needed
-    victimCacheSize = Param.Unsigned(16, "Number of entries in the victim cache")
+    victimCacheSize = Param.Unsigned(0, "Number of entries in the victim cache")
 
 class AheadBTB(TimedBaseBTBPredictor):
     type = 'AheadBTB'


### PR DESCRIPTION
Change-Id: I0d422470e967986833d988bc0eae08c4d20b1fd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified branch predictor victim cache size from 16 to 0 entries, disabling the victim cache functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->