### PR TITLE
mem-cache: berti add l2 ahead prefetch

### DIFF
--- a/src/mem/cache/prefetch/berti.cc
+++ b/src/mem/cache/prefetch/berti.cc
@@ -247,16 +247,23 @@ BertiPrefetcher::calculatePrefetch(const PrefetchInfo &pfi, std::vector<AddrPrio
                     Addr pf_addr =
                         useByteAddr ? pfi.getAddr() + delta : (blockIndex(pfi.getAddr()) + delta) << lBlkSize;
                     sendPFWithFilter(pfi, pf_addr, addresses, 32, PrefetchSourceType::Berti,
-                                     delta == entry->bestDelta.delta && entry->bestDelta.coverageCounter >= 8);
+                                     delta == entry->bestDelta.delta && entry->bestDelta.coverageCounter >= 8, 1);
                 }
             }
         } else {
             if (entry->bestDelta.status != NO_PREF) {
                 DPRINTF(BertiPrefetcher, "Using best delta %d to prefetch\n", entry->bestDelta.delta);
-                Addr pf_addr = useByteAddr ? pfi.getAddr() + entry->bestDelta.delta
-                                           : (blockIndex(pfi.getAddr()) + entry->bestDelta.delta) << lBlkSize;
+                Addr pf_addr = useByteAddr ?
+                    pfi.getAddr() + entry->bestDelta.delta :
+                    (blockIndex(pfi.getAddr()) + entry->bestDelta.delta) << lBlkSize;
                 sendPFWithFilter(pfi, pf_addr, addresses, 32, PrefetchSourceType::Berti,
-                                 entry->bestDelta.coverageCounter >= 8);
+                                 entry->bestDelta.coverageCounter >= 8, 1);
+                uint64_t l2_depth_ratio = 2;
+                Addr pf_addr_l2 = useByteAddr ?
+                    pfi.getAddr() + (entry->bestDelta.delta << l2_depth_ratio) :
+                    (blockIndex(pfi.getAddr()) + (entry->bestDelta.delta << l2_depth_ratio)) << lBlkSize;
+                sendPFWithFilter(pfi, pf_addr_l2, addresses, 32, PrefetchSourceType::Berti,
+                                 entry->bestDelta.coverageCounter >= 8, 2);
                 if (triggerPht && entry->bestDelta.coverageCounter > 5) {
                     local_delta_pf_addr = pf_addr;
                 }
@@ -267,23 +274,27 @@ BertiPrefetcher::calculatePrefetch(const PrefetchInfo &pfi, std::vector<AddrPrio
 
 bool
 BertiPrefetcher::sendPFWithFilter(const PrefetchInfo &pfi, Addr addr, std::vector<AddrPriority> &addresses, int prio,
-                                  PrefetchSourceType src, bool using_best_delta_and_confident)
+                                  PrefetchSourceType src, bool using_best_delta_and_confident, int ahead_level)
 {
-    if (archDBer && cache->level() == 1) {
+    if (archDBer && cache->level() == 1 && ahead_level == 1) {
         archDBer->l1PFTraceWrite(curTick(), pfi.getPC(), pfi.getAddr(), addr, src);
     }
     if (using_best_delta_and_confident) {
         lastUsedBestDelta = blockIndex(addr) - blockIndex(pfi.getAddr());
     }
-    if (filter->contains(addr)) {
+    boost::compute::detail::lru_cache<Addr, Addr>* filterHere;
+    filterHere = ahead_level > 1 ? filterL2 : filter;
+    if (filterHere->contains(addr)) {
         DPRINTF(BertiPrefetcher, "Skip recently prefetched: %lx\n", addr);
         return false;
     } else {
         int64_t blk_delta = (int64_t)blockIndex(addr) - blockIndex(pfi.getAddr());
         topDeltas[blk_delta] = topDeltas.count(blk_delta) ? topDeltas[blk_delta] + 1 : 1;
         DPRINTF(BertiPrefetcher, "Send pf: %lx\n", addr);
-        filter->insert(addr, 0);
+        filterHere->insert(addr, 0);
         addresses.push_back(AddrPriority(addr, prio, src));
+        addresses.back().pfahead_host = ahead_level;
+        addresses.back().pfahead = ahead_level > cache->level();
         return true;
     }
 }

--- a/src/mem/cache/prefetch/berti.hh
+++ b/src/mem/cache/prefetch/berti.hh
@@ -166,6 +166,7 @@ class BertiPrefetcher : public Queued
   public:
 
     boost::compute::detail::lru_cache<Addr, Addr> *filter;
+    boost::compute::detail::lru_cache<Addr, Addr> *filterL2;
 
     BertiPrefetcher(const BertiPrefetcherParams &p);
 
@@ -187,7 +188,7 @@ class BertiPrefetcher : public Queued
     int getBestDelta() { return lastUsedBestDelta; }
 
     bool sendPFWithFilter(const PrefetchInfo &pfi, Addr addr, std::vector<AddrPriority> &addresses, int prio,
-                          PrefetchSourceType src, bool using_best_delta_and_confident);
+                          PrefetchSourceType src, bool using_best_delta_and_confident, int ahead_level);
 
     void notifyFill(const PacketPtr &pkt) override;
 

--- a/src/mem/cache/prefetch/sms.cc
+++ b/src/mem/cache/prefetch/sms.cc
@@ -61,8 +61,10 @@ XSCompositePrefetcher::XSCompositePrefetcher(const XSCompositePrefetcherParams &
     largeBOP->filter = &this->pfBlockLRUFilter;
     smallBOP->filter = &this->pfBlockLRUFilter;
     learnedBOP->filter = &this->pfBlockLRUFilter;
-    if (berti)
+    if (berti) {
         berti->filter = &this->pfBlockLRUFilter;
+        berti->filterL2 = &this->pfPageLRUFilterL2;
+    }
     if (Sstride) {
         Sstride->filter = &this->pfBlockLRUFilter;
         Sstride->filterL2 = &this->pfPageLRUFilterL2;


### PR DESCRIPTION
Change-Id: I01d9003bf78eaabc3619349a60c3f80a24afe58c
Config: idealkmhv3, 0.8 coverage
Result: a lot improvement in GemsFDTD.

<img width="362" height="641" alt="02ea36bc-c14d-4261-bbcb-7279fbce2e2e" src="https://github.com/user-attachments/assets/6915b940-f564-416f-a005-d32329664f1a" />

Improve the threshold from 2 to 3 to balance L1_PREF and L2_PREF.
<img width="338" height="686" alt="image" src="https://github.com/user-attachments/assets/78fffc6b-deb2-424d-b1f6-545a4517ebeb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Enhancements**
  * Implemented multi-level cache prefetching strategy supporting coordinated operations across different cache hierarchy levels
  * Enhanced prefetch metadata tracking and optimization mechanisms for improved memory access patterns
  * Refined prefetch filtering to dynamically leverage different cache level strategies for better performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->