### PR TITLE
mem: Add XS DRRIP Replacement Policy

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -126,6 +126,9 @@ def setKmhV3Params(args, system):
                 system.l2_caches[i].wpu = NULL
                 system.l2_caches[i].do_fast_writeline = False
                 system.l2_caches[i].prefetch_can_offload = False
+                # Configure XSDRRIP replacement policy (DRRIP mode)
+                # L2: 2MB, 8-way, 64B line → 4096 sets
+                system.l2_caches[i].replacement_policy = XSDRRIPRP(mode=2, num_sets=4096)
             else:
                 l2_wrapper = system.l2_wrappers[i]
                 l2_wrapper.data_sram_banks = 1
@@ -136,6 +139,9 @@ def setKmhV3Params(args, system):
                     l2_wrapper.slices[j].inner_cache.wpu = NULL
                     l2_wrapper.slices[j].inner_cache.do_fast_writeline = False
                     l2_wrapper.slices[j].inner_cache.prefetch_can_offload = False
+                    # Configure XSDRRIP replacement policy (DRRIP mode)
+                    # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
+                    l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
             system.tol2bus_list[i].forward_latency = 3  # 3->0
             system.tol2bus_list[i].response_latency = 3  # 3->0
             system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 1->0

--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -153,3 +153,14 @@ class WeightedLRURP(LRURP):
     type = "WeightedLRURP"
     cxx_class = 'gem5::replacement_policy::WeightedLRU'
     cxx_header = "mem/cache/replacement_policies/weighted_lru_rp.hh"
+
+# XiangShan RRIP replacement policy series (unified implementation)
+class XSDRRIPRP(BaseReplacementPolicy):
+    type = 'XSDRRIPRP'
+    cxx_class = 'gem5::replacement_policy::XSDRRIP'
+    cxx_header = "mem/cache/replacement_policies/xs_drrip_rp.hh"
+
+    # Working mode: 0=SRRIP, 1=BRRIP, 2=DRRIP
+    mode = Param.Int(2, "Mode: 0=SRRIP, 1=BRRIP, 2=DRRIP (Set Dueling)")
+    num_sets = Param.Int(0, "Number of sets in the cache (required for DRRIP mode)")
+    num_ways = Param.Int(Parent.assoc, "Number of ways in each set")

