### PR TITLE
H extention

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -475,6 +475,26 @@ ISA::readMiscReg(int misc_reg)
             DPRINTF(RiscvMisc, "Read IE value: %#lx.\n", ic->readIE());
             return ic->readIE();
         }
+      case MISCREG_MIDELEG:
+        {
+            // Note: old versions of bbl don't like HS_INTERRUPTS on mideleg.
+            // If your bootloader panics, keep this return as-is.
+            auto mideleg_val = readMiscRegNoEffect(MISCREG_MIDELEG);
+            return mideleg_val;
+            // MISA misa = readMiscRegNoEffect(MISCREG_ISA);
+            // return misa.rvh ? mideleg_val | HS_INTERRUPTS : mideleg_val;
+        }
+      case MISCREG_UIE:
+        {
+            RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
+            mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IE) & mask;
+        }
+      case MISCREG_SIE:
+        {
+            RegVal mask = readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IE) & mask;
+        }
       case MISCREG_SEPC:
       case MISCREG_MEPC:
         {

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -484,17 +484,6 @@ ISA::readMiscReg(int misc_reg)
             // MISA misa = readMiscRegNoEffect(MISCREG_ISA);
             // return misa.rvh ? mideleg_val | HS_INTERRUPTS : mideleg_val;
         }
