### PR TITLE
cpu-o3: add more performance counter in resolve queue

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -251,12 +251,16 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
                     statistics::units::Count, statistics::units::Cycle>::get(),
              "Frontend Bandwidth Bound",
              frontendBound - frontendLatencyBound),
-    ADD_STAT(resolveQueueFullCycles, statistics::units::Count::get(),
-             "Number of cycles the resolve queue is full"),
     ADD_STAT(resolveQueueFullEvents, statistics::units::Count::get(),
              "Number of events the resolve queue becomes full"),
     ADD_STAT(resolveEnqueueFailEvent, statistics::units::Count::get(),
-             "Number of times an entry could not be enqueued to the resolve queue")
+             "Number of times an entry could not be enqueued to the resolve queue"),
+    ADD_STAT(resolveDequeueCount, statistics::units::Count::get(),
+             "Number of times an entry is dequeued from the resolve queue"),
+    ADD_STAT(resolveEnqueueCount, statistics::units::Count::get(),
+             "Number of times an entry is enqueued to the resolve queue"),
+    ADD_STAT(resolveQueueOccupancy, statistics::units::Count::get(),
+             "Number of entries in the resolve queue")
 {
         icacheStallCycles
             .prereq(icacheStallCycles);
@@ -326,6 +330,10 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .flags(statistics::total);
         frontendBandwidthBound
             .flags(statistics::total);
+        resolveEnqueueCount
+            .init(1, 8, 1);
+        resolveQueueOccupancy
+            .init(0, 32, 1);
 }
 void
 Fetch::setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer)
@@ -1502,31 +1510,38 @@ Fetch::handleIEWSignals()
     }
 
     auto &incoming = fromIEW->iewInfo->resolvedCFIs;
+    uint8_t enqueueSize = fromIEW->iewInfo->resolvedCFIs.size();
+    uint8_t enqueueCount = 0;
 
-    for (const auto &resolved : incoming) {
-        bool merged = false;
-        for (auto &queued : resolveQueue) {
-            if (queued.resolvedFSQId == resolved.fsqId) {
-                queued.resolvedInstPC.push_back(resolved.pc);
-                merged = true;
-                break;
+    if (resolveQueueSize && resolveQueue.size() > resolveQueueSize - 4) {
+        fetchStats.resolveQueueFullEvents++;
+        fetchStats.resolveEnqueueFailEvent += enqueueSize;
+    } else {
+
+        for (const auto &resolved : incoming) {
+            bool merged = false;
+            for (auto &queued : resolveQueue) {
+                if (queued.resolvedFSQId == resolved.fsqId) {
+                    queued.resolvedInstPC.push_back(resolved.pc);
+                    merged = true;
+                    break;
+                }
             }
-        }
 
-        if (merged) {
-            continue;
-        }
+            if (merged) {
+                continue;
+            }
 
-        if (resolveQueueSize && resolveQueue.size() >= resolveQueueSize) {
-            fetchStats.resolveQueueFullEvents++;
-            continue;
+            ResolveQueueEntry new_entry;
+            new_entry.resolvedFSQId = resolved.fsqId;
+            new_entry.resolvedInstPC.push_back(resolved.pc);
+            resolveQueue.push_back(std::move(new_entry));
+            enqueueCount++;
         }
-
-        ResolveQueueEntry new_entry;
-        new_entry.resolvedFSQId = resolved.fsqId;
-        new_entry.resolvedInstPC.push_back(resolved.pc);
-        resolveQueue.push_back(std::move(new_entry));
+        fetchStats.resolveEnqueueCount.sample(enqueueCount);
     }
+
+    fetchStats.resolveQueueOccupancy.sample(resolveQueue.size());
 
     if (!resolveQueue.empty()) {
         auto &entry = resolveQueue.front();
@@ -1539,6 +1554,7 @@ Fetch::handleIEWSignals()
         if (success) {
             dbpbtb->notifyResolveSuccess();
             resolveQueue.pop_front();
+            fetchStats.resolveDequeueCount++;
         } else {
             dbpbtb->notifyResolveFailure();
         }

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -1103,11 +1103,15 @@ class Fetch
         /** Frontend Bandwidth Bound */
         statistics::Formula frontendBandwidthBound;
         /** Stat for total cycles the resolve queue is full. */
-        statistics::Scalar resolveQueueFullCycles;
-        /** Stat for total events of the resolve queue becomes full. */
         statistics::Scalar resolveQueueFullEvents;
         /** Stat for total number of resolve enqueue fail events. */
         statistics::Scalar resolveEnqueueFailEvent;
+        /** Stat for total number of resolve dequeue events. */
+        statistics::Scalar resolveDequeueCount;
+        /** Stat for total number of resolve enqueue events. */
+        statistics::Distribution resolveEnqueueCount;
+        /** Stat for entry occupancy distribution of the resolve queue. */
+        statistics::Distribution resolveQueueOccupancy;
     } fetchStats;
 
     SquashVersion localSquashVer;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new runtime metrics tracking resolve-queue enqueue events, dequeue events, and per-cycle queue occupancy to improve observability.
* **Chores**
  * Removed the older "queue full" metric and replaced it with the more granular enqueue/dequeue and occupancy measurements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<img width="400" height="225" alt="image" src="https://github.com/user-attachments/assets/beebbe92-6d58-48a7-8515-13394906ca24" />
