### PR TITLE
cpu-o3: update fetch to decode delay parameters 4 -> 2

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -28,7 +28,6 @@ def setKmhV3IdealParams(args, system):
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
-        cpu.fetchToDecodeDelay = 2
 
         # decode
         cpu.decodeWidth = 8

--- a/configs/example/se.py
+++ b/configs/example/se.py
@@ -300,7 +300,6 @@ def setKmhV3IdealParams(args, system):
         cpu.fetchWidth = 32     # 64byte fetch block have up to 32 instructions
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
-        cpu.fetchToDecodeDelay = 2
 
         cpu.decodeWidth = 8
         cpu.renameWidth = 8

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -128,7 +128,7 @@ class BaseO3CPU(BaseCPU):
     iewToDecodeDelay = Param.Cycles(1, "Issue/Execute/Writeback to decode "
                                     "delay")
     commitToDecodeDelay = Param.Cycles(1, "Commit to decode delay")
-    fetchToDecodeDelay = Param.Cycles(4, "Fetch to decode delay")
+    fetchToDecodeDelay = Param.Cycles(2, "Fetch to decode delay")
     decodeWidth = Param.Unsigned(6, "Decode width")
 
     iewToRenameDelay = Param.Cycles(1, "Issue/Execute/Writeback to rename "


### PR DESCRIPTION
RTL:	bp/FTQ	if0	if1	if2	if3/ibuffer decode (6 cycle)
GEM5: bp/FSQ  FTQ	if	buildInst/if0	if1	if2	if3/ibuffer	decode (8 cycle)

since we have FSQ, and icache get,
need to align RTL

Change-Id: I67b0caea81eaff9319552ff644f82fac6bd9720d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant CPU parameter assignments in configuration files.
  * Adjusted CPU fetch-to-decode pipeline delay from 4 to 2 cycles in the base CPU configuration, streamlining parameter management across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->