### PR TITLE
cpu-o3: rename execWB to  toCommit wire for instruction squashing

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -141,7 +141,6 @@ class BaseO3CPU(BaseCPU):
                "Issue/Execute/Writeback delay")
     renameToIEWDelay = Param.Cycles(1, "Rename to "
                "Issue/Execute/Writeback delay")
-    executeToWriteBackDelay = Param.Cycles(1, "Execute to issue delay")
 
     enableDispatchStage = Param.Bool(False, "Enable the dispatch stage")
     numDQEntries = VectorParam.Unsigned([32, 16, 16], "Number of entries in the dispQue, (Int, Float/Vector, Mem)")

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -433,11 +433,13 @@ IEW::setIEWQueue(TimeBuffer<IEWStruct> *iq_ptr)
 {
     iewQueue = iq_ptr;
 
-    // Setup wire to write instructions to commit.
-    toCommit = iewQueue->getWire(0);
-
-    execBypass = iewQueue->getWire(0);
-    execWB = iewQueue->getWire(-wbDelay);
+    // Setup wire to write instructions and squash signals to commit.
+    // Note: This wire is named "toCommit" (previously "execWB") to clarify its purpose.
+    // Since wbDelay == iewToCommitDelay == 1, IEW writes to position [-1] and Commit
+    // reads from position [-1] in the same cycle, achieving zero-cycle latency for
+    // IEW→Commit communication. This allows Commit to immediately arbitrate squash
+    // signals from IEW (e.g., branch mispredictions) before forwarding to Fetch.
+    toCommit = iewQueue->getWire(-wbDelay);
 }
 
 void
@@ -560,30 +562,30 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
             " PC: %s "
             "\n", tid, inst->seqNum, inst->pcState() );
 
-    if (!execWB->squash[tid] ||
-            inst->seqNum < execWB->squashedSeqNum[tid]) {
-        execWB->squash[tid] = true;
-        execWB->squashedSeqNum[tid] = inst->seqNum;
-        execWB->squashedStreamId[tid] = inst->getFsqId();
-        execWB->squashedTargetId[tid] = inst->getFtqId();
-        execWB->squashedLoopIter[tid] = inst->getLoopIteration();
-        execWB->branchTaken[tid] = inst->pcState().branching();
+    if (!toCommit->squash[tid] ||
+            inst->seqNum < toCommit->squashedSeqNum[tid]) {
+        toCommit->squash[tid] = true;
+        toCommit->squashedSeqNum[tid] = inst->seqNum;
+        toCommit->squashedStreamId[tid] = inst->getFsqId();
+        toCommit->squashedTargetId[tid] = inst->getFtqId();
+        toCommit->squashedLoopIter[tid] = inst->getLoopIteration();
+        toCommit->branchTaken[tid] = inst->pcState().branching();
 
-        set(execWB->pc[tid], inst->pcState());
-        inst->staticInst->advancePC(*execWB->pc[tid]);
+        set(toCommit->pc[tid], inst->pcState());
+        inst->staticInst->advancePC(*toCommit->pc[tid]);
 
-        execWB->mispredictInst[tid] = inst;
-        execWB->includeSquashInst[tid] = false;
+        toCommit->mispredictInst[tid] = inst;
+        toCommit->includeSquashInst[tid] = false;
 
         wroteToTimeBuffer = true;
 
         DPRINTF(DecoupleBP,
                 "Branch misprediction (pc=%#lx) set stream id to %lu, target "
                 "id to %lu, loop iter to %u\n",
-                execWB->pc[tid]->instAddr(),
-                execWB->squashedStreamId[tid],
-                execWB->squashedTargetId[tid],
-                execWB->squashedLoopIter[tid]);
+                toCommit->pc[tid]->instAddr(),
+                toCommit->squashedStreamId[tid],
+                toCommit->squashedTargetId[tid],
+                toCommit->squashedLoopIter[tid]);
     }
 
 }
@@ -599,29 +601,29 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
     // case the memory violator should take precedence over the branch
     // misprediction because it requires the violator itself to be included in
     // the squash.
-    if (!execWB->squash[tid] ||
-            inst->seqNum <= execWB->squashedSeqNum[tid]) {
-        execWB->squash[tid] = true;
+    if (!toCommit->squash[tid] ||
+            inst->seqNum <= toCommit->squashedSeqNum[tid]) {
+        toCommit->squash[tid] = true;
 
-        execWB->squashedSeqNum[tid] = inst->seqNum;
-        execWB->squashedStreamId[tid] = inst->getFsqId();
-        execWB->squashedTargetId[tid] = inst->getFtqId();
-        execWB->squashedLoopIter[tid] = inst->getLoopIteration();
-        set(execWB->pc[tid], inst->pcState());
-        execWB->mispredictInst[tid] = NULL;
+        toCommit->squashedSeqNum[tid] = inst->seqNum;
+        toCommit->squashedStreamId[tid] = inst->getFsqId();
+        toCommit->squashedTargetId[tid] = inst->getFtqId();
+        toCommit->squashedLoopIter[tid] = inst->getLoopIteration();
+        set(toCommit->pc[tid], inst->pcState());
+        toCommit->mispredictInst[tid] = NULL;
 
         // Must include the memory violator in the squash.
-        execWB->includeSquashInst[tid] = true;
+        toCommit->includeSquashInst[tid] = true;
 
         wroteToTimeBuffer = true;
 
         DPRINTF(DecoupleBP,
                 "Memory violation (pc=%#lx) set stream id to %lu, target id "
                 "to %lu, loop iter to %u\n",
-                execWB->pc[tid]->instAddr(),
-                execWB->squashedStreamId[tid],
-                execWB->squashedTargetId[tid],
-                execWB->squashedLoopIter[tid]);
+                toCommit->pc[tid]->instAddr(),
+                toCommit->squashedStreamId[tid],
+                toCommit->squashedTargetId[tid],
+                toCommit->squashedLoopIter[tid]);
 
 
     }
