### PR TITLE
mem-cache: stream add hysteresis

### DIFF
--- a/src/mem/cache/prefetch/xs_stream.cc
+++ b/src/mem/cache/prefetch/xs_stream.cc
@@ -93,19 +93,26 @@ XsStreamPrefetcher::streamLookup(const PrefetchInfo &pfi, bool &in_active_page, 
             entry->bitVec |= region_bit_accessed;
             entry->cnt += 1;
         }
+        entry->hysteresis = true;
         return entry;
     }
-    entry = stream_array.findVictim(0);
-
     in_active_page = (entry_plus_active || entry_min_active);
     decr = entry_plus != nullptr;
-    entry->tag = regionHashTag(vaddr_tag_num);
-    entry->decrMode = decr;
-    entry->bitVec = 1UL << vaddr_offset;
-    entry->cnt = 1;
-    entry->active = in_active_page;
-    stream_array.insertEntry(regionHashTag(vaddr_tag_num), secure, entry);
-    return entry;
+    // replace
+    entry = stream_array.findVictim(0);
+    if (entry->hysteresis){
+        entry->hysteresis = false;
+        stream_array.insertEntry(entry->tag, entry->isSecure(), entry, false);
+    } else {
+        entry->tag = regionHashTag(vaddr_tag_num);
+        entry->decrMode = decr;
+        entry->bitVec = 1UL << vaddr_offset;
+        entry->cnt = 1;
+        entry->active = in_active_page;
+        entry->hysteresis = false;
+        stream_array.insertEntry(regionHashTag(vaddr_tag_num), secure, entry);
+    }
+    return nullptr;
 }
 
 void

--- a/src/mem/cache/prefetch/xs_stream.hh
+++ b/src/mem/cache/prefetch/xs_stream.hh
@@ -75,6 +75,7 @@ class XsStreamPrefetcher : public Queued
         bool active;
         int cnt;
         bool decrMode;
+        bool hysteresis = false;
         STREAMEntry() : TaggedEntry(), tag(0), bitVec(0), active(false), cnt(0), decrMode(false) {}
     };
     AssociativeSet<STREAMEntry> stream_array;


### PR DESCRIPTION
Change-Id: I710e7645a78dc48cf890e9223b76d92bc0a43d2a
Config: kmhv3, 0.8 coverage
Result: a little improvement, especially GemsFDTD and zeusmp

Data before rebasing `xs-dev`:

<img width="325" height="653" alt="image" src="https://github.com/user-attachments/assets/239d1ff6-7cd9-4597-b7e1-20b4a20a980a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cache stream prefetcher replacement logic to optimize handling of repeated stream accesses through enhanced entry state tracking and deferred replacement handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->