--- a/src/mem/cache/replacement_policies/SConscript
+++ b/src/mem/cache/replacement_policies/SConscript
@@ -31,7 +31,7 @@ Import('*')
 SimObject('ReplacementPolicies.py', sim_objects=[
     'BaseReplacementPolicy', 'DuelingRP', 'FIFORP', 'SecondChanceRP',
     'LFURP', 'LRURP', 'BIPRP', 'MRURP', 'RandomRP', 'BRRIPRP', 'SHiPRP',
-    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP'])
+    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP', 'XSDRRIPRP'])
 
 Source('bip_rp.cc')
 Source('brrip_rp.cc')
@@ -45,5 +45,6 @@ Source('second_chance_rp.cc')
 Source('ship_rp.cc')
 Source('tree_plru_rp.cc')
 Source('weighted_lru_rp.cc')
+Source('xs_drrip_rp.cc')
 
 GTest('replaceable_entry.test', 'replaceable_entry.test.cc')

--- a/src/mem/cache/replacement_policies/xs_drrip_rp.cc
+++ b/src/mem/cache/replacement_policies/xs_drrip_rp.cc
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2024 XiangShan
+ * All rights reserved.
+ *
+ * Unified implementation of XiangShan RRIP replacement policy series
+ */
+
+#include "mem/cache/replacement_policies/xs_drrip_rp.hh"
+
+#include <cassert>
+#include <memory>
+
+#include "base/logging.hh"
+#include "params/XSDRRIPRP.hh"
+
+namespace gem5
+{
+
+GEM5_DEPRECATED_NAMESPACE(ReplacementPolicy, replacement_policy);
+namespace replacement_policy
+{
+
+XSDRRIP::XSDRRIP(const Params &p)
+  : Base(p),
+    mode(static_cast<Mode>(p.mode)),
+    numSets(p.num_sets),
+    numWays(p.num_ways),
+    pselCounter(PSEL_WIDTH, PSEL_THRESHOLD),
+    entryCount(0),
+    duelingStats(this)
+{
+    // DRRIP mode requires Set Dueling parameters
+    if (mode == DRRIP_MODE) {
+        fatal_if(numSets < 4, "DRRIP mode requires at least 4 sets for proper set dueling");
+
+        setBits = floorLog2(numSets);
+        halfSetBits = setBits - setBits / 2 - 1;
+        setMask = (1 << (setBits - setBits / 2)) - 1;
+    }
+}
+
+bool
+XSDRRIP::useBRRIP(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    std::shared_ptr<XSDRRIPReplData> casted_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    // SRRIP mode or SRRIP dedicated set → use SRRIP logic
+    if (mode == SRRIP_MODE || casted_data->setType == 0) {
+        return false;
+    }
+
+    // BRRIP mode or BRRIP dedicated set → use BRRIP logic
+    if (mode == BRRIP_MODE || casted_data->setType == 1) {
+        return true;
+    }
+
+    // Follower set in DRRIP mode → decide based on PSEL counter value
+    // When PSEL >= threshold, BRRIP performs better; otherwise SRRIP performs better
+    bool use_brrip = (pselCounter >= PSEL_THRESHOLD);
+    if (use_brrip) {
+        duelingStats.followerUseBrrip++;
+    } else {
+        duelingStats.followerUseSrrip++;
+    }
+    return use_brrip;
+}
+
+uint8_t
+XSDRRIP::getRRPV(const PacketPtr pkt,
+                 const std::shared_ptr<ReplacementData>& replacement_data,
+                 bool use_brrip) const
+{
+    // Extract access characteristics from packet
+    // These correspond to the 4-bit req_type encoding in XiangShan RTL
+    bool is_reuse = false;
+    bool is_release = false;
+    bool is_prefetch = false;
+    bool is_refill = false;
+
+    if (pkt) {
+        std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+            std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+        // Reuse: block has been accessed before (originBit=1)
+        is_reuse = casted_replacement_data->originBit;
+
+        // Release: write or eviction operation
+        is_release = pkt->isWrite() || pkt->isEviction();
+
+        // Prefetch: request from prefetcher
+        is_prefetch = pkt->req->isPrefetch();
+
+        // Refill: newly inserted block (originBit=0)
+        // NOTE: originBit=0 indicates this is a refill operation
+        is_refill = !casted_replacement_data->originBit;
+    }
+
+    bool is_non_prefetch = !is_prefetch;
+
+    // Determine RRPV based on access pattern
+    // Case 1: non-prefetch hit OR non-prefetch refill OR non-prefetch release reuse → RRPV=0
+    // These are high-priority accesses, same for both SRRIP and BRRIP
+    if ((is_non_prefetch && is_reuse) ||
+        (is_non_prefetch && is_refill && !is_release) ||
+        (is_non_prefetch && is_release && is_reuse)) {
+        return 0;
+    }
+
+    // Case 2: prefetch refill → RRPV=1
+    // Prefetched data gets medium-high priority, same for both SRRIP and BRRIP
+    if (!is_non_prefetch && is_refill) {
+        return 1;
+    }
+
+    // Case 3: non-prefetch release first-use OR prefetch release
+    // The only difference between SRRIP and BRRIP:
+    // - SRRIP returns 2 (medium priority, "give it a chance")
+    // - BRRIP returns 3 (low priority, more pessimistic)
+    if ((is_non_prefetch && is_release && !is_reuse) ||
+        (!is_non_prefetch && is_release)) {
+        return use_brrip ? 3 : 2;
+    }
+
+    // Default case: other access patterns
+    // SRRIP returns 2, BRRIP returns 3
+    return use_brrip ? 3 : 2;
+}
+
+void
+XSDRRIP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+{
+    std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    casted_replacement_data->valid = false;
+    casted_replacement_data->originBit = false;
+    casted_replacement_data->rrpv.saturate();
+}
+
+void
+XSDRRIP::touch(const std::shared_ptr<ReplacementData>& replacement_data,
+               const PacketPtr pkt)
+{
+    std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    // Decide which logic to use based on mode and pre-computed set type
+    bool use_brrip = useBRRIP(replacement_data);
+
+    // Determine RRPV based on access characteristics and mode
+    casted_replacement_data->rrpv = SatCounter8(2, getRRPV(pkt, replacement_data, use_brrip));
+
+    // Update originBit: mark this block as accessed
+    casted_replacement_data->originBit = true;
+}
+
+void
+XSDRRIP::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    // No packet info, set RRPV=0
+    casted_replacement_data->rrpv.reset();
+}
+
+void
+XSDRRIP::reset(const std::shared_ptr<ReplacementData>& replacement_data,
+               const PacketPtr pkt)
+{
+    std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    // DRRIP mode: update PSEL counter (only in leader sets)
+    if (mode == DRRIP_MODE) {
+        unsigned set_type = casted_replacement_data->setType;
+
+        if (set_type == 0) {
+            // SRRIP region miss → PSEL++ (favor BRRIP)
+            pselCounter++;
+            duelingStats.srripMisses++;
+        } else if (set_type == 1) {
+            // BRRIP region miss → PSEL-- (favor SRRIP)
+            pselCounter--;
+            duelingStats.brripMisses++;
+        }
+
+        // Update PSEL statistics value
+        duelingStats.pselValue = pselCounter;
+    }
+
+    // Initialize originBit=0 (indicates newly inserted block, first-use)
+    casted_replacement_data->originBit = false;
+
+    // Decide which logic to use based on mode and pre-computed set type
+    bool use_brrip = useBRRIP(replacement_data);
+
+    // Determine RRPV based on access characteristics and mode
+    casted_replacement_data->rrpv = SatCounter8(2, getRRPV(pkt, replacement_data, use_brrip));
+
+    casted_replacement_data->valid = true;
+}
+
+void
+XSDRRIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    std::shared_ptr<XSDRRIPReplData> casted_replacement_data =
+        std::static_pointer_cast<XSDRRIPReplData>(replacement_data);
+
+    // No packet info, use default RRPV
+    // Depends on mode: SRRIP=2, BRRIP=3
+    bool use_brrip = useBRRIP(replacement_data);
+
+    casted_replacement_data->rrpv = SatCounter8(2, use_brrip ? 3 : 2);
+    casted_replacement_data->valid = true;
+}
+
+ReplaceableEntry*
+XSDRRIP::getVictim(const ReplacementCandidates& candidates) const
+{
+    assert(candidates.size() > 0);
+
+    // Find entry with maximum RRPV
+    ReplaceableEntry* victim = candidates[0];
+    std::shared_ptr<XSDRRIPReplData> victim_repl_data =
+        std::static_pointer_cast<XSDRRIPReplData>(
+            victim->replacementData);
+
+    for (const auto& candidate : candidates) {
+        std::shared_ptr<XSDRRIPReplData> candidate_repl_data =
+            std::static_pointer_cast<XSDRRIPReplData>(
+                candidate->replacementData);
+
+        // Prioritize selecting invalid entry
+        if (!candidate_repl_data->valid) {
+            return candidate;
+        }
+
+        // Update victim to entry with larger RRPV
+        if (candidate_repl_data->rrpv > victim_repl_data->rrpv) {
+            victim = candidate;
+            victim_repl_data = candidate_repl_data;
+        }
+    }
+
+    // Calculate aging increment
+    int victim_rrpv = victim_repl_data->rrpv;
+    int increcement = MAX_RRPV - victim_rrpv;
+
+    // Perform aging
+    if (increcement > 0) {
+        for (const auto& candidate : candidates) {
+            std::shared_ptr<XSDRRIPReplData> candidate_repl_data =
+                std::static_pointer_cast<XSDRRIPReplData>(
+                    candidate->replacementData);
+
+            if (candidate_repl_data->valid) {
+                candidate_repl_data->rrpv += increcement;
+            }
+        }
+    }
+
+    return victim;
+}
+
+std::shared_ptr<ReplacementData>
+XSDRRIP::instantiateEntry()
+{
+    XSDRRIPReplData* repl_data = new XSDRRIPReplData();
+
+    // Allocate set ID
+    // entryCount / numWays = set index
+    repl_data->setId = entryCount / numWays;
+    entryCount++;
+
+    // Pre-compute set type for DRRIP mode (optimization: compute once, use many times)
+    // This avoids repeated bit-pattern matching in the hot path (touch/reset)
+    if (mode == DRRIP_MODE) {
+        unsigned set_id = repl_data->setId;
+
+        bool match_srrip = (set_id >> halfSetBits) == (set_id & setMask);
+        bool match_brrip = (set_id >> halfSetBits) == ((~set_id) & setMask);
+
+        // Determine set type using bit-pattern matching
+        if (match_srrip) {
+            repl_data->setType = 0;  // SRRIP dedicated
+        } else if (match_brrip) {
+            repl_data->setType = 1;  // BRRIP dedicated
+        } else {
+            repl_data->setType = 2;  // Follower
+        }
+    }
+
+    return std::shared_ptr<ReplacementData>(repl_data);
+}
+
+XSDRRIP::XSDRRIPStats::XSDRRIPStats(statistics::Group* parent)
+  : statistics::Group(parent),
+    ADD_STAT(srripMisses, "Number of misses in SRRIP leader sets"),
+    ADD_STAT(brripMisses, "Number of misses in BRRIP leader sets"),
+    ADD_STAT(followerUseSrrip, "Number of times follower sets used SRRIP"),
+    ADD_STAT(followerUseBrrip, "Number of times follower sets used BRRIP"),
+    ADD_STAT(pselValue, "Current PSEL counter value")
+{
+}
+
+} // namespace replacement_policy
+} // namespace gem5

