### PR TITLE
fix uninitialized reg arr for VlWhole staticInst type

### DIFF
--- a/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
@@ -423,6 +423,8 @@ def template VlWholeConstructor {{
 %(class_name)s::%(class_name)s(ExtMachInst _machInst)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
 {
+    %(set_reg_idx_arr)s;
+
     size_t NFIELDS = machInst.nf + 1;
     eew = 8;
     StaticInstPtr microop;


### PR DESCRIPTION
### Problem

When running gcpt with `--debug-flags=Exec`, a segmentation fault is encountered when dumping disassembly of `vl1re64.v` instruction.

When compiling gem5. with `--with-asan`, the following error is shown.

> ==1134360==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50e0000304df at pc 0x561e9b58bf95 bp 0x7ffe4ce60cd0 sp 0x7ffe4ce60cc0
READ of size 12 at 0x50e0000304df thread T0
    #0 0x561e9b58bf94 in gem5::RiscvISA::VlWholeMacroInst::generateDisassembly[abi:cxx11](unsigned long, gem5::loader::SymbolTable const*) const build/RISCV/arch/riscv/insts/vector.cc:247
    #1 0x561e9876d564 in gem5::StaticInst::disassemble[abi:cxx11](unsigned long, gem5::loader::SymbolTable const*) const build/RISCV/cpu/static_inst.cc:64
    #2 0x561e98727840 in gem5::Trace::ExeTracerRecord::traceInst(gem5::RefCountingPtr<gem5::StaticInst> const&, bool) build/RISCV/cpu/exetrace.cc:105
    #3 0x561e9872d9a6 in gem5::Trace::ExeTracerRecord::dump() build/RISCV/cpu/exetrace.cc:174
    #4 0x561e9990cd1d in gem5::o3::Commit::commitHead(gem5::RefCountingPtr<gem5::o3::DynInst> const&, unsigned int) build/RISCV/cpu/o3/commit.cc:1714
    #5 0x561e9991d629 in gem5::o3::Commit::commitInsts() build/RISCV/cpu/o3/commit.cc:1196
    #6 0x561e99926ddf in gem5::o3::Commit::commit() build/RISCV/cpu/o3/commit.cc:1069
    #7 0x561e999290cf in gem5::o3::Commit::tick() build/RISCV/cpu/o3/commit.cc:801
    #8 0x561e9998230d in gem5::o3::CPU::tick() build/RISCV/cpu/o3/cpu.cc:581
    #9 0x561e95e76f7f in std::function<void ()>::operator()() const /usr/include/c++/11/bits/std_function.h:590

### Root cause

The error happens in the following snippet, where accessing `destRegIdx` and `srcRegIdx` throws illegal memory access errors.
```c++
  std::string VlWholeMacroInst::generateDisassembly(Addr pc,
          const loader::SymbolTable *symtab) const
  {
      std::stringstream ss;
      // destRegIdx(0) and srcRegIdx(0) are uninitialized
      ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", " <<
          '(' << registerName(srcRegIdx(0)) << ')';
      return ss.str();
  }
```

The illegal memory access happens because the `srcReg` and `dstReg` fields are uninitialized for this StaticInst type.
From the generated StaticInst constructor for VlWhole instruction type in `build/RISCV/arch/riscv/generated/decoder-ns.cc.inc`, there is no reg arr initialization.

```c++
  Vl1re8_v::Vl1re8_v(ExtMachInst _machInst)
      : VlWholeMacroInst("vl1re8_v", _machInst, VectorWholeRegisterLoadOp)
  {
      // missing reg arr initializations
      size_t NFIELDS = machInst.nf + 1;
      eew = 8;
      StaticInstPtr microop;
      VectorMicroInfo vmi;
      for (int i = 0; i < NFIELDS; ++i) {
          vmi.rs = 0;
          vmi.re = VLEN / eew;
          vmi.microVd = VD + i;
          microop = new Vl1re8_vMicro(_machInst, i, vmi);
          microop->setDelayedCommit();
          microop->setFlag(IsLoad);
          this->microops.push_back(microop);
      }

      this->microops.front()->setFirstMicroop();
      this->microops.back()->setLastMicroop();
  }
```

### After Fix

After the fix, the register fields are correctly initialized and no illegal memory access fault is observed.

```c++
  Vl1re8_v::Vl1re8_v(ExtMachInst _machInst)
      : VlWholeMacroInst("vl1re8_v", _machInst, VectorWholeRegisterLoadOp)
  {

      setRegIdxArrays(
          reinterpret_cast<RegIdArrayPtr>(
              &std::remove_pointer_t<decltype(this)>::srcRegIdxArr),
          reinterpret_cast<RegIdArrayPtr>(
              &std::remove_pointer_t<decltype(this)>::destRegIdxArr));
              ;

      size_t NFIELDS = machInst.nf + 1;
      eew = 8;
      StaticInstPtr microop;
      VectorMicroInfo vmi;
      for (int i = 0; i < NFIELDS; ++i) {
          vmi.rs = 0;
          vmi.re = VLEN / eew;
          vmi.microVd = VD + i;
          microop = new Vl1re8_vMicro(_machInst, i, vmi);
          microop->setDelayedCommit();
          microop->setFlag(IsLoad);
          this->microops.push_back(microop);
      }

      this->microops.front()->setFirstMicroop();
      this->microops.back()->setLastMicroop();
  }
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vector instruction initialization order to ensure proper register configuration during construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->