### PR TITLE
cpu-o3: Add set-div bank conflict model to LSQ

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -44,6 +44,7 @@ import math
 import m5
 from m5.objects import *
 from common.Caches import *
+from common.LSQBankConflict import set_lsq_bank_conflict_cache_params
 from common import ObjectList
 from common.PrefetcherConfig import *
 
@@ -369,6 +370,7 @@ def config_cache(options, system):
                         ExternalCache("cpu%d.dcache" % i))
 
         system.cpu[i].createInterruptController()
+        set_lsq_bank_conflict_cache_params(system.cpu[i], system)
         if options.l2cache:
             system.cpu[i].connectAllPorts(
                 system.tol2bus_list[i].cpu_side_ports,

--- a/configs/common/LSQBankConflict.py
+++ b/configs/common/LSQBankConflict.py
@@ -1,0 +1,28 @@
+from m5.util import fatal
+from m5.util.convert import toMemorySize
+
+
+def set_lsq_bank_conflict_cache_params(cpu, system):
+    """
+    Derive LSQ bank conflict model params from DCache geometry.
+
+    Currently LSQ needs DCache set bits to build (set+bank) keys for
+    bank-conflict checks. We keep this derivation in Python to avoid
+    coupling LSQ with DCache internal implementations.
+    """
+
+    cache_line_size = (
+        system.cache_line_size.getValue()
+        if hasattr(system.cache_line_size, "getValue")
+        else int(system.cache_line_size)
+    )
+    assoc = int(cpu.dcache.assoc)
+    size = int(toMemorySize(str(cpu.dcache.size)))
+    num_sets = size // (assoc * cache_line_size)
+    if num_sets <= 0 or (num_sets & (num_sets - 1)) != 0:
+        fatal(
+            f"Invalid dcache geometry: size={cpu.dcache.size}, assoc={assoc}, "
+            f"line={cache_line_size}, num_sets={num_sets}"
+        )
+
+    cpu.DcacheSetBits = num_sets.bit_length() - 1

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -10,6 +10,7 @@ from m5.util.fdthelper import *
 addToPath('../')
 
 from ruby import Ruby
+from common.LSQBankConflict import set_lsq_bank_conflict_cache_params
 
 from common.FSConfig import *
 from common.SysPaths import *
@@ -17,7 +18,6 @@ from common.Benchmarks import *
 from common import Simulation
 from common.Caches import *
 from common.xiangshan import *
-
 
 def setKmhV3IdealParams(args, system):
     for cpu in system.cpu:
@@ -61,6 +61,7 @@ def setKmhV3IdealParams(args, system):
         cpu.EnablePipeNukeCheck = True
         cpu.BankConflictCheck = True
         cpu.sbufferBankWriteAccurately = True
+        cpu.DcacheSetDivNum = 2
 
         # lsq
         cpu.LQEntries = 128
@@ -87,6 +88,7 @@ def setKmhV3IdealParams(args, system):
             cpu.dcache.tag_load_read_ports = 100
             cpu.dcache.mshrs = 16
             cpu.dcache.simulate_dcache_refill = True
+            set_lsq_bank_conflict_cache_params(cpu, system)
 
     # l2 caches
     if args.l2cache:

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -10,6 +10,7 @@ from m5.util.fdthelper import *
 addToPath('../')
 
 from ruby import Ruby
+from common.LSQBankConflict import set_lsq_bank_conflict_cache_params
 
 from common.FSConfig import *
 from common.SysPaths import *
@@ -17,7 +18,6 @@ from common.Benchmarks import *
 from common import Simulation
 from common.Caches import *
 from common.xiangshan import *
-
 
 def setKmhV3Params(args, system):
     for cpu in system.cpu:
@@ -117,6 +117,7 @@ def setKmhV3Params(args, system):
             cpu.dcache.do_fast_writeline = False
             cpu.dcache.simulate_dcache_refill = True
             cpu.dcache.prefetch_can_offload = False
+            set_lsq_bank_conflict_cache_params(cpu, system)
 
     # l2 caches
     if args.l2cache:

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -200,6 +200,8 @@ class BaseO3CPU(BaseCPU):
 
     BankConflictCheck = Param.Bool(True, "open Bank conflict check")
     sbufferBankWriteAccurately = Param.Bool(False, "Sbuffer write to memory with bank conflict check")
+    DcacheSetBits = Param.Unsigned(8, "Dcache set bits for LSQ bank conflict model")
+    DcacheSetDivNum = Param.Unsigned(1, "Dcache set div num for LSQ bank conflict model (power of two)")
     EnableLdMissReplay = Param.Bool(True, "Replay Cache missed load instrution from ReplayQ if True")
     EnablePipeNukeCheck = Param.Bool(True, "Replay load if Raw violation is detected in loadPipe if True")
 

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -52,6 +52,7 @@
 #include "arch/riscv/insts/fusion.hh"
 #include "arch/riscv/insts/vector.hh"
 #include "base/compiler.hh"
+#include "base/intmath.hh"
 #include "base/logging.hh"
 #include "base/trace.hh"
 #include "base/types.hh"
@@ -89,12 +90,16 @@ std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;
 
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     : cpu(cpu_ptr), iewStage(iew_ptr),
-      recentlyloadAddr(8),
+      recentlyloadAddr(8 * (params.DcacheSetDivNum ? params.DcacheSetDivNum : 1)),
       _cacheBlocked(false),
       cacheStorePorts(params.cacheStorePorts), usedStorePorts(0),
       cacheLoadPorts(params.cacheLoadPorts), usedLoadPorts(0),
       enableBankConflictCheck(params.BankConflictCheck),
       sbufferBankWriteAccurately(params.sbufferBankWriteAccurately),
+      dcacheSetBits(params.DcacheSetBits),
+      dcacheSetDivNum(params.DcacheSetDivNum),
+      dcacheLineBits(floorLog2(cpu_ptr->cacheLineSize())),
+      dcacheSetBankBits(params.DcacheSetBits + 3),
       _enableLdMissReplay(params.EnableLdMissReplay),
       _enablePipeNukeCheck(params.EnablePipeNukeCheck),
       _storeWbStage(params.StoreWbStage),
@@ -115,6 +120,16 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
         panic("LSQ can not support pipeline nuke replay when EnableLdMissReplay is False");
     }
     assert(_storeWbStage >= 2 && _storeWbStage <= 4);