-      case MISCREG_UIE:
-        {
-            RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
-            mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
-            return readMiscReg(MISCREG_IE) & mask;
-        }
-      case MISCREG_SIE:
-        {
-            RegVal mask = readMiscRegNoEffect(MISCREG_MIDELEG);
-            return readMiscReg(MISCREG_IE) & mask;
-        }
       case MISCREG_SEPC:
       case MISCREG_MEPC:
         {

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2042,13 +2042,6 @@ decode QUADRANT {
         }}, IsDirectControl, IsUncondControl);
 
         0x1c: decode FUNCT3 {
-            format LoadH {
-                0x04:  decode HFUNCT2{
-                    0x643: hlvx_hu({{
-                        Rd = Mem_uh;
-                    }},inst_flags = IsHInst);
-                }
-            }
             format SystemOp {
                 0x0: decode FUNCT7 {
                     0x0: decode RS2 {
@@ -2173,17 +2166,15 @@ decode QUADRANT {
 
                      0x11: hfence_vvma({{
                         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
-                        MISA misa = xc->readMiscReg(MISCREG_ISA);
+                        RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-                        if (!misa.rvh) {
+                        if ((misa & ISA_EXT_H_MASK) == 0) {
                             return std::make_shared<IllegalInstFault>(
                                             "hfence needs RVH",
                                             machInst);
                         }
-                        if (isV(xc)) {
-                            return std::make_shared<VirtualInstFault>(
-                                            "hfence with V=1",
-                                            machInst);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            return std::make_shared<HVFault>();
                         }
                         if (pm < PRV_S) {
                             return std::make_shared<IllegalInstFault>(
@@ -2224,17 +2215,15 @@ decode QUADRANT {
                             auto pm = (PrivilegeMode)xc->readMiscReg(
                                                         MISCREG_PRV);
                             STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                            MISA misa = xc->readMiscReg(MISCREG_ISA);
+                            RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-                            if (!misa.rvh) {
+                            if ((misa & ISA_EXT_H_MASK) == 0) {
                                 return std::make_shared<IllegalInstFault>(
                                                 "hfence needs RVH",
                                                 machInst);
                             }
-                            if (isV(xc)) {
-                                return std::make_shared<VirtualInstFault>(
-                                                "hfence with V=1",
-                                                machInst);
+                            if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                                return std::make_shared<HVFault>();
                             }
 
                             if (pm < PRV_S ||

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -773,7 +773,8 @@ decode QUADRANT {
             0x2: decode AMOFUNCT {
                 0x2: LoadReserved::lr_w({{
                     Rd_sd = Mem_sw;
-                }}, inst_flags=IsLoadReserved, mem_flags=LLSC);
+                }}, inst_flags=IsLoadReserved,
+                    mem_flags=[LLSC, 'ARCH_BITS & XlateFlags::LR']);
                 0x3: StoreCond::sc_w({{
                     Mem_uw = Rs2_uw;
                 }}, {{
@@ -846,7 +847,8 @@ decode QUADRANT {
             0x3: decode AMOFUNCT {
                 0x2: LoadReserved::lr_d({{
                     Rd_sd = Mem_sd;
-                }}, mem_flags=LLSC, inst_flags=IsLoadReserved);
+                }}, mem_flags=[LLSC, 'ARCH_BITS & XlateFlags::LR'],
+                    inst_flags=IsLoadReserved);
                 0x3: StoreCond::sc_d({{
                     Mem = Rs2;
                 }}, {{
@@ -2154,6 +2156,49 @@ decode QUADRANT {
                         }
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
                     }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+
+                    0xb: sinval_vvma({{
+                        warn("sinval_vvma not implemented");
+                    }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+
+                    0xc: decode RS2{
+                        0x0: sfence_w_inval({{
+                            warn("sfence_w_inval not implemented");
+                        }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+
+                        0x1: sfence_inval_ir({{
+                            warn("sfence_inval_ir not implemented");
+                        }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+                    }
+
+                     0x11: hfence_vvma({{
+                        auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
+                        MISA misa = xc->readMiscReg(MISCREG_ISA);
+
+                        if (!misa.rvh) {
+                            return std::make_shared<IllegalInstFault>(
+                                            "hfence needs RVH",
+                                            machInst);
+                        }
+                        if (isV(xc)) {
+                            return std::make_shared<VirtualInstFault>(
+                                            "hfence with V=1",
+                                            machInst);
+                        }
+                        if (pm < PRV_S) {
+                            return std::make_shared<IllegalInstFault>(
+                                        "hfence needs at least S priv",
+                                        machInst);
+                        }
+                        xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        return NoFault;
+
+                    }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+
+                    0x13: hinval_vvma({{
+                        warn("hinval_vvma not implemented");
+                    }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+
                     0x18: mret({{
                         if (xc->readMiscReg(MISCREG_PRV) != PRV_M) {
                             return std::make_shared<IllegalInstFault>(
@@ -2174,29 +2219,41 @@ decode QUADRANT {
                             xc->setMiscReg(MISCREG_VIRMODE,status_mpv);
                         }
                     }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
-                    0x31: priv({{
-                        auto pm = (PrivilegeMode)xc->readMiscReg(
-                                MISCREG_PRV);
-                        auto vir = (PrivilegeMode)xc->readMiscReg(
-                                MISCREG_VIRMODE);
-                        STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                        xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                    0x31: decode FUNCT3 {
+                        0x0: hfence_gvma({{
+                            auto pm = (PrivilegeMode)xc->readMiscReg(
+                                                        MISCREG_PRV);
+                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                            MISA misa = xc->readMiscReg(MISCREG_ISA);
 
-                        if(vir){
-                            panic("add priv vir code\n");
+                            if (!misa.rvh) {
+                                return std::make_shared<IllegalInstFault>(
+                                                "hfence needs RVH",
+                                                machInst);
+                            }
+                            if (isV(xc)) {
+                                return std::make_shared<VirtualInstFault>(
+                                                "hfence with V=1",
+                                                machInst);
+                            }
 
-                        }
-                        if(pm == PRV_U){
-                            return std::make_shared<IllegalInstFault>(
-                                        "h-priv pm == prv_u", machInst);
+                            if (pm < PRV_S ||
+                                (pm == PRV_S && status.tvm == 1)) {
+                                return std::make_shared<IllegalInstFault>(
+                                            "hfence in U or TVM on",
+                                            machInst);
+                            }
+                            xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                            return NoFault;
 
-                        }
-                        if(!(pm == PRV_M ||(pm == PRV_S && !vir && status.tvm ==0))){
-                            return std::make_shared<IllegalInstFault>(
-                                        "h-priv pm == prv_u", machInst);
+                        }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+                    }
 
-                        }
-                    }},IsNonSpeculative, IsSerializeAfter, No_OpClass);
+                    0x33: decode FUNCT3 {
+                        0x0: hinval_gvma({{
+                            warn("hinval_gvma unimplemented");
+                        }}, IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                    }
                 }
             }
             format CSROp {
@@ -2345,6 +2402,82 @@ decode QUADRANT {
                         write = uimm != 0;
                     }}, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 }
+
+            }
+            0x4: decode FUNCT7{
+                0x30: decode RS2 {
+                    0x0: HyperLoad::hlv_b({{
+                        Rd_sd = Mem_sb;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                    0x1: HyperLoad::hlv_bu({{
+                        Rd = Mem_ub;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                }
+                0x31: HyperStore::hsv_b({{
+                    Mem_ub = Rs2_ub;
+                }}, mem_flags=[
+                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                ]);
+                0x32: decode RS2 {
+                    0x0: HyperLoad::hlv_h({{
+                        Rd_sd = Mem_sh;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                    0x1: HyperLoad::hlv_hu({{
+                        Rd = Mem_uh;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                    0x3: HyperLoad::hlvx_hu({{
+                        Rd = Mem_uh;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT',
+                        'ARCH_BITS & XlateFlags::HLVX'
+                    ]);
+                }
+                0x33: HyperStore::hsv_h({{
+                        Mem_uh = Rs2_uh
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                0x34: decode RS2 {
+                    0x0: HyperLoad::hlv_w({{
+                        Rd_sd = Mem_sw;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                    0x1: HyperLoad::hlv_wu({{
+                        Rd = Mem_uw;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                    ]);
+                    0x3: HyperLoad::hlvx_wu({{
+                        Rd = Mem_uw;
+                    }}, mem_flags=[
+                        'ARCH_BITS & XlateFlags::FORCE_VIRT',
+                        'ARCH_BITS & XlateFlags::HLVX'
+                    ]);
+                }
+                0x35: HyperStore::hsv_w({{
+                    Mem_uw = Rs2_uw;
+                }}, mem_flags=[
+                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                ]);
+                0x36: HyperLoad::hlv_d({{
+                    Rd_sd = Mem_sd;
+                }}, mem_flags=[
+                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                ]);
+                0x37: HyperStore::hsv_d({{
+                    Mem_ud = Rs2_ud;
+                }}, mem_flags=[
+                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
+                ]);
 
             }
         }

--- a/src/arch/riscv/isa/formats/amo.isa
+++ b/src/arch/riscv/isa/formats/amo.isa
@@ -564,7 +564,6 @@ def format AtomicMemOp(memacc_code, amoop_code, postacc_code={{ }},
                              'postacc_code': postacc_code,
                              'amoop_code': amoop_code},
                             rmw_inst_flags)
-
     rmw_iop.constructor += '\n\tmemAccessFlags = memAccessFlags | ' + \
           '|'.join(['Request::%s' % flag for flag in rmw_mem_flags]) + ';'
 

--- a/src/arch/riscv/isa/formats/amo.isa
+++ b/src/arch/riscv/isa/formats/amo.isa
@@ -505,8 +505,9 @@ def format LoadReserved(memacc_code, postacc_code={{ }}, ea_code={{EA = Rs1;}},
     iop = InstObjParams(name, Name, 'LoadReservedMicro',
         {'ea_code': ea_code, 'memacc_code': memacc_code,
         'postacc_code': postacc_code}, inst_flags)
+    mem_flags = ['(Request::%s)' % flag for flag in mem_flags]
     iop.constructor += '\n\tmemAccessFlags = memAccessFlags | ' + \
-        '|'.join(['Request::%s' % flag for flag in mem_flags]) + ';'
+        '|'.join(mem_flags) + ';'
 
     header_output += LRSCMicroDeclare.subst(iop)
     decoder_output += LRSCMicroConstructor.subst(iop)
@@ -533,8 +534,9 @@ def format StoreCond(memacc_code, postacc_code={{ }}, ea_code={{EA = Rs1;}},
     iop = InstObjParams(name, Name, 'StoreCondMicro',
         {'ea_code': ea_code, 'memacc_code': memacc_code,
         'postacc_code': postacc_code}, inst_flags)
+    mem_flags = ['(Request::%s)' % flag for flag in mem_flags]
     iop.constructor += '\n\tmemAccessFlags = memAccessFlags | ' + \
-        '|'.join(['Request::%s' % flag for flag in mem_flags]) + ';'
+        '|'.join(mem_flags) + ';'
 
     header_output += LRSCMicroDeclare.subst(iop)
     decoder_output += LRSCMicroConstructor.subst(iop)
@@ -564,8 +566,9 @@ def format AtomicMemOp(memacc_code, amoop_code, postacc_code={{ }},
                              'postacc_code': postacc_code,
                              'amoop_code': amoop_code},
                             rmw_inst_flags)
+    rmw_mem_flags = ['(Request::%s)' % flag for flag in rmw_mem_flags]
     rmw_iop.constructor += '\n\tmemAccessFlags = memAccessFlags | ' + \
-          '|'.join(['Request::%s' % flag for flag in rmw_mem_flags]) + ';'
+          '|'.join(rmw_mem_flags) + ';'
 
     header_output += AtomicMemOpRMWDeclare.subst(rmw_iop)
     decoder_output += AtomicMemOpRMWConstructor.subst(rmw_iop)

--- a/src/arch/riscv/isa/formats/mem.isa
+++ b/src/arch/riscv/isa/formats/mem.isa
@@ -75,7 +75,9 @@ def LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
          'memacc_code': memacc_code, 'postacc_code': postacc_code },
         inst_flags)
     if mem_flags:
-        mem_flags = [ 'Request::%s' % flag for flag in mem_flags ]
+        # Wrap each flag so expressions like `ARCH_BITS & XlateFlags::FOO`
+        # don't trigger -Wparentheses when combined with '|'.
+        mem_flags = [ '(Request::%s)' % flag for flag in mem_flags ]
         s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
         iop.constructor += s
 
@@ -230,16 +232,15 @@ def template HyperLoadExecute {{
 
         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
         HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
-        MISA misa = xc->readMiscReg(MISCREG_ISA);
+        RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-        if (!misa.rvh) {
+        if ((misa & ISA_EXT_H_MASK) == 0) {
             return std::make_shared<IllegalInstFault>(
                 "HyperLoad without RVH", machInst);
         }
 
-        if (isV(xc)) {
-            return std::make_shared<VirtualInstFault>(
-                "HyperLoad with V-bit on", machInst);
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            return std::make_shared<HVFault>();
         }
 
         if (pm == PRV_U && hstatus.hu == 0) {
@@ -275,16 +276,15 @@ def template HyperLoadInitiateAcc {{
 
         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
         HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
-        MISA misa = xc->readMiscReg(MISCREG_ISA);
+        RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-        if (!misa.rvh) {
+        if ((misa & ISA_EXT_H_MASK) == 0) {
             return std::make_shared<IllegalInstFault>(
                 "HyperLoad without RVH", machInst);
         }
 
-        if (isV(xc)) {
-            return std::make_shared<VirtualInstFault>(
-                "HyperLoad with V-bit on", machInst);
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            return std::make_shared<HVFault>();
         }
 
         if (pm == PRV_U && hstatus.hu == 0) {
@@ -328,16 +328,15 @@ def template HyperStoreExecute {{
 
         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
         HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
-        MISA misa = xc->readMiscReg(MISCREG_ISA);
+        RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-        if (!misa.rvh) {
+        if ((misa & ISA_EXT_H_MASK) == 0) {
             return std::make_shared<IllegalInstFault>(
                 "HyperStore without RVH", machInst);
         }
 
-        if (isV(xc)) {
-            return std::make_shared<VirtualInstFault>(
-                "HyperStore with V-bit on", machInst);
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            return std::make_shared<HVFault>();
         }
 
         if (pm == PRV_U && hstatus.hu == 0) {
@@ -375,16 +374,15 @@ def template HyperStoreInitiateAcc {{
 
         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
         HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
-        MISA misa = xc->readMiscReg(MISCREG_ISA);
+        RegVal misa = xc->readMiscReg(MISCREG_ISA);
 
-        if (!misa.rvh) {
+        if ((misa & ISA_EXT_H_MASK) == 0) {
             return std::make_shared<IllegalInstFault>(
                 "HyperStore without RVH", machInst);
         }
 
-        if (isV(xc)) {
-            return std::make_shared<VirtualInstFault>(
-                "HyperStore with V-bit on", machInst);
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            return std::make_shared<HVFault>();
         }
 
         if (pm == PRV_U && hstatus.hu == 0) {

--- a/src/arch/riscv/isa/formats/mem.isa
+++ b/src/arch/riscv/isa/formats/mem.isa
@@ -74,7 +74,6 @@ def LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
         {'offset_code': offset_code, 'ea_code': ea_code,
          'memacc_code': memacc_code, 'postacc_code': postacc_code },
         inst_flags)
-
     if mem_flags:
         mem_flags = [ 'Request::%s' % flag for flag in mem_flags ]
         s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
@@ -216,6 +215,208 @@ def template StoreCompleteAcc {{
     }
 }};
 
+// H-extension formats execution templates
+
+def template HyperLoadExecute {{
+    Fault
+    %(class_name)s::execute(
+        ExecContext *xc, Trace::InstRecord *traceData) const
+    {
+        Addr EA;
+
+        %(op_decl)s;
+        %(op_rd)s;
+        %(ea_code)s;
+
+        auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
+        HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+        MISA misa = xc->readMiscReg(MISCREG_ISA);
+
+        if (!misa.rvh) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperLoad without RVH", machInst);
+        }
+
+        if (isV(xc)) {
+            return std::make_shared<VirtualInstFault>(
+                "HyperLoad with V-bit on", machInst);
+        }
+
+        if (pm == PRV_U && hstatus.hu == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperLoad in PRV_U with hstatus.hu == 0", machInst);
+        }
+
+        {
+            Fault fault =
+                readMemAtomicLE(xc, traceData, EA, Mem, memAccessFlags);
+            if (fault != NoFault)
+                return fault;
+        }
+
+        %(memacc_code)s;
+
+        %(op_wb)s;
+
+        return NoFault;
+    }
+}};
+
+def template HyperLoadInitiateAcc {{
+    Fault
+    %(class_name)s::initiateAcc(ExecContext *xc,
+        Trace::InstRecord *traceData) const
+    {
+        Addr EA;
+
+        %(op_src_decl)s;
+        %(op_rd)s;
+        %(ea_code)s;
+
+        auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
+        HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+        MISA misa = xc->readMiscReg(MISCREG_ISA);
+
+        if (!misa.rvh) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperLoad without RVH", machInst);
+        }
+
+        if (isV(xc)) {
+            return std::make_shared<VirtualInstFault>(
+                "HyperLoad with V-bit on", machInst);
+        }
+
+        if (pm == PRV_U && hstatus.hu == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperLoad in PRV_U with hstatus.hu == 0", machInst);
+        }
+
+        return initiateMemRead(xc, traceData, EA, Mem, memAccessFlags);
+    }
+}};
+
+def template HyperLoadCompleteAcc {{
+    Fault
+    %(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
+        Trace::InstRecord *traceData) const
+    {
+        %(op_decl)s;
+        %(op_rd)s;
+
+        getMemLE(pkt, Mem, traceData);
+
+        %(memacc_code)s;
+        %(op_wb)s;
+
+        return NoFault;
+    }
+}};
+
+def template HyperStoreExecute {{
+    Fault
+    %(class_name)s::execute(ExecContext *xc,
+        Trace::InstRecord *traceData) const
+    {
+        Addr EA;
+
+        %(op_decl)s;
+        %(op_rd)s;
+        %(ea_code)s;
+
+        %(memacc_code)s;
+
+        auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
+        HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+        MISA misa = xc->readMiscReg(MISCREG_ISA);
+
+        if (!misa.rvh) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperStore without RVH", machInst);
+        }
+
+        if (isV(xc)) {
+            return std::make_shared<VirtualInstFault>(
+                "HyperStore with V-bit on", machInst);
+        }
+
+        if (pm == PRV_U && hstatus.hu == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperStore in PRV_U with hstatus.hu == 0", machInst);
+        }
+
+        {
+            Fault fault =
+                writeMemAtomicLE(xc, traceData, Mem, EA, memAccessFlags,
+                        nullptr);
+            if (fault != NoFault)
+                return fault;
+        }
+
+        %(postacc_code)s;
+        %(op_wb)s;
+
+        return NoFault;
+    }
+}};
+
+def template HyperStoreInitiateAcc {{
+    Fault
+    %(class_name)s::initiateAcc(ExecContext *xc,
+        Trace::InstRecord *traceData) const
+    {
+        Addr EA;
+
+        %(op_decl)s;
+        %(op_rd)s;
+        %(ea_code)s;
+
+        %(memacc_code)s;
+
+        auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
+        HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+        MISA misa = xc->readMiscReg(MISCREG_ISA);
+
+        if (!misa.rvh) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperStore without RVH", machInst);
+        }
+
+        if (isV(xc)) {
+            return std::make_shared<VirtualInstFault>(
+                "HyperStore with V-bit on", machInst);
+        }
+
+        if (pm == PRV_U && hstatus.hu == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "HyperStore in PRV_U with hstatus.hu == 0", machInst);
+        }
+
+        {
+            Fault fault = writeMemTimingLE(xc, traceData, Mem, EA,
+                memAccessFlags, nullptr);
+            if (fault != NoFault)
+                return fault;
+        }
+
+        %(op_wb)s;
+
+        return NoFault;
+    }
+}};
+
+def template HyperStoreCompleteAcc {{
+    Fault
+    %(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
+        Trace::InstRecord *traceData) const
+    {
+        return NoFault;
+    }
+}};
+
+
+// Format definitions
+
 def format Load(memacc_code, ea_code = {{EA = Rs1 + offset;}},
         offset_code={{offset = sext<12>(IMM12);}},
         mem_flags=[], inst_flags=[]) {{
@@ -238,4 +439,22 @@ def format LoadH(memacc_code, ea_code = {{EA = Rs1;}},
     (header_output, decoder_output, decode_block, exec_output) = \
         LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
         inst_flags, 'Load', exec_template_base='Load')
+}};
+
+// H-extension formats
+
+def format HyperLoad(memacc_code, ea_code = {{EA = Rs1 + offset;}},
+        offset_code={{offset = 0;}},
+        mem_flags=[], inst_flags=[]) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
+        inst_flags, 'Load', exec_template_base='HyperLoad')
+}};
+
+def format HyperStore(memacc_code, ea_code={{EA = Rs1 + offset;}},
+        offset_code={{offset = 0;}},
+        mem_flags=[], inst_flags=[]) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
+        inst_flags, 'Store', exec_template_base='HyperStore')
 }};

--- a/src/arch/riscv/isa/includes.isa
+++ b/src/arch/riscv/isa/includes.isa
@@ -75,6 +75,7 @@ output decoder {{
 
 #include "arch/riscv/decoder.hh"
 #include "arch/riscv/faults.hh"
+#include "arch/riscv/memflags.hh"
 #include "arch/riscv/mmu.hh"
 #include "arch/riscv/regs/float.hh"
 #include "base/cprintf.hh"

--- a/src/arch/riscv/isa/includes.isa
+++ b/src/arch/riscv/isa/includes.isa
@@ -78,6 +78,7 @@ output decoder {{
 #include "arch/riscv/memflags.hh"
 #include "arch/riscv/mmu.hh"
 #include "arch/riscv/regs/float.hh"
+#include "arch/riscv/regs/misc.hh"
 #include "base/cprintf.hh"
 #include "base/loader/symtab.hh"
 #include "cpu/thread_context.hh"

--- a/src/arch/riscv/isa/vector/base/vector_mem.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.isa
@@ -134,7 +134,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
         inst_flags)
 
     if mem_flags:
-        mem_flags = [ 'Request::%s' % flag for flag in mem_flags ]
+        mem_flags = [ '(Request::%s)' % flag for flag in mem_flags ]
         s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
         microiop.constructor += s
 

--- a/src/arch/riscv/memflags.hh
+++ b/src/arch/riscv/memflags.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * This file provides RISC-V-specific request flag bits which live in
+ * Request::ARCH_BITS (the low 8 bits of Request::FlagsType).
+ */
+
+#ifndef __ARCH_RISCV_MEMFLAGS_HH__
+#define __ARCH_RISCV_MEMFLAGS_HH__
+
+#include "mem/request.hh"
+
+namespace gem5
+{
+
+namespace RiscvISA
+{
+
+namespace XlateFlags
+{
+
+// Force the RISC-V MMU to perform (guest) virtual address translation even when
+// the current V bit is off (used by H-extension hypervisor load/store).
+constexpr Request::FlagsType FORCE_VIRT = 1u << 0;
+
+// For HLVX.* instructions: treat the access as "execute-permission checked"
+// without changing the fault type (it is still a load).
+constexpr Request::FlagsType HLVX = 1u << 1;
+
+// Mark a load-reserved request (LR.*). This is carried through Request::ARCH_BITS
+// for RISC-V-specific translation/permission handling when needed.
+constexpr Request::FlagsType LR = 1u << 2;
+
+static_assert((FORCE_VIRT | HLVX | LR) <= Request::ARCH_BITS,
+              "RISC-V XlateFlags must fit in Request::ARCH_BITS");
+
+} // namespace XlateFlags
+
+} // namespace RiscvISA
+
+} // namespace gem5
+
+#endif // __ARCH_RISCV_MEMFLAGS_HH__
+

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -164,6 +164,10 @@ BitUnion64(PTESv48)
 EndBitUnion(PTESv48)
 
 BitUnion64(PTE)
+    // Svpbmt/Svnapot (if unsupported/disabled these bits must be zero, else PF)
+    Bitfield<63> n;
+    Bitfield<62, 61> pbmt;
+    Bitfield<60, 54> reserved;
     Bitfield<53, 10> ppn;
     Bitfield<53, 46> ppn4;
     Bitfield<45, 37> ppn3;

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -55,6 +55,7 @@
 #include <numeric>
 
 #include "arch/riscv/faults.hh"
+#include "arch/riscv/memflags.hh"
 #include "arch/riscv/page_size.hh"
 #include "arch/riscv/pagetable.hh"
 #include "arch/riscv/tlb.hh"
@@ -295,7 +296,9 @@ Walker::WalkerState::initState(ThreadContext *_tc, const RequestPtr &_req, BaseM
         fromBackPre = false;
         translateMode = twoStageMode;
         hgatp = _tc->readMiscReg(MISCREG_HGATP);
-        isHInst = _req->get_h_inst();
+        isHInst = (_req->getFlags() &
+                      (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                  _req->get_h_inst();
         isVsatp0Mode = _req->get_vsatp_0_mode();
         virt = _req->get_virt();
         GstageFault = false;
@@ -694,10 +697,12 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
         } else if (!pte.u) {
             endWalk();
             return endGstageWalk();
-        } else if (((mode == BaseMMU::Execute) || isHInst) && (!pte.x)) {
+        } else if (((mode == BaseMMU::Execute) ||
+                    (mode == BaseMMU::Read && isHInst)) && (!pte.x)) {
             endWalk();
             return endGstageWalk();
-        } else if ((mode == BaseMMU::Read) && (!pte.r && !(status.mxr && pte.x))) {
+        } else if ((mode == BaseMMU::Read) && !isHInst &&
+                   (!pte.r && !(status.mxr && pte.x))) {
             endWalk();
             return endGstageWalk();
         } else if ((mode == BaseMMU::Write) && !(pte.r && pte.w)) {
@@ -907,9 +912,11 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
             if (pte.r || pte.x) {
                 doEndWalk = true;
                 if (virt) {
-                    fault = walker->tlb->checkPermissions(vsstatus, pmode, entry.vaddr, mode, pte, 0, false);
+                    fault = walker->tlb->checkPermissions(vsstatus, pmode, entry.vaddr, mode, pte, 0, false,
+                                                          isHInst);
                 } else {
-                    fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false);
+                    fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false,
+                                                          isHInst);
                 }
 
                 if (fault == NoFault) {
@@ -1171,7 +1178,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
             if (pte.r || pte.x) {
                 // step 5: leaf PTE
                 doEndWalk = true;
-                fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false);
+                fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false,
+                                                      isHInst);
                 // step 6
                 if (fault == NoFault) {
                     if (level >= 1 && pte.ppn0 != 0) {

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -78,6 +78,31 @@ namespace gem5
 
 namespace RiscvISA {
 
+namespace
+{
+
+// Svpbmt uses PTE.PBMT, enabled by *envcfg.PBMTE. When PBMTE=0, any non-zero
+// PBMT is reserved and must raise a page fault (this is exercised by pbmt
+// tests).
+constexpr int PbmteBit = 62;
+
+inline bool
+pbmtEnabled(ThreadContext *tc, bool twoStage)
+{
+    if (!tc)
+        return false;
+
+    // This fork doesn't fully model all envcfg interactions; be conservative
+    // and accept PBMTE from either menvcfg/henvcfg depending on context.
+    const RegVal menvcfg = tc->readMiscRegNoEffect(MISCREG_MENVCFG);
+    const RegVal henvcfg = tc->readMiscRegNoEffect(MISCREG_HENVCFG);
+
+    return bits(twoStage ? henvcfg : menvcfg, PbmteBit, PbmteBit) ||
+           bits(twoStage ? menvcfg : henvcfg, PbmteBit, PbmteBit);
+}
+
+} // anonymous namespace
+
 std::pair<bool, Fault>
 Walker::tryCoalesce(ThreadContext *_tc, BaseMMU::Translation *translation,
                     const RequestPtr &req, BaseMMU::Mode mode, bool from_l2tlb,
@@ -641,6 +666,9 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
 
     if (fault == NoFault) {
         if (pte.v && !pte.r && !pte.w && !pte.x) {
+            // Reserved/unsupported encodings in G-stage non-leaf PTE.
+            if (pte.reserved || pte.n || pte.pbmt)
+                return endGstageWalk();
             twoStageLevel--;
             if (twoStageLevel < 0) {
                 endWalk();
@@ -714,6 +742,12 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
             inGstage = false;
             doEndWalk = true;
             doLLwalk = true;
+
+            // Reserved/unsupported encodings in G-stage leaf PTE.
+            if (pte.reserved || pte.n || (pte.pbmt == 0x3) ||
+                (pte.pbmt && !pbmtEnabled(requestors.front().tc, /*twoStage*/true)))
+                return endGstageWalk();
+
             entry.gpaddr = gPaddr;
             entry.pte = pte;
             entry.logBytes = PageShift + (twoStageLevel * LEVEL_BITS);
@@ -911,11 +945,23 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
         } else {
             if (pte.r || pte.x) {
                 doEndWalk = true;
+
+                // Reserved/unsupported encodings in VS-stage leaf PTE.
+                if (pte.reserved || pte.n || (pte.pbmt == 0x3) ||
+                    (pte.pbmt && !pbmtEnabled(requestors.front().tc, /*twoStage*/true))) {
+                    GstageFault = false;
+                    fault = pageFault(true, false);
+                    endWalk();
+                    return fault;
+                }
+
                 if (virt) {
-                    fault = walker->tlb->checkPermissions(vsstatus, pmode, entry.vaddr, mode, pte, 0, false,
+                    fault = walker->tlb->checkPermissions(requestors.front().tc, vsstatus, pmode, entry.vaddr,
+                                                          mode, pte, 0, false,
                                                           isHInst);
                 } else {
-                    fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false,
+                    fault = walker->tlb->checkPermissions(requestors.front().tc, status, pmode, entry.vaddr,
+                                                          mode, pte, 0, false,
                                                           isHInst);
                 }
 
@@ -1020,6 +1066,13 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
                 }
 
             } else {
+                // Reserved/unsupported encodings in VS-stage non-leaf PTE.
+                if (pte.reserved || pte.n || pte.pbmt) {
+                    GstageFault = false;
+                    fault = pageFault(true, false);
+                    endWalk();
+                    return fault;
+                }
                 level--;
                 if (level < 0) {
                     doEndWalk = true;
@@ -1178,8 +1231,15 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
             if (pte.r || pte.x) {
                 // step 5: leaf PTE
                 doEndWalk = true;
-                fault = walker->tlb->checkPermissions(status, pmode, entry.vaddr, mode, pte, 0, false,
-                                                      isHInst);
+                // Reserved/unsupported encodings in leaf PTE.
+                if (pte.reserved || pte.n || (pte.pbmt == 0x3) ||
+                    (pte.pbmt && !pbmtEnabled(requestors.front().tc, /*twoStage*/false))) {
+                    fault = pageFault(true, false);
+                } else {
+                    fault = walker->tlb->checkPermissions(requestors.front().tc, status, pmode, entry.vaddr,
+                                                          mode, pte, 0, false,
+                                                          isHInst);
+                }
                 // step 6
                 if (fault == NoFault) {
                     if (level >= 1 && pte.ppn0 != 0) {
@@ -1244,6 +1304,13 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                     }
                 }
             } else {
+                // Reserved/unsupported encodings in non-leaf PTE.
+                if (pte.reserved || pte.n || pte.pbmt) {
+                    doEndWalk = true;
+                    fault = pageFault(true, false);
+                    endWalk();
+                    return fault;
+                }
                 level--;
                 if (level < 0) {
                     DPRINTF(PageTableWalker3,
@@ -1617,8 +1684,13 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
     Addr topAddr;
     int top_level;
     if (translateMode == twoStageMode) {
-        panic_if(vsatp.mode == AddrXlateMode::BARE, "should be processed in isVsatpOMode.");
-        top_level = PTW_TOP_LEVEL(vsatp.mode);
+        // When VS-stage translation is disabled (vsatp.mode == BARE),
+        // we should skip the VS-stage page-table walk and treat the guest
+        // virtual address as the guest physical address (handled via
+        // isVsatp0Mode below).
+        panic_if(vsatp.mode == AddrXlateMode::BARE && !isVsatp0Mode,
+                 "vsatp.mode == AddrXlateMode::BARE should be processed in isVsatp0Mode.");
+        top_level = isVsatp0Mode ? 0 : PTW_TOP_LEVEL(vsatp.mode);
     } else {
         top_level = satp.mode == AddrXlateMode::SV48 ? 3: 2;
     }

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "arch/riscv/faults.hh"
+#include "arch/riscv/memflags.hh"
 #include "arch/riscv/mmu.hh"
 #include "arch/riscv/page_size.hh"
 #include "arch/riscv/pagetable.hh"
@@ -1112,15 +1113,19 @@ TLB::l2TLBRemove(size_t idx, int choose)
 
 Fault
 TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
-                      BaseMMU::Mode mode, PTE pte,Addr gpaddr,bool G)
+                      BaseMMU::Mode mode, PTE pte, Addr gpaddr, bool G,
+                      bool hlvx)
 {
     Fault fault = NoFault;
 
-    if (mode == BaseMMU::Read && !pte.r) {
+    const bool exec_like = (mode == BaseMMU::Execute) ||
+        (mode == BaseMMU::Read && hlvx);
+
+    if (exec_like && !pte.x) {
+        fault = createPagefault(vaddr, gpaddr, mode, G);
+    } else if (!exec_like && mode == BaseMMU::Read && !pte.r) {
         fault = createPagefault(vaddr, gpaddr, mode, G);
     } else if (mode == BaseMMU::Write && !pte.w) {
-        fault = createPagefault(vaddr, gpaddr, mode, G);
-    } else if (mode == BaseMMU::Execute && !pte.x) {
         fault = createPagefault(vaddr, gpaddr, mode, G);
     }
 
@@ -1136,17 +1141,23 @@ TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
 }
 
 std::pair<bool, Fault>
-TLB::checkGPermissions(STATUS status,Addr vaddr,Addr gpaddr,BaseMMU::Mode mode, PTE pte,bool h_inst){
+TLB::checkGPermissions(STATUS status, Addr vaddr, Addr gpaddr,
+                       BaseMMU::Mode mode, PTE pte, bool hlvx)
+{
     bool continuePtw = false;
+    const bool exec_like = (mode == BaseMMU::Execute) ||
+        (mode == BaseMMU::Read && hlvx);
+
     if (pte.v && !pte.r && !pte.w && !pte.x) {
         return std::make_pair(true,NoFault);
     } else if (!pte.v || (!pte.r && pte.w)) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
     } else if (!pte.u) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
-    } else if (((mode == BaseMMU::Execute) || (h_inst)) && (!pte.x)) {
+    } else if (exec_like && (!pte.x)) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
-    } else if ((mode == BaseMMU::Read) && (!pte.r && !(status.mxr && pte.x))) {
+    } else if ((mode == BaseMMU::Read) && !hlvx &&
+               (!pte.r && !(status.mxr && pte.x))) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
     } else if ((mode == BaseMMU::Write) && !(pte.r && pte.w)) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
@@ -1234,7 +1245,10 @@ TLB::L2TLBCheck(PTE pte, int level, STATUS status, PrivilegeMode pmode, Addr vad
     } else {
         if (pte.r || pte.x) {
             hitInSp = true;
-            fault = checkPermissions(status, pmode, vaddr, mode, pte, 0, false);
+            fault = checkPermissions(status, pmode, vaddr, mode, pte, 0, false,
+                (req->getFlags() &
+                    (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                    req->get_h_inst());
             if (fault == NoFault) {
                 if (level >= L2L1CheckLevel && pte.ppn0 != 0) {
                     fault = L2TLBPagefault(vaddr, mode, req, isPre, is_back_pre);
@@ -1392,14 +1406,22 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             }
-            fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pteVS, 0, false);
+            fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pteVS, 0,
+                false,
+                (req->getFlags() &
+                    (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                    req->get_h_inst());
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             }
         }
         Addr fault_gpaddr = ((e[0]->gpaddr >> 12) << 12) | (vaddr & 0xfff);
 
-        std::pair(continuePtw,fault) = checkGPermissions(status,vaddr,fault_gpaddr,mode,e[0]->pte,req->get_h_inst());
+        std::pair(continuePtw,fault) = checkGPermissions(status, vaddr,
+            fault_gpaddr, mode, e[0]->pte,
+            (req->getFlags() &
+                (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                req->get_h_inst());
         if (fault != NoFault) {
             return std::make_pair(hit_type, fault);
         }
@@ -1435,7 +1457,11 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 //return fault;
                 return std::make_pair(hit_type,fault);
             } else {
-                fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0, false);
+                fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0,
+                    false,
+                    (req->getFlags() &
+                        (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                        req->get_h_inst());
                 if (fault != NoFault) {
                     return std::make_pair(hit_type, fault);
                 }
@@ -1451,7 +1477,10 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 hit_type = h_l1GstageHit;
                 DPRINTF(TLB, "l1tlb hit in Gstage: level %d, ppn %#x\n", e[0]->level, e[0]->pte.ppn);
                 std::pair(continuePtw, fault) =
-                    checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                    checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte,
+                        (req->getFlags() &
+                            (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                            req->get_h_inst());
                 if (e[0]->level >0){
                     pg_mask = (1ULL << (12 + 9 * e[0]->level)) - 1;
                     pgBase = ((e[0]->pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
@@ -1541,7 +1570,10 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
             e_l2tlbGstage = e[0];
             gPaddr = req->getgPaddr();
             std::pair<bool, Fault> result =
-                checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte,
+                    (req->getFlags() &
+                        (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                        req->get_h_inst());
             continuePtw = result.first;
             fault = result.second;
             DPRINTF(TLB, "l2tlb hit in Gstage: "
@@ -1655,7 +1687,11 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     e_l2tlbGstage = e[0];
                     twoStageLevel = e[0]->level;
                     req->setgPaddr(gPaddr);
-                    auto check_res = checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                    auto check_res = checkGPermissions(status, vaddr, gPaddr,
+                        mode, e[0]->pte,
+                        (req->getFlags() &
+                            (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                            req->get_h_inst());
                     continuePtw = check_res.first;
                     fault = check_res.second;
                     DPRINTF(TLB, "found pte for gPaddr: %#x in Gstage -> "
@@ -1759,7 +1795,9 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
             virt = status.mpv && (two_stage_pmode != PrivilegeMode::PRV_M);
         }
 
-        if (req->get_h_inst()) {
+        bool force_virt =
+            req->getFlags() & (Request::ARCH_BITS & XlateFlags::FORCE_VIRT);
+        if (force_virt || req->get_h_inst()) {
             virt = 1;
             two_stage_pmode = (PrivilegeMode)(RegVal)hstatus.spvp;
         }
@@ -2063,7 +2101,10 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         DPRINTF(TLB, "final checkpermission\n");
         DPRINTF(TLB, "translate(vpn=%#x, asid=%#x): %#x pc %#x mode %i pte.d %d\n", vaddr, satp.asid, paddr,
                 req->getPC(), mode, e[0]->pte.d);
-        fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0, false);
+        fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0, false,
+            (req->getFlags() &
+                (Request::ARCH_BITS & XlateFlags::HLVX)) ||
+                req->get_h_inst());
     }
 
 
@@ -2139,7 +2180,10 @@ TLB::hasTwoStageTranslation(ThreadContext *tc, const RequestPtr &req, BaseMMU::M
 {
     STATUS status = (STATUS)tc->readMiscReg(MISCREG_STATUS);
     int v_mode = tc->readMiscReg(MISCREG_VIRMODE);
-    return (req->get_h_inst()) || (status.mprv && status.mpv) || v_mode;
+    bool force_virt =
+        req->getFlags() & (Request::ARCH_BITS & XlateFlags::FORCE_VIRT);
+    return force_virt || req->get_h_inst() || (status.mprv && status.mpv) ||
+        v_mode;
 }
 
 MMUMode
@@ -2304,7 +2348,9 @@ TLB::configVmodeInTLB(const RequestPtr &req, ThreadContext *tc,
             v_mode = status.mpv && (two_stage_pmode != PrivilegeMode::PRV_M);
         }
 
-        if (req->get_h_inst()) {
+        bool force_virt =
+            req->getFlags() & (Request::ARCH_BITS & XlateFlags::FORCE_VIRT);
+        if (force_virt || req->get_h_inst()) {
             v_mode = 1;
             two_stage_pmode = (PrivilegeMode)(RegVal)hstatus.spvp;
         }

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -75,6 +75,37 @@ using namespace RiscvISA;
 //  RISC-V TLB
 //
 
+namespace
+{
+
+// Svpbmt uses PTE.PBMT, enabled by *envcfg.PBMTE.
+constexpr int PbmteBit = 62;
+
+inline bool
+pbmtEnabled(ThreadContext *tc)
+{
+    if (!tc)
+        return false;
+
+    const RegVal menvcfg = tc->readMiscRegNoEffect(MISCREG_MENVCFG);
+    const RegVal henvcfg = tc->readMiscRegNoEffect(MISCREG_HENVCFG);
+    return bits(menvcfg, PbmteBit, PbmteBit) || bits(henvcfg, PbmteBit, PbmteBit);
+}
+
+inline bool
+reservedPteBitsFault(ThreadContext *tc, const PTE &pte)
+{
+    // Reserved/unsupported encodings: Svnapot (N) not supported; PBMT=3
+    // reserved; PBMT non-zero requires PBMTE.
+    if (pte.reserved || pte.n || (pte.pbmt == 0x3))
+        return true;
+    if (pte.pbmt && !pbmtEnabled(tc))
+        return true;
+    return false;
+}
+
+} // anonymous namespace
+
 static Addr
 buildKey(Addr vpn, uint16_t asid, uint8_t translateMode)
 {
@@ -1112,14 +1143,17 @@ TLB::l2TLBRemove(size_t idx, int choose)
 }
 
 Fault
-TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
-                      BaseMMU::Mode mode, PTE pte, Addr gpaddr, bool G,
-                      bool hlvx)
+TLB::checkPermissions(ThreadContext *tc, STATUS status, PrivilegeMode pmode,
+                      Addr vaddr, BaseMMU::Mode mode, PTE pte, Addr gpaddr,
+                      bool G, bool hlvx)
 {
     Fault fault = NoFault;
 
     const bool exec_like = (mode == BaseMMU::Execute) ||
         (mode == BaseMMU::Read && hlvx);
+
+    if (reservedPteBitsFault(tc, pte))
+        return createPagefault(vaddr, gpaddr, mode, G);
 
     if (exec_like && !pte.x) {
         fault = createPagefault(vaddr, gpaddr, mode, G);
@@ -1141,16 +1175,28 @@ TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
 }
 
 std::pair<bool, Fault>
-TLB::checkGPermissions(STATUS status, Addr vaddr, Addr gpaddr,
-                       BaseMMU::Mode mode, PTE pte, bool hlvx)
+TLB::checkGPermissions(ThreadContext *tc, STATUS status, Addr vaddr,
+                       Addr gpaddr, BaseMMU::Mode mode, PTE pte, bool hlvx)
 {
     bool continuePtw = false;
     const bool exec_like = (mode == BaseMMU::Execute) ||
         (mode == BaseMMU::Read && hlvx);
 
+    // For non-leaf entries, PBMT/N/reserved must be zero.
     if (pte.v && !pte.r && !pte.w && !pte.x) {
-        return std::make_pair(true,NoFault);
-    } else if (!pte.v || (!pte.r && pte.w)) {
+        if (pte.reserved || pte.n || pte.pbmt) {
+            return std::make_pair(continuePtw,
+                                  createPagefault(vaddr, gpaddr, mode, true));
+        }
+        return std::make_pair(true, NoFault);
+    }
+
+    if (reservedPteBitsFault(tc, pte)) {
+        return std::make_pair(continuePtw,
+                              createPagefault(vaddr, gpaddr, mode, true));
+    }
+
+    if (!pte.v || (!pte.r && pte.w)) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
     } else if (!pte.u) {
         return std::make_pair(continuePtw,createPagefault(vaddr, gpaddr, mode, true));
@@ -1226,7 +1272,8 @@ TLB::L2TLBPagefault(Addr vaddr, BaseMMU::Mode mode, const RequestPtr &req, bool 
 }
 
 Fault
-TLB::L2TLBCheck(PTE pte, int level, STATUS status, PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode,
+TLB::L2TLBCheck(ThreadContext *tc, PTE pte, int level, STATUS status,
+                PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode,
                 const RequestPtr &req, bool isPre, bool is_back_pre)
 {
     Fault fault = NoFault;
@@ -1245,7 +1292,7 @@ TLB::L2TLBCheck(PTE pte, int level, STATUS status, PrivilegeMode pmode, Addr vad
     } else {
         if (pte.r || pte.x) {
             hitInSp = true;
-            fault = checkPermissions(status, pmode, vaddr, mode, pte, 0, false,
+            fault = checkPermissions(tc, status, pmode, vaddr, mode, pte, 0, false,
                 (req->getFlags() &
                     (Request::ARCH_BITS & XlateFlags::HLVX)) ||
                     req->get_h_inst());
@@ -1269,6 +1316,12 @@ TLB::L2TLBCheck(PTE pte, int level, STATUS status, PrivilegeMode pmode, Addr vad
             }
 
         } else {
+            // Reserved/unsupported encodings in non-leaf PTE.
+            if (pte.reserved || pte.n || pte.pbmt) {
+                hitInSp = true;
+                fault = L2TLBPagefault(vaddr, mode, req, isPre, is_back_pre);
+                return fault;
+            }
             level--;
             if (level < 0) {
                 hitInSp = true;
@@ -1337,7 +1390,8 @@ TLB::sendPreHitOnHitRequest(TlbEntry *e_pre_1, TlbEntry *e_pre_2, const RequestP
         e_pre = e_pre_1;
     else
         e_pre = e_pre_2;
-    Fault pre_fault = L2TLBCheck(e_pre->pte, check_level, status, pmode, pre_block, mode, req, forward, !forward);
+    Fault pre_fault = L2TLBCheck(tc, e_pre->pte, check_level, status, pmode,
+                                 pre_block, mode, req, forward, !forward);
     if ((pre_fault == NoFault) && (!hitInSp) && pre_precision) {
         DPRINTF(TLBGPre, "pre_vaddr %#x\n", pre_block);
         walker->start(e_pre->pte.ppn, tc, translation, req, mode, forward, !forward, check_level - 1, true,
@@ -1406,7 +1460,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             }
-            fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pteVS, 0,
+            fault = checkPermissions(tc, status, pmode, vaddr, mode, e[0]->pteVS, 0,
                 false,
                 (req->getFlags() &
                     (Request::ARCH_BITS & XlateFlags::HLVX)) ||
@@ -1417,7 +1471,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
         }
         Addr fault_gpaddr = ((e[0]->gpaddr >> 12) << 12) | (vaddr & 0xfff);
 
-        std::pair(continuePtw,fault) = checkGPermissions(status, vaddr,
+        std::pair(continuePtw,fault) = checkGPermissions(tc, status, vaddr,
             fault_gpaddr, mode, e[0]->pte,
             (req->getFlags() &
                 (Request::ARCH_BITS & XlateFlags::HLVX)) ||
@@ -1457,7 +1511,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 //return fault;
                 return std::make_pair(hit_type,fault);
             } else {
-                fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0,
+                fault = checkPermissions(tc, status, pmode, vaddr, mode, e[0]->pte, 0,
                     false,
                     (req->getFlags() &
                         (Request::ARCH_BITS & XlateFlags::HLVX)) ||
@@ -1477,7 +1531,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 hit_type = h_l1GstageHit;
                 DPRINTF(TLB, "l1tlb hit in Gstage: level %d, ppn %#x\n", e[0]->level, e[0]->pte.ppn);
                 std::pair(continuePtw, fault) =
-                    checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte,
+                    checkGPermissions(tc, status, vaddr, gPaddr, mode, e[0]->pte,
                         (req->getFlags() &
                             (Request::ARCH_BITS & XlateFlags::HLVX)) ||
                             req->get_h_inst());
@@ -1570,7 +1624,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
             e_l2tlbGstage = e[0];
             gPaddr = req->getgPaddr();
             std::pair<bool, Fault> result =
-                checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte,
+                checkGPermissions(tc, status, vaddr, gPaddr, mode, e[0]->pte,
                     (req->getFlags() &
                         (Request::ARCH_BITS & XlateFlags::HLVX)) ||
                         req->get_h_inst());
@@ -1636,7 +1690,8 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
             e_l2tlbVsstage = e[0];
             hit_type = h_l2VSstageHitContinue;
             level = e[0]->level;
-            fault = L2TLBCheck(e[0]->pte, e[0]->level, vstatus, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[0]->pte, e[0]->level, vstatus, pmode,
+                               vaddr, mode, req, false, false);
             finishgva = hitInSp;
             req->setPte(e[0]->pte);
             uint64_t hit_vaddr = e[0]->vaddr;
@@ -1687,7 +1742,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     e_l2tlbGstage = e[0];
                     twoStageLevel = e[0]->level;
                     req->setgPaddr(gPaddr);
-                    auto check_res = checkGPermissions(status, vaddr, gPaddr,
+                    auto check_res = checkGPermissions(tc, status, vaddr, gPaddr,
                         mode, e[0]->pte,
                         (req->getFlags() &
                             (Request::ARCH_BITS & XlateFlags::HLVX)) ||
@@ -1966,7 +2021,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     if (!e[0]) {  // look up l2tlb
         if (e[L_L2L0] && e[L_L2L0]->pte.v) {  // if hit in l2l0 (leaf 4KB page)
             DPRINTF(TLBVerbosel2, "hit in l2TLB l0\n");
-            fault = L2TLBCheck(e[L_L2L0]->pte, L2L0CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2L0]->pte, L2L0CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp) {
                 e[0] = e[L_L2L0];
                 if (fault == NoFault) {
@@ -2015,7 +2071,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
 
         } else if (e[L_L2sp1] && e[L_L2sp1]->pte.v) {  // hit in sp1
             DPRINTF(TLBVerbosel2, "hit in l2 tlb sp1\n");
-            fault = L2TLBCheck(e[L_L2sp1]->pte, L2L1CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2sp1]->pte, L2L1CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2sp1];
             auto [return_flag, fault_return] =
@@ -2024,7 +2081,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 return fault_return;
         } else if (e[L_L2sp2] && e[L_L2sp2]->pte.v) {  // hit in sp2
             DPRINTF(TLBVerbosel2, "hit in l2 tlb sp2\n");
-            fault = L2TLBCheck(e[L_L2sp2]->pte, L2L2CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2sp2]->pte, L2L2CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2sp2];
             auto [return_flag, fault_return] =
@@ -2033,7 +2091,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 return fault_return;
         } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2sp3] && e[L_L2sp3]->pte.v) {  // hit in sp3
             DPRINTF(TLBVerbosel2, "hit in l2 tlb sp3\n");
-            fault = L2TLBCheck(e[L_L2sp3]->pte, L2L3CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2sp3]->pte, L2L3CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2sp3];
             auto [return_flag, fault_return] =
@@ -2043,7 +2102,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         } else if (e[L_L2L1] && e[L_L2L1]->pte.v) {
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l1\n");
             DPRINTF(TLBVerbosel2, "hit ppn: %#x\n", e[L_L2L1]->pte.ppn);
-            fault = L2TLBCheck(e[L_L2L1]->pte, L2L1CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2L1]->pte, L2L1CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2L1];
             auto [return_flag, fault_return] =
@@ -2053,7 +2113,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         } else if (e[L_L2L2] && e[L_L2L2]->pte.v) {
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l2\n");
             DPRINTF(TLBVerbosel2, "hit pte: %#x\n", e[L_L2L2]->pte);
-            fault = L2TLBCheck(e[L_L2L2]->pte, L2L2CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2L2]->pte, L2L2CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2L2];
             auto [return_flag, fault_return] =
@@ -2062,7 +2123,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 return fault_return;
         } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2L3] && e[L_L2L3]->pte.v) {
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l3\n");
-            fault = L2TLBCheck(e[L_L2L3]->pte, L2L3CheckLevel, status, pmode, vaddr, mode, req, false, false);
+            fault = L2TLBCheck(tc, e[L_L2L3]->pte, L2L3CheckLevel, status,
+                               pmode, vaddr, mode, req, false, false);
             if (hitInSp)
                 e[0] = e[L_L2L3];
             auto [return_flag, fault_return] =
@@ -2101,7 +2163,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         DPRINTF(TLB, "final checkpermission\n");
         DPRINTF(TLB, "translate(vpn=%#x, asid=%#x): %#x pc %#x mode %i pte.d %d\n", vaddr, satp.asid, paddr,
                 req->getPC(), mode, e[0]->pte.d);
-        fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0, false,
+        fault = checkPermissions(tc, status, pmode, vaddr, mode, e[0]->pte, 0,
+                                 false,
             (req->getFlags() &
                 (Request::ARCH_BITS & XlateFlags::HLVX)) ||
                 req->get_h_inst());

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -198,11 +198,14 @@ class TLB : public BaseTLB
     void demapPage(Addr vaddr, uint64_t asn) override;
     void demapPageL2(Addr vaddr,uint64_t asn);
 
-    Fault checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode, PTE pte,
-                           Addr gpaddr, bool G, bool hlvx = false);
+    Fault checkPermissions(ThreadContext *tc, STATUS status, PrivilegeMode pmode,
+                           Addr vaddr, BaseMMU::Mode mode, PTE pte, Addr gpaddr,
+                           bool G, bool hlvx = false);
     Fault checkGuestPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
                       BaseMMU::Mode mode, PTESv39 pte);
-    std::pair<bool, Fault> checkGPermissions(STATUS status, Addr vaddr, Addr gpaddr, BaseMMU::Mode mode, PTE pte,
+    std::pair<bool, Fault> checkGPermissions(ThreadContext *tc, STATUS status,
+                                             Addr vaddr, Addr gpaddr,
+                                             BaseMMU::Mode mode, PTE pte,
                                              bool hlvx = false);
     Fault createPagefault(Addr vaddr, Addr gPaddr,BaseMMU::Mode mode,bool G);
 
@@ -228,7 +231,8 @@ class TLB : public BaseTLB
 
     Fault L2TLBPagefault(Addr vaddr, BaseMMU::Mode mode, const RequestPtr &req, bool is_pre, bool is_back_pre);
 
-    Fault L2TLBCheck(PTE pte, int level, STATUS status, PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode,
+    Fault L2TLBCheck(ThreadContext *tc, PTE pte, int level, STATUS status,
+                     PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode,
                      const RequestPtr &req, bool is_pre, bool is_back_pre);
     bool checkPrePrecision(uint64_t &removeNoUsePre, uint64_t &usedPre);
     void sendPreHitOnHitRequest(TlbEntry *e_pre_1, TlbEntry *e_pre_2, const RequestPtr &req, Addr pre_block,

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -199,11 +199,11 @@ class TLB : public BaseTLB
     void demapPageL2(Addr vaddr,uint64_t asn);
 
     Fault checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr, BaseMMU::Mode mode, PTE pte,
-                           Addr gpaddr, bool G);
+                           Addr gpaddr, bool G, bool hlvx = false);
     Fault checkGuestPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
                       BaseMMU::Mode mode, PTESv39 pte);
     std::pair<bool, Fault> checkGPermissions(STATUS status, Addr vaddr, Addr gpaddr, BaseMMU::Mode mode, PTE pte,
-                                             bool h_inst);
+                                             bool hlvx = false);
     Fault createPagefault(Addr vaddr, Addr gPaddr,BaseMMU::Mode mode,bool G);
 
     PrivilegeMode getMemPriv(ThreadContext *tc, BaseMMU::Mode mode);


### PR DESCRIPTION
cherry-pick from upstream gem5, 
https://github.com/OpenXiangShan/riscv-hyp-tests
for this unit-tests, still have bugs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broad RISC-V hypervisor support: hypervisor load/store operations, new fence/invalidation instructions, and new memory-translation templates for hyper modes.
  * Introduced new memory-translation flags to force guest virtual translation and to adjust execute/HLVX semantics.

* **Bug Fixes**
  * Improved load-reserved memory-barrier handling.
  * Fixed namespace/formatting closure to ensure correct build behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->