--- a/src/mem/cache/replacement_policies/xs_drrip_rp.hh
+++ b/src/mem/cache/replacement_policies/xs_drrip_rp.hh
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2024 XiangShan
+ * All rights reserved.
+ *
+ * Unified implementation of XiangShan RRIP replacement policy series
+ *
+ * This class unifies three replacement policies: SRRIP, BRRIP, and DRRIP:
+ * - SRRIP mode: Static Re-reference Interval Prediction
+ * - BRRIP mode: Bimodal Re-reference Interval Prediction (more pessimistic)
+ * - DRRIP mode: Dynamic selection between SRRIP and BRRIP using Set Dueling
+ */
+
+#ifndef __MEM_CACHE_REPLACEMENT_POLICIES_XS_DRRIP_RP_HH__
+#define __MEM_CACHE_REPLACEMENT_POLICIES_XS_DRRIP_RP_HH__
+
+#include "base/sat_counter.hh"
+#include "base/statistics.hh"
+#include "mem/cache/replacement_policies/base.hh"
+
+namespace gem5
+{
+
+struct XSDRRIPRPParams;
+
+GEM5_DEPRECATED_NAMESPACE(ReplacementPolicy, replacement_policy);
+namespace replacement_policy
+{
+
+/**
+ * Unified XiangShan RRIP replacement policy
+ *
+ * Supports three working modes:
+ * 1. SRRIP: All sets use SRRIP logic (insert with RRPV=2)
+ * 2. BRRIP: All sets use BRRIP logic (insert with RRPV=3, more pessimistic)
+ * 3. DRRIP: Dynamically select between SRRIP and BRRIP using Set Dueling
+ *
+ * The only difference between SRRIP and BRRIP:
+ * - For "non-prefetch release first-use" and "prefetch release"
+ * - SRRIP inserts with RRPV=2, BRRIP inserts with RRPV=3
+ */
+class XSDRRIP : public Base
+{
+  public:
+    // Working mode
+    enum Mode
+    {
+        SRRIP_MODE,   // Static RRIP
+        BRRIP_MODE,   // Bimodal RRIP
+        DRRIP_MODE    // Dynamic RRIP (Set Dueling)
+    };
+
+  protected:
+    // Unified replacement data structure (shared by all modes)
+    struct XSDRRIPReplData : ReplacementData
+    {
+        // Re-Reference Prediction Value (2-bit saturating counter)
+        // 0 = near-immediate re-reference, 3 = distant re-reference
+        SatCounter8 rrpv;
+
+        // Whether the entry is valid
+        bool valid;
+
+        // Origin bit: Marks whether this block is first-use or reuse
+        // - false (0): First-use (block has never been accessed)
+        // - true (1): Reuse (block has been accessed at least once)
+        // Used for req_type bit[3]
+        bool originBit;
+
+        // Set ID (used only in DRRIP mode)
+        // Used in Set Dueling to determine which policy to use
+        unsigned setId;
+
+        // Set type (used only in DRRIP mode)
+        // Pre-computed in instantiateEntry() to avoid repeated calculation
+        // 0 = SRRIP dedicated set
+        // 1 = BRRIP dedicated set
+        // 2 = Follower set
+        uint8_t setType;
+
+        // Default constructor
+        XSDRRIPReplData() : rrpv(2), valid(false), originBit(false), setId(0), setType(2)
+        {
+        }
+    };
+
+    // Maximum RRPV value
+    static constexpr unsigned MAX_RRPV = 3;
+
+    // Set index bit manipulation for Set Dueling
+    // These are computed from numSets in constructor
+    unsigned setBits;      // log2(numSets)
+    unsigned halfSetBits;  // setBits / 2
+    uint32_t setMask;      // Mask for low half bits
+
+    // PSEL counter bit width (used only in DRRIP mode)
+    //  TODO: Not frequently modified, temporarily use constants.
+    static constexpr unsigned PSEL_WIDTH = 10;
+
+    // PSEL counter maximum value
+    static constexpr unsigned PSEL_MAX = (1 << PSEL_WIDTH);
+
+    // PSEL threshold (>= 512 uses BRRIP, < 512 uses SRRIP)
+    static constexpr unsigned PSEL_THRESHOLD = PSEL_MAX / 2;
+
+    // Current working mode
+    const Mode mode;
+
+    // Total number of sets in cache (used only in DRRIP mode)
+    const unsigned numSets;
+
+    // Number of ways per set
+    const unsigned numWays;
+
+    // Policy Selection Counter (used only in DRRIP mode)
+    // Tracks relative performance of SRRIP and BRRIP
+    mutable SatCounter32 pselCounter;
+
+    // Current number of instantiated entries
+    // Used for allocating set IDs
+    unsigned entryCount;
+
+    // Set Dueling related statistics (used only in DRRIP mode)
+    mutable struct XSDRRIPStats : public statistics::Group
+    {
+        XSDRRIPStats(statistics::Group* parent);
+
+        /** Number of misses in SRRIP region */
+        statistics::Scalar srripMisses;
+        /** Number of misses in BRRIP region */
+        statistics::Scalar brripMisses;
+        /** Number of times follower region used SRRIP */
+        statistics::Scalar followerUseSrrip;
+        /** Number of times follower region used BRRIP */
+        statistics::Scalar followerUseBrrip;
+        /** Current PSEL counter value */
+        statistics::Scalar pselValue;
+    } duelingStats;
+
+    /**
+     * Decide whether to use BRRIP or SRRIP logic
+     *
+     * For DRRIP mode, uses pre-computed setType from replacement_data:
+     * - setType 0 (SRRIP dedicated): return false
+     * - setType 1 (BRRIP dedicated): return true
+     * - setType 2 (Follower): query PSEL MSB
+     *
+     * @param replacement_data Replacement data containing pre-computed setType
+     * @return true=use BRRIP logic, false=use SRRIP logic
+     */
+    bool useBRRIP(const std::shared_ptr<ReplacementData>& replacement_data) const;
+
+    /**
+     * Determine RRPV value for a cache access
+     *
+     * Extracts access characteristics from packet and decides RRPV based on:
+     * - Access type (first-use vs reuse)
+     * - Operation type (acquire vs release)
+     * - Request source (demand vs prefetch)
+     * - Cache status (hit vs refill)
+     * - Replacement mode (SRRIP vs BRRIP)
+     *
+     * Internal encoding matches XiangShan RTL req_type:
+     *   bit[3]: 0=first-use, 1=reuse
+     *   bit[2]: 0=acquire(read), 1=release(write/evict)
+     *   bit[1]: 0=non-prefetch, 1=prefetch
+     *   bit[0]: 0=non-refill, 1=refill
+     *
+     * @param pkt Packet pointer
+     * @param replacement_data Replacement data (used to read originBit)
+     * @param use_brrip Whether to use BRRIP logic (vs SRRIP)
+     * @return RRPV value (0-3)
+     */
+    uint8_t getRRPV(const PacketPtr pkt,
+                    const std::shared_ptr<ReplacementData>& replacement_data,
+                    bool use_brrip) const;
+
+  public:
+    typedef XSDRRIPRPParams Params;
+    XSDRRIP(const Params &p);
+    ~XSDRRIP() = default;
+
+    /**
+     * Invalidate replacement data
+     */
+    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+                                                                    override;
+
+    /**
+     * Touch entry (called on hit)
+     */
+    void touch(const std::shared_ptr<ReplacementData>& replacement_data,
+               const PacketPtr pkt) override;
+
+    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+                                                                     override;
+
+    /**
+     * Reset entry (called on miss refill)
+     * Updates PSEL counter in DRRIP mode
+     */
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data,
+               const PacketPtr pkt) override;
+
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+                                                                     override;
+
+    /**
+     * Find victim for replacement
+     */
+    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
+                                                                     override;
+
+    /**
+     * Instantiate replacement data
+     */
+    std::shared_ptr<ReplacementData> instantiateEntry() override;
+};
+
+} // namespace replacement_policy
+} // namespace gem5
+
+#endif // __MEM_CACHE_REPLACEMENT_POLICIES_XS_DRRIP_RP_HH__


### PR DESCRIPTION
Change-Id: I9fcfc19fb58a7c133ebf6f7007d2ed814977d1dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XSDRRIP: a unified RRIP replacement policy supporting SRRIP, BRRIP, and DRRIP.
  * DRRIP includes set-dueling with a PSEL counter and leader/follower tracking for improved eviction choices.
  * Policy offers configurable mode, set/way sizing, and runtime statistics (miss breakdowns, PSEL).
  * Can be selected as the replacement policy for L2 caches and included in example configs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->