+    panic_if(dcacheSetDivNum == 0, "DcacheSetDivNum must be >= 1\n");
+    panic_if(!isPowerOf2(dcacheSetDivNum),
+             "DcacheSetDivNum must be power of two (got %u)\n",
+             dcacheSetDivNum);
+    panic_if(dcacheSetBankBits >= 64,
+             "DcacheSetBits too large for bank conflict model (setBits=%u)\n",
+             dcacheSetBits);
+    panic_if(dcacheSetDivNum > (1ULL << dcacheSetBits),
+             "DcacheSetDivNum (%u) must be <= num_sets (2^%u)\n",
+             dcacheSetDivNum, dcacheSetBits);
 
     //**********************************************
     //************ Handle SMT Parameters ***********
@@ -152,7 +167,11 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
         thread[tid].setDcachePort(&dcachePort);
     }
 
-    bankOccupied.resize(8, false);
+    bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
+    pendingDcacheRefill.resize(dcacheSetDivNum, false);
+    dcacheRefillDataRead.resize(dcacheSetDivNum, 0);
+    dcacheRefillDataWrite.resize(dcacheSetDivNum, 0);
+    dcacheRefillTagWrite.resize(dcacheSetDivNum, 0);
 }
 
 
@@ -230,63 +249,89 @@ LSQ::tick()
 void
 LSQ::clearAddresses()
 {
-    // Check if the current cycle is already occupied by previous operations (e.g. delayed writeback)
-    bool currentCycleBusy = (dcacheRefillDataRead | dcacheRefillDataWrite) & 0x1;
+    for (unsigned div = 0; div < dcacheSetDivNum; div++) {
+        // Check if the current cycle is already occupied by previous operations
+        // (e.g. delayed writeback).
+        bool currentCycleBusy =
+            (dcacheRefillDataRead[div] | dcacheRefillDataWrite[div]) & 0x1;
 
-    if (pendingDcacheRefill) {
-        // If current cycle is busy, we stall the new request (keep pendingDcacheRefill = true)
-        // If free, we issue the new request
-        if (!currentCycleBusy) {
-            pendingDcacheRefill = false;
-            // Data Read at current cycle (Bit 0)
-            dcacheRefillDataRead |= 0x1;
-            // Tag Write at 3 cycles later (Bit 3)
-            dcacheRefillTagWrite |= (1 << 3);
-            // Data Write at 4 cycles later (Bit 4)
-            dcacheRefillDataWrite |= (1 << 4);
+        if (pendingDcacheRefill[div]) {
+            // If current cycle is busy, we stall the new request (keep pending).
+            // If free, we issue the new request.
+            if (!currentCycleBusy) {
+                pendingDcacheRefill[div] = false;
+                // Data Read at current cycle (Bit 0)
+                dcacheRefillDataRead[div] |= 0x1;
+                // Tag Write at 3 cycles later (Bit 3)
+                dcacheRefillTagWrite[div] |= (1 << 3);
+                // Data Write at 4 cycles later (Bit 4)
+                dcacheRefillDataWrite[div] |= (1 << 4);
 
-            // We just occupied the current cycle
-            currentCycleBusy = true;
+                // We just occupied the current cycle.
+                currentCycleBusy = true;
+            }
         }
-    }
 
-    // Advance the pipeline for the next cycle
-    dcacheRefillDataRead >>= 1;
-    dcacheRefillTagWrite >>= 1;
-    dcacheRefillDataWrite >>= 1;
+        // Advance the pipeline for the next cycle.
+        dcacheRefillDataRead[div] >>= 1;
+        dcacheRefillTagWrite[div] >>= 1;
+        dcacheRefillDataWrite[div] >>= 1;
 
-    if (currentCycleBusy) {
-        std::fill(bankOccupied.begin(), bankOccupied.end(), true);
-    } else {
-        std::fill(bankOccupied.begin(), bankOccupied.end(), false);
+        std::fill(bankOccupied[div].begin(), bankOccupied[div].end(),
+                  currentCycleBusy);
     }
     recentlyloadAddr.clear();
+}
+
+unsigned
+LSQ::getDcacheDiv(Addr vaddr) const
+{
+    return (vaddr >> dcacheLineBits) & (dcacheSetDivNum - 1);
+}
+
+uint64_t
+LSQ::getDcacheBankSetKey(Addr vaddr) const
+{
+    // [setIndex][bankIndex][dataOffset]
+    //         ^ (cacheLineBits)   ^ (3 bits)
+    return (vaddr >> 3) & ((1ULL << dcacheSetBankBits) - 1);
+}
+
+uint64_t
+LSQ::getDcacheDivBankSetKey(Addr vaddr) const
+{
+    return (static_cast<uint64_t>(getDcacheDiv(vaddr)) << dcacheSetBankBits) |
+        getDcacheBankSetKey(vaddr);
 }
 
 bool
 LSQ::loadBankConflictedCheck(Addr vaddr)
 {
     bool now_bank_conflict = false;
-    // [13:6]   [5:3]     [2:0]
-    // setIndex bankIndex dataOffset
-    const uint64_t cacheBankmask = 0b11111111111000;
     const int bankIndex = bankNum(vaddr);
+    const unsigned div = getDcacheDiv(vaddr);
+    const uint64_t key = getDcacheDivBankSetKey(vaddr);
 
     if (enableBankConflictCheck) {
-        if (recentlyloadAddr.contains((vaddr & cacheBankmask))) {
-            recentlyloadAddr.get((vaddr & cacheBankmask));
+        if (recentlyloadAddr.contains(key)) {
+            recentlyloadAddr.get(key);
             return false;
         }
-        auto bank_occupied = bankOccupied.at(bankIndex);
-        if (bank_occupied) {
+        if (bankOccupied[div][bankIndex]) {
             now_bank_conflict = true;
 
         } else {
-            bank_occupied = true;
-            recentlyloadAddr.insert((vaddr & cacheBankmask), {});
+            bankOccupied[div][bankIndex] = true;
+            recentlyloadAddr.insert(key, {});
         }
     }
     return now_bank_conflict;
+}
+
+void
+LSQ::notifyDcacheRefill(Addr addr)
+{
+    pendingDcacheRefill.at(getDcacheDiv(addr)) = true;
 }
 
 unsigned

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -962,22 +962,33 @@ class LSQ
 
     void clearAddresses();
 
+    unsigned
+    getDcacheDiv(Addr vaddr) const;
+
+    uint64_t
+    getDcacheBankSetKey(Addr vaddr) const;
+
+    uint64_t
+    getDcacheDivBankSetKey(Addr vaddr) const;
+
     Addr bankNum(Addr a) const { return (a >> 3) & 0x7; };
 
     bool loadBankConflictedCheck(Addr vaddr);
 
-    void sbufferWriteBank(std::vector<bool>& mask) {
+    void sbufferWriteBank(Addr vaddr, const std::vector<bool>& mask) {
         assert(mask.size() == 8 * numBank);
         dcacheWriteStall = true;
+        const unsigned div = getDcacheDiv(vaddr);
         if (sbufferBankWriteAccurately) {
             for (int i=0; i<numBank; i++) {
                 if (std::any_of(mask.begin() + 8 * i, mask.begin() + 8 * i + 8,
                                 [](bool v) { return v; })) {
-                    bankOccupied[i] = true;
+                    bankOccupied.at(div).at(i) = true;
                 }
             }
         } else {
-            std::fill(bankOccupied.begin(), bankOccupied.end(), true);
+            std::fill(bankOccupied.at(div).begin(), bankOccupied.at(div).end(),
+                      true);
         }
     }
 
@@ -1010,14 +1021,23 @@ class LSQ
   public:
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
-    std::vector<bool> bankOccupied;
+    std::vector<std::vector<bool>> bankOccupied;
 
-    bool pendingDcacheRefill = false;
-    uint32_t dcacheRefillDataRead = 0;
-    uint32_t dcacheRefillDataWrite = 0;
-    uint32_t dcacheRefillTagWrite = 0;
+    void notifyDcacheRefill(Addr addr);
 
-    bool isDcacheRefillTagWrite() const { return dcacheRefillTagWrite & 0b1; }
+    std::vector<bool> pendingDcacheRefill;
+    std::vector<uint32_t> dcacheRefillDataRead;
+    std::vector<uint32_t> dcacheRefillDataWrite;
+    std::vector<uint32_t> dcacheRefillTagWrite;
+
+    bool isDcacheRefillTagWrite() const
+    {
+        for (auto stage : dcacheRefillTagWrite) {
+            if (stage & 0x1)
+                return true;
+        }
+        return false;
+    }
 
   protected:
     /** D-cache is blocked */
@@ -1036,6 +1056,11 @@ class LSQ
 
     bool enableBankConflictCheck;
     bool sbufferBankWriteAccurately;
+
+    const unsigned dcacheSetBits;
+    const unsigned dcacheSetDivNum;
+    const unsigned dcacheLineBits;
+    const unsigned dcacheSetBankBits;
 
     bool _enableLdMissReplay;
     bool _enablePipeNukeCheck;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2276,7 +2276,7 @@ LSQUnit::storeBufferEvictToCache()
         }
         DPRINTF(StoreBuffer, "send packet successed\n");
         entry->sending = true;
-        lsq->sbufferWriteBank(entry->validMask);
+        lsq->sbufferWriteBank(entry->blockVaddr, entry->validMask);
         storeBufferWritebackInactive = 0;
     } else {
         // Timeout

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -924,7 +924,10 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         // Optionally indicate that the Dcache received a refill request
         // to drive LSQ-side modelling.
         if (simulateDcacheRefill && cacheLevel == 1 && pkt->getLSQPtr()) {
-            pkt->getLSQPtr()->pendingDcacheRefill = true;
+            const Addr refill_addr =
+                pkt->req && pkt->req->hasVaddr() ? pkt->req->getVaddr() :
+                pkt->getAddr();
+            pkt->getLSQPtr()->notifyDcacheRefill(refill_addr);
             stats.DcacheRefillTimes++;
         }
         blk = handleFill(pkt, blk, writebacks, allocate);


### PR DESCRIPTION
Make LSQ bank-conflict checks set-aware and support configurable "div" partitions derived from low set-index bits.

- Replace hard-coded cache bank mask with a (set+bank) key based on DcacheSetBits.
- Track bank occupancy and refill pipeline per div; map loads/stores/refills to div using vaddr.
- Fix load path to update bankOccupied on non-conflict.
- Add BaseO3CPU params DcacheSetBits and DcacheSetDivNum, plus a shared configs/common helper to derive set bits from DCache geometry.
- Set idealkmhv3 DcacheSetDivNum=2 (kmhv3 keeps default 1).

Change-Id: I88c5e967641423d7da2e929cf01d8b8567e6d68e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configurable D-cache options to control per-division LSQ bank-conflict behavior
  * Automated helper to derive and apply LSQ bank-conflict parameters from cache geometry
  * Example configs set a per-core D-cache division default

* **Improvements**
  * Per-division D-cache bank occupancy and conflict tracking for finer-grained modeling
  * D-cache refill notifications now use virtual-address-aware refill reporting
  * Writeback handling updated to account for block addresses during buffer eviction

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->