### PR TITLE
base: Remove DPRINTF_UNCONDITIONAL (#1724)

### DIFF
--- a/src/base/trace.hh
+++ b/src/base/trace.hh
@@ -172,7 +172,6 @@ struct StringWrap
  * \def DPRINTFV(x, ...)
  * \def DPRINTFN(...)
  * \def DPRINTFNR(...)
- * \def DPRINTF_UNCONDITIONAL(x, ...) (deprecated)
  *
  * @ingroup api_trace
  * @{
@@ -237,16 +236,6 @@ struct StringWrap
             (::gem5::Tick)-1, "", __VA_ARGS__); \
     }                                                                \
 } while (0)
-
-#define DPRINTF_UNCONDITIONAL(x, ...)                      \
-    GEM5_DEPRECATED_MACRO_STMT(DPRINTF_UNCONDITIONAL,      \
-    do {                                                   \
-        if (TRACING_ON) {                                  \
-            ::gem5::Trace::getDebugLogger()->dprintf_flag(         \
-                ::gem5::curTick(), name(), #x, __VA_ARGS__);       \
-        }                                                  \
-    } while (0),                                           \
-    "Use DPRINTFN or DPRINTF with a debug flag instead.")
 
 /** @} */ // end of api_trace
 

--- a/src/base/trace.test.cc
+++ b/src/base/trace.test.cc
@@ -556,34 +556,6 @@ TEST(TraceTest, MacroDPRINTFNR)
 #endif
 }
 
-/** Test DPRINTF_UNCONDITIONAL with tracing on. */
-TEST(TraceTest, MacroDPRINTF_UNCONDITIONAL)
-{
-    StringWrap name("Foo");
-
-    // Flag enabled
-    Trace::enable();
-    EXPECT_TRUE(debug::changeFlag("TraceTestDebugFlag", true));
-    EXPECT_TRUE(debug::changeFlag("FmtFlag", true));
-    DPRINTF_UNCONDITIONAL(TraceTestDebugFlag, "Test message");
-#if TRACING_ON
-    ASSERT_EQ(getString(Trace::output()),
-        "      0: TraceTestDebugFlag: Foo: Test message");
-#else
-    ASSERT_EQ(getString(Trace::output()), "");
-#endif
-
-    // Flag disabled
-    Trace::disable();
-    EXPECT_TRUE(debug::changeFlag("TraceTestDebugFlag", false));
-    DPRINTF_UNCONDITIONAL(TraceTestDebugFlag, "Test message");
-#if TRACING_ON
-    ASSERT_EQ(getString(Trace::output()), "      0: Foo: Test message");
-#else
-    ASSERT_EQ(getString(Trace::output()), "");
-#endif
-}
-
 /**
  * Test that there is a global name() to fall through when a locally scoped
  * name() is not defined.

--- a/src/cpu/pred/btb/test/test_dprintf.hh
+++ b/src/cpu/pred/btb/test/test_dprintf.hh
@@ -37,10 +37,6 @@ namespace debug {
 #undef DPRINTFNR
 #endif
 
-#ifdef DPRINTF_UNCONDITIONAL
-#undef DPRINTF_UNCONDITIONAL
-#endif
-
 #define DPRINTF_AS_NOP
 
 #if defined(DPRINTF_AS_NOP)
@@ -76,10 +72,6 @@ namespace debug {
 
 #ifndef DPRINTFNR
 #define DPRINTFNR(...) std::printf(__VA_ARGS__)
-#endif
-
-#ifndef DPRINTF_UNCONDITIONAL
-#define DPRINTF_UNCONDITIONAL(x, ...) std::printf(__VA_ARGS__)
 #endif
 
 #endif


### PR DESCRIPTION
This macro has been marked as deprecated since 2021. Wrap its deprecation process up.

Change-Id: I2dac05f7edf915c3d9e6f9b1ec1bfbdadbba8a2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated debug-printing macro from the public API; callers must migrate to the supported debug-print alternatives.
* **Tests**
  * Removed the test that covered the deprecated debug-printing path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->