### PR TITLE
scons: explicitly define call arg in `CheckLibWithHeader`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -599,15 +599,18 @@ for variant_path in variant_paths:
     with gem5_scons.Configure(env) as conf:
         # On Solaris you need to use libsocket for socket ops
         if not conf.CheckLibWithHeader(
-                [None, 'socket'], 'sys/socket.h', 'C++', 'accept(0,0,0);'):
+                [None, 'socket'], 'sys/socket.h', 'C++',
+                call='accept(0,0,0);'):
            error("Can't find library with socket calls (e.g. accept()).")
 
-        if not conf.CheckLibWithHeader('z', 'zlib.h', 'C++','zlibVersion();'):
+        if not conf.CheckLibWithHeader('z', 'zlib.h', 'C++',
+                                       call='zlibVersion();'):
             error('Did not find needed zlib compression library '
                   'and/or zlib.h header file.\n'
                   'Please install zlib and try again.')
 
-        if not conf.CheckLibWithHeader('zstd', 'zstd.h', 'C++','ZSTD_isError(0);'):
+        if not conf.CheckLibWithHeader('zstd', 'zstd.h', 'C++',
+                                       call='ZSTD_isError(0);'):
             error('Did not find needed zstd compression library '
                   'and/or zstd.h header file.\n'
                   'Please install zstd and try again.')

--- a/src/base/SConsopts
+++ b/src/base/SConsopts
@@ -52,7 +52,7 @@ with gem5_scons.Configure(main) as conf:
 
     conf.env['CONF']['HAVE_POSIX_CLOCK'] = \
         conf.CheckLibWithHeader([None, 'rt'], 'time.h', 'C',
-                                'clock_nanosleep(0,0,NULL,NULL);')
+                                call='clock_nanosleep(0,0,NULL,NULL);')
     if not conf.env['CONF']['HAVE_POSIX_CLOCK']:
         warning("Can't find library for POSIX clocks.")
 

--- a/src/base/stats/SConsopts
+++ b/src/base/stats/SConsopts
@@ -43,9 +43,9 @@ with gem5_scons.Configure(main) as conf:
     # since some installations don't use pkg-config.
     conf.env['CONF']['HAVE_HDF5'] = \
             conf.CheckLibWithHeader('hdf5', 'hdf5.h', 'C',
-                                    'H5Fcreate("", 0, 0, 0);') and \
+                                    call='H5Fcreate("", 0, 0, 0);') and \
             conf.CheckLibWithHeader('hdf5_cpp', 'H5Cpp.h', 'C++',
-                                    'H5::H5File("", 0);')
+                                    call='H5::H5File("", 0);')
 
     if conf.env['CONF']['HAVE_HDF5']:
         conf.env.TagImplies('hdf5', 'gem5 lib')

--- a/src/cpu/kvm/SConsopts
+++ b/src/cpu/kvm/SConsopts
@@ -47,7 +47,7 @@ with gem5_scons.Configure(main) as conf:
         print("Info: Compatible header file <linux/kvm.h> not found, "
               "disabling KVM support.")
     elif not conf.CheckLibWithHeader([None, 'rt'], [ 'time.h', 'signal.h' ],
-            'C', 'timer_create(CLOCK_MONOTONIC, NULL, NULL);'):
+            'C', call='timer_create(CLOCK_MONOTONIC, NULL, NULL);'):
         warning("Cannot enable KVM, host doesn't support POSIX timers")
     elif host_isa == 'x86_64':
         if conf.CheckTypeSize('struct kvm_xsave',

--- a/src/mem/SConsopts
+++ b/src/mem/SConsopts
@@ -33,6 +33,6 @@ import gem5_scons
 with gem5_scons.Configure(main) as conf:
     have_shm_open = \
         conf.CheckLibWithHeader([None, 'rt'], 'sys/mman.h', 'C',
-                                'shm_open("/test", 0, 0);')
+                                call='shm_open("/test", 0, 0);')
     if not have_shm_open:
         warning("Can't find library for sys/mman.")

--- a/src/proto/SConsopts
+++ b/src/proto/SConsopts
@@ -61,7 +61,7 @@ with gem5_scons.Configure(main) as conf:
         (conf.env['HAVE_PKG_CONFIG'] and
          conf.CheckPkgConfig('protobuf', '--cflags', '--libs')) or
         conf.CheckLibWithHeader('protobuf', 'google/protobuf/message.h',
-                                'C++', 'GOOGLE_PROTOBUF_VERIFY_VERSION;'))
+                                'C++', call='GOOGLE_PROTOBUF_VERIFY_VERSION;'))
 
 # If we have the compiler but not the library, print another warning.
 if main['HAVE_PROTOC'] and not main['CONF']['HAVE_PROTOBUF']:

--- a/src/sim/SConsopts
+++ b/src/sim/SConsopts
@@ -31,7 +31,7 @@ import gem5_scons
 
 with gem5_scons.Configure(main) as conf:
     if conf.CheckLibWithHeader([None, 'execinfo'], 'execinfo.h', 'C',
-            'char temp; backtrace_symbols_fd((void *)&temp, 0, 0);'):
+            call='char temp; backtrace_symbols_fd((void *)&temp, 0, 0);'):
         conf.env['BACKTRACE_IMPL'] = 'glibc'
     else:
         conf.env['BACKTRACE_IMPL'] = 'none'


### PR DESCRIPTION
For better compatibility with SCons version 4.9.0 and after.

See also:

* GEM5 upstream repository PR: https://github.com/gem5/gem5/pull/2080
* SCons break change: https://github.com/SCons/scons/pull/4676

Change-Id: I0082f1b12d6afc25e0791673cd8f7d4c400d8644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated build configuration API usage by adopting explicit keyword-based parameter passing for library and header validation checks across multiple components, enhancing code consistency without affecting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->