### PR TITLE
cpu-o3: refine BTBEntry initialization and update logic

### DIFF
--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -688,7 +688,7 @@ MBTB::update(const FetchStream &stream)
         std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get());
 
     // only update btb entry for control squash T-> NT or NT -> T
-    if (stream.squashType == SQUASH_CTRL) {
+    if (stream.squashType == SQUASH_CTRL && stream.exeTaken) {
         warn_if(stream.exeBranchInfo.pc > stream.updateEndInstPC, "exeBranchInfo.pc > updateEndInstPC");
         updateBTBEntry(stream.exeBranchInfo, stream);
     }

--- a/src/cpu/pred/btb/stream_struct.hh
+++ b/src/cpu/pred/btb/stream_struct.hh
@@ -177,7 +177,7 @@ struct BTBEntry : BranchInfo
     Addr tag;
     // Addr offset; // retrived from lowest bits of pc
     BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0) {}
-    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0) {}
+    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(false), ctr(0) {}
     BranchInfo getBranchInfo() { return BranchInfo(*this); }
 };
 


### PR DESCRIPTION
Change-Id: Id45966509ac21cca9b919b76e24189ab24e6fd0c
turn off mbtb always taken and change mbtb branch info update requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch prediction accuracy by correcting when branch target information is updated, ensuring entries are only modified when branches are actually executed.
  * Fixed branch prediction state initialization to accurately reflect branch behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->