### PR TITLE
cpu-o3: prevent updating return branches during control squash

### DIFF
--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -688,7 +688,7 @@ MBTB::update(const FetchStream &stream)
         std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get());
 
     // only update btb entry for control squash T-> NT or NT -> T
-    if (stream.squashType == SQUASH_CTRL) {
+    if (stream.squashType == SQUASH_CTRL && !stream.exeBranchInfo.isReturn) {
         warn_if(stream.exeBranchInfo.pc > stream.updateEndInstPC, "exeBranchInfo.pc > updateEndInstPC");
         updateBTBEntry(stream.exeBranchInfo, stream);
     }


### PR DESCRIPTION
Change-Id: Iacb92ecfd4c03d6b4228c87f1c7798ab78100ef1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined branch target buffer update logic to restrict updates to specific control-flow scenarios, improving prediction accuracy for certain instruction types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->