### PR TITLE
cpu-o3: 2 entry size resolve queue for evaluation

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -28,6 +28,7 @@ def setKmhV3IdealParams(args, system):
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
+        cpu.resolveQueueSize = 2
 
         # decode
         cpu.decodeWidth = 8

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -28,6 +28,7 @@ def setKmhV3Params(args, system):
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
+        cpu.resolveQueueSize = 2
 
         # decode
         cpu.decodeWidth = 8

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1510,36 +1510,37 @@ Fetch::handleIEWSignals()
     }
 
     auto &incoming = fromIEW->iewInfo->resolvedCFIs;
-    uint8_t enqueueSize = fromIEW->iewInfo->resolvedCFIs.size();
     uint8_t enqueueCount = 0;
 
-    if (resolveQueueSize && resolveQueue.size() > resolveQueueSize - 4) {
-        fetchStats.resolveQueueFullEvents++;
-        fetchStats.resolveEnqueueFailEvent += enqueueSize;
-    } else {
-
-        for (const auto &resolved : incoming) {
-            bool merged = false;
-            for (auto &queued : resolveQueue) {
-                if (queued.resolvedFSQId == resolved.fsqId) {
-                    queued.resolvedInstPC.push_back(resolved.pc);
-                    merged = true;
-                    break;
-                }
+    for (const auto &resolved : incoming) {
+        bool merged = false;
+        for (auto &queued : resolveQueue) {
+            if (queued.resolvedFSQId == resolved.fsqId) {
+                queued.resolvedInstPC.push_back(resolved.pc);
+                merged = true;
+                break;
             }
-
-            if (merged) {
-                continue;
-            }
-
-            ResolveQueueEntry new_entry;
-            new_entry.resolvedFSQId = resolved.fsqId;
-            new_entry.resolvedInstPC.push_back(resolved.pc);
-            resolveQueue.push_back(std::move(new_entry));
-            enqueueCount++;
         }
-        fetchStats.resolveEnqueueCount.sample(enqueueCount);
+
+        if (merged) {
+            continue;
+        }
+
+
+        if (resolveQueue.size() >= resolveQueueSize) {
+            fetchStats.resolveQueueFullEvents++;
+            fetchStats.resolveEnqueueFailEvent++;
+            continue;
+        }
+
+        ResolveQueueEntry new_entry;
+        new_entry.resolvedFSQId = resolved.fsqId;
+        new_entry.resolvedInstPC.push_back(resolved.pc);
+        resolveQueue.push_back(std::move(new_entry));
+        enqueueCount++;
     }
+
+    fetchStats.resolveEnqueueCount.sample(enqueueCount);
 
     fetchStats.resolveQueueOccupancy.sample(resolveQueue.size());
 

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -157,6 +157,11 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
 }
 
 void
+BTBITTAGE::dryRunCycle(Addr startPC) {
+  return;
+}
+
+void
 BTBITTAGE::putPCHistory(Addr stream_start, const bitset &history, std::vector<FullBTBPrediction> &stagePreds) {
     if (debugPC == stream_start) {
         debugFlag = true;

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -93,6 +93,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     void tickStart() override;
 
     void tick() override;
+    void dryRunCycle(Addr startAddr) override;
     // make predictions, record in stage preds
     void putPCHistory(Addr startAddr,
                       const boost::dynamic_bitset<> &history,

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -333,6 +333,16 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
     }
 }
 
+void
+BTBTAGE::dryRunCycle(Addr startPC) {
+    // No operation in dry run cycle for BTBTAGE
+    // Record prediction bank for next tick's conflict detection
+    lastPredBankId = getBankId(startPC);
+    predBankValid = true;
+
+    return;
+}
+
 /**
  * @brief Makes predictions for a stream of instructions using TAGE predictor
  * 

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -118,6 +118,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     void tickStart() override;
 
     void tick() override;
+    void dryRunCycle(Addr startAddr) override;
     // Make predictions for a stream of instructions and record in stage preds
     void putPCHistory(Addr startAddr,
                       const boost::dynamic_bitset<> &history,

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -133,6 +133,7 @@ DecoupledBPUWithBTB::tick()
     if (squashing) {
         bpuState = BpuState::IDLE;
         numOverrideBubbles = 0;
+        tage->dryRunCycle(s0PC);
         DPRINTF(Override, "Squashing, BPU state updated.\n");
         squashing = false;
         return;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -163,6 +163,10 @@ DecoupledBPUWithBTB::tick()
         }
     }
 
+    if (bpuState == BpuState::PREDICTION_OUTSTANDING && numOverrideBubbles > 0) {
+        tage->dryRunCycle(s0PC);
+    }
+
     // 3. Process enqueue operations and bubble counter
     tryEnqFetchTarget();
 

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -55,6 +55,7 @@ class TimedBaseBTBPredictor: public SimObject
 
     virtual void tickStart() {}
     virtual void tick() {}
+    virtual void dryRunCycle(Addr startAddr) {};
     // make predictions, record in stage preds
     virtual void putPCHistory(Addr startAddr,
                               const boost::dynamic_bitset<> &history,


### PR DESCRIPTION
Change-Id: Ie1936843e32037b77c45b6134a175563b3e6833a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resolve-queue processing with per-item merging, tighter overflow handling, and more accurate enqueue/dequeue accounting; added post-processing of the front resolve entry with conditional dequeue on success.
  * Introduced a lightweight "dry-run" prediction hook invoked in squash and outstanding-prediction paths to better track prediction state without committing changes.

* **Chores**
  * Added per-core resolve-queue sizing option for finer pipeline tuning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->