### PR TITLE
mem: MemRenaming analysis

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -267,6 +267,12 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
                "number cycles where commit BW limit reached"),
       ADD_STAT(loadTriple, statistics::units::Cycle::get(),
                "load trip number"),
+      ADD_STAT(loadEAReused, statistics::units::Cycle::get(),
+               "Committed loads whose EA equals last committed instance of same static load (PC)"),
+      ADD_STAT(loadsWithProducer, statistics::units::Cycle::get(),
+               "store-load related"),
+      ADD_STAT(producerStable, statistics::units::Cycle::get(),
+               "Loads whose producer store PC equals last time for same static load (PC)"),
       ADD_STAT(segUnitStrideNF, statistics::units::Count::get(),
                "Distribution of segment unit stride NF"),
       ADD_STAT(segStrideNF, statistics::units::Count::get(),
@@ -1387,6 +1393,25 @@ Commit::commitInsts()
                     if (hit) {
                         // same PC && same addr && same value
                         stats.loadTriple++;
+                    }
+                    // EA reuse: compare to last committed EA of same static load
+                    auto itEA = lastLoadEA.find(load_pc);
+                    if (itEA != lastLoadEA.end() && itEA->second == load_addr) {
+                        stats.loadEAReused++;
+                    }
+                    lastLoadEA[load_pc] = load_addr;
+                    // Producer stability: only if this load had a forwarding producer
+                    if (head_inst->hasProducerStorePC()) {
+                        stats.loadsWithProducer++;
+                        const Addr prodPC = head_inst->producerStorePC();
+                        auto itP = lastLoadProducerStorePC.find(load_pc);
+                        if (itP != lastLoadProducerStorePC.end() && itP->second == prodPC) {
+                            stats.producerStable++;
+                        }
+                        lastLoadProducerStorePC[load_pc] = prodPC;
+
+                    // optional: clear after use to avoid confusing later stages
+                    head_inst->clearProducerStorePC();
                     }
                 }
 

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -199,6 +199,10 @@ private:
     void processTrapEvent(ThreadID tid);
     LoadTripleCounter loadTripleCounter;
 
+    // --- Maps for "last time" tracking, keyed by static load PC ---
+    std::unordered_map<Addr, Addr> lastLoadEA;
+    std::unordered_map<Addr, Addr> lastLoadProducerStorePC;
+
   public:
     /** Construct a Commit with the given parameters. */
     Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUParams &params);
@@ -609,6 +613,9 @@ private:
         statistics::Scalar commitEligibleSamples;
         /** Number of load get the same pc && addr && value*/
         statistics::Scalar loadTriple;
+        statistics::Scalar loadEAReused;
+        statistics::Scalar loadsWithProducer;
+        statistics::Scalar producerStable;
 
         statistics::Distribution segUnitStrideNF;
         statistics::Distribution segStrideNF;

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -252,6 +252,9 @@ class DynInst : public ExecContext, public RefCounted
     /* replay type of this instruction */
     std::optional<LdStReplayType> replayType;
 
+    bool _hasProducerStorePC = false;
+    Addr _producerStorePC = 0;
+
   protected:
     /** The result of the instruction; assumes an instruction can have many
      *  destination registers.
@@ -381,6 +384,22 @@ class DynInst : public ExecContext, public RefCounted
     {
         uint8_t &byte = _readySrcIdx[idx / 8];
         replaceBits(byte, idx % 8, ready ? 1 : 0);
+    }
+
+    void
+    setProducerStorePC(Addr pc)
+    {
+        _hasProducerStorePC = true;
+        _producerStorePC = pc;
+    }
+
+    bool hasProducerStorePC() const { return _hasProducerStorePC; }
+    Addr producerStorePC() const { return _producerStorePC; }
+
+    void clearProducerStorePC()
+    {
+        _hasProducerStorePC = false;
+        _producerStorePC = 0;
     }
 
     /** The thread this instruction is from. */

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1630,6 +1630,7 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             if (enableStoreSetTrain) {
                 instQueue.violation(inst, violator);
             }
+            violator->setProducerStorePC(inst->pcState().instAddr());
 
             // Squash.
             squashDueToMemOrder(violator, tid);

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -3320,6 +3320,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
 
                 // Don't need to do anything special for split loads.
                 ++stats.forwLoads;
+                load_inst->setProducerStorePC(store_it->instruction()->pcState().instAddr());
 
                 return NoFault;
             } else if (

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1276,6 +1276,7 @@ LSQUnit::loadDoSendRequest(const DynInstPtr &inst)
             auto& store_inst = storePipeSx[1]->insts[i];
             if (pipeLineNukeCheck(inst, store_inst)) {
                 DPRINTF(LoadPipeline, "Load [sn:%llu] Nuke need replay\n", inst->seqNum);
+                inst->setProducerStorePC(store_inst->pcState().instAddr());
                 inst->setNukeReplay();
                 return NoFault;
             }


### PR DESCRIPTION
The number of load instructions whose accessed addresses are the same as in the previous execution.

The number of store–load instruction pairs in which the producer–consumer relationship remains unchanged.

Change-Id: I35352385b57ce09ceb744b9781e5642bac723c2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three performance metrics for load behavior: effective-address reuse, loads seeing a forwarding producer, and producer stability.
  * Propagates producer store information to loads so pipeline stages can record and report producer relationships.

* **Minor Behavior Change**
  * Optionally clears producer information after it’s consumed, slightly altering observable state during commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->