### PR TITLE
mem: add prefetch_can_offload to caches

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -116,6 +116,7 @@ def setKmhV3Params(args, system):
             cpu.dcache.mshrs = 16
             cpu.dcache.do_fast_writeline = False
             cpu.dcache.simulate_dcache_refill = True
+            cpu.dcache.prefetch_can_offload = False
 
     # l2 caches
     if args.l2cache:
@@ -124,6 +125,7 @@ def setKmhV3Params(args, system):
                 system.l2_caches[i].slice_num = 4
                 system.l2_caches[i].wpu = NULL
                 system.l2_caches[i].do_fast_writeline = False
+                system.l2_caches[i].prefetch_can_offload = False
             else:
                 l2_wrapper = system.l2_wrappers[i]
                 l2_wrapper.data_sram_banks = 1
@@ -133,6 +135,7 @@ def setKmhV3Params(args, system):
                 for j in range(args.l2_slices):
                     l2_wrapper.slices[j].inner_cache.wpu = NULL
                     l2_wrapper.slices[j].inner_cache.do_fast_writeline = False
+                    l2_wrapper.slices[j].inner_cache.prefetch_can_offload = False
             system.tol2bus_list[i].forward_latency = 3  # 3->0
             system.tol2bus_list[i].response_latency = 3  # 3->0
             system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 1->0
@@ -149,6 +152,7 @@ def setKmhV3Params(args, system):
     if args.l3cache:
         system.l3.mshrs = 64
         system.l3.do_fast_writeline = False
+        system.l3.prefetch_can_offload = False
         system.l3.num_slices = 4
 
 if __name__ == '__m5_main__':

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -181,6 +181,10 @@ class BaseCache(ClockedObject):
         LRURP(),
         "Replacement policy of active generation table"
     )
+    prefetch_can_offload = Param.Bool(
+        True,
+        "Whether this cache can offload prefetches to downstream caches when mshr is full"
+    )
 
     simulate_dcache_refill = Param.Bool(
         False,

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -186,7 +186,8 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       cacheLevel(p.cache_level),
       forceHit(p.force_hit),
       simulateDcacheRefill(p.simulate_dcache_refill),
-      doFastWriteline(p.do_fast_writeline)
+      doFastWriteline(p.do_fast_writeline),
+      Prefetch_CanOffload(p.prefetch_can_offload)
 {
     // the MSHR queue has no reserve entries as we check the MSHR
     // queue on every single allocation, whereas the write queue has
@@ -1376,7 +1377,8 @@ BaseCache::getNextQueueEntry()
         }
     }
 
-    if (prefetcher && (!mshrQueue.canPrefetch() || isBlocked()) && prefetcher->hasHintDownStream()) {
+    if (prefetcher && (!mshrQueue.canPrefetch() || isBlocked()) &&
+        prefetcher->hasHintDownStream() && Prefetch_CanOffload) {
         DPRINTF(HWPrefetch, "Offloading prefetch to downstream cache\n");
         prefetcher->offloadToDownStream();
     }

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1681,6 +1681,8 @@ public:
         auto blk = tags->findBlock(addr, is_secure);
         return blk ? blk->data: nullptr;
     }
+    private:
+    const bool Prefetch_CanOffload;
 };
 
 /**


### PR DESCRIPTION
Change-Id: Ia001e71a9f8b9f096b88eb882cc2953709c379db
this pr add switch to passive offload PFreq to downlevel cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-cache controls to enable/disable prefetch offloading to downstream caches. Configs can now disable prefetch offload at individual cache levels (L1/L2 slice/L3); an example configuration disables offload across all cache levels to help tune performance for specific workloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->