### PR TITLE
bpu: test old: only enable sc imli table

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -105,8 +105,15 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
-            cpu.branchPred.mgsc.enabled = False
+            cpu.branchPred.mgsc.enabled = not args.disable_mgsc
             cpu.branchPred.ras.enabled = True
+
+            cpu.branchPred.mgsc.enableBwTable = False
+            cpu.branchPred.mgsc.enableLTable = False
+            cpu.branchPred.mgsc.enableITable = True
+            cpu.branchPred.mgsc.enableGTable = False
+            cpu.branchPred.mgsc.enablePTable = False
+            cpu.branchPred.mgsc.enableBiasTable = False
 
         # l1 cache per core
         if args.caches:

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -105,15 +105,8 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
-            cpu.branchPred.mgsc.enabled = not args.disable_mgsc
+            cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True
-
-            cpu.branchPred.mgsc.enableBwTable = False
-            cpu.branchPred.mgsc.enableLTable = False
-            cpu.branchPred.mgsc.enableITable = True
-            cpu.branchPred.mgsc.enableGTable = False
-            cpu.branchPred.mgsc.enablePTable = False
-            cpu.branchPred.mgsc.enableBiasTable = False
 
         # l1 cache per core
         if args.caches:

--- a/src/cpu/pred/btb/folded_hist.cc
+++ b/src/cpu/pred/btb/folded_hist.cc
@@ -1,4 +1,5 @@
 #include "cpu/pred/btb/folded_hist.hh"
+// #include "debug/MGSC.hh"
 
 namespace gem5
 {
@@ -152,15 +153,20 @@ ImliFoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool taken
     const uint64_t foldedMask = ((1ULL << foldedLen) - 1);
     uint64_t temp = _folded;
 
-    // Simple shift and set case
-    if (taken && temp < ((1ULL << histLen) - 1) && shamt == 1) {  // backward taken, inner most loop
-        temp = temp + 1;                                          // counter++ (index++)
-    } else if (taken && shamt > 1) {                              // backward taken, not inner most loop
-        temp = 1;
-    } else if (!taken) {  // backward not taken, hist = 0
+    // For IMLI, we treat "taken" as a backward-taken event (i.e., loop continues).
+    // Update rule (CBP-like):
+    // - backward taken: counter++
+    // - otherwise: counter = 0 (loop exits or no backward-taken event)
+    if (taken) {
+        const uint64_t max = ((1ULL << histLen) - 1);
+        if (temp < max) {
+            temp++;
+        }
+    } else {
         temp = 0;
     }
     _folded = temp & foldedMask;
+    // DPRINTF(MGSC, "IMLI FoldedHist update: shamt %d, taken %d, folded %ld\n", shamt, taken, _folded);
 }
 
 /**


### PR DESCRIPTION
Change-Id: I43a70f3b8b82efd9aa02d4be717ee27cb5ca80fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Branch predictor configuration updated: MGSC is now conditionally enabled and each MGSC prediction table has independent enable/disable controls for finer configuration.

* **Behavior Changes**
  * Simplified folded history update rule for branch prediction, producing more consistent backward-taken handling and history masking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->