### PR TITLE
bpu: add stats for recomputed vs actual/original prediction diff

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -707,14 +707,24 @@ BTBTAGE::update(const FetchStream &stream) {
     }
 
     // Process each BTB entry
+    bool hasRecomputedVsActualDiff = false;
+    bool hasRecomputedVsOriginalDiff = false;
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
         TagePrediction recomputed;
         if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
+            // Track differences for statistics
+            auto it = predMeta->preds.find(btb_entry.pc);
+            if (it != predMeta->preds.end() && recomputed.taken != it->second.taken) {
+                hasRecomputedVsOriginalDiff = true;
+            }
         } else { // otherwise, use the prediction from the prediction-time main/alt
             recomputed = predMeta->preds[btb_entry.pc];
+        }
+        if (recomputed.taken != actual_taken) {
+            hasRecomputedVsActualDiff = true;
         }
 
         // Update predictor state and check if need to allocate new entry
@@ -759,6 +769,13 @@ BTBTAGE::update(const FetchStream &stream) {
             tageMissTrace->write_record(t);
         }
 #endif
+    }
+    // Update recomputed difference statistics (per fetchBlock)
+    if (hasRecomputedVsActualDiff) {
+        tageStats.recomputedVsActualDiff++;
+    }
+    if (hasRecomputedVsOriginalDiff) {
+        tageStats.recomputedVsOriginalDiff++;
     }
     if (getDelay() <2){
         checkUtageUpdateMisspred(stream);
@@ -1026,6 +1043,8 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
     ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
     ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
+    ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != actual_taken"),
+    ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != original pred.taken"),
     ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
     ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(), "number of updates deferred due to bank conflict (retried later)"),
     ADD_STAT(updateBankConflictPerBank, statistics::units::Count::get(), "bank conflicts per bank"),

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -350,6 +350,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
         Scalar updateMispred;
         Scalar updateResetU;
 
+        // Recomputed prediction difference statistics (per fetchBlock)
+        Scalar recomputedVsActualDiff;   // recomputed.taken != actual_taken
+        Scalar recomputedVsOriginalDiff; // recomputed.taken != original pred.taken
+
         // Bank conflict statistics
         Scalar updateBankConflict;           // Number of bank conflicts detected
         Scalar updateDeferredDueToConflict;  // Number of updates deferred due to bank conflict (retried later)


### PR DESCRIPTION
Add two per-fetchBlock statistics to track TAGE prediction differences:
- recomputedVsActualDiff: recomputed.taken != actual_taken
- recomputedVsOriginalDiff: recomputed.taken != original pred.taken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added enhanced metrics for monitoring branch prediction recomputation accuracy against actual outcomes and baseline predictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->