### PR TITLE
cpu-o3: csr oper should not flush sbuffer

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1503,7 +1503,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 "at the head of the ROB, PC %s.\n",
                 tid, head_inst->seqNum, head_inst->pcState());
 
-        if (inst_num > 0 || !iewStage->flushAllStores(tid)) {
+        if (head_inst->isMemRef() && (inst_num > 0 || !iewStage->flushAllStores(tid))) {
             DPRINTF(Commit,
                     "[tid:%i] [sn:%llu] "
                     "Waiting for all stores to writeback.\n",


### PR DESCRIPTION
Change-Id: I4653ff54064e99ca675656c114e1564d7458fee5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined CPU commit logic to improve instruction handling efficiency, ensuring non-memory instructions are processed without unnecessary delays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->