@@ -1573,8 +1575,8 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
     }
 
     if (!fetchRedirect[tid] ||
-        !execWB->squash[tid] ||
-        execWB->squashedSeqNum[tid] > inst->seqNum) {
+        !toCommit->squash[tid] ||
+        toCommit->squashedSeqNum[tid] > inst->seqNum) {
 
         // Prevent testing for misprediction on load instructions,
         // that have not been executed.
@@ -1815,8 +1817,8 @@ IEW::writebackInsts()
     // as part of backwards communication.
 
     for (int inst_num = 0; inst_num < wbWidth &&
-             execWB->insts[inst_num]; inst_num++) {
-        DynInstPtr inst = execWB->insts[inst_num];
+             toCommit->insts[inst_num]; inst_num++) {
+        DynInstPtr inst = toCommit->insts[inst_num];
         ThreadID tid = inst->threadNumber;
 
         if (inst->savedRequest && inst->isLoad()) {
@@ -2041,8 +2043,8 @@ IEW::checkMisprediction(const DynInstPtr& inst)
     ThreadID tid = inst->threadNumber;
 
     if (!fetchRedirect[tid] ||
-        !execWB->squash[tid] ||
-        execWB->squashedSeqNum[tid] > inst->seqNum) {
+        !toCommit->squash[tid] ||
+        toCommit->squashedSeqNum[tid] > inst->seqNum) {
 
         if (inst->mispredicted()) {
             fetchRedirect[tid] = true;

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -89,7 +89,7 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       renameWidth(params.renameWidth),
       wbNumInst(0),
       wbCycle(0),
-      wbDelay(params.executeToWriteBackDelay),
+      iewToCommitDelay(params.iewToCommitDelay),
       wbWidth(params.wbWidth),
       enableStoreSetTrain(params.enable_storeSet_train),
       numThreads(params.numThreads),
@@ -435,11 +435,11 @@ IEW::setIEWQueue(TimeBuffer<IEWStruct> *iq_ptr)
 
     // Setup wire to write instructions and squash signals to commit.
     // Note: This wire is named "toCommit" (previously "execWB") to clarify its purpose.
-    // Since wbDelay == iewToCommitDelay == 1, IEW writes to position [-1] and Commit
-    // reads from position [-1] in the same cycle, achieving zero-cycle latency for
+    // Since iewToCommitDelay == 1, IEW writes to position [-1] and Commit reads from
+    // position [-1] (via fromIEW) in the same cycle, achieving zero-cycle latency for
     // IEW→Commit communication. This allows Commit to immediately arbitrate squash
     // signals from IEW (e.g., branch mispredictions) before forwarding to Fetch.
-    toCommit = iewQueue->getWire(-wbDelay);
+    toCommit = iewQueue->getWire(-iewToCommitDelay);
 }
 
 void

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -402,9 +402,6 @@ class IEW
     /** Wire to write infromation heading to commit. */
     TimeBuffer<IEWStruct>::wire toCommit;
 
-    TimeBuffer<IEWStruct>::wire execBypass;
-    TimeBuffer<IEWStruct>::wire execWB;
-
     /** Queue of all instructions coming from rename this cycle. */
     std::deque<DynInstPtr> insts[MaxThreads];
 

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -476,7 +476,8 @@ class IEW
      */
     unsigned wbCycle;
 
-    const unsigned wbDelay;
+    /** IEW to Commit delay. */
+    const Cycles iewToCommitDelay;
 
     /** Writeback width. */
     unsigned wbWidth;


### PR DESCRIPTION
- delete old toCommit and execBypass
- Updated the IEW class to replace execWB with toCommit for handling instruction squashing and commit signals.
- Enhanced comments to clarify the purpose of the toCommit wire and its zero-cycle latency communication with Commit.

Change-Id: I43ab0206c70ea3d7152a40bd8f589dc8de164cc9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal communication between execution and commit stages, centralizing commit signaling and streamlining data flow while preserving functionality and behavior.

* **Chores**
  * Removed the separate execute-to-writeback delay configuration, simplifying delay parameters and clarifying zero-latency semantics between execution and commit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->