### PR TITLE
Ideal 2-Taken & 2-Fetch

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -34,19 +34,19 @@ def setKmhV3IdealParams(args, system):
         cpu.fetchQueueSize = 64
 
         # decode
-        cpu.decodeWidth = 8
+        cpu.decodeWidth = 16
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False
 
         # rename
-        cpu.renameWidth = 8
+        cpu.renameWidth = 16
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
 
         # dispatch
         cpu.enableDispatchStage = True
-        cpu.numDQEntries = [8, 8, 8]
-        cpu.dispWidth = [8, 8, 8]
+        cpu.numDQEntries = [16, 16, 16]
+        cpu.dispWidth = [16, 16, 16]
 
         # scheduler
         cpu.scheduler = KMHV3Scheduler()

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -86,6 +86,7 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.ftq_size = 64
             cpu.branchPred.fsq_size = 64
             # cpu.branchPred.microtage.enabled = False
+            cpu.branchPred.enable2Fetch = True
 
         # l1 cache per core
         if args.caches:

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -27,6 +27,8 @@ def setKmhV3IdealParams(args, system):
         # fetch
         cpu.mmu.itb.size = 96
         cpu.fetchWidth = 32
+        cpu.fetchBufferSize = 258
+        cpu.idealFetchWindowFill = True
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
@@ -88,6 +90,7 @@ def setKmhV3IdealParams(args, system):
             # cpu.branchPred.microtage.enabled = False
             cpu.branchPred.enable2Taken = True
             cpu.branchPred.enable2Fetch = True
+            cpu.branchPred.maxFetchBytesPerCycle = 256
 
         # l1 cache per core
         if args.caches:

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -86,6 +86,7 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.ftq_size = 64
             cpu.branchPred.fsq_size = 64
             # cpu.branchPred.microtage.enabled = False
+            cpu.branchPred.enable2Taken = True
             cpu.branchPred.enable2Fetch = True
 
         # l1 cache per core

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -112,6 +112,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
             cpu.branchPred.ras.enabled = True
+            cpu.branchPred.enable2Fetch = True
 
             # RTL alignment: only enable bias + path + IMLI tables, disable PC threshold
             cpu.branchPred.mgsc.enableBwTable = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -112,6 +112,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
             cpu.branchPred.ras.enabled = True
+            cpu.branchPred.enable2Taken = True
             cpu.branchPred.enable2Fetch = True
 
             # RTL alignment: only enable bias + path + IMLI tables, disable PC threshold

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -33,20 +33,20 @@ def setKmhV3Params(args, system):
         cpu.fetchQueueSize = 64
 
         # decode
-        cpu.decodeWidth = 8
+        cpu.decodeWidth = 16
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False
 
         # rename
-        cpu.renameWidth = 8
+        cpu.renameWidth = 16
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
         cpu.enable_storeSet_train = False
 
         # dispatch
         cpu.enableDispatchStage = False
-        cpu.numDQEntries = [8, 8, 8]
-        cpu.dispWidth = [8, 8, 8]
+        cpu.numDQEntries = [16, 16, 16]
+        cpu.dispWidth = [16, 16, 16]
 
         # scheduler
         cpu.scheduler = KMHV3Scheduler()

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -26,6 +26,8 @@ def setKmhV3Params(args, system):
         # fetch (idealfetch not care)
         cpu.mmu.itb.size = 96
         cpu.fetchWidth = 32
+        cpu.fetchBufferSize = 258
+        cpu.idealFetchWindowFill = True
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
         cpu.fetchQueueSize = 64
@@ -114,6 +116,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ras.enabled = True
             cpu.branchPred.enable2Taken = True
             cpu.branchPred.enable2Fetch = True
+            cpu.branchPred.maxFetchBytesPerCycle = 256
 
             # RTL alignment: only enable bias + path + IMLI tables, disable PC threshold
             cpu.branchPred.mgsc.enableBwTable = False

--- a/docs/plans/2026-03-19-fetch-2fetch-diagnostic-report.md
+++ b/docs/plans/2026-03-19-fetch-2fetch-diagnostic-report.md
@@ -1,0 +1,1071 @@
+# 2Taken/2Fetch Fetch-Side Diagnostic Report
+
+## English
+
+### 1. Purpose
+
+This report documents a focused fetch-side diagnostic experiment for the current gem5 `idealkmhv3` configuration. The goal is to explain, with direct counters, why some slices benefit from `2Taken/2Fetch` while others do not, and to answer three specific questions:
+
+1. How often does fetch enter the main `performInstructionFetch()` while loop, and why does it fail to enter?
+2. Once fetch is active, how often does a second in-cycle fetch (`2Fetch`) happen, and why does it fail when it does not happen?
+3. In cycles with only one fetch versus cycles with successful `2Fetch`, how many instructions are fetched on average?
+
+The experiment was run on two slices chosen for contrast:
+
+- `mcf_12253`
+- `gcc_200_5849`
+
+The first is a low-IPC, backend-heavy slice where earlier analysis suggested weak `2Fetch` benefit. The second is a GCC slice where earlier analysis suggested meaningful frontend benefit from short-block stitching.
+
+### 2. Code Changes
+
+The diagnostic instrumentation was added in three places:
+
+- `GEM5/src/cpu/o3/fetch.hh`
+- `GEM5/src/cpu/o3/fetch.cc`
+- `DataProcess/targets/branch.yaml`
+
+#### 2.1 Added fetch-side counters
+
+The following counters were added to gem5 fetch statistics:
+
+**While-loop entry and non-entry diagnostics**
+
+- `performIFCalls`
+- `performIFWhileEntered`
+- `performIFWhileIterations`
+- `performIFWhileNotEnteredFetchWidth`
+- `performIFWhileNotEnteredFetchQueueFull`
+- `performIFWhileNotEnteredStopFetch`
+- `performIFWhileNotEnteredFtqEmpty`
+- `performIFWhileNotEnteredWaitForVsetvl`
+
+**2Fetch opportunity and failure diagnostics**
+
+- `twoFetchOpportunity`
+- `twoFetchTaken`
+- `twoFetchNotTakenNotPredTaken`
+- `twoFetchNotTakenDisabled`
+- `twoFetchNotTakenNoNext`
+- `twoFetchNotTakenTargetMismatch`
+- `twoFetchNotTakenSpanTooLarge`
+- `twoFetchNotTakenTargetNotInBuffer`
+
+**Single-fetch versus double-fetch cycle effectiveness**
+
+- `singleFetchCycleCount`
+- `singleFetchCycleInsts`
+- `doubleFetchCycleCount`
+- `doubleFetchCycleInsts`
+
+#### 2.2 Added derived metrics in DataProcess
+
+The following derived metrics were added in `DataProcess/targets/branch.yaml`:
+
+- `singleFetchInstsPerCycle`
+- `doubleFetchInstsPerCycle`
+- `performIFWhileEnterRate`
+- `performIFWhileItersPerEntered`
+- `twoFetchTakeRate`
+
+These metrics allow direct slice-level analysis from `perf.csv` without re-parsing raw `stats.txt` every time.
+
+### 3. Build and Run Procedure
+
+#### 3.1 Build
+
+gem5 was rebuilt with the repository's preferred parallel build style:
+
+```bash
+cd GEM5
+scons build/RISCV/gem5.opt --gold-linker -j60
+```
+
+The build completed successfully.
+
+#### 3.2 Runtime details
+
+The run command followed the information in `build-system/GEM5.just`, especially the checkpoint restorer path:
+
+- `--gcpt-restorer /nfs/share/gem5_ci/tools/normal-gcb-restorer.bin`
+- `--difftest-ref-so /nfs/home/wangrui/OpenXiangShan/XSWorkbench/NEMU/build/riscv64-nemu-interpreter-so`
+
+The two runs were produced under:
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849`
+
+Counters were extracted into:
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv`
+
+### 4. Experimental Results
+
+The extracted rows are in `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv:2` and `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv:3`.
+
+#### 4.1 Summary table
+
+| Slice | IPC | fetch_nisn_mean | dispatchRateMean | issueRate | while enter rate | 2Fetch take rate | singleFetchInstsPerCycle | doubleFetchInstsPerCycle |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gcc_200_5849` | 4.124 | 4.783 | 4.454 | 4.053 | 81.3% | 61.0% | 5.132 | 12.427 |
+| `mcf_12253` | 0.730 | 4.878 | 3.493 | 2.753 | 78.0% | ~0% | 6.713 | 16.0* |
+
+`*` The `mcf_12253` double-fetch average is not representative because it is based on only 2 successful double-fetch cycles.
+
+### 5. Question 1: How often does fetch enter the main while loop?
+
+#### 5.1 `gcc_200_5849`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12596`:
+
+- `performIFCalls = 4,739,813`
+- `performIFWhileEntered = 3,853,184`
+- `performIFWhileNotEnteredFetchQueueFull = 886,629`
+
+This gives:
+
+- while entered rate: `3,853,184 / 4,739,813 = 81.3%`
+- not-entered-due-to-fetchQueueFull rate: `18.7%`
+
+Interpretation:
+
+- Fetch is active most of the time.
+- The dominant reason for not entering the while loop is not lack of FTQ work, not stop-fetch state, and not vector configuration; it is `fetchQueueFull`.
+- This means the fetch side is already aggressive enough that the next-stage queue often becomes the immediate gate.
+
+#### 5.2 `mcf_12253`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12148`:
+
+- `performIFCalls = 26,777,461`
+- `performIFWhileEntered = 20,893,195`
+- `performIFWhileNotEnteredFetchQueueFull = 5,884,266`
+
+This gives:
+
+- while entered rate: `78.0%`
+- not-entered-due-to-fetchQueueFull rate: `22.0%`
+
+Interpretation:
+
+- The same primary gating pattern appears here: the main reason for not entering the loop is `fetchQueueFull`.
+- Therefore, `mcf_12253` is not failing simply because fetch frequently has no FTQ target.
+- Its main problem lies later: either in what happens inside fetch, or in whether a useful second fetch can actually be formed.
+
+### 6. Question 2: How often does `2Fetch` happen, and why does it fail?
+
+### 6.1 `gcc_200_5849`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12600`:
+
+- `twoFetchOpportunity = 6,331,693`
+- `twoFetchTaken = 3,862,767`
+- `twoFetchNotTakenNotPredTaken = 137,207`
+- `twoFetchNotTakenNoNext = 1,047,659`
+- `twoFetchNotTakenSpanTooLarge = 640,980`
+- `twoFetchNotTakenTargetNotInBuffer = 643,080`
+
+Derived breakdown:
+
+- success: `61.0%`
+- fail because stream did not end with predicted taken branch: `2.2%`
+- fail because next stream unavailable: `16.5%`
+- fail because combined span too large: `10.1%`
+- fail because target not covered by current fetch buffer: `10.2%`
+
+Interpretation:
+
+- `2Fetch` is a normal and frequent event in this slice.
+- The mechanism is not marginal here; it succeeds in a majority of eligible opportunities.
+- The biggest failure reason is not predictor direction quality. It is supply/geometry related:
+  - next stream not ready,
+  - merged span too large,
+  - target not inside the current buffer window.
+
+This strongly suggests that `gcc_200_5849` is a slice where `2Fetch` materially contributes to wider effective fetch bursts.
+
+### 6.2 `mcf_12253`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12152`:
+
+- `twoFetchOpportunity = 19,308,509`
+- `twoFetchTaken = 2`
+- `twoFetchNotTakenNotPredTaken = 6,069,339`
+- `twoFetchNotTakenNoNext = 380,913`
+- `twoFetchNotTakenSpanTooLarge = 3,543,947`
+- `twoFetchNotTakenTargetNotInBuffer = 9,314,308`
+
+Derived breakdown:
+
+- success: effectively `0%`
+- fail because stream did not end with predicted taken branch: `31.4%`
+- fail because next stream unavailable: `2.0%`
+- fail because combined span too large: `18.4%`
+- fail because target not covered by current fetch buffer: `48.2%`
+
+Interpretation:
+
+- `2Fetch` almost never succeeds in this slice.
+- The dominant failure mode is not `NoNext`; the next entry usually exists.
+- The dominant blockers are:
+  - `target not in buffer`
+  - `span too large`
+- This means the control-flow shape and fetch-buffer geometry prevent useful in-cycle stitching.
+
+This result is much stronger than saying "`mcf` does not benefit much from 2Fetch." It says that, for this slice, `2Fetch` is almost structurally inapplicable.
+
+### 7. Question 3: How many instructions are fetched in single-fetch versus 2Fetch cycles?
+
+### 7.1 `gcc_200_5849`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12606`:
+
+- `singleFetchCycleCount = 1,554,306`
+- `singleFetchCycleInsts = 7,977,092`
+- `singleFetchCycleInstMean = 5.132`
+- `doubleFetchCycleCount = 1,224,635`
+- `doubleFetchCycleInsts = 15,219,044`
+- `doubleFetchCycleInstMean = 12.427`
+
+Interpretation:
+
+- A successful double-fetch cycle fetches more than twice as many instructions as a single-fetch cycle on average.
+- This directly confirms that `2Fetch` is not just toggling a control path; it materially increases instantaneous frontend width.
+- Since `fetch_nisn_mean` is only `4.783`, these wide cycles are being diluted by zero-fetch cycles and other constrained cycles, but the burst benefit is real and large.
+
+### 7.2 `mcf_12253`
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12158`:
+
+- `singleFetchCycleCount = 19,911,683`
+- `singleFetchCycleInsts = 133,665,244`
+- `singleFetchCycleInstMean = 6.713`
+- `doubleFetchCycleCount = 2`
+- `doubleFetchCycleInsts = 32`
+- `doubleFetchCycleInstMean = 16.0`
+
+Interpretation:
+
+- The measured `doubleFetchInstsPerCycle = 16.0` is not meaningful as a stable average because there are only 2 such cycles.
+- The real insight is the opposite: nearly all useful fetch work happens in single-fetch cycles.
+- `mcf_12253` is not a slice where double-fetch behavior materially shapes overall throughput.
+
+### 8. Relationship to Dispatch and Issue Bandwidth
+
+The new fetch counters become much more meaningful when compared with `dispatchRateMean` and `issueRate`.
+
+#### 8.1 `gcc_200_5849`
+
+- `fetch_nisn_mean = 4.783`
+- `dispatchRateMean = 4.454`
+- `issueRate = 4.053`
+
+Interpretation:
+
+- Frontend average supply is slightly higher than dispatch average, and dispatch average is slightly higher than issue average.
+- This is the expected shape when the frontend is effective but downstream bandwidth and queueing still absorb part of the gain.
+- In other words, `2Fetch` is helping, but it is not the only determinant of final IPC.
+
+#### 8.2 `mcf_12253`
+
+- `fetch_nisn_mean = 4.878`
+- `dispatchRateMean = 3.493`
+- `issueRate = 2.753`
+
+Interpretation:
+
+- The frontend fetch average is not extremely low.
+- The larger drop happens after fetch, especially by the time instructions reach issue.
+- Therefore, this slice has two simultaneous problems:
+  1. `2Fetch` nearly never forms successfully.
+  2. Even when fetch keeps moving, the backend consumes far less than fetch supplies.
+
+### 9. Root-Cause Comparison
+
+### 9.1 Why `gcc_200_5849` can benefit
+
+`gcc_200_5849` shows a textbook "useful 2Fetch" pattern:
+
+- the fetch loop enters frequently,
+- `2Fetch` succeeds often,
+- double-fetch cycles are much wider than single-fetch cycles,
+- average issue remains below fetch, so not all gain converts to IPC, but the frontend mechanism is clearly doing productive work.
+
+The main remaining losses are structural rather than conceptual:
+
+- fetch queue full,
+- next stream not yet ready,
+- span and fetch-buffer coverage constraints.
+
+### 9.2 Why `mcf_12253` does not benefit much
+
+`mcf_12253` does **not** mainly fail because the frontend is asleep or because no next stream exists. Instead:
+
+- the fetch loop still enters often,
+- the next stream is usually available,
+- but the target frequently falls outside the current fetch buffer window,
+- and the merged span often exceeds the per-cycle fetch-span limit.
+
+So the dominant explanation is geometric/structural incompatibility with the current `2Fetch` conditions, not merely insufficient predictor aggressiveness.
+
+This is an important distinction:
+
+- `gcc_200_5849`: "`2Fetch` works and helps, then downstream limits reduce full payoff."
+- `mcf_12253`: "`2Fetch` almost never becomes legal in the first place, and downstream limitations exist on top of that."
+
+### 10. Key Conclusions
+
+1. In both slices, the main reason `performInstructionFetch()` does not enter its main while loop is `fetchQueueFull`, not FTQ emptiness.
+2. `gcc_200_5849` is a genuine `2Fetch`-friendly slice: the `2Fetch` success rate is `61.0%`, and successful double-fetch cycles fetch `12.43` instructions on average versus `5.13` in single-fetch cycles.
+3. `mcf_12253` is almost structurally hostile to `2Fetch`: out of `19.3M` opportunities, only `2` succeed.
+4. The primary blockers for `mcf_12253` are `target not in buffer` and `span too large`, not `NoNext`.
+5. `mcf_12253` also has much weaker backend consumption than frontend supply, so even a better frontend would not automatically produce proportional IPC gain.
+6. The experiment therefore separates two classes of slices:
+   - slices where `2Fetch` is valid and useful but later stages limit total gain,
+   - slices where `2Fetch` is almost never valid under current fetch-buffer/span constraints.
+
+### 11. Practical Implications
+
+If the next step is to improve `2Taken/2Fetch`, this experiment suggests two different optimization directions:
+
+#### 11.1 For slices like `gcc_200_5849`
+
+Focus on converting successful frontend widening into sustained throughput:
+
+- reduce fetch queue pressure,
+- improve downstream acceptance,
+- examine decode/rename/dispatch backpressure.
+
+#### 11.2 For slices like `mcf_12253`
+
+Focus on why legal `2Fetch` formation is so rare:
+
+- fetch-buffer coverage,
+- target-in-buffer condition,
+- per-cycle merged-span restriction,
+- exact cross-block geometry at run-out points.
+
+### 12. Important Caveat
+
+The current instrumentation only counts the specific reasons already exposed in the present implementation path. In the two completed runs:
+
+- `twoFetchNotTakenDisabled`
+- `twoFetchNotTakenTargetMismatch`
+
+did not appear in `stats.txt`, which means they were not exercised in these two slices rather than proving they are impossible globally.
+
+### 13. Second-Round Deep Dive: Is `target not in buffer` a forward overflow or a backward jump?
+
+After the first diagnostic round, one ambiguity remained: the earlier `target-not-in-buffer` statistic did not distinguish whether the branch target was beyond the **right edge** of the current fetch buffer or whether it jumped **backward to an address before the current buffer start**. Likewise, `span-too-large` could reflect a real long forward span or an unsigned-underflow-style backward case.
+
+To resolve this, a second round of counters was added and the experiment was rerun on five slices:
+
+- `mcf_12253`
+- `gcc_200_5849`
+- `bzip2_program_16771`
+- `xalancbmk_8082`
+- `astar_biglakes_13437`
+
+#### 13.1 Additional counters added in the second round
+
+The second round added the following directional counters:
+
+- `twoFetchTargetBeforeBuffer`
+- `twoFetchTargetAfterBuffer`
+- `twoFetchNextStreamForward`
+- `twoFetchNextStreamBackward`
+- `twoFetchSpanForwardOrZero`
+- `twoFetchSpanBackward`
+- `twoFetchTargetDistanceBeforeBufferStart`
+- `twoFetchBackwardSpanDistance`
+- `twoFetchBackwardNextStartDistance`
+
+These counters let us distinguish whether a failure is dominated by:
+
+- a forward extension that exceeds the buffer window,
+- a backward jump whose target lies to the left of the current buffer,
+- a truly large span,
+- or a backward next-stream relationship.
+
+The rerun results were extracted to:
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+
+#### 13.2 Key comparative table
+
+| Slice | 2Fetch take rate | target-before rate | target-after rate | next-stream-backward rate | span-backward rate |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `mcf_12253` | ~0% | 48.29% | 0.0013% | 48.29% | 0.054% |
+| `gcc_200_5849` | 61.01% | 14.33% | 4.64% | 39.41% | 4.17% |
+| `bzip2_program_16771` | 15.74% | 30.52% | 33.96% | 30.52% | 28.79% |
+| `xalancbmk_8082` | 59.79% | 14.28% | 8.97% | 14.28% | 8.66% |
+| `astar_biglakes_13437` | 32.83% | 30.84% | 22.53% | 30.84% | 17.20% |
+
+All rates above are normalized by `twoFetchOpportunity`.
+
+#### 13.3 Refined conclusion for `mcf_12253`
+
+The second round gives a much sharper answer for `mcf_12253`.
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`:
+
+- `twoFetchTakeRate` is effectively zero
+- `twoFetchTargetBeforeBufferRate = 48.29%`
+- `twoFetchTargetAfterBufferRate = 0.0013%`
+- `twoFetchNextStreamBackwardRate = 48.29%`
+- `twoFetchSpanBackwardRate = 0.054%`
+- `twoFetchFailOnlyTargetNotInBufferRate = 48.24%`
+- `twoFetchFailBothSpanAndTargetNotInBufferRate = 0.055%`
+
+This means:
+
+1. The dominant `target-not-in-buffer` mode is **not** a forward overflow.
+2. The target is almost always **before** the current fetch buffer, not after it.
+3. The next stream is very often **backward** relative to the current stream start.
+4. `span-too-large` is almost never coupled with `target-not-in-buffer` in this slice.
+
+So the refined root cause for `mcf_12253` is:
+
+- `2Fetch` fails mainly because many opportunities correspond to **backward-taken control flow** whose next stream begins to the left of the current fetch buffer window.
+- This is fundamentally different from a forward chaining problem where one only needs a larger fetch window or slightly larger max span.
+
+In short: for `mcf_12253`, `target-not-in-buffer` should be read as **"backward target outside the current buffer window"**, not **"forward target extends beyond the right edge"**.
+
+#### 13.4 Interpretation of the other slices
+
+##### `gcc_200_5849`
+
+- `twoFetchTakeRate = 61.01%`
+- `target-before rate = 14.33%`
+- `target-after rate = 4.64%`
+- `next-stream-backward rate = 39.41%`
+- `span-backward rate = 4.17%`
+
+Interpretation:
+
+- Backward next streams are common, but they do not dominate the way they do in `mcf_12253`.
+- Most backward next-stream cases do **not** immediately turn into span-backward failures.
+- This slice still supports successful `2Fetch` in a majority of opportunities, which is why the frontend mechanism remains highly productive here.
+
+##### `bzip2_program_16771`
+
+- `twoFetchTakeRate = 15.74%`
+- `target-before rate = 30.52%`
+- `target-after rate = 33.96%`
+- `next-stream-backward rate = 30.52%`
+- `span-backward rate = 28.79%`
+- `twoFetchFailBothSpanAndTargetNotInBufferRate = 62.75%`
+
+Interpretation:
+
+- This slice is not dominated by a single direction.
+- It has substantial backward behavior **and** substantial forward-out-of-buffer behavior.
+- The strongest pattern is the high joint-failure rate: `span-too-large` and `target-not-in-buffer` frequently happen together.
+- This looks more like a general geometric mismatch between stream layout and current `2Fetch` constraints.
+
+##### `xalancbmk_8082`
+
+- `twoFetchTakeRate = 59.79%`
+- `target-before rate = 14.28%`
+- `target-after rate = 8.97%`
+- `next-stream-backward rate = 14.28%`
+- `span-backward rate = 8.66%`
+
+Interpretation:
+
+- This slice is much more balanced and much more `2Fetch`-friendly.
+- Neither backward-target nor forward-overflow behavior dominates enough to suppress `2Fetch` broadly.
+- The final performance result is consistent with a slice where `2Fetch` remains broadly legal and useful.
+
+##### `astar_biglakes_13437`
+
+- `twoFetchTakeRate = 32.83%`
+- `target-before rate = 30.84%`
+- `target-after rate = 22.53%`
+- `next-stream-backward rate = 30.84%`
+- `span-backward rate = 17.20%`
+
+Interpretation:
+
+- `astar_biglakes_13437` sits between `mcf` and `xalancbmk`.
+- Backward next-stream opportunities are common, but not as overwhelmingly dominant as in `mcf`.
+- It still has a meaningful successful `2Fetch` fraction, but a large portion of opportunities are geometrically difficult.
+
+#### 13.5 What the second round changes in our understanding
+
+The first round said:
+
+- `mcf_12253` fails mainly because of `target-not-in-buffer`, with some `span-too-large`
+
+The second round refines this to:
+
+- `mcf_12253` fails mainly because its next stream is often **backward**, and the backward target falls **before the current fetch buffer window**
+
+This is a much stronger and more actionable conclusion.
+
+It means that simply enlarging the right-side fetch window is unlikely to solve the main problem for `mcf_12253`. The real issue is that the current same-cycle stitching rule is naturally favorable to forward continuation, but many `mcf` opportunities want to jump backward relative to the current buffer anchor.
+
+#### 13.6 Practical implication from the second round
+
+There are now two clearly different classes of `2Fetch` challenges:
+
+1. **Forward geometric pressure**
+   - target goes beyond the current right edge
+   - merged span exceeds the forward byte budget
+
+2. **Backward-target pressure**
+   - next stream is backward relative to current stream start
+   - target lies before the current fetch buffer window
+
+`mcf_12253` is overwhelmingly of the second type.
+
+This suggests that any future optimization targeted at `mcf` should consider whether same-cycle stitching can support backward-taken transitions more naturally, rather than only relaxing forward span limits.
+
+### 14. Output Artifacts
+
+Main result files:
+
+- `docs/plans/2026-03-19-fetch-2fetch-diagnostic-report.md`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/gcc_200_5849/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/mcf_12253/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt`
+
+---
+
+## Chinese Translation / 中文翻译
+
+### 1. 目的
+
+本报告记录了一次针对当前 gem5 `idealkmhv3` 配置的 fetch 侧诊断实验。目标是通过直接计数器解释：为什么有些切片能从 `2Taken/2Fetch` 中获益，而另一些不能；并回答以下三个问题：
+
+1. fetch 在 `performInstructionFetch()` 的主 while 循环中到底进入了多少次，没进入时的原因是什么？
+2. 在 fetch 已经开始工作后，第二次同周期取指（`2Fetch`）发生了多少次；若没有发生，失败原因是什么？
+3. 在“只有一次 fetch 的周期”和“发生了成功 2Fetch 的周期”中，平均每周期分别取到多少条指令？
+
+本次实验选取了两个具有对比性的切片：
+
+- `mcf_12253`
+- `gcc_200_5849`
+
+前者是一个低 IPC、后端压力较重的切片，先前分析中已显示其 `2Fetch` 收益较弱；后者是一个 GCC 切片，先前分析中显示它可能能够从短 block 拼接中显著受益。
+
+### 2. 代码改动
+
+本次诊断插桩涉及三个位置：
+
+- `GEM5/src/cpu/o3/fetch.hh`
+- `GEM5/src/cpu/o3/fetch.cc`
+- `DataProcess/targets/branch.yaml`
+
+#### 2.1 新增的 fetch 侧计数器
+
+新增的 gem5 fetch 统计包括：
+
+**while 循环进入与未进入诊断**
+
+- `performIFCalls`
+- `performIFWhileEntered`
+- `performIFWhileIterations`
+- `performIFWhileNotEnteredFetchWidth`
+- `performIFWhileNotEnteredFetchQueueFull`
+- `performIFWhileNotEnteredStopFetch`
+- `performIFWhileNotEnteredFtqEmpty`
+- `performIFWhileNotEnteredWaitForVsetvl`
+
+**2Fetch 机会与失败原因诊断**
+
+- `twoFetchOpportunity`
+- `twoFetchTaken`
+- `twoFetchNotTakenNotPredTaken`
+- `twoFetchNotTakenDisabled`
+- `twoFetchNotTakenNoNext`
+- `twoFetchNotTakenTargetMismatch`
+- `twoFetchNotTakenSpanTooLarge`
+- `twoFetchNotTakenTargetNotInBuffer`
+
+**single fetch 与 double fetch 周期效果对比**
+
+- `singleFetchCycleCount`
+- `singleFetchCycleInsts`
+- `doubleFetchCycleCount`
+- `doubleFetchCycleInsts`
+
+#### 2.2 在 DataProcess 中新增的派生指标
+
+在 `DataProcess/targets/branch.yaml` 中新增了以下派生指标：
+
+- `singleFetchInstsPerCycle`
+- `doubleFetchInstsPerCycle`
+- `performIFWhileEnterRate`
+- `performIFWhileItersPerEntered`
+- `twoFetchTakeRate`
+
+这些派生指标使我们能够直接从 `perf.csv` 做切片级分析，而不必每次都重新读取原始 `stats.txt`。
+
+### 3. 编译与运行流程
+
+#### 3.1 编译
+
+gem5 按仓库推荐方式并行编译：
+
+```bash
+cd GEM5
+scons build/RISCV/gem5.opt --gold-linker -j60
+```
+
+编译成功完成。
+
+#### 3.2 运行细节
+
+运行命令参考了 `build-system/GEM5.just` 中的配置，尤其是 checkpoint restorer 路径：
+
+- `--gcpt-restorer /nfs/share/gem5_ci/tools/normal-gcb-restorer.bin`
+- `--difftest-ref-so /nfs/home/wangrui/OpenXiangShan/XSWorkbench/NEMU/build/riscv64-nemu-interpreter-so`
+
+两个切片的结果目录为：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849`
+
+抽取得到的总 CSV 为：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv`
+
+### 4. 实验结果
+
+抽取后的两行结果位于：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv:2`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv:3`
+
+#### 4.1 结果总表
+
+| Slice | IPC | fetch_nisn_mean | dispatchRateMean | issueRate | while 进入率 | 2Fetch 成功率 | singleFetchInstsPerCycle | doubleFetchInstsPerCycle |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gcc_200_5849` | 4.124 | 4.783 | 4.454 | 4.053 | 81.3% | 61.0% | 5.132 | 12.427 |
+| `mcf_12253` | 0.730 | 4.878 | 3.493 | 2.753 | 78.0% | 约 0% | 6.713 | 16.0* |
+
+`*` `mcf_12253` 的 `doubleFetchInstsPerCycle=16.0` 并没有统计代表性，因为它只来自 2 个成功的 double-fetch 周期。
+
+### 5. 问题一：fetch 主 while 循环进入了多少次？
+
+#### 5.1 `gcc_200_5849`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12596`：
+
+- `performIFCalls = 4,739,813`
+- `performIFWhileEntered = 3,853,184`
+- `performIFWhileNotEnteredFetchQueueFull = 886,629`
+
+对应得到：
+
+- while 进入率：`81.3%`
+- 因 `fetchQueueFull` 而未进入的比例：`18.7%`
+
+解释：
+
+- fetch 大部分时间都能正常进入主循环。
+- 没进入 while 的主要原因不是 FTQ 没工作，不是 stop-fetch 状态，也不是向量配置阻塞，而是 `fetchQueueFull`。
+- 这意味着该切片上的前端其实已经相当积极，下一阶段队列更像是当前第一层门槛。
+
+#### 5.2 `mcf_12253`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12148`：
+
+- `performIFCalls = 26,777,461`
+- `performIFWhileEntered = 20,893,195`
+- `performIFWhileNotEnteredFetchQueueFull = 5,884,266`
+
+对应得到：
+
+- while 进入率：`78.0%`
+- 因 `fetchQueueFull` 而未进入的比例：`22.0%`
+
+解释：
+
+- 这里出现了和 `gcc_200_5849` 相同的主导模式：没进入 while 的主要原因也是 `fetchQueueFull`。
+- 因此，`mcf_12253` 的问题不能简单理解成“fetch 经常没有 FTQ target”。
+- 它的主要问题要么发生在 fetch 内部后续阶段，要么发生在“第二次 fetch 能不能形成”这一层。
+
+### 6. 问题二：`2Fetch` 发生了多少次，失败原因是什么？
+
+#### 6.1 `gcc_200_5849`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12600`：
+
+- `twoFetchOpportunity = 6,331,693`
+- `twoFetchTaken = 3,862,767`
+- `twoFetchNotTakenNotPredTaken = 137,207`
+- `twoFetchNotTakenNoNext = 1,047,659`
+- `twoFetchNotTakenSpanTooLarge = 640,980`
+- `twoFetchNotTakenTargetNotInBuffer = 643,080`
+
+换算后：
+
+- 成功率：`61.0%`
+- 因“流末尾不是 predicted taken branch”失败：`2.2%`
+- 因下一 stream 不可用失败：`16.5%`
+- 因 span 太大失败：`10.1%`
+- 因 target 不在当前 fetch buffer 覆盖范围内失败：`10.2%`
+
+解释：
+
+- `2Fetch` 在这个切片上是一个正常且频繁发生的事件。
+- 这里的机制不是边缘性的，而是在多数可评估机会中都能真正成功。
+- 最大的失败原因并不是预测方向质量，而是供给/几何条件：
+  - next stream 尚未准备好，
+  - 合并 span 超过限制，
+  - target 没有落在当前 buffer 窗口内。
+
+这强烈说明 `gcc_200_5849` 是一个 `2Fetch` 的真实受益切片。
+
+#### 6.2 `mcf_12253`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12152`：
+
+- `twoFetchOpportunity = 19,308,509`
+- `twoFetchTaken = 2`
+- `twoFetchNotTakenNotPredTaken = 6,069,339`
+- `twoFetchNotTakenNoNext = 380,913`
+- `twoFetchNotTakenSpanTooLarge = 3,543,947`
+- `twoFetchNotTakenTargetNotInBuffer = 9,314,308`
+
+换算后：
+
+- 成功率：几乎 `0%`
+- 因“流末尾不是 predicted taken branch”失败：`31.4%`
+- 因下一 stream 不可用失败：`2.0%`
+- 因 span 太大失败：`18.4%`
+- 因 target 不在当前 fetch buffer 覆盖范围内失败：`48.2%`
+
+解释：
+
+- `2Fetch` 在这个切片上几乎从不成功。
+- 主导失败原因不是 `NoNext`；也就是说 next entry 大多数时候其实是存在的。
+- 真正的主阻碍是：
+  - `target not in buffer`
+  - `span too large`
+
+因此，这个结果比“`mcf` 对 2Fetch 收益小”更强：它说明对于这个切片，`2Fetch` 在结构上几乎不满足成立条件。
+
+### 7. 问题三：single fetch 周期与 2Fetch 周期的平均取指数是多少？
+
+#### 7.1 `gcc_200_5849`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt:12606`：
+
+- `singleFetchCycleCount = 1,554,306`
+- `singleFetchCycleInsts = 7,977,092`
+- `singleFetchCycleInstMean = 5.132`
+- `doubleFetchCycleCount = 1,224,635`
+- `doubleFetchCycleInsts = 15,219,044`
+- `doubleFetchCycleInstMean = 12.427`
+
+解释：
+
+- 成功发生 `2Fetch` 的周期，平均取指宽度超过 single-fetch 周期的两倍。
+- 这直接说明 `2Fetch` 并不只是改变了一条控制路径，而是真实地显著扩大了瞬时 frontend 宽度。
+- 虽然整体 `fetch_nisn_mean` 只有 `4.783`，这些宽 burst 会被 0-fetch 周期或受限周期摊薄，但它们的 burst 收益是真实且很大的。
+
+#### 7.2 `mcf_12253`
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt:12158`：
+
+- `singleFetchCycleCount = 19,911,683`
+- `singleFetchCycleInsts = 133,665,244`
+- `singleFetchCycleInstMean = 6.713`
+- `doubleFetchCycleCount = 2`
+- `doubleFetchCycleInsts = 32`
+- `doubleFetchCycleInstMean = 16.0`
+
+解释：
+
+- 这里的 `doubleFetchInstsPerCycle = 16.0` 不具有稳定统计意义，因为只有 2 个样本。
+- 真正有意义的结论恰好相反：几乎所有有效 fetch 工作都发生在 single-fetch 周期中。
+- `mcf_12253` 不是一个由 double-fetch 行为主导整体吞吐的切片。
+
+### 8. 与 Dispatch / Issue 带宽的关系
+
+把新的 fetch 计数器和 `dispatchRateMean`、`issueRate` 放在一起看，意义会更清楚。
+
+#### 8.1 `gcc_200_5849`
+
+- `fetch_nisn_mean = 4.783`
+- `dispatchRateMean = 4.454`
+- `issueRate = 4.053`
+
+解释：
+
+- frontend 平均供给略高于 dispatch 平均宽度，而 dispatch 又略高于 issue 平均宽度。
+- 这是一个非常合理的形态：前端确实有效，但下游带宽和队列压力仍然吃掉了一部分收益。
+- 换句话说，`2Fetch` 的确在帮忙，但它不是最终 IPC 的唯一决定因素。
+
+#### 8.2 `mcf_12253`
+
+- `fetch_nisn_mean = 4.878`
+- `dispatchRateMean = 3.493`
+- `issueRate = 2.753`
+
+解释：
+
+- 这个切片的 frontend 平均取指并不算特别低。
+- 更大的跌落发生在 fetch 之后，尤其是在 issue 阶段之前。
+- 因此，这个切片实际上有两个叠加问题：
+  1. `2Fetch` 几乎根本形成不起来；
+  2. 即使 fetch 还能继续推进，后端实际消费能力也远低于 fetch 供给能力。
+
+### 9. 根因对比
+
+#### 9.1 为什么 `gcc_200_5849` 能受益
+
+`gcc_200_5849` 呈现出典型的“`2Fetch` 有效”模式：
+
+- fetch 主循环经常进入，
+- `2Fetch` 经常成功，
+- double-fetch 周期明显比 single-fetch 周期更宽，
+- 平均 issue 虽仍低于 average fetch，说明不是所有收益都能变成 IPC，但前端机制本身确实在产生有效工作。
+
+它的主要剩余损失更偏结构性：
+
+- fetch queue full，
+- next stream 尚未准备好，
+- span 和 fetch-buffer 覆盖限制。
+
+#### 9.2 为什么 `mcf_12253` 受益不大
+
+`mcf_12253` **并不是** 主要因为“前端太弱”或者“没有 next stream”才失败。相反：
+
+- fetch 主循环仍然经常进入，
+- next stream 通常也是存在的，
+- 但 target 经常落在当前 fetch buffer 窗口之外，
+- 同时合并后的 span 也经常超过每周期允许的 fetch-span 限制。
+
+所以，更可信的主解释是：当前 `2Fetch` 的几何/结构条件与该切片的控制流形态不兼容，而不仅仅是预测器不够积极。
+
+这一区别很重要：
+
+- `gcc_200_5849`：`2Fetch` 能工作并且有收益，只是后续流水线限制了最终收益上限。
+- `mcf_12253`：`2Fetch` 在现有条件下几乎从来不合法，后端问题则是在此之上进一步叠加。
+
+### 10. 关键结论
+
+1. 在两个切片中，`performInstructionFetch()` 不进入主 while 的首要原因都是 `fetchQueueFull`，而不是 FTQ 空。
+2. `gcc_200_5849` 是一个真正的 `2Fetch` 友好切片：成功率 `61.0%`，且成功 double-fetch 周期平均可取 `12.43` 条指令，而 single-fetch 周期平均只有 `5.13`。
+3. `mcf_12253` 几乎在结构上不适合 `2Fetch`：`19.3M` 次机会中只有 `2` 次成功。
+4. `mcf_12253` 的主要阻碍是 `target not in buffer` 和 `span too large`，而不是 `NoNext`。
+5. `mcf_12253` 还存在明显的后端消费不足，因此即使前端进一步改进，也未必会线性转化为 IPC 提升。
+6. 因此，这次实验把切片清晰地区分成两类：
+   - 一类是 `2Fetch` 合法且有效，但后段限制了总收益；
+   - 一类是当前 fetch-buffer/span 条件下 `2Fetch` 几乎从不合法。
+
+### 11. 工程启示
+
+如果下一步要继续改进 `2Taken/2Fetch`，本实验提示了两条不同方向：
+
+#### 11.1 对于 `gcc_200_5849` 这类切片
+
+重点应放在如何把前端已经做出来的宽 burst 转化为持续吞吐：
+
+- 降低 fetch queue 压力，
+- 提高下游接收能力，
+- 进一步检查 decode/rename/dispatch 背压。
+
+#### 11.2 对于 `mcf_12253` 这类切片
+
+重点应放在为什么合法 `2Fetch` 形成得这么少：
+
+- fetch-buffer 覆盖范围，
+- `target-in-buffer` 条件，
+- 每周期 merged-span 限制，
+- run-out 点上的精确跨块几何关系。
+
+### 12. 重要说明
+
+当前插桩只统计了现有实现路径中已经显式暴露出的失败原因。在这两个已完成的切片中：
+
+- `twoFetchNotTakenDisabled`
+- `twoFetchNotTakenTargetMismatch`
+
+没有出现在 `stats.txt` 中。这意味着它们在这两个切片中没有被触发，而不能据此推出它们在全局范围内不可能发生。
+
+### 14. 第二轮深挖：`target not in buffer` 到底是向前越界，还是向后回跳？
+
+在第一轮诊断之后，还剩下一个关键歧义：之前的 `target-not-in-buffer` 统计并不能区分 branch target 是超出了当前 fetch buffer 的**右边界**，还是回跳到了当前 buffer 起点**左边**。同理，`span-too-large` 也可能是真正的前向跨度过大，也可能是 backward 情况下的无符号差值放大。
+
+为解决这个问题，第二轮又增加了一批方向性更明确的计数器，并在五个切片上重跑：
+
+- `mcf_12253`
+- `gcc_200_5849`
+- `bzip2_program_16771`
+- `xalancbmk_8082`
+- `astar_biglakes_13437`
+
+#### 14.1 第二轮新增计数器
+
+第二轮新增的方向性计数器包括：
+
+- `twoFetchTargetBeforeBuffer`
+- `twoFetchTargetAfterBuffer`
+- `twoFetchNextStreamForward`
+- `twoFetchNextStreamBackward`
+- `twoFetchSpanForwardOrZero`
+- `twoFetchSpanBackward`
+- `twoFetchTargetDistanceBeforeBufferStart`
+- `twoFetchBackwardSpanDistance`
+- `twoFetchBackwardNextStartDistance`
+
+这些计数器使我们能够明确区分：
+
+- 是向前扩展时超出了 buffer 窗口，
+- 还是向后跳回了 buffer 左边，
+- 是真正的跨度太大，
+- 还是 backward next-stream 关系导致的结构不兼容。
+
+第二轮结果抽取到：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+
+#### 14.2 核心对比表
+
+| Slice | 2Fetch 成功率 | target-before 比例 | target-after 比例 | next-stream-backward 比例 | span-backward 比例 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `mcf_12253` | 约 0% | 48.29% | 0.0013% | 48.29% | 0.054% |
+| `gcc_200_5849` | 61.01% | 14.33% | 4.64% | 39.41% | 4.17% |
+| `bzip2_program_16771` | 15.74% | 30.52% | 33.96% | 30.52% | 28.79% |
+| `xalancbmk_8082` | 59.79% | 14.28% | 8.97% | 14.28% | 8.66% |
+| `astar_biglakes_13437` | 32.83% | 30.84% | 22.53% | 30.84% | 17.20% |
+
+上表中的比例都相对于 `twoFetchOpportunity` 归一化。
+
+#### 14.3 对 `mcf_12253` 的精炼结论
+
+第二轮给出了对 `mcf_12253` 更明确的答案。
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`：
+
+- `twoFetchTakeRate` 几乎为零
+- `twoFetchTargetBeforeBufferRate = 48.29%`
+- `twoFetchTargetAfterBufferRate = 0.0013%`
+- `twoFetchNextStreamBackwardRate = 48.29%`
+- `twoFetchSpanBackwardRate = 0.054%`
+- `twoFetchFailOnlyTargetNotInBufferRate = 48.24%`
+- `twoFetchFailBothSpanAndTargetNotInBufferRate = 0.055%`
+
+这意味着：
+
+1. `target-not-in-buffer` 的主导模式并不是向前越界。
+2. target 几乎总是落在当前 fetch buffer **左侧**，而不是右侧。
+3. next stream 相对于当前 stream 起点经常是 **backward** 的。
+4. `span-too-large` 在这个切片里几乎不会与 `target-not-in-buffer` 一起成为主导失败模式。
+
+因此，`mcf_12253` 的精炼根因是：
+
+- `2Fetch` 失败的主因，是大量机会对应的都是**向后跳转控制流**，而这些 backward target 落在当前 fetch buffer 窗口左侧。
+- 这和单纯的“前向链式扩展不够长”是完全不同的问题。
+
+换句话说：对 `mcf_12253` 来说，`target-not-in-buffer` 应理解为**“向后跳回，target 落在当前 buffer 左边”**，而不是**“向前取太宽，冲出右边界”**。
+
+#### 14.4 其他切片的解释
+
+##### `gcc_200_5849`
+
+- `twoFetchTakeRate = 61.01%`
+- `target-before rate = 14.33%`
+- `target-after rate = 4.64%`
+- `next-stream-backward rate = 39.41%`
+- `span-backward rate = 4.17%`
+
+解释：
+
+- backward next-stream 虽然常见，但不像 `mcf_12253` 那样形成压倒性主导。
+- 大多数 backward next-stream 情况并不会立刻变成 span-backward 失败。
+- 这个切片仍然能在多数机会中成功进行 `2Fetch`，因此该机制在这里仍然是高产出的。
+
+##### `bzip2_program_16771`
+
+- `twoFetchTakeRate = 15.74%`
+- `target-before rate = 30.52%`
+- `target-after rate = 33.96%`
+- `next-stream-backward rate = 30.52%`
+- `span-backward rate = 28.79%`
+- `twoFetchFailBothSpanAndTargetNotInBufferRate = 62.75%`
+
+解释：
+
+- 这个切片不是单一方向主导。
+- 它同时存在明显的 backward 行为，也存在明显的 forward-out-of-buffer 行为。
+- 最强特征是高 joint-failure：`span-too-large` 和 `target-not-in-buffer` 经常一起发生。
+- 这更像是 stream 布局和当前 `2Fetch` 约束之间存在普遍几何不匹配。
+
+##### `xalancbmk_8082`
+
+- `twoFetchTakeRate = 59.79%`
+- `target-before rate = 14.28%`
+- `target-after rate = 8.97%`
+- `next-stream-backward rate = 14.28%`
+- `span-backward rate = 8.66%`
+
+解释：
+
+- 这是一个更加平衡、也更 `2Fetch`-友好的切片。
+- 无论是 backward-target 还是 forward-overflow，都没有强到足以广泛压制 `2Fetch`。
+- 其最终性能表现也和“`2Fetch` 仍然大体合法且有效”的判断一致。
+
+##### `astar_biglakes_13437`
+
+- `twoFetchTakeRate = 32.83%`
+- `target-before rate = 30.84%`
+- `target-after rate = 22.53%`
+- `next-stream-backward rate = 30.84%`
+- `span-backward rate = 17.20%`
+
+解释：
+
+- `astar_biglakes_13437` 处在 `mcf` 和 `xalancbmk` 之间。
+- backward next-stream 很常见，但没有像 `mcf` 那样压倒性主导。
+- 它仍有相当可观的成功 `2Fetch` 比例，但很多机会在几何上依然比较困难。
+
+#### 14.5 第二轮如何改变我们的理解
+
+第一轮的结论是：
+
+- `mcf_12253` 主要失败在 `target-not-in-buffer`，并伴随少量 `span-too-large`
+
+第二轮把它精炼成：
+
+- `mcf_12253` 主要失败在 **backward next stream**，而 backward target 落在当前 fetch buffer 左侧
+
+这比第一轮结论更强，也更可操作。
+
+它说明：单纯增大右侧 fetch window，未必能解决 `mcf_12253` 的主问题。真正的问题在于：当前 same-cycle stitching 规则天然更适合前向延伸，而 `mcf` 的很多机会都要求相对于当前 buffer anchor 向后跳转。
+
+#### 14.6 第二轮带来的工程启示
+
+现在可以把 `2Fetch` 的困难更清晰地分成两类：
+
+1. **前向几何压力**
+   - target 超出当前右边界
+   - merged span 超过前向字节预算
+
+2. **向后跳转压力**
+   - next stream 相对当前 stream start 是 backward 的
+   - target 落在当前 fetch buffer 左侧
+
+`mcf_12253` 明显属于第二类。
+
+这意味着，如果后续要专门优化 `mcf` 类切片，应考虑 same-cycle stitching 是否能更自然地支持 backward-taken 转移，而不只是继续放宽前向 span 限制。
+
+### 15. 输出产物
+
+主要结果文件如下：
+
+- `docs/plans/2026-03-19-fetch-2fetch-diagnostic-report.md`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/perf.csv`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/gcc_200_5849/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-diag/mcf_12253/stats.txt`

--- a/docs/plans/2026-03-19-fetch-2fetch-three-slice-analysis.md
+++ b/docs/plans/2026-03-19-fetch-2fetch-three-slice-analysis.md
@@ -1,0 +1,807 @@
+# 2Taken/2Fetch Analysis for Three Additional Slices
+
+## English
+
+### 1. Purpose
+
+This report extends the previous `2Taken/2Fetch` diagnostic study to three additional slices:
+
+- `bzip2_program_16771`
+- `xalancbmk_8082`
+- `astar_biglakes_13437`
+
+The goal is to analyze them in the same style as the earlier two-slice report: for each slice, explain
+
+1. how often fetch enters the main `performInstructionFetch()` loop,
+2. how often `2Fetch` succeeds and why it fails when it does not,
+3. how much wider successful double-fetch cycles are than single-fetch cycles,
+4. how frontend widening relates to dispatch and issue bandwidth,
+5. what kind of geometric pattern dominates the slice.
+
+The analysis uses the refined deep-dive counters extracted into:
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+
+and the corresponding `stats.txt` files under the same directory.
+
+### 2. Input Data and Context
+
+The runs were produced with the same setup as the previous report:
+
+- gem5 built with `scons build/RISCV/gem5.opt --gold-linker -j60`
+- runtime arguments consistent with `build-system/GEM5.just`
+- no BP DB dump enabled, to save runtime
+
+The relevant result directories are:
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437`
+
+### 3. Summary Table
+
+The three slices already show three different `2Fetch` personalities.
+
+| Slice | IPC | fetch_nisn_mean | dispatchRateMean | issueRate | while enter rate | 2Fetch take rate | singleFetchInstsPerCycle | doubleFetchInstsPerCycle |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `bzip2_program_16771` | 2.672 | 7.743 | 5.253 | 4.523 | 94.6% | 15.7% | 8.695 | 11.668 |
+| `xalancbmk_8082` | 6.173 | 6.220 | 6.201 | 6.349 | 89.7% | 59.8% | 6.283 | 11.898 |
+| `astar_biglakes_13437` | 1.051 | 6.631 | 4.027 | 2.828 | 87.4% | 32.8% | 6.297 | 19.308 |
+
+These numbers already suggest:
+
+- `xalancbmk_8082` is `2Fetch`-friendly and balanced
+- `bzip2_program_16771` has a high fetch rate but weak conversion into successful `2Fetch`
+- `astar_biglakes_13437` has very wide successful double-fetch bursts, but poor downstream conversion
+
+### 4. Slice 1: `bzip2_program_16771`
+
+#### 4.1 While-loop entry behavior
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11606`:
+
+- `performIFCalls = 7,137,133`
+- `performIFWhileEntered = 6,751,939`
+- `performIFWhileNotEnteredFetchQueueFull = 385,194`
+
+Derived:
+
+- while entered rate: `94.6%`
+- fetchQueueFull non-entry rate: `5.4%`
+
+Interpretation:
+
+- Fetch enters its main loop extremely often.
+- This slice is not frontend-starved at the point of entering `performInstructionFetch()`.
+- The main while-loop gate is relatively mild compared with the previous slices.
+
+#### 4.2 `2Fetch` success and failure pattern
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11610`:
+
+- `twoFetchOpportunity = 6,102,449`
+- `twoFetchTaken = 960,399`
+- `twoFetchNotTakenNotPredTaken = 953,955`
+- `twoFetchNotTakenNoNext = 54,778`
+- `twoFetchNotTakenSpanTooLarge = 4,027,628`
+- `twoFetchNotTakenTargetNotInBuffer = 3,934,918`
+
+Derived rates from `perf.csv`:
+
+- success: `15.74%`
+- fail only because stream end is not predicted taken: `15.63%`
+- fail only because next stream unavailable: `0.90%`
+- fail only because span too large: `3.25%`
+- fail only because target not in buffer: `1.73%`
+- fail because both span-too-large and target-not-in-buffer: `62.75%`
+
+Interpretation:
+
+- `2Fetch` succeeds in only a small minority of opportunities.
+- The dominant issue is **joint geometric failure**, not a single isolated cause.
+- This slice is not mainly failing because the predictor cannot provide the next stream.
+- It is also not failing mainly because of one-sided backward geometry like `mcf_12253`.
+- Instead, it looks like a case where current stream layout often violates both:
+  - the per-cycle fetch span budget,
+  - and the current buffer coverage requirement.
+
+#### 4.3 Single-fetch versus double-fetch effectiveness
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11955`:
+
+- `singleFetchCycleCount = 5,802,724`
+- `singleFetchCycleInstMean = 8.695`
+- `doubleFetchCycleCount = 642,863`
+- `doubleFetchCycleInstMean = 11.668`
+
+Interpretation:
+
+- A successful double-fetch cycle is wider than a single-fetch cycle, but the gap is only moderate compared with GCC or ASTAR.
+- This slice already fetches quite a lot even in single-fetch cycles.
+- Therefore the marginal gain from double-fetch is smaller than in short-block slices.
+
+#### 4.4 Relationship to dispatch and issue
+
+From `perf.csv`:
+
+- `fetch_nisn_mean = 7.743`
+- `dispatchRateMean = 5.253`
+- `issueRate = 4.523`
+
+Interpretation:
+
+- The frontend is already very strong on average.
+- The bigger drop happens after fetch.
+- This means `bzip2_program_16771` is not a pure frontend-limited case. It already has high fetch supply, but downstream conversion is significantly lower.
+
+#### 4.5 Geometric interpretation
+
+From the refined counters in `perf.csv`:
+
+- `twoFetchTargetBeforeBufferRate = 30.52%`
+- `twoFetchTargetAfterBufferRate = 33.96%`
+- `twoFetchNextStreamBackwardRate = 30.52%`
+- `twoFetchSpanBackwardRate = 28.79%`
+
+Interpretation:
+
+- This slice has both backward-target and forward-overflow behavior.
+- Neither direction dominates completely.
+- The high joint-failure rate suggests that this slice is broadly geometry-unfriendly to the current `2Fetch` rule.
+
+#### 4.6 Slice conclusion
+
+`bzip2_program_16771` is not a slice where `2Fetch` is absent. Instead, it is a slice where:
+
+- fetch already runs strongly,
+- single-fetch cycles are already wide,
+- successful `2Fetch` is somewhat wider,
+- but most `2Fetch` opportunities fail because stream geometry violates both span and buffer constraints.
+
+So its limited `2Fetch` gain comes from **geometric incompatibility plus limited marginal frontend benefit**, not from lack of fetch activity.
+
+### 5. Slice 2: `xalancbmk_8082`
+
+#### 5.1 While-loop entry behavior
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12346`:
+
+- `performIFCalls = 2,975,590`
+- `performIFWhileEntered = 2,669,216`
+- `performIFWhileNotEnteredFetchQueueFull = 306,374`
+
+Derived:
+
+- while entered rate: `89.7%`
+- fetchQueueFull non-entry rate: `10.3%`
+
+Interpretation:
+
+- Fetch is active for most cycles.
+- The frontend is not blocked at entry very often.
+- Queue pressure exists, but it is not overwhelming.
+
+#### 5.2 `2Fetch` success and failure pattern
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12350`:
+
+- `twoFetchOpportunity = 3,749,604`
+- `twoFetchTaken = 2,241,779`
+- `twoFetchNotTakenNotPredTaken = 114,397`
+- `twoFetchNotTakenNoNext = 311,836`
+- `twoFetchNotTakenSpanTooLarge = 870,673`
+- `twoFetchNotTakenTargetNotInBuffer = 871,920`
+
+Derived rates:
+
+- success: `59.79%`
+- fail only because stream end is not predicted taken: `3.05%`
+- fail only because next stream unavailable: `8.32%`
+- fail only because span too large: `5.59%`
+- fail only because target not in buffer: `5.63%`
+- fail because both span-too-large and target-not-in-buffer: `17.63%`
+
+Interpretation:
+
+- `2Fetch` succeeds in a clear majority of opportunities.
+- This is one of the most `2Fetch`-friendly slices in the current deep-dive set.
+- Geometry still matters, but it does not dominate the slice the way it does for `bzip2` or `mcf`.
+
+#### 5.3 Single-fetch versus double-fetch effectiveness
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12695`:
+
+- `singleFetchCycleCount = 1,403,007`
+- `singleFetchCycleInstMean = 6.283`
+- `doubleFetchCycleCount = 952,862`
+- `doubleFetchCycleInstMean = 11.898`
+
+Interpretation:
+
+- Successful double-fetch cycles are about 1.9x as wide as single-fetch cycles.
+- This is a strong widening effect.
+- The widening is not as extreme as ASTAR, but it is much more frequent and much more consistently useful.
+
+#### 5.4 Relationship to dispatch and issue
+
+- `fetch_nisn_mean = 6.220`
+- `dispatchRateMean = 6.201`
+- `issueRate = 6.349`
+
+Interpretation:
+
+- This slice is unusually well balanced.
+- Fetch, dispatch, and issue are all near the same level.
+- This is a strong sign that successful `2Fetch` widening is actually getting converted into useful machine throughput.
+
+#### 5.5 Geometric interpretation
+
+- `twoFetchTargetBeforeBufferRate = 14.28%`
+- `twoFetchTargetAfterBufferRate = 8.97%`
+- `twoFetchNextStreamBackwardRate = 14.28%`
+- `twoFetchSpanBackwardRate = 8.66%`
+
+Interpretation:
+
+- Backward geometry exists, but it is modest.
+- Forward overflow also exists, but is not dominant.
+- The overall pattern is balanced enough that `2Fetch` remains broadly legal and beneficial.
+
+#### 5.6 Slice conclusion
+
+`xalancbmk_8082` is a highly successful `2Fetch` slice because:
+
+- the fetch loop is active most of the time,
+- `2Fetch` succeeds often,
+- double-fetch cycles are much wider than single-fetch cycles,
+- and frontend widening is well reflected in dispatch and issue bandwidth.
+
+This is close to an ideal “`2Fetch` works and the machine can use it” case.
+
+### 6. Slice 3: `astar_biglakes_13437`
+
+#### 6.1 While-loop entry behavior
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13302`:
+
+- `performIFCalls = 17,765,172`
+- `performIFWhileEntered = 15,529,719`
+- `performIFWhileNotEnteredFetchQueueFull = 2,235,453`
+
+Derived:
+
+- while entered rate: `87.4%`
+- fetchQueueFull non-entry rate: `12.6%`
+
+Interpretation:
+
+- Fetch is again active most of the time.
+- The slice is not failing because the frontend cannot start work.
+
+#### 6.2 `2Fetch` success and failure pattern
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13306`:
+
+- `twoFetchOpportunity = 17,719,736`
+- `twoFetchTaken = 5,817,294`
+- `twoFetchNotTakenNotPredTaken = 885,080`
+- `twoFetchNotTakenNoNext = 1,558,779`
+- `twoFetchNotTakenSpanTooLarge = 7,041,872`
+- `twoFetchNotTakenTargetNotInBuffer = 9,455,307`
+
+Derived rates:
+
+- success: `32.83%`
+- fail only because stream end is not predicted taken: `4.99%`
+- fail only because next stream unavailable: `8.80%`
+- fail only because span too large: `0.018%`
+- fail only because target not in buffer: `13.64%`
+- fail because both span-too-large and target-not-in-buffer: `39.72%`
+
+Interpretation:
+
+- `2Fetch` succeeds in about one-third of all opportunities.
+- The dominant problem is again geometry, especially the overlap between span-too-large and target-not-in-buffer.
+- Unlike `bzip2`, however, the slice still retains a substantial successful `2Fetch` fraction.
+
+#### 6.3 Single-fetch versus double-fetch effectiveness
+
+From `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13651`:
+
+- `singleFetchCycleCount = 10,013,965`
+- `singleFetchCycleInstMean = 6.297`
+- `doubleFetchCycleCount = 3,266,883`
+- `doubleFetchCycleInstMean = 19.308`
+
+Interpretation:
+
+- This is the most dramatic widening among the three new slices.
+- Successful double-fetch cycles are more than 3x as wide as single-fetch cycles.
+- So when `2Fetch` works here, it works very strongly.
+
+#### 6.4 Relationship to dispatch and issue
+
+- `fetch_nisn_mean = 6.631`
+- `dispatchRateMean = 4.027`
+- `issueRate = 2.828`
+
+Interpretation:
+
+- This slice shows a large frontend-to-backend drop.
+- The frontend can create very wide bursts, but the machine cannot sustain them downstream.
+- This is the clearest case among the three new slices where `2Fetch` can help frontend burst width, but later stages absorb a large fraction of the benefit.
+
+#### 6.5 Geometric interpretation
+
+- `twoFetchTargetBeforeBufferRate = 30.84%`
+- `twoFetchTargetAfterBufferRate = 22.53%`
+- `twoFetchNextStreamBackwardRate = 30.84%`
+- `twoFetchSpanBackwardRate = 17.20%`
+
+Interpretation:
+
+- This slice has both backward and forward geometric pressure.
+- It is not as one-sided as `mcf_12253`.
+- It is also not as balanced and forgiving as `xalancbmk_8082`.
+
+#### 6.6 Slice conclusion
+
+`astar_biglakes_13437` is a mixed case:
+
+- `2Fetch` succeeds often enough to matter,
+- successful double-fetch cycles are extremely wide,
+- but geometry blocks many opportunities,
+- and backend consumption is far weaker than frontend burst width.
+
+So its bottleneck is not only `2Fetch` legality; it is also the machine’s ability to absorb the widened fetch stream.
+
+### 7. Cross-Slice Comparison
+
+These three slices form a useful contrast set.
+
+#### 7.1 `bzip2_program_16771`: frontend already strong, geometry hostile
+
+- Very high `fetch_nisn_mean`
+- low `2Fetch` success
+- high joint-failure rate
+- moderate widening when `2Fetch` succeeds
+- noticeable drop from fetch to issue
+
+This is a slice where the frontend is already powerful, but current `2Fetch` geometry is not a good match.
+
+#### 7.2 `xalancbmk_8082`: best-balanced `2Fetch` case
+
+- high `2Fetch` success
+- strong widening
+- low-to-moderate geometric pressure
+- dispatch and issue remain close to fetch
+
+This is the cleanest positive example among the three.
+
+#### 7.3 `astar_biglakes_13437`: very wide bursts, weak downstream conversion
+
+- medium `2Fetch` success
+- extremely large widening when successful
+- significant geometric difficulty
+- large drop from fetch to issue
+
+This is a slice where `2Fetch` can create big frontend bursts, but backend throughput is the real limit.
+
+### 8. Main Conclusions
+
+1. All three slices enter `performInstructionFetch()` frequently; none is primarily blocked at loop entry.
+2. `bzip2_program_16771` is limited mainly by joint geometric failure, not by lack of fetch activity.
+3. `xalancbmk_8082` is a strong positive `2Fetch` case: successful, balanced, and well-converted into issue bandwidth.
+4. `astar_biglakes_13437` gets large frontend burst widening from `2Fetch`, but much of that gain is lost before issue.
+5. Across the three slices, `2Fetch` effectiveness depends on two things together:
+   - whether the fetch geometry allows same-cycle stitching,
+   - whether downstream stages can absorb the resulting wider fetch stream.
+
+### 9. Output Artifacts
+
+- `docs/plans/2026-03-19-fetch-2fetch-three-slice-analysis.md`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt`
+
+---
+
+## Chinese Translation / 中文翻译
+
+### 1. 目的
+
+本报告将之前的 `2Taken/2Fetch` 诊断扩展到另外三个切片：
+
+- `bzip2_program_16771`
+- `xalancbmk_8082`
+- `astar_biglakes_13437`
+
+目标是延续上一份报告的分析方式，对每个切片分别回答：
+
+1. fetch 进入 `performInstructionFetch()` 主循环的频率如何；
+2. `2Fetch` 成功发生的频率如何，失败时的主要原因是什么；
+3. single-fetch 周期与成功 `2Fetch` 周期分别平均取多少条指令；
+4. 前端变宽和 dispatch / issue 带宽之间是什么关系；
+5. 哪种几何模式在该切片中占主导。
+
+分析使用的核心输入为：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+
+及对应目录下的 `stats.txt`。
+
+### 2. 输入数据与实验背景
+
+这些运行与上一份报告保持一致：
+
+- gem5 用 `scons build/RISCV/gem5.opt --gold-linker -j60` 编译
+- 运行参数参考 `build-system/GEM5.just`
+- 为节省时间，不启用 BP DB dump
+
+对应的结果目录为：
+
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437`
+
+### 3. 总览表
+
+这三个切片分别代表了三种不同的 `2Fetch` 形态。
+
+| Slice | IPC | fetch_nisn_mean | dispatchRateMean | issueRate | while 进入率 | 2Fetch 成功率 | singleFetchInstsPerCycle | doubleFetchInstsPerCycle |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `bzip2_program_16771` | 2.672 | 7.743 | 5.253 | 4.523 | 94.6% | 15.7% | 8.695 | 11.668 |
+| `xalancbmk_8082` | 6.173 | 6.220 | 6.201 | 6.349 | 89.7% | 59.8% | 6.283 | 11.898 |
+| `astar_biglakes_13437` | 1.051 | 6.631 | 4.027 | 2.828 | 87.4% | 32.8% | 6.297 | 19.308 |
+
+从总表可以初步看出：
+
+- `xalancbmk_8082` 是一个 `2Fetch` 友好且较平衡的切片；
+- `bzip2_program_16771` 的平均 fetch 很高，但成功 `2Fetch` 转化较弱；
+- `astar_biglakes_13437` 的成功 `2Fetch` 周期很宽，但下游消化能力明显不足。
+
+### 4. 切片一：`bzip2_program_16771`
+
+#### 4.1 while 循环进入情况
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11606`：
+
+- `performIFCalls = 7,137,133`
+- `performIFWhileEntered = 6,751,939`
+- `performIFWhileNotEnteredFetchQueueFull = 385,194`
+
+可得：
+
+- while 进入率：`94.6%`
+- 因 `fetchQueueFull` 未进入的比例：`5.4%`
+
+解释：
+
+- fetch 几乎总能进入主循环。
+- 这个切片并不是在 `performInstructionFetch()` 入口就被卡住的。
+- while 入口处的前端活动已经非常积极。
+
+#### 4.2 `2Fetch` 成功与失败模式
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11610`：
+
+- `twoFetchOpportunity = 6,102,449`
+- `twoFetchTaken = 960,399`
+- `twoFetchNotTakenNotPredTaken = 953,955`
+- `twoFetchNotTakenNoNext = 54,778`
+- `twoFetchNotTakenSpanTooLarge = 4,027,628`
+- `twoFetchNotTakenTargetNotInBuffer = 3,934,918`
+
+由 `perf.csv` 换算可得：
+
+- 成功率：`15.74%`
+- 仅因“流末尾不是 predicted taken”而失败：`15.63%`
+- 仅因 next stream 不可用而失败：`0.90%`
+- 仅因 span 太大而失败：`3.25%`
+- 仅因 target 不在 buffer 中而失败：`1.73%`
+- 因 `span-too-large` 与 `target-not-in-buffer` 同时出现而失败：`62.75%`
+
+解释：
+
+- `2Fetch` 虽然存在，但成功机会只占少数。
+- 最主要的问题不是单一失败项，而是**联合几何失败**。
+- 这个切片既不是因为 next stream 不存在，也不是因为单向 backward 几何像 `mcf_12253` 那样压倒性主导。
+- 它更像是：stream 布局经常同时违反
+  - 每周期 fetch span 限制，
+  - 以及当前 fetch buffer 覆盖条件。
+
+#### 4.3 single-fetch 与 double-fetch 周期效果
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt:11955`：
+
+- `singleFetchCycleCount = 5,802,724`
+- `singleFetchCycleInstMean = 8.695`
+- `doubleFetchCycleCount = 642,863`
+- `doubleFetchCycleInstMean = 11.668`
+
+解释：
+
+- 成功 `2Fetch` 周期确实更宽，但相对提升幅度没有 GCC 或 ASTAR 那么大。
+- 这是因为该切片在 single-fetch 周期里本来就已经能取得很多指令。
+- 因此，`2Fetch` 的边际收益相对较小。
+
+#### 4.4 与 dispatch / issue 的关系
+
+- `fetch_nisn_mean = 7.743`
+- `dispatchRateMean = 5.253`
+- `issueRate = 4.523`
+
+解释：
+
+- 该切片的前端平均供给已经很强。
+- 更大的跌落发生在 fetch 之后。
+- 这说明它并不是一个纯前端受限切片；即便 fetch 很强，下游的转化效率仍然有限。
+
+#### 4.5 几何解释
+
+- `twoFetchTargetBeforeBufferRate = 30.52%`
+- `twoFetchTargetAfterBufferRate = 33.96%`
+- `twoFetchNextStreamBackwardRate = 30.52%`
+- `twoFetchSpanBackwardRate = 28.79%`
+
+解释：
+
+- 这个切片既有明显的 backward-target，也有明显的 forward-overflow。
+- 没有哪一边完全主导。
+- 高 joint-failure 比例说明：当前 `2Fetch` 的几何条件与该切片的 stream 形态整体匹配度不高。
+
+#### 4.6 小结
+
+`bzip2_program_16771` 不是没有 `2Fetch` 的切片，而是一个：
+
+- fetch 本身已经很强，
+- single-fetch 周期已经比较宽，
+- double-fetch 周期能更宽一些，
+- 但大多数 `2Fetch` 机会会被 span 和 buffer 两类几何约束同时挡住。
+
+因此，它的 `2Fetch` 收益偏小，主要来自**几何不匹配 + 前端边际收益有限**，而不是 fetch 活跃度不足。
+
+### 5. 切片二：`xalancbmk_8082`
+
+#### 5.1 while 循环进入情况
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12346`：
+
+- `performIFCalls = 2,975,590`
+- `performIFWhileEntered = 2,669,216`
+- `performIFWhileNotEnteredFetchQueueFull = 306,374`
+
+可得：
+
+- while 进入率：`89.7%`
+- 因 `fetchQueueFull` 未进入的比例：`10.3%`
+
+解释：
+
+- fetch 在大多数周期都能进入主循环。
+- 入口处并没有明显的前端饥饿现象。
+- 队列压力存在，但不算严重。
+
+#### 5.2 `2Fetch` 成功与失败模式
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12350`：
+
+- `twoFetchOpportunity = 3,749,604`
+- `twoFetchTaken = 2,241,779`
+- `twoFetchNotTakenNotPredTaken = 114,397`
+- `twoFetchNotTakenNoNext = 311,836`
+- `twoFetchNotTakenSpanTooLarge = 870,673`
+- `twoFetchNotTakenTargetNotInBuffer = 871,920`
+
+对应比率：
+
+- 成功率：`59.79%`
+- 仅因“末尾不是 predicted taken”失败：`3.05%`
+- 仅因 next stream 不可用失败：`8.32%`
+- 仅因 span 太大失败：`5.59%`
+- 仅因 target 不在 buffer 中失败：`5.63%`
+- 因 span 与 target 两者同时失败：`17.63%`
+
+解释：
+
+- `2Fetch` 在这个切片上能在大多数机会中成功。
+- 这是目前 deep-dive 样本里最 `2Fetch` 友好的切片之一。
+- 几何条件仍有影响，但远没有达到压倒性主导。
+
+#### 5.3 single-fetch 与 double-fetch 周期效果
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt:12695`：
+
+- `singleFetchCycleCount = 1,403,007`
+- `singleFetchCycleInstMean = 6.283`
+- `doubleFetchCycleCount = 952,862`
+- `doubleFetchCycleInstMean = 11.898`
+
+解释：
+
+- 成功 `2Fetch` 周期大约是 single-fetch 周期的 `1.9x`。
+- 这是一个很明显的前端扩宽效果。
+- 它不像 ASTAR 那样“单次特别极端”，但更频繁、更稳定、更能转化成整体收益。
+
+#### 5.4 与 dispatch / issue 的关系
+
+- `fetch_nisn_mean = 6.220`
+- `dispatchRateMean = 6.201`
+- `issueRate = 6.349`
+
+解释：
+
+- 这是一个非常平衡的切片。
+- fetch、dispatch、issue 三者都在同一量级。
+- 这表明成功的 `2Fetch` 扩宽在这里确实被后续流水线有效利用了。
+
+#### 5.5 几何解释
+
+- `twoFetchTargetBeforeBufferRate = 14.28%`
+- `twoFetchTargetAfterBufferRate = 8.97%`
+- `twoFetchNextStreamBackwardRate = 14.28%`
+- `twoFetchSpanBackwardRate = 8.66%`
+
+解释：
+
+- backward 几何存在，但不重。
+- forward overflow 也存在，但不重。
+- 整体上它的几何分布足够温和，因此 `2Fetch` 保持了高可用性。
+
+#### 5.6 小结
+
+`xalancbmk_8082` 是一个非常成功的 `2Fetch` 切片，因为：
+
+- fetch 主循环活跃，
+- `2Fetch` 成功率高，
+- 成功 double-fetch 周期明显更宽，
+- 且这种扩宽基本能顺利传递到 dispatch / issue。
+
+这可以视为一个接近理想的“`2Fetch` 有效且机器能吃下去”的案例。
+
+### 6. 切片三：`astar_biglakes_13437`
+
+#### 6.1 while 循环进入情况
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13302`：
+
+- `performIFCalls = 17,765,172`
+- `performIFWhileEntered = 15,529,719`
+- `performIFWhileNotEnteredFetchQueueFull = 2,235,453`
+
+可得：
+
+- while 进入率：`87.4%`
+- 因 `fetchQueueFull` 未进入的比例：`12.6%`
+
+解释：
+
+- fetch 大多数时候都能进入主循环。
+- 它的瓶颈不在于前端“启动不起来”。
+
+#### 6.2 `2Fetch` 成功与失败模式
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13306`：
+
+- `twoFetchOpportunity = 17,719,736`
+- `twoFetchTaken = 5,817,294`
+- `twoFetchNotTakenNotPredTaken = 885,080`
+- `twoFetchNotTakenNoNext = 1,558,779`
+- `twoFetchNotTakenSpanTooLarge = 7,041,872`
+- `twoFetchNotTakenTargetNotInBuffer = 9,455,307`
+
+对应比率：
+
+- 成功率：`32.83%`
+- 仅因“末尾不是 predicted taken”失败：`4.99%`
+- 仅因 next stream 不可用失败：`8.80%`
+- 仅因 span 太大失败：`0.018%`
+- 仅因 target 不在 buffer 中失败：`13.64%`
+- 因 span 与 target 两者同时失败：`39.72%`
+
+解释：
+
+- `2Fetch` 在这个切片上能成功约三分之一机会。
+- 最主要的问题依然是几何条件，尤其是 `span-too-large` 和 `target-not-in-buffer` 的重叠。
+- 但与 `bzip2` 不同的是，它仍保留了相当可观的成功 `2Fetch` 比例。
+
+#### 6.3 single-fetch 与 double-fetch 周期效果
+
+根据 `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt:13651`：
+
+- `singleFetchCycleCount = 10,013,965`
+- `singleFetchCycleInstMean = 6.297`
+- `doubleFetchCycleCount = 3,266,883`
+- `doubleFetchCycleInstMean = 19.308`
+
+解释：
+
+- 这是三个新增切片里最显著的扩宽效果。
+- 成功 `2Fetch` 周期平均宽度超过 single-fetch 周期的三倍。
+- 说明只要 `2Fetch` 成功，它在这个切片上就非常有力。
+
+#### 6.4 与 dispatch / issue 的关系
+
+- `fetch_nisn_mean = 6.631`
+- `dispatchRateMean = 4.027`
+- `issueRate = 2.828`
+
+解释：
+
+- 这个切片存在明显的前端到后端跌落。
+- frontend 能做出很宽的 burst，但后续流水线无法持续消化。
+- 这是三个新增切片里最典型的“前端做出来了，但后段吃不下去”的案例。
+
+#### 6.5 几何解释
+
+- `twoFetchTargetBeforeBufferRate = 30.84%`
+- `twoFetchTargetAfterBufferRate = 22.53%`
+- `twoFetchNextStreamBackwardRate = 30.84%`
+- `twoFetchSpanBackwardRate = 17.20%`
+
+解释：
+
+- backward 与 forward 的几何压力都比较明显。
+- 它不像 `mcf_12253` 那样完全单边，也不像 `xalancbmk_8082` 那样足够温和。
+
+#### 6.6 小结
+
+`astar_biglakes_13437` 是一个混合型切片：
+
+- `2Fetch` 成功率足以产生作用，
+- 成功 double-fetch 周期非常宽，
+- 但几何条件拦掉了很多机会，
+- 且后端消费能力明显弱于前端 burst 宽度。
+
+因此，它的问题不仅仅是 `2Fetch` 合法性，还包括后续流水线对 widened fetch stream 的承接能力。
+
+### 7. 跨切片对比
+
+这三个切片构成了一组很有代表性的对照。
+
+#### 7.1 `bzip2_program_16771`：前端已强，但几何不友好
+
+- `fetch_nisn_mean` 很高
+- `2Fetch` 成功率低
+- joint-failure 很高
+- 成功时扩宽幅度有限
+- fetch 到 issue 有明显跌落
+
+这是一个前端本来就很强，但当前 `2Fetch` 几何条件并不匹配的切片。
+
+#### 7.2 `xalancbmk_8082`：最平衡的 `2Fetch` 成功案例
+
+- `2Fetch` 成功率高
+- 扩宽明显
+- 几何压力较轻
+- dispatch / issue 与 fetch 保持接近
+
+这是三个新增切片中最干净的正面样例。
+
+#### 7.3 `astar_biglakes_13437`：burst 很宽，但后段转化弱
+
+- `2Fetch` 成功率中等
+- 成功时 burst 极宽
+- 几何困难明显
+- fetch 到 issue 的跌落很大
+
+这是一个 `2Fetch` 可以制造巨大前端 burst，但真正限制在后段吞吐的切片。
+
+### 8. 主要结论
+
+1. 三个切片都能频繁进入 `performInstructionFetch()`，没有哪个主要卡在 while 入口。
+2. `bzip2_program_16771` 的主要限制是联合几何失败，而不是 fetch 活跃度不足。
+3. `xalancbmk_8082` 是一个很强的正面 `2Fetch` 样例：成功率高、平衡好、能有效转化为 issue 带宽。
+4. `astar_biglakes_13437` 能从 `2Fetch` 得到非常宽的 frontend burst，但大量收益在 issue 之前就损失掉了。
+5. 这三个切片共同说明：`2Fetch` 的有效性取决于两个因素同时满足：
+   - fetch 几何上是否允许 same-cycle stitching；
+   - 下游流水线是否能消化更宽的 fetch stream。
+
+### 9. 输出产物
+
+- `docs/plans/2026-03-19-fetch-2fetch-three-slice-analysis.md`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/perf.csv`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/bzip2_program_16771/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/xalancbmk_8082/stats.txt`
+- `out/gem5/single-2026-03-19-2taken-2fetch-deepdive/astar_biglakes_13437/stats.txt`

--- a/docs/plans/2026-04-02-2taken-2fetch-benchmark-tables.md
+++ b/docs/plans/2026-04-02-2taken-2fetch-benchmark-tables.md
@@ -1,0 +1,165 @@
+# 2-Taken / 2-Fetch Benchmark Tables
+
+## 中文版
+
+### 1. 总体分数
+
+| Version | SPECint Weighted Score | Delta vs Baseline | Delta vs Intermediate |
+| --- | ---: | ---: | ---: |
+| Baseline (`fc6422716`) | 20.6959 | - | - |
+| Intermediate (`eac43be47`) | 21.4439 | +3.61% | - |
+| Final (`1cae93a`) | 21.8804 | +5.72% | +2.04% |
+
+### 2. 各 benchmark 分数对比
+
+| Benchmark | Ref Score | Mid Score | Final Score | Final vs Ref | Final vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| perlbench | 16.94 | 18.31 | 19.97 | +17.90% | +9.05% |
+| xalancbmk | 33.96 | 36.91 | 38.17 | +12.40% | +3.41% |
+| sjeng | 13.17 | 14.47 | 14.51 | +10.20% | +0.30% |
+| gcc | 21.17 | 22.61 | 23.24 | +9.77% | +2.80% |
+| gobmk | 15.61 | 16.35 | 16.59 | +6.24% | +1.47% |
+| h264ref | 25.23 | 25.43 | 26.29 | +4.18% | +3.36% |
+| astar | 14.33 | 14.75 | 14.89 | +3.91% | +0.99% |
+| bzip2 | 11.26 | 11.41 | 11.55 | +2.52% | +1.20% |
+| libquantum | 46.86 | 46.79 | 47.58 | +1.53% | +1.69% |
+| mcf | 34.65 | 34.93 | 34.93 | +0.80% | -0.01% |
+| omnetpp | 21.85 | 21.91 | 22.00 | +0.72% | +0.43% |
+| hmmer | 17.07 | 17.07 | 17.08 | +0.09% | +0.07% |
+
+### 3. 高收益 benchmark 的关键证据
+
+| Benchmark | Score Gain vs Ref | `fetch_nisn_mean` Gain | Final `doubleFetchCycle` Share | Final `2-Fetch` Success Rate | `frontendBound` Drop | `fetchBubbles` Drop |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +17.90% | +33.83% | 29.96% | 33.30% | -89.77% | -89.98% |
+| xalancbmk | +12.40% | +18.55% | 46.47% | 55.25% | -83.29% | -84.70% |
+| sjeng | +10.20% | +33.15% | 21.75% | 30.48% | -59.45% | -63.19% |
+| gcc | +9.77% | +22.07% | 42.76% | 49.00% | -73.46% | -78.06% |
+| gobmk | +6.24% | +32.25% | 24.48% | 32.15% | -70.72% | -71.42% |
+| h264ref | +4.18% | +5.74% | 11.60% | 17.35% | -89.74% | -90.43% |
+
+### 4. Final 聚合 2-Fetch 计数器
+
+| Metric | Value |
+| --- | ---: |
+| `twoFetchOpportunity` | 61.09M |
+| `twoFetchTaken` | 22.98M |
+| `2-Fetch success rate` | 37.61% |
+| `doubleFetchCycle share` | 28.70% |
+
+### 5. Final 失败原因拆分
+
+| Failure Class | Share of Failed Opportunities |
+| --- | ---: |
+| Only `not predicted taken` | 29.69% |
+| Only `no next stream` | 13.83% |
+| Only `span too large` | 7.01% |
+| Only `target not in buffer` | 10.51% |
+| Both `span too large` and `target not in buffer` | 38.96% |
+
+### 6. Intermediate vs Final: idealized fetch-window 效果
+
+| Benchmark | Final vs Mid | `span_rate` Mid | `span_rate` Final | `oob_rate` Mid | `oob_rate` Final | `doubleFetchCycle` Mid | `doubleFetchCycle` Final | `fetchBubbles` Drop vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +9.05% | 75.54% | 52.30% | 4.00% | 52.55% | 8.88% | 29.96% | -79.78% |
+| xalancbmk | +3.41% | 37.12% | 27.14% | 3.43% | 23.97% | 33.34% | 46.47% | -56.24% |
+| h264ref | +3.36% | 39.44% | 30.34% | 13.51% | 37.33% | 4.67% | 11.60% | -86.65% |
+| gcc | +2.80% | 51.27% | 31.78% | 6.07% | 32.82% | 22.30% | 42.76% | -44.97% |
+| libquantum | +1.69% | 57.10% | 28.58% | 8.63% | 8.60% | 25.60% | 56.79% | -99.86% |
+| gobmk | +1.47% | 53.37% | 35.27% | 5.56% | 34.75% | 9.65% | 24.48% | -28.94% |
+| bzip2 | +1.20% | 45.40% | 25.11% | 7.05% | 25.63% | 11.51% | 27.72% | -57.17% |
+| astar | +0.99% | 73.01% | 25.10% | 1.12% | 26.46% | 1.49% | 31.15% | -25.33% |
+| omnetpp | +0.43% | 69.10% | 43.04% | 4.33% | 36.64% | 4.19% | 23.70% | -66.27% |
+| sjeng | +0.30% | 53.65% | 38.44% | 5.08% | 38.10% | 7.53% | 21.75% | -6.77% |
+| hmmer | +0.07% | 20.08% | 17.35% | 1.36% | 18.43% | 9.95% | 11.80% | -25.89% |
+| mcf | -0.01% | 27.53% | 10.92% | 31.53% | 29.38% | 8.89% | 26.13% | -35.61% |
+
+### 7. 可直接贴 PPT 的短结论
+
+- 总体收益: final vs baseline `+5.72%`，final vs intermediate `+2.04%`
+- 最大受益 workload: `perlbench / xalancbmk / sjeng / gcc / gobmk`
+- 核心证据: `fetch_nisn_mean` 上升、`fetchBubbles` 大降、`frontendBound` 大降、`doubleFetchCycle` 占比提高
+- 主要瓶颈: `span too large` + `target not in buffer`，而不是 `no next stream`
+
+---
+
+## English Version
+
+### 1. Overall Scores
+
+| Version | SPECint Weighted Score | Delta vs Baseline | Delta vs Intermediate |
+| --- | ---: | ---: | ---: |
+| Baseline (`fc6422716`) | 20.6959 | - | - |
+| Intermediate (`eac43be47`) | 21.4439 | +3.61% | - |
+| Final (`1cae93a`) | 21.8804 | +5.72% | +2.04% |
+
+### 2. Per-Benchmark Score Comparison
+
+| Benchmark | Ref Score | Mid Score | Final Score | Final vs Ref | Final vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| perlbench | 16.94 | 18.31 | 19.97 | +17.90% | +9.05% |
+| xalancbmk | 33.96 | 36.91 | 38.17 | +12.40% | +3.41% |
+| sjeng | 13.17 | 14.47 | 14.51 | +10.20% | +0.30% |
+| gcc | 21.17 | 22.61 | 23.24 | +9.77% | +2.80% |
+| gobmk | 15.61 | 16.35 | 16.59 | +6.24% | +1.47% |
+| h264ref | 25.23 | 25.43 | 26.29 | +4.18% | +3.36% |
+| astar | 14.33 | 14.75 | 14.89 | +3.91% | +0.99% |
+| bzip2 | 11.26 | 11.41 | 11.55 | +2.52% | +1.20% |
+| libquantum | 46.86 | 46.79 | 47.58 | +1.53% | +1.69% |
+| mcf | 34.65 | 34.93 | 34.93 | +0.80% | -0.01% |
+| omnetpp | 21.85 | 21.91 | 22.00 | +0.72% | +0.43% |
+| hmmer | 17.07 | 17.07 | 17.08 | +0.09% | +0.07% |
+
+### 3. Key Evidence for High-Gain Benchmarks
+
+| Benchmark | Score Gain vs Ref | `fetch_nisn_mean` Gain | Final `doubleFetchCycle` Share | Final `2-Fetch` Success Rate | `frontendBound` Drop | `fetchBubbles` Drop |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +17.90% | +33.83% | 29.96% | 33.30% | -89.77% | -89.98% |
+| xalancbmk | +12.40% | +18.55% | 46.47% | 55.25% | -83.29% | -84.70% |
+| sjeng | +10.20% | +33.15% | 21.75% | 30.48% | -59.45% | -63.19% |
+| gcc | +9.77% | +22.07% | 42.76% | 49.00% | -73.46% | -78.06% |
+| gobmk | +6.24% | +32.25% | 24.48% | 32.15% | -70.72% | -71.42% |
+| h264ref | +4.18% | +5.74% | 11.60% | 17.35% | -89.74% | -90.43% |
+
+### 4. Final Aggregate 2-Fetch Counters
+
+| Metric | Value |
+| --- | ---: |
+| `twoFetchOpportunity` | 61.09M |
+| `twoFetchTaken` | 22.98M |
+| `2-Fetch success rate` | 37.61% |
+| `doubleFetchCycle share` | 28.70% |
+
+### 5. Final Failure Breakdown
+
+| Failure Class | Share of Failed Opportunities |
+| --- | ---: |
+| Only `not predicted taken` | 29.69% |
+| Only `no next stream` | 13.83% |
+| Only `span too large` | 7.01% |
+| Only `target not in buffer` | 10.51% |
+| Both `span too large` and `target not in buffer` | 38.96% |
+
+### 6. Intermediate vs Final: Idealized Fetch-Window Effect
+
+| Benchmark | Final vs Mid | `span_rate` Mid | `span_rate` Final | `oob_rate` Mid | `oob_rate` Final | `doubleFetchCycle` Mid | `doubleFetchCycle` Final | `fetchBubbles` Drop vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +9.05% | 75.54% | 52.30% | 4.00% | 52.55% | 8.88% | 29.96% | -79.78% |
+| xalancbmk | +3.41% | 37.12% | 27.14% | 3.43% | 23.97% | 33.34% | 46.47% | -56.24% |
+| h264ref | +3.36% | 39.44% | 30.34% | 13.51% | 37.33% | 4.67% | 11.60% | -86.65% |
+| gcc | +2.80% | 51.27% | 31.78% | 6.07% | 32.82% | 22.30% | 42.76% | -44.97% |
+| libquantum | +1.69% | 57.10% | 28.58% | 8.63% | 8.60% | 25.60% | 56.79% | -99.86% |
+| gobmk | +1.47% | 53.37% | 35.27% | 5.56% | 34.75% | 9.65% | 24.48% | -28.94% |
+| bzip2 | +1.20% | 45.40% | 25.11% | 7.05% | 25.63% | 11.51% | 27.72% | -57.17% |
+| astar | +0.99% | 73.01% | 25.10% | 1.12% | 26.46% | 1.49% | 31.15% | -25.33% |
+| omnetpp | +0.43% | 69.10% | 43.04% | 4.33% | 36.64% | 4.19% | 23.70% | -66.27% |
+| sjeng | +0.30% | 53.65% | 38.44% | 5.08% | 38.10% | 7.53% | 21.75% | -6.77% |
+| hmmer | +0.07% | 20.08% | 17.35% | 1.36% | 18.43% | 9.95% | 11.80% | -25.89% |
+| mcf | -0.01% | 27.53% | 10.92% | 31.53% | 29.38% | 8.89% | 26.13% | -35.61% |
+
+### 7. PPT-Ready Takeaways
+
+- Overall gain: final vs baseline `+5.72%`, final vs intermediate `+2.04%`
+- Biggest winners: `perlbench / xalancbmk / sjeng / gcc / gobmk`
+- Main evidence: higher `fetch_nisn_mean`, lower `fetchBubbles`, lower `frontendBound`, higher `doubleFetchCycle` share
+- Main bottleneck: `span too large` + `target not in buffer`, not `no next stream`

--- a/docs/plans/2026-04-02-2taken-2fetch-bilingual-eval-report.md
+++ b/docs/plans/2026-04-02-2taken-2fetch-bilingual-eval-report.md
@@ -1,0 +1,617 @@
+# 2-Taken / 2-Fetch Evaluation Report (Bilingual)
+
+## 中文报告
+
+### 1. 分析范围与数据来源
+
+- 最终版本: `out/gem5/parallel-2026-03-25-idealize-fetch-window-fill/spec_all`
+  - commit: `1cae93a32bb04be2376aa5d77eb24e755751c157`
+- 中间版本: `out/gem5/parallel-2026-03-23-deepdive-on-2fetch-fetch/spec_all`
+  - commit: `eac43be470b912d3c3e63dbde80a846cd3377113`
+- baseline: `out/gem5/parallel-2026-03-25-idealize-fetch-window-fill/ref/spec_all`
+  - commit: `fc642271651f9460719b12a5fa7573cfa696587f`
+
+本报告同时检查了 GEM5 代码实现、配置改动和 `perf-weighted*.csv` / `perf-score*.csv` 中的加权 SPEC 数据。重点是理解：
+
+1. `2-Taken` 如何给 `2-Fetch` 提供下一条 fetch stream。
+2. `2-Fetch` 在 fetch stage 中何时成功、何时失败。
+3. 理想 fetch buffer / ideal fetch window fill 对结果的影响。
+4. 哪些 SPEC 子项收益明显，哪些没有收益，以及原因是什么。
+
+### 2. 代码实现结论
+
+#### 2.1 2-Taken 的角色
+
+- 在 `GEM5/src/cpu/pred/btb/decoupled_bpred.cc` 中，`DecoupledBPUWithBTB::tick()` 在 `enable2Taken` 打开时会在一个 tick 内尝试做两次 prediction。
+- `GEM5/src/cpu/pred/btb/decoupled_bpred.hh` 暴露了 `ftqHasNext()` / `ftqNext()` / `is2FetchEnabled()` / `getMaxFetchBytesPerCycle()` 这些 fetch 侧接口。
+- 从结构上看，`2-Taken` 的主要作用不是直接提升 fetch 带宽，而是更早把“下一段 fetch target”放进 FTQ，给 `2-Fetch` 提供同周期拼接的机会。
+
+结论: 这套设计里 `2-Taken` 更像前提条件，`2-Fetch` 才是把 predictor 端 lookahead 转换成 fetch 吞吐提升的关键执行点。
+
+#### 2.2 2-Fetch 的真实执行点
+
+- 核心逻辑在 `GEM5/src/cpu/o3/fetch.cc` 的 `Fetch::lookupAndUpdateNextPC(...)`。
+- 当当前 stream `run_out` 且当前分支 `predict_taken` 时，fetch 会检查：
+  - feature 是否开启；
+  - FTQ 中是否已经有 next stream；
+  - 分支 target 是否与 next stream start 匹配；
+  - 合并后 span 是否超过 `maxFetchBytesPerCycle`；
+  - target 是否仍落在当前 fetch buffer 覆盖范围内。
+- 只有这些条件同时满足时，`do_2fetch = true`，fetch 才不会在这个分支点停下来，而是继续在同一个周期把下一段 stream 也吃进去。
+
+这说明 `2-Fetch` 的本质不是简单“多取一条 cache line”，而是“在同一 fetch 周期跨越一个已预测 taken branch，继续消费下一条已知 fetch target”。
+
+#### 2.3 final 版本相对中间版本的关键改动
+
+`1cae93a` 的关键点不是重新发明 `2-Fetch`，而是把 fetch window 的约束大幅理想化：
+
+- `GEM5/configs/example/kmhv3.py`
+- `GEM5/configs/example/idealkmhv3.py`
+- `GEM5/src/cpu/o3/BaseO3CPU.py`
+- `GEM5/src/cpu/o3/fetch.cc`
+
+具体变化：
+
+- `fetchBufferSize` 从默认的 `66B` 提升到 `258B`。
+- 新增 `idealFetchWindowFill = True`，走 `Fetch::idealFillFetchBuffer(...)`，用 functional read 一次填满整个 fetch window。
+- `maxFetchBytesPerCycle` 提升到 `256B`。
+
+这意味着 final vs intermediate 不是“只隔离 ideal fetch buffer”这么简单，它更准确地说是“理想化/放宽 fetch window 约束”的实验：
+
+- 更大的可覆盖窗口；
+- 更理想的窗口填充方式；
+- 更大的同周期可接受 span。
+
+因此 final vs mid 的结果应该解读为“idealized fetch-window experiment”的效果，而不是纯粹只由一个 buffer-fill 机制单独带来的效果。
+
+### 3. 新增计数器的价值
+
+中间版本 `eac43be47` 已经加入了较完整的 `2-Fetch` 计数器，final 在其基础上又补充了更细的 failure 分类和几何分布信息。主要新增计数器位于：
+
+- `GEM5/src/cpu/o3/fetch.hh`
+- `GEM5/src/cpu/o3/fetch.cc`
+
+最有用的计数器分三类：
+
+#### 3.1 机会与成功率
+
+- `twoFetchOpportunity`
+- `twoFetchTaken`
+- `singleFetchCycleCount`
+- `doubleFetchCycleCount`
+
+这组计数器回答三个问题：
+
+1. 到底有多少次 run-out 场景可以评估 `2-Fetch`；
+2. 成功率是多少；
+3. 真正落到“同周期双 stream fetch”的 cycle 比例是多少。
+
+#### 3.2 失败原因
+
+- `twoFetchFailOnlyNotPredTaken`
+- `twoFetchFailOnlyNoNext`
+- `twoFetchFailOnlySpanTooLarge`
+- `twoFetchFailOnlyTargetNotInBuffer`
+- `twoFetchFailBothSpanAndTargetNotInBuffer`
+
+这组计数器非常关键，因为它们把“失败”从一个模糊现象拆成了 predictor 约束、FTQ 可见性约束、几何 span 约束、buffer coverage 约束。
+
+#### 3.3 几何分布
+
+- `twoFetchSpanBytes`
+- `twoFetchTargetOffsetFromBufferStart`
+- `twoFetchTargetDistancePastBufferEnd`
+- `twoFetchNextStartDelta`
+- `twoFetchRunOutBranchOffset`
+
+这组计数器让 `2-Fetch` 不再只是“成功/失败”的黑盒，而是可以判断瓶颈到底来自：
+
+- next stream 太远；
+- branch target 太靠后；
+- 当前 stream 结束点与下一段之间存在较大跨度；
+- 或者分支本身就出现在不适合拼接的位置。
+
+### 4. 总体性能结果
+
+#### 4.1 总分
+
+- baseline overall/int avg: `20.6959`
+- intermediate overall/int avg: `21.4439` (`+3.61%` vs baseline)
+- final overall/int avg: `21.8804` (`+5.72%` vs baseline, `+2.04%` vs intermediate)
+
+这说明：
+
+- `2-Taken + 2-Fetch` 主体机制本身已经带来明显收益；
+- final 的 idealized fetch-window 改动又在此基础上再抬高了一档；
+- 但增益并不均匀，明显集中在一部分前端更敏感、控制流更碎片化的 benchmark 上。
+
+#### 4.2 SPEC 子项增益表
+
+| Benchmark | Ref Score | Mid Score | Final Score | Final vs Ref | Final vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| perlbench | 16.94 | 18.31 | 19.97 | +17.90% | +9.05% |
+| xalancbmk | 33.96 | 36.91 | 38.17 | +12.40% | +3.41% |
+| sjeng | 13.17 | 14.47 | 14.51 | +10.20% | +0.30% |
+| gcc | 21.17 | 22.61 | 23.24 | +9.77% | +2.80% |
+| gobmk | 15.61 | 16.35 | 16.59 | +6.24% | +1.47% |
+| h264ref | 25.23 | 25.43 | 26.29 | +4.18% | +3.36% |
+| astar | 14.33 | 14.75 | 14.89 | +3.91% | +0.99% |
+| bzip2 | 11.26 | 11.41 | 11.55 | +2.52% | +1.20% |
+| libquantum | 46.86 | 46.79 | 47.58 | +1.53% | +1.69% |
+| mcf | 34.65 | 34.93 | 34.93 | +0.80% | -0.01% |
+| omnetpp | 21.85 | 21.91 | 22.00 | +0.72% | +0.43% |
+| hmmer | 17.07 | 17.07 | 17.08 | +0.09% | +0.07% |
+
+### 5. 哪些 benchmark 收益最明显，以及证据是什么
+
+下面把“高收益 benchmark”与关键计数器放在一起看。
+
+| Benchmark | Score Gain vs Ref | `fetch_nisn_mean` Gain | Final `doubleFetchCycle` 占比 | Final `2-Fetch` 成功率 | `frontendBound` 降幅 | `fetchBubbles` 降幅 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +17.90% | +33.83% | 29.96% | 33.30% | -89.77% | -89.98% |
+| xalancbmk | +12.40% | +18.55% | 46.47% | 55.25% | -83.29% | -84.70% |
+| sjeng | +10.20% | +33.15% | 21.75% | 30.48% | -59.45% | -63.19% |
+| gcc | +9.77% | +22.07% | 42.76% | 49.00% | -73.46% | -78.06% |
+| gobmk | +6.24% | +32.25% | 24.48% | 32.15% | -70.72% | -71.42% |
+| h264ref | +4.18% | +5.74% | 11.60% | 17.35% | -89.74% | -90.43% |
+
+#### 5.1 perlbench / gcc / xalancbmk: 最像“教科书式受益者”
+
+这几项的共同特征是：
+
+- `fetch_nisn_mean` 明显上升；
+- `doubleFetchCycleCount` 占比不低；
+- `fetchBubbles` 和 `frontendBound` 大幅下降；
+- score 提升幅度也在前列。
+
+说明它们的关键瓶颈确实在前端供给，而不是后端执行。对这类 workload，`2-Taken` 提供 next stream、`2-Fetch` 把 next stream 直接拼进当前周期，能非常直接地转化成吞吐收益。
+
+#### 5.2 sjeng / gobmk: 也受益，但几何约束仍重
+
+这两项有不小收益，但 final 中：
+
+- `twoFetchNotTakenTargetNotInBuffer` 仍高；
+- `twoFetchNotTakenSpanTooLarge` 仍高；
+- `2-Fetch` 成功率只有约 30% 左右。
+
+这说明它们虽然存在大量可利用的分支密集场景，但 stream 几何关系仍然很差，很多机会会卡在“跨度太大”或“target 超出当前窗口覆盖范围”。
+
+#### 5.3 h264ref: 前端问题被明显缓解，但不是最强 `2-Fetch` 受益者
+
+`h264ref` 的 `frontendBound` / `fetchBubbles` 降幅非常大，但 `doubleFetchCycle` 占比和 `2-Fetch` 成功率并不高。这通常意味着：
+
+- final 的理想化 fetch window 确实修复了前端供给中的一部分窗口填充问题；
+- 但 `h264ref` 的增益不完全来自频繁成功的 `2-Fetch`，而是来自 fetch 供给链整体被平滑后带来的收益。
+
+### 6. 2-Fetch 的失败原因与瓶颈
+
+#### 6.1 final 版本总体统计
+
+把 12 个 INT benchmark 聚合后：
+
+- `twoFetchOpportunity`: 约 `61.09M`
+- `twoFetchTaken`: 约 `22.98M`
+- 总成功率: `37.61%`
+- `doubleFetchCycleCount / (single + double)`: `28.70%`
+
+失败的机会进一步按 final 新增的 fail-only 计数器拆开后：
+
+- 仅因 `not predicted taken`: `29.69%`
+- 仅因 `no next stream`: `13.83%`
+- 仅因 `span too large`: `7.01%`
+- 仅因 `target not in buffer`: `10.51%`
+- 同时因 `span too large` 与 `target not in buffer`: `38.96%`
+
+这里最关键的结论是：
+
+1. 最大的瓶颈不是 FTQ 没有 next stream，而是 fetch geometry；
+2. `span` 和 `buffer coverage` 经常不是单独出现，而是一起出现；
+3. 也就是说，很多场景不是“只差一点点 buffer”，而是“整个下一段 stream 对当前周期来说就是太远了”。
+
+#### 6.2 为什么说 `2-Fetch` 的主要瓶颈是几何约束
+
+final 聚合数据中：
+
+- `twoFetchNotTakenSpanTooLarge / opportunity = 28.68%`
+- `twoFetchNotTakenTargetNotInBuffer / opportunity = 30.86%`
+
+并且这两类失败高度重叠。说明一旦允许 fetch 跨越一个 taken branch，真正限制继续向前吃下一段 stream 的，往往是：
+
+- 下一段结束点太远；
+- 或下一段 target 已超出当前 fetch window。
+
+这也解释了为什么 final 虽然显著进步，但仍然只有 `37.6%` 的机会真正成功变成 `2-Fetch`。
+
+#### 6.3 各 benchmark 的失败模式差异
+
+- `astar`: `no_next_rate` 达到 `18.62%`，同时 `span/oob` 也高，说明既有 predictor/FTQ 可见性问题，也有 stream geometry 问题。
+- `sjeng`: `oob_rate` 与 `span_rate` 都接近 `38%`，几何约束很重，所以 final 相对 mid 已接近饱和。
+- `xalancbmk`: 最终成功率高达 `55.25%`，几何条件比大多数 benchmark 更适合 `2-Fetch`。
+- `hmmer`: `doubleFetchCycle` 仅 `11.8%`，而且总体前端本来就不重，所以几乎没有性能空间。
+- `mcf`: 即使前端计数器改善不少，最终性能仍几乎不变，说明后端/内存系统仍是主导瓶颈。
+
+### 7. intermediate vs final: ideal fetch buffer / idealized fetch window 的效果
+
+#### 7.1 总结论
+
+- final 相比 intermediate: overall `+2.04%`
+- 最大受益者: `perlbench (+9.05%)`
+- 其次: `xalancbmk (+3.41%)`, `h264ref (+3.36%)`, `gcc (+2.80%)`, `libquantum (+1.69%)`, `gobmk (+1.47%)`
+- 基本不动: `sjeng`, `omnetpp`, `hmmer`, `mcf`
+
+这说明 ideal fetch-window 实验的收益主要集中在“前端仍有残余 fetch 供给瓶颈”的 workload 上；而那些已经接近别的瓶颈的 benchmark，即便再放宽 fetch 窗口也不会继续明显上涨。
+
+#### 7.2 一个容易误读但很关键的现象
+
+从 intermediate 到 final，很多 benchmark 上：
+
+- `span_rate` 明显下降；
+- `doubleFetchCycle` 占比明显上升；
+- `fetchBubbles` 明显下降；
+- 但 `targetNotInBuffer` 的比例反而可能上升。
+
+这并不表示 ideal fetch buffer 没起作用。更合理的解释是：
+
+1. `maxFetchBytesPerCycle` 被放宽到 `256B` 以后，很多原本先被判成 `span too large` 的机会，被重新分类为“仍然不在 buffer 内”或者直接成功；
+2. 同时更多机会真正走到了更深入的几何检查阶段；
+3. 所以 `targetNotInBuffer` 的计数不是单独看绝对高低，而要结合 `span`、`doubleFetchCycleCount`、`fetchBubbles` 和最终性能一起看。
+
+换句话说，final 相比 mid 的关键现象不是“某一个失败计数单独下降”，而是：
+
+- 失败分类结构发生了重排；
+- 成功的 `2-Fetch` 明显增加；
+- 真正的 fetch supply 泡泡显著减少；
+- 这些共同转化成了性能收益。
+
+#### 7.3 典型 benchmark 观察
+
+- `perlbench`: `doubleFetchCycle` 占比从约 `8.9%` 提到 `30.0%`，score 再涨 `9.05%`，是 final 版本最强证据。
+- `gcc`: `doubleFetchCycle` 占比从约 `22.3%` 提到 `42.8%`，score 再涨 `2.80%`。
+- `h264ref`: `fetchBubbles` 相对 mid 再降 `86.65%`，说明 idealized fetch window 极大缓解了前端空泡。
+- `libquantum`: `fetchBubbles` 几乎清零，说明它对 fetch window 的供给连续性非常敏感。
+- `sjeng`: final 只比 mid 再涨 `0.30%`，说明即便 fetch window 再理想化，它的剩余瓶颈也不主要在这里。
+
+### 8. 对 2-Taken / 2-Fetch feature 的完整理解
+
+#### 8.1 这套 feature 的本质
+
+更准确地说，这不是一个单点 feature，而是一条链：
+
+1. predictor 侧的 `2-Taken` 让 next stream 更早可见；
+2. fetch 侧的 `2-Fetch` 尝试在当前周期直接拼接 next stream；
+3. fetch window / fetch buffer 的覆盖能力决定这个拼接最终能否落地；
+4. 真正的收益只会出现在前端供给确实是主要瓶颈的 benchmark 上。
+
+#### 8.2 为什么 final 是“上界评估”而不是“RTL 等价评估”
+
+从代码结构看，GEM5 final 版本在 fetch 侧使用了 `idealFillFetchBuffer(...)`，它本质上绕过了真实 cache line / 时序填充成本，把整个 fetch window 理想化。
+
+因此 final 结果适合回答的是：
+
+- 如果 `2-Taken + 2-Fetch` 的几何约束被大幅放宽，理论上还能吃到多少前端收益？
+
+它不等价于：
+
+- RTL 已经具备同样实现成本下的可达收益。
+
+换句话说，final 是一个很有价值的上界，但不能直接视为硬件最终可实现值。
+
+#### 8.3 当前数据里，2-Taken 的独立贡献并没有被完全隔离
+
+虽然代码上 `2-Taken` 很重要，但在这批 `2026-03-25` 数据里，真正详尽的是 `2-Fetch` 计数器，而不是 predictor block1 的独立统计。因此：
+
+- 我们可以很清楚地分析 `2-Fetch` 成功/失败和瓶颈；
+- 但很难仅凭这批数据把“2-Taken 单独贡献”与“2-Fetch 落地贡献”完全分离。
+
+目前最接近 `2-Taken` 独立信号的，是 `noNext` 相关计数，因为它反映了 fetch 想继续拼 next stream 时，FTQ 里有没有已经准备好的下一段。
+
+### 9. 其他值得注意的点
+
+#### 9.1 这批数据的收益模式非常像“控制流密集 / 前端敏感” workloads 的专项优化
+
+收益最高的 benchmark 基本都是：
+
+- CFG 碎片化；
+- 分支较多；
+- 前端供给本来就容易形成 bubble；
+- fetch 带宽改善能较直接转化成 IPC。
+
+反过来，像 `mcf` 这类更偏后端/内存系统主导的 workload，就算 `fetchBubbles` 改善，也不一定转化成最终 score。
+
+#### 9.2 对后续硬件化最重要的不是继续加“是否成功”计数，而是继续缩小几何失败
+
+如果后续要把这个 feature 往更真实的实现推进，最关键的问题不是“2-Fetch 有没有成功过”，而是：
+
+- 如何缩小 `span too large`；
+- 如何减少 `target not in buffer`；
+- 如何让更多机会从“几何上失败”变成“几何上可行”。
+
+也就是说，下一阶段优化重点应该是 fetch window 组织方式、buffer 覆盖策略和真实 I-cache / IFU 路径，而不是继续只盯着 predictor 端。
+
+### 10. 中文总结
+
+最终结论可以概括为四句：
+
+1. `2-Taken` 的价值主要在于更早提供 next stream，真正把它变成性能的是 fetch 侧的 `2-Fetch`。
+2. `2-Fetch` 的主要瓶颈不是“没有 next”，而是 `span` 和 `buffer coverage` 这两个几何约束，而且经常是同时出现。
+3. `2026-03-25` 的 final 版本把整体 SPEC int 平均分从 baseline 的 `20.6959` 提升到 `21.8804`，总增益 `+5.72%`；其中 idealized fetch-window 实验相对中间版本再贡献 `+2.04%`。
+4. 收益最明显的是 `perlbench / xalancbmk / sjeng / gcc / gobmk` 这类前端敏感 workload；而 `mcf / hmmer / omnetpp` 等 workload 说明该 feature 不是普适万能，而是明显偏前端供给型优化。
+
+---
+
+## English Report
+
+### 1. Scope and Datasets
+
+- Final run: `out/gem5/parallel-2026-03-25-idealize-fetch-window-fill/spec_all`
+  - commit: `1cae93a32bb04be2376aa5d77eb24e755751c157`
+- Intermediate run: `out/gem5/parallel-2026-03-23-deepdive-on-2fetch-fetch/spec_all`
+  - commit: `eac43be470b912d3c3e63dbde80a846cd3377113`
+- Baseline run: `out/gem5/parallel-2026-03-25-idealize-fetch-window-fill/ref/spec_all`
+  - commit: `fc642271651f9460719b12a5fa7573cfa696587f`
+
+This report combines code inspection and weighted SPEC analysis. The main goal is to understand:
+
+1. how `2-Taken` feeds `2-Fetch`,
+2. when `2-Fetch` succeeds or fails,
+3. how much the idealized fetch-window experiment contributes,
+4. which SPEC benchmarks benefit and why.
+
+### 2. Implementation-Level Understanding
+
+#### 2.1 What `2-Taken` really does
+
+- In `GEM5/src/cpu/pred/btb/decoupled_bpred.cc`, `DecoupledBPUWithBTB::tick()` can issue two prediction attempts per tick when `enable2Taken` is enabled.
+- In `GEM5/src/cpu/pred/btb/decoupled_bpred.hh`, fetch uses `ftqHasNext()` and `ftqNext()` to look ahead to the next stream.
+
+So the main function of `2-Taken` is not a direct fetch-bandwidth gain by itself. Its real value is making the next fetch target visible early enough for fetch-side same-cycle stitching.
+
+#### 2.2 What `2-Fetch` really does
+
+- The key logic is in `GEM5/src/cpu/o3/fetch.cc`, especially `Fetch::lookupAndUpdateNextPC(...)`.
+- At stream run-out, fetch attempts same-cycle continuation only if:
+  - the current stream ends with a predicted taken branch,
+  - `2-Fetch` is enabled,
+  - the next FTQ entry is already present,
+  - the predicted branch target matches the next stream start,
+  - the merged span does not exceed `maxFetchBytesPerCycle`,
+  - and the target is still covered by the current fetch buffer.
+
+Therefore, `2-Fetch` is not just “fetching more bytes”. It is same-cycle continuation across a predicted-taken branch into the next already-known stream.
+
+#### 2.3 What the final version changes
+
+The final commit `1cae93a` mainly idealizes the fetch window:
+
+- `fetchBufferSize` increases from the default `66B` to `258B`.
+- `idealFetchWindowFill = True` enables `Fetch::idealFillFetchBuffer(...)`, which fills the whole window using a functional read.
+- `maxFetchBytesPerCycle` increases to `256B`.
+
+This matters for interpretation: final vs intermediate is not a pure “ideal fetch buffer only” experiment. It is more accurately an **idealized fetch-window** experiment combining:
+
+- a larger coverage window,
+- a more ideal fill mechanism,
+- and a much looser same-cycle span constraint.
+
+### 3. Why the New Counters Matter
+
+The intermediate run already introduces useful `2-Fetch` counters, and the final version adds finer failure decomposition plus geometry distributions.
+
+The most valuable groups are:
+
+#### 3.1 Opportunity and success
+
+- `twoFetchOpportunity`
+- `twoFetchTaken`
+- `singleFetchCycleCount`
+- `doubleFetchCycleCount`
+
+These tell us how often `2-Fetch` could be evaluated, how often it succeeds, and how often it really turns into same-cycle dual-stream fetch.
+
+#### 3.2 Failure reasons
+
+- `twoFetchFailOnlyNotPredTaken`
+- `twoFetchFailOnlyNoNext`
+- `twoFetchFailOnlySpanTooLarge`
+- `twoFetchFailOnlyTargetNotInBuffer`
+- `twoFetchFailBothSpanAndTargetNotInBuffer`
+
+These counters are the key reason the analysis is actionable: they separate predictor-side availability, FTQ visibility, span limits, and buffer-coverage limits.
+
+#### 3.3 Geometry diagnostics
+
+- `twoFetchSpanBytes`
+- `twoFetchTargetOffsetFromBufferStart`
+- `twoFetchTargetDistancePastBufferEnd`
+- `twoFetchNextStartDelta`
+- `twoFetchRunOutBranchOffset`
+
+These explain *why* a benchmark is geometry-friendly or geometry-hostile for `2-Fetch`.
+
+### 4. Overall Performance Result
+
+- Baseline overall/int avg: `20.6959`
+- Intermediate overall/int avg: `21.4439` (`+3.61%` vs baseline)
+- Final overall/int avg: `21.8804` (`+5.72%` vs baseline, `+2.04%` vs intermediate)
+
+This indicates:
+
+- the core `2-Taken + 2-Fetch` mechanism already produces a meaningful gain,
+- and the idealized fetch-window experiment unlocks another visible step,
+- but the benefit is concentrated in frontend-sensitive workloads rather than being uniformly distributed.
+
+### 5. Per-Benchmark Result
+
+| Benchmark | Ref Score | Mid Score | Final Score | Final vs Ref | Final vs Mid |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| perlbench | 16.94 | 18.31 | 19.97 | +17.90% | +9.05% |
+| xalancbmk | 33.96 | 36.91 | 38.17 | +12.40% | +3.41% |
+| sjeng | 13.17 | 14.47 | 14.51 | +10.20% | +0.30% |
+| gcc | 21.17 | 22.61 | 23.24 | +9.77% | +2.80% |
+| gobmk | 15.61 | 16.35 | 16.59 | +6.24% | +1.47% |
+| h264ref | 25.23 | 25.43 | 26.29 | +4.18% | +3.36% |
+| astar | 14.33 | 14.75 | 14.89 | +3.91% | +0.99% |
+| bzip2 | 11.26 | 11.41 | 11.55 | +2.52% | +1.20% |
+| libquantum | 46.86 | 46.79 | 47.58 | +1.53% | +1.69% |
+| mcf | 34.65 | 34.93 | 34.93 | +0.80% | -0.01% |
+| omnetpp | 21.85 | 21.91 | 22.00 | +0.72% | +0.43% |
+| hmmer | 17.07 | 17.07 | 17.08 | +0.09% | +0.07% |
+
+### 6. Where the Gains Come From
+
+| Benchmark | Score Gain vs Ref | `fetch_nisn_mean` Gain | Final `doubleFetchCycle` Share | Final `2-Fetch` Success Rate | `frontendBound` Drop | `fetchBubbles` Drop |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| perlbench | +17.90% | +33.83% | 29.96% | 33.30% | -89.77% | -89.98% |
+| xalancbmk | +12.40% | +18.55% | 46.47% | 55.25% | -83.29% | -84.70% |
+| sjeng | +10.20% | +33.15% | 21.75% | 30.48% | -59.45% | -63.19% |
+| gcc | +9.77% | +22.07% | 42.76% | 49.00% | -73.46% | -78.06% |
+| gobmk | +6.24% | +32.25% | 24.48% | 32.15% | -70.72% | -71.42% |
+| h264ref | +4.18% | +5.74% | 11.60% | 17.35% | -89.74% | -90.43% |
+
+The strongest beneficiaries are the benchmarks where better fetch supply directly translates into higher throughput: especially `perlbench`, `xalancbmk`, `gcc`, `sjeng`, and `gobmk`.
+
+### 7. Why `2-Fetch` Fails
+
+Across the 12 INT benchmarks in the final run:
+
+- `twoFetchOpportunity`: about `61.09M`
+- `twoFetchTaken`: about `22.98M`
+- overall success rate: `37.61%`
+- `doubleFetchCycleCount / (single + double)`: `28.70%`
+
+Among failed opportunities, using the final fail-only counters:
+
+- only `not predicted taken`: `29.69%`
+- only `no next stream`: `13.83%`
+- only `span too large`: `7.01%`
+- only `target not in buffer`: `10.51%`
+- both `span too large` and `target not in buffer`: `38.96%`
+
+This is the key architectural conclusion:
+
+1. the dominant bottleneck is **not** “no next FTQ entry”,
+2. the dominant bottleneck is **fetch geometry**,
+3. and span-limit and buffer-coverage failures often happen together.
+
+In other words, many candidate cases are not merely “slightly out of range”; they are structurally too far away for same-cycle continuation.
+
+### 8. Intermediate vs Final: Effect of the Idealized Fetch Window
+
+The final run improves the overall score by `+2.04%` over the intermediate run.
+
+Largest additional gains:
+
+- `perlbench`: `+9.05%`
+- `xalancbmk`: `+3.41%`
+- `h264ref`: `+3.36%`
+- `gcc`: `+2.80%`
+- `libquantum`: `+1.69%`
+- `gobmk`: `+1.47%`
+
+Nearly flat:
+
+- `sjeng`
+- `omnetpp`
+- `hmmer`
+- `mcf`
+
+An important interpretation point: from intermediate to final, `span` failure often drops, `doubleFetchCycle` rises, and `fetchBubbles` drops sharply, but `targetNotInBuffer` can still rise in rate for some benchmarks. That does **not** mean the idealized window is ineffective. It more likely means the looser `256B` span limit reclassifies many previously span-limited cases into deeper geometry checks, some of which now become either `target-not-in-buffer` or outright successes.
+
+So the real signature of the final experiment is not one single counter going down. It is the combination of:
+
+- more successful `2-Fetch`,
+- fewer fetch bubbles,
+- larger double-fetch cycle share,
+- and a higher final SPEC score.
+
+### 9. Complete Assessment of the Feature
+
+The cleanest way to understand the feature is as a chain:
+
+1. `2-Taken` exposes the next stream earlier.
+2. `2-Fetch` tries to stitch that next stream into the current cycle.
+3. fetch-window coverage decides whether that stitch is physically possible.
+4. actual speedup appears only on workloads that are genuinely frontend-limited.
+
+The final run is best interpreted as an **upper-bound study**, not an RTL-equivalent result, because `idealFillFetchBuffer(...)` idealizes the fetch-window fill path.
+
+Also, in this dataset the `2-Fetch` side is very well instrumented, but the isolated contribution of `2-Taken` is not fully separable. The closest proxy is the `noNext` family of counters, because they indicate when fetch wanted to continue but the next FTQ stream was not ready.
+
+### 10. English Summary
+
+The main conclusions are:
+
+1. `2-Taken` is mostly an enabler; `2-Fetch` is the mechanism that turns prediction lookahead into throughput.
+2. The main bottleneck of `2-Fetch` is not missing-next-stream; it is fetch geometry: span and buffer coverage.
+3. The final `2026-03-25` run raises the SPEC int average from `20.6959` to `21.8804`, for a total `+5.72%`, while the idealized fetch-window step alone contributes another `+2.04%` over the intermediate run.
+4. The biggest winners are frontend-sensitive benchmarks such as `perlbench`, `xalancbmk`, `sjeng`, `gcc`, and `gobmk`; low-gain cases like `mcf`, `hmmer`, and `omnetpp` show that this is a frontend optimization, not a universal one.
+
+---
+
+## Executive Summary / 汇报摘要
+
+### 中文 Executive Summary
+
+#### 一页结论
+
+- 本次 `2-Taken + 2-Fetch` 评估显示，final 版本相对 baseline 把 SPECint 加权平均分从 `20.6959` 提升到 `21.8804`，总增益 `+5.72%`。
+- 相对中间版本，final 的 idealized fetch-window 实验再带来 `+2.04%`，说明 fetch-window 覆盖能力和窗口填充方式仍然是 `2-Fetch` 能否兑现收益的关键因素。
+- 收益最明显的 benchmark 是 `perlbench (+17.90%)`、`xalancbmk (+12.40%)`、`sjeng (+10.20%)`、`gcc (+9.77%)`、`gobmk (+6.24%)`。
+- 低收益 benchmark 包括 `mcf (+0.80%)`、`omnetpp (+0.72%)`、`hmmer (+0.09%)`，说明该 feature 更偏向前端供给优化，而不是对所有工作负载都普适有效。
+
+#### 机制理解
+
+- `2-Taken` 的核心价值是让 next stream 更早进入 FTQ，可视为 `2-Fetch` 的前提条件。
+- `2-Fetch` 的核心价值是在当前 stream run-out 且预测 taken 时，在同一个 fetch 周期继续消费下一条 stream。
+- 因此，真正转化成 IPC/score 的关键执行点在 fetch stage，而不是 predictor 单独一侧。
+
+#### 主要证据
+
+- 高收益 benchmark 上，`fetch_nisn_mean` 普遍显著上升，例如 `perlbench +33.83%`、`sjeng +33.15%`、`gobmk +32.25%`、`gcc +22.07%`。
+- 同时，`fetchBubbles` 与 `frontendBound` 大幅下降，例如 `perlbench` 分别下降 `89.98%` / `89.77%`，`xalancbmk` 分别下降 `84.70%` / `83.29%`。
+- final 聚合统计中，`twoFetchOpportunity` 约 `61.09M`，`twoFetchTaken` 约 `22.98M`，总体成功率 `37.61%`；`doubleFetchCycle` 占比约 `28.70%`。
+
+#### 瓶颈判断
+
+- `2-Fetch` 的最大瓶颈不是 `no next stream`，而是 fetch geometry。
+- 在失败机会中：仅因 `not predicted taken` 占 `29.69%`，仅因 `no next stream` 占 `13.83%`，仅因 `span too large` 占 `7.01%`，仅因 `target not in buffer` 占 `10.51%`，同时受 `span + target-not-in-buffer` 影响的占比高达 `38.96%`。
+- 这说明后续若想把该 feature 硬件化、实用化，重点应放在缩小 `span too large` 和 `target not in buffer`，而不是只继续堆 predictor 侧 lookahead。
+
+#### 汇报建议话术
+
+- 这套 feature 的收益链条可以概括为：`2-Taken` 提前暴露 next stream，`2-Fetch` 负责同周期拼接，fetch window 决定拼接能否真正落地。
+- final 版本更适合被解读为“前端上界评估”，而不是 RTL 等价结果，因为它同时理想化了 fetch-window fill、window size 和 max span。
+- 如果后续继续推进，建议把工作重点放在真实 fetch-window 组织、buffer 覆盖和 I-cache/IFU 路径上。
+
+### English Executive Summary
+
+#### One-page conclusion
+
+- The final `2-Taken + 2-Fetch` configuration raises the weighted SPECint average from `20.6959` to `21.8804`, a total gain of `+5.72%` over the baseline.
+- Relative to the intermediate run, the final idealized fetch-window experiment contributes another `+2.04%`, showing that fetch-window coverage and fill behavior are still key enablers for `2-Fetch`.
+- The largest benchmark gains are `perlbench (+17.90%)`, `xalancbmk (+12.40%)`, `sjeng (+10.20%)`, `gcc (+9.77%)`, and `gobmk (+6.24%)`.
+- Low-gain cases such as `mcf (+0.80%)`, `omnetpp (+0.72%)`, and `hmmer (+0.09%)` show that this is primarily a frontend-supply optimization rather than a universal speedup.
+
+#### Mechanism
+
+- `2-Taken` matters because it exposes the next stream early enough in the FTQ.
+- `2-Fetch` matters because it converts that lookahead into same-cycle continuation across a predicted-taken branch.
+- So the actual throughput conversion happens in fetch, not in the predictor alone.
+
+#### Main evidence
+
+- High-gain benchmarks also show strong `fetch_nisn_mean` growth, including `perlbench +33.83%`, `sjeng +33.15%`, `gobmk +32.25%`, and `gcc +22.07%`.
+- `fetchBubbles` and `frontendBound` also drop sharply, for example `perlbench` by `89.98%` / `89.77%` and `xalancbmk` by `84.70%` / `83.29%`.
+- In the final aggregate counters, `twoFetchOpportunity` is about `61.09M`, `twoFetchTaken` is about `22.98M`, overall success rate is `37.61%`, and `doubleFetchCycle` share is about `28.70%`.
+
+#### Bottleneck assessment
+
+- The dominant `2-Fetch` bottleneck is not missing-next-stream; it is fetch geometry.
+- Among failed opportunities, `29.69%` are only due to `not predicted taken`, `13.83%` only due to `no next stream`, `7.01%` only due to `span too large`, `10.51%` only due to `target not in buffer`, and `38.96%` are constrained by both `span too large` and `target-not-in-buffer`.
+- This strongly suggests that future hardware-oriented work should focus on reducing geometry failures, especially span and coverage limits, rather than only extending predictor-side lookahead.
+
+#### Presentation-ready phrasing
+
+- The feature can be summarized as: `2-Taken` exposes the next stream early, `2-Fetch` stitches it into the same cycle, and the fetch window determines whether the stitch is physically feasible.
+- The final run should be treated as an upper-bound frontend study rather than an RTL-equivalent result, because it idealizes fetch-window fill, window size, and max span together.
+- The next practical step is to improve realistic fetch-window organization, coverage, and the I-cache/IFU path.

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -122,6 +122,8 @@ class BaseO3CPU(BaseCPU):
     commitToFetchDelay = Param.Cycles(3, "Commit to fetch delay")
     fetchWidth = Param.Unsigned(16, "Fetch width")
     fetchBufferSize = Param.Unsigned(66, "Fetch buffer size in bytes")
+    idealFetchWindowFill = Param.Bool(False,
+        "Fill the full fetch buffer in one cycle using functional access")
     fetchQueueSize = Param.Unsigned(48, "Fetch queue size in micro-ops "
                                     "per-thread")
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -258,6 +258,44 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "2Fetch not taken because merged span exceeds max fetch bytes per cycle"),
     ADD_STAT(twoFetchNotTakenTargetNotInBuffer, statistics::units::Count::get(),
              "2Fetch not taken because target is not fully covered by current fetch buffer"),
+    ADD_STAT(twoFetchFailOnlyNoNext, statistics::units::Count::get(),
+             "2Fetch failure caused only by missing next stream"),
+    ADD_STAT(twoFetchFailOnlyNotPredTaken, statistics::units::Count::get(),
+             "2Fetch failure caused only by stream end without predicted taken branch"),
+    ADD_STAT(twoFetchFailOnlySpanTooLarge, statistics::units::Count::get(),
+             "2Fetch failure caused only by span exceeding max fetch bytes per cycle"),
+    ADD_STAT(twoFetchFailOnlyTargetNotInBuffer, statistics::units::Count::get(),
+             "2Fetch failure caused only by target not being fully covered by current fetch buffer"),
+    ADD_STAT(twoFetchFailBothSpanAndTargetNotInBuffer, statistics::units::Count::get(),
+             "2Fetch failure caused by both span-too-large and target-not-in-buffer"),
+    ADD_STAT(twoFetchTargetBeforeBuffer, statistics::units::Count::get(),
+             "2Fetch target falls before current fetch buffer start"),
+    ADD_STAT(twoFetchTargetAfterBuffer, statistics::units::Count::get(),
+             "2Fetch target falls after current fetch buffer end"),
+    ADD_STAT(twoFetchNextStreamForward, statistics::units::Count::get(),
+             "2Fetch next stream starts at or after current stream start"),
+    ADD_STAT(twoFetchNextStreamBackward, statistics::units::Count::get(),
+             "2Fetch next stream starts before current stream start"),
+    ADD_STAT(twoFetchSpanForwardOrZero, statistics::units::Count::get(),
+             "2Fetch next stream predicted end is at or after current stream start"),
+    ADD_STAT(twoFetchSpanBackward, statistics::units::Count::get(),
+             "2Fetch next stream predicted end is before current stream start"),
+    ADD_STAT(twoFetchTargetOffsetFromBufferStart, statistics::units::Byte::get(),
+             "Target offset from current fetch buffer start for 2Fetch opportunities"),
+    ADD_STAT(twoFetchTargetDistanceBeforeBufferStart, statistics::units::Byte::get(),
+             "Distance from target to current fetch buffer start when target is before it"),
+    ADD_STAT(twoFetchTargetDistancePastBufferEnd, statistics::units::Byte::get(),
+             "Distance in bytes by which target exceeds current fetch buffer end"),
+    ADD_STAT(twoFetchSpanBytes, statistics::units::Byte::get(),
+             "Span in bytes from current stream start to next stream predicted end"),
+    ADD_STAT(twoFetchBackwardSpanDistance, statistics::units::Byte::get(),
+             "Backward span distance when next stream predicted end precedes current stream start"),
+    ADD_STAT(twoFetchNextStartDelta, statistics::units::Byte::get(),
+             "Byte delta from current stream start to next stream start"),
+    ADD_STAT(twoFetchBackwardNextStartDistance, statistics::units::Byte::get(),
+             "Backward start delta when next stream starts before current stream start"),
+    ADD_STAT(twoFetchRunOutBranchOffset, statistics::units::Byte::get(),
+             "Offset of predicted control PC within current stream at run-out"),
     ADD_STAT(singleFetchCycleCount, statistics::units::Count::get(),
              "Cycles with fetched instructions but without 2Fetch"),
     ADD_STAT(singleFetchCycleInsts, statistics::units::Count::get(),
@@ -400,6 +438,52 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .prereq(twoFetchNotTakenSpanTooLarge);
         twoFetchNotTakenTargetNotInBuffer
             .prereq(twoFetchNotTakenTargetNotInBuffer);
+        twoFetchFailOnlyNoNext
+            .prereq(twoFetchFailOnlyNoNext);
+        twoFetchFailOnlyNotPredTaken
+            .prereq(twoFetchFailOnlyNotPredTaken);
+        twoFetchFailOnlySpanTooLarge
+            .prereq(twoFetchFailOnlySpanTooLarge);
+        twoFetchFailOnlyTargetNotInBuffer
+            .prereq(twoFetchFailOnlyTargetNotInBuffer);
+        twoFetchFailBothSpanAndTargetNotInBuffer
+            .prereq(twoFetchFailBothSpanAndTargetNotInBuffer);
+        twoFetchTargetBeforeBuffer
+            .prereq(twoFetchTargetBeforeBuffer);
+        twoFetchTargetAfterBuffer
+            .prereq(twoFetchTargetAfterBuffer);
+        twoFetchNextStreamForward
+            .prereq(twoFetchNextStreamForward);
+        twoFetchNextStreamBackward
+            .prereq(twoFetchNextStreamBackward);
+        twoFetchSpanForwardOrZero
+            .prereq(twoFetchSpanForwardOrZero);
+        twoFetchSpanBackward
+            .prereq(twoFetchSpanBackward);
+        twoFetchTargetOffsetFromBufferStart
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchTargetDistanceBeforeBufferStart
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchTargetDistancePastBufferEnd
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchSpanBytes
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchBackwardSpanDistance
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchNextStartDelta
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchBackwardNextStartDistance
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
+        twoFetchRunOutBranchOffset
+            .init(0, 128, 4)
+            .flags(statistics::pdf);
         singleFetchCycleCount
             .prereq(singleFetchCycleCount);
         singleFetchCycleInsts
@@ -894,18 +978,65 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
         } else {
             const Addr target_pc = stream.predBranchInfo.target;
             const auto &next_stream = dbpbtb->ftqNext(tid);
+            const Addr buffer_start = threads[tid].startPC;
+            const Addr buffer_end = threads[tid].startPC + fetchBufferSize;
             const Addr span = next_stream.predEndPC - stream.startPC;
             const unsigned max_bytes = dbpbtb->getMaxFetchBytesPerCycle();
+            const bool target_before_buffer = target_pc < buffer_start;
+            const bool target_after_buffer = target_pc + 4 > buffer_end;
+            const bool next_stream_backward = next_stream.startPC < stream.startPC;
+            const bool span_backward = next_stream.predEndPC < stream.startPC;
+            const Addr target_offset = target_pc - buffer_start;
+            const Addr next_start_delta = next_stream.startPC - stream.startPC;
+            const Addr branch_offset = stream.predBranchInfo.pc - stream.startPC;
             const bool target_in_buffer =
-                target_pc >= threads[tid].startPC &&
-                target_pc + 4 <= threads[tid].startPC + fetchBufferSize;
+                !target_before_buffer && !target_after_buffer;
+            const bool span_too_large = span > max_bytes;
+
+            if (target_before_buffer) {
+                ++fetchStats.twoFetchTargetBeforeBuffer;
+                fetchStats.twoFetchTargetDistanceBeforeBufferStart.sample(
+                    buffer_start - target_pc);
+            } else if (target_after_buffer) {
+                ++fetchStats.twoFetchTargetAfterBuffer;
+                fetchStats.twoFetchTargetDistancePastBufferEnd.sample(
+                    target_pc + 4 - buffer_end);
+            } else {
+                fetchStats.twoFetchTargetOffsetFromBufferStart.sample(target_offset);
+            }
+
+            if (next_stream_backward) {
+                ++fetchStats.twoFetchNextStreamBackward;
+                fetchStats.twoFetchBackwardNextStartDistance.sample(
+                    stream.startPC - next_stream.startPC);
+            } else {
+                ++fetchStats.twoFetchNextStreamForward;
+                fetchStats.twoFetchNextStartDelta.sample(next_start_delta);
+            }
+
+            if (span_backward) {
+                ++fetchStats.twoFetchSpanBackward;
+                fetchStats.twoFetchBackwardSpanDistance.sample(
+                    stream.startPC - next_stream.predEndPC);
+            } else {
+                ++fetchStats.twoFetchSpanForwardOrZero;
+                fetchStats.twoFetchSpanBytes.sample(span);
+            }
+
+            fetchStats.twoFetchRunOutBranchOffset.sample(branch_offset);
 
             if (target_pc != next_stream.startPC) {
                 ++fetchStats.twoFetchNotTakenTargetMismatch;
-            } else if (span > max_bytes) {
+            } else if (span_too_large && !target_in_buffer) {
                 ++fetchStats.twoFetchNotTakenSpanTooLarge;
+                ++fetchStats.twoFetchNotTakenTargetNotInBuffer;
+                ++fetchStats.twoFetchFailBothSpanAndTargetNotInBuffer;
+            } else if (span_too_large) {
+                ++fetchStats.twoFetchNotTakenSpanTooLarge;
+                ++fetchStats.twoFetchFailOnlySpanTooLarge;
             } else if (!target_in_buffer) {
                 ++fetchStats.twoFetchNotTakenTargetNotInBuffer;
+                ++fetchStats.twoFetchFailOnlyTargetNotInBuffer;
             } else {
                 do_2fetch = true;
                 cycleUsed2Fetch = true;
@@ -915,6 +1046,12 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
                         "max=%u)\n",
                         stream.startPC, stream.predEndPC, next_stream.startPC, next_stream.predEndPC, span, max_bytes);
             }
+        }
+
+        if (!predict_taken) {
+            ++fetchStats.twoFetchFailOnlyNotPredTaken;
+        } else if (dbpbtb->is2FetchEnabled() && !dbpbtb->ftqHasNext(tid)) {
+            ++fetchStats.twoFetchFailOnlyNoNext;
         }
 
         dbpbtb->consumeFetchTarget(ftqEntryFetchedInsts[tid], tid);

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -226,6 +226,54 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "Number of outstanding ITLB misses that were squashed"),
     ADD_STAT(nisnDist, statistics::units::Count::get(),
              "Number of instructions fetched each cycle (Total)"),
+    ADD_STAT(performIFCalls, statistics::units::Count::get(),
+             "Number of performInstructionFetch calls"),
+    ADD_STAT(performIFWhileEntered, statistics::units::Count::get(),
+             "Number of performInstructionFetch calls that enter the main while loop"),
+    ADD_STAT(performIFWhileIterations, statistics::units::Count::get(),
+             "Total number of iterations in the main fetch while loop"),
+    ADD_STAT(performIFWhileNotEnteredFetchWidth, statistics::units::Count::get(),
+             "Main fetch while loop not entered because fetch width was already exhausted"),
+    ADD_STAT(performIFWhileNotEnteredFetchQueueFull, statistics::units::Count::get(),
+             "Main fetch while loop not entered because fetch queue was full"),
+    ADD_STAT(performIFWhileNotEnteredStopFetch, statistics::units::Count::get(),
+             "Main fetch while loop not entered because fetch had already decided to stop"),
+    ADD_STAT(performIFWhileNotEnteredFtqEmpty, statistics::units::Count::get(),
+             "Main fetch while loop not entered because FTQ had no fetch target"),
+    ADD_STAT(performIFWhileNotEnteredWaitForVsetvl, statistics::units::Count::get(),
+             "Main fetch while loop not entered because vector config blocked fetch"),
+    ADD_STAT(twoFetchOpportunity, statistics::units::Count::get(),
+             "Number of end-of-stream opportunities that evaluate 2Fetch"),
+    ADD_STAT(twoFetchTaken, statistics::units::Count::get(),
+             "Number of successful 2Fetch extensions"),
+    ADD_STAT(twoFetchNotTakenNotPredTaken, statistics::units::Count::get(),
+             "2Fetch not taken because the stream ended without a predicted taken branch"),
+    ADD_STAT(twoFetchNotTakenDisabled, statistics::units::Count::get(),
+             "2Fetch not taken because 2Fetch is disabled"),
+    ADD_STAT(twoFetchNotTakenNoNext, statistics::units::Count::get(),
+             "2Fetch not taken because the next FTQ entry is unavailable"),
+    ADD_STAT(twoFetchNotTakenTargetMismatch, statistics::units::Count::get(),
+             "2Fetch not taken because next stream start does not match branch target"),
+    ADD_STAT(twoFetchNotTakenSpanTooLarge, statistics::units::Count::get(),
+             "2Fetch not taken because merged span exceeds max fetch bytes per cycle"),
+    ADD_STAT(twoFetchNotTakenTargetNotInBuffer, statistics::units::Count::get(),
+             "2Fetch not taken because target is not fully covered by current fetch buffer"),
+    ADD_STAT(singleFetchCycleCount, statistics::units::Count::get(),
+             "Cycles with fetched instructions but without 2Fetch"),
+    ADD_STAT(singleFetchCycleInsts, statistics::units::Count::get(),
+             "Fetched instructions in cycles without 2Fetch"),
+    ADD_STAT(singleFetchCycleInstMean, statistics::units::Rate<
+                    statistics::units::Count, statistics::units::Cycle>::get(),
+             "Average fetched instructions in cycles without 2Fetch",
+             singleFetchCycleInsts / singleFetchCycleCount),
+    ADD_STAT(doubleFetchCycleCount, statistics::units::Count::get(),
+             "Cycles with fetched instructions and with 2Fetch"),
+    ADD_STAT(doubleFetchCycleInsts, statistics::units::Count::get(),
+             "Fetched instructions in cycles with 2Fetch"),
+    ADD_STAT(doubleFetchCycleInstMean, statistics::units::Rate<
+                    statistics::units::Count, statistics::units::Cycle>::get(),
+             "Average fetched instructions in cycles with 2Fetch",
+             doubleFetchCycleInsts / doubleFetchCycleCount),
     ADD_STAT(idleRate, statistics::units::Ratio::get(),
              "Ratio of cycles fetch was idle",
              idleCycles / cpu->baseStats.numCycles),
@@ -320,6 +368,50 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
               /* last value */ fetch->fetchWidth,
               /* bucket size */ 1)
             .flags(statistics::pdf);
+        performIFCalls
+            .prereq(performIFCalls);
+        performIFWhileEntered
+            .prereq(performIFWhileEntered);
+        performIFWhileIterations
+            .prereq(performIFWhileIterations);
+        performIFWhileNotEnteredFetchWidth
+            .prereq(performIFWhileNotEnteredFetchWidth);
+        performIFWhileNotEnteredFetchQueueFull
+            .prereq(performIFWhileNotEnteredFetchQueueFull);
+        performIFWhileNotEnteredStopFetch
+            .prereq(performIFWhileNotEnteredStopFetch);
+        performIFWhileNotEnteredFtqEmpty
+            .prereq(performIFWhileNotEnteredFtqEmpty);
+        performIFWhileNotEnteredWaitForVsetvl
+            .prereq(performIFWhileNotEnteredWaitForVsetvl);
+        twoFetchOpportunity
+            .prereq(twoFetchOpportunity);
+        twoFetchTaken
+            .prereq(twoFetchTaken);
+        twoFetchNotTakenNotPredTaken
+            .prereq(twoFetchNotTakenNotPredTaken);
+        twoFetchNotTakenDisabled
+            .prereq(twoFetchNotTakenDisabled);
+        twoFetchNotTakenNoNext
+            .prereq(twoFetchNotTakenNoNext);
+        twoFetchNotTakenTargetMismatch
+            .prereq(twoFetchNotTakenTargetMismatch);
+        twoFetchNotTakenSpanTooLarge
+            .prereq(twoFetchNotTakenSpanTooLarge);
+        twoFetchNotTakenTargetNotInBuffer
+            .prereq(twoFetchNotTakenTargetNotInBuffer);
+        singleFetchCycleCount
+            .prereq(singleFetchCycleCount);
+        singleFetchCycleInsts
+            .prereq(singleFetchCycleInsts);
+        singleFetchCycleInstMean
+            .flags(statistics::total);
+        doubleFetchCycleCount
+            .prereq(doubleFetchCycleCount);
+        doubleFetchCycleInsts
+            .prereq(doubleFetchCycleInsts);
+        doubleFetchCycleInstMean
+            .flags(statistics::total);
         idleRate
             .prereq(idleRate);
         branchRate
@@ -792,7 +884,14 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
     // Track how many dynamic instructions were fetched for this (legacy) FTQ/FSQ entry.
     ftqEntryFetchedInsts[tid]++;
     if (run_out) {
-        if (predict_taken && dbpbtb->is2FetchEnabled() && dbpbtb->ftqHasNext(tid)) {
+        ++fetchStats.twoFetchOpportunity;
+        if (!predict_taken) {
+            ++fetchStats.twoFetchNotTakenNotPredTaken;
+        } else if (!dbpbtb->is2FetchEnabled()) {
+            ++fetchStats.twoFetchNotTakenDisabled;
+        } else if (!dbpbtb->ftqHasNext(tid)) {
+            ++fetchStats.twoFetchNotTakenNoNext;
+        } else {
             const Addr target_pc = stream.predBranchInfo.target;
             const auto &next_stream = dbpbtb->ftqNext(tid);
             const Addr span = next_stream.predEndPC - stream.startPC;
@@ -801,8 +900,16 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
                 target_pc >= threads[tid].startPC &&
                 target_pc + 4 <= threads[tid].startPC + fetchBufferSize;
 
-            if (target_pc == next_stream.startPC && span <= max_bytes && target_in_buffer) {
+            if (target_pc != next_stream.startPC) {
+                ++fetchStats.twoFetchNotTakenTargetMismatch;
+            } else if (span > max_bytes) {
+                ++fetchStats.twoFetchNotTakenSpanTooLarge;
+            } else if (!target_in_buffer) {
+                ++fetchStats.twoFetchNotTakenTargetNotInBuffer;
+            } else {
                 do_2fetch = true;
+                cycleUsed2Fetch = true;
+                ++fetchStats.twoFetchTaken;
                 DPRINTF(DecoupleBP,
                         "2Fetch: extend in-cycle to next FSQ entry (cur [%#lx, %#lx), next [%#lx, %#lx), span=%lu, "
                         "max=%u)\n",
@@ -1239,6 +1346,7 @@ Fetch::initializeTickState()
     bool status_change = false;
 
     wroteToTimeBuffer = false;
+    cycleUsed2Fetch = false;
     setAllFetchStalls(StallReason::NoStall);
 
     // get the distribution of fetch status
@@ -1278,6 +1386,15 @@ Fetch::fetchAndProcessInstructions(bool status_change)
 
     // Record number of instructions fetched this cycle for distribution.
     fetchStats.nisnDist.sample(numInst);
+    if (numInst > 0) {
+        if (cycleUsed2Fetch) {
+            ++fetchStats.doubleFetchCycleCount;
+            fetchStats.doubleFetchCycleInsts += numInst;
+        } else {
+            ++fetchStats.singleFetchCycleCount;
+            fetchStats.singleFetchCycleInsts += numInst;
+        }
+    }
 
     if (status_change) {
         // Change the fetch stage status if there was a status change.
@@ -1954,13 +2071,18 @@ Fetch::performInstructionFetch(ThreadID tid)
     // Control flags for main fetch loop
     bool stopFetchThisCycle = false;
 
+    ++fetchStats.performIFCalls;
+
     DPRINTF(Fetch, "[tid:%i] Adding instructions to queue to decode.\n", tid);
 
     // Main instruction fetch loop - process until fetch width or other limits
     // For decoupled frontend (including trace mode), check FTQ availability
     StallReason stall = StallReason::NoStall;
+    bool enteredMainLoop = false;
     while (numInst < fetchWidth && fetchQueue[tid].size() < fetchQueueSize &&
            !stopFetchThisCycle && !ftqEmpty(tid) && !waitForVsetvl) {
+        enteredMainLoop = true;
+        ++fetchStats.performIFWhileIterations;
 
         // Check memory needs and supply bytes to decoder if required
         stall = checkMemoryNeeds(tid, pc_state, curMacroop);
@@ -1978,6 +2100,20 @@ Fetch::performInstructionFetch(ThreadID tid)
         } while (curMacroop &&
                  numInst < fetchWidth &&
                  fetchQueue[tid].size() < fetchQueueSize);
+    }
+
+    if (enteredMainLoop) {
+        ++fetchStats.performIFWhileEntered;
+    } else if (numInst >= fetchWidth) {
+        ++fetchStats.performIFWhileNotEnteredFetchWidth;
+    } else if (fetchQueue[tid].size() >= fetchQueueSize) {
+        ++fetchStats.performIFWhileNotEnteredFetchQueueFull;
+    } else if (stopFetchThisCycle) {
+        ++fetchStats.performIFWhileNotEnteredStopFetch;
+    } else if (ftqEmpty(tid)) {
+        ++fetchStats.performIFWhileNotEnteredFtqEmpty;
+    } else if (waitForVsetvl) {
+        ++fetchStats.performIFWhileNotEnteredWaitForVsetvl;
     }
 
     // Debug output for fetch queue contents

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -71,6 +71,8 @@
 #include "debug/O3PipeView.hh"
 #include "debug/TraceReader.hh"
 #include "mem/packet.hh"
+#include "mem/se_translating_port_proxy.hh"
+#include "mem/translating_port_proxy.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/full_system.hh"
 #include "sim/system.hh"
@@ -101,6 +103,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       retryTid(InvalidThreadID),
       cacheBlkSize(cpu->cacheLineSize()),
       fetchBufferSize(params.fetchBufferSize),
+      idealFetchWindowFill(params.idealFetchWindowFill),
       fetchQueueSize(params.fetchQueueSize),
       numThreads(params.numThreads),
       numFetchingThreads(params.smtNumFetchingThreads),
@@ -644,12 +647,11 @@ Fetch::handleMultiCacheLineFetch(Addr vaddr, ThreadID tid, Addr pc)
     threads[tid].cacheReq.totalSize = fetchBufferSize;
 
     Addr fetchPC = vaddr;
-    unsigned fetchSize = cacheBlkSize - fetchPC % cacheBlkSize;  // Size for first cache line
+    unsigned fetchSize = cacheBlkSize - fetchPC % cacheBlkSize;
 
     DPRINTF(Fetch, "[tid:%i] Creating first cache line request: addr=%#x, size=%d\n",
             tid, fetchPC, fetchSize);
 
-    // Create and send first request (tail of first cache line)
     RequestPtr first_mem_req = std::make_shared<Request>(
         fetchPC, fetchSize,
         Request::INST_FETCH, cpu->instRequestorId(), pc,
@@ -659,24 +661,21 @@ Fetch::handleMultiCacheLineFetch(Addr vaddr, ThreadID tid, Addr pc)
     first_mem_req->setMisalignedFetch();
     first_mem_req->setReqNum(1);
 
-    threads[tid].cacheReq.addRequest(first_mem_req); // packet will be created later
+    threads[tid].cacheReq.addRequest(first_mem_req);
 
-    // Initiate translation for first request
     updateCacheRequestStatusByRequest(tid, first_mem_req, TlbWait);
     setAllFetchStalls(StallReason::ITlbStall);
     FetchTranslation *trans = new FetchTranslation(this);
     cpu->mmu->translateTiming(first_mem_req, cpu->thread[tid]->getTC(),
                               trans, BaseMMU::Execute);
 
-    // Prepare second request (head of second cache line)
-    fetchPC += fetchSize;  // Move to start of next cache line
+    fetchPC += fetchSize;
     assert(fetchPC % cacheBlkSize == 0);
-    fetchSize = fetchBufferSize - fetchSize;  // Remaining size
+    fetchSize = fetchBufferSize - fetchSize;
 
     DPRINTF(Fetch, "[tid:%i] Creating second cache line request: addr=%#x, size=%d\n",
             tid, fetchPC, fetchSize);
 
-    // Create and send second request
     RequestPtr second_mem_req = std::make_shared<Request>(
         fetchPC, fetchSize,
         Request::INST_FETCH, cpu->instRequestorId(), pc,
@@ -686,16 +685,53 @@ Fetch::handleMultiCacheLineFetch(Addr vaddr, ThreadID tid, Addr pc)
     second_mem_req->setMisalignedFetch();
     second_mem_req->setReqNum(2);
 
-    threads[tid].cacheReq.addRequest(second_mem_req);  // Add second request to cache request
+    threads[tid].cacheReq.addRequest(second_mem_req);
 
     DPRINTF(Fetch, "[tid:%i] Initiating translation for second cache line\n", tid);
 
-    // Always initiate translation for second request, regardless of first request status
     updateCacheRequestStatusByRequest(tid, second_mem_req, TlbWait);
     setAllFetchStalls(StallReason::ITlbStall);
     FetchTranslation *trans2 = new FetchTranslation(this);
     cpu->mmu->translateTiming(second_mem_req, cpu->thread[tid]->getTC(),
                               trans2, BaseMMU::Execute);
+    return true;
+}
+
+bool
+Fetch::idealFillFetchBuffer(Addr vaddr, ThreadID tid, Addr pc)
+{
+    DPRINTF(Fetch,
+            "[tid:%i] Ideal full-window fill for addr %#x, pc=%#lx, size=%u\n",
+            tid, vaddr, pc, fetchBufferSize);
+
+    auto *tc = cpu->thread[tid]->getTC();
+    threads[tid].cacheReq.reset();
+    threads[tid].cacheReq.baseAddr = vaddr;
+    threads[tid].cacheReq.totalSize = fetchBufferSize;
+    threads[tid].startPC = vaddr;
+
+    bool ok = false;
+    if (FullSystem) {
+        TranslatingPortProxy proxy(tc, Request::INST_FETCH);
+        ok = proxy.tryReadBlob(vaddr, threads[tid].data, fetchBufferSize);
+    } else {
+        SETranslatingPortProxy proxy(tc, SETranslatingPortProxy::Always,
+                                     Request::INST_FETCH);
+        ok = proxy.tryReadBlob(vaddr, threads[tid].data, fetchBufferSize);
+    }
+
+    if (!ok) {
+        DPRINTF(Fetch,
+                "[tid:%i] Ideal full-window fill failed at addr %#x size=%u\n",
+                tid, vaddr, fetchBufferSize);
+        return false;
+    }
+
+    threads[tid].valid = true;
+    setThreadStatus(tid, Running);
+    setAllFetchStalls(StallReason::NoStall);
+    cpu->wakeCPU();
+    switchToActive();
     return true;
 }
 
@@ -735,7 +771,6 @@ Fetch::processMultiCacheLineCompletion(ThreadID tid, PacketPtr pkt)
     // All packets have arrived - merge them directly into fetchBuffer
     DPRINTF(Fetch, "[tid:%i] All packets arrived, merging data into fetchBuffer.\n", tid);
 
-    // Find the packets by request number
     PacketPtr firstPkt = nullptr;
     PacketPtr secondPkt = nullptr;
 
@@ -749,12 +784,10 @@ Fetch::processMultiCacheLineCompletion(ThreadID tid, PacketPtr pkt)
 
     assert(firstPkt && secondPkt);
 
-    // Copy merged data directly into fetchBuffer
     memcpy(threads[tid].data, firstPkt->getConstPtr<uint8_t>(), firstPkt->getSize());
     memcpy(threads[tid].data + firstPkt->getSize(), secondPkt->getConstPtr<uint8_t>(), secondPkt->getSize());
     threads[tid].valid = true;
 
-    // Clean up the packets
     delete firstPkt;
     delete secondPkt;
 
@@ -1111,6 +1144,10 @@ Fetch::fetchCacheLine(Addr vaddr, ThreadID tid, Addr pc)
     DPRINTF(Fetch, "[tid:%i] Fetching cache line %#x for addr %#x, pc=%#lx\n",
             tid, vaddr, vaddr, pc);
 
+    if (idealFetchWindowFill) {
+        return idealFillFetchBuffer(vaddr, tid, pc);
+    }
+
     // With 66-byte fetchBufferSize, we always need to access 2 cache lines
     return handleMultiCacheLineFetch(vaddr, tid, pc);
 }
@@ -1331,15 +1368,12 @@ Fetch::doSquash(PCStateBase &new_pc, const DynInstPtr squashInst, const InstSeqN
     // Clear the icache miss if it's outstanding.
     DPRINTF(Fetch, "[tid:%i] Squash: clear cacheReq, current fetchStatus[tid]=%d\n", tid, fetchStatus[tid]);
 
-    // Cancel all active cache requests in new status system
     threads[tid].cacheReq.cancelAllRequests();
     DPRINTF(Fetch, "[tid:%i] Squash: cancelled all cache requests, status: %s\n",
             tid, threads[tid].cacheReq.getStatusSummary().c_str());
 
-    // Reset the cache request after cancelling
     threads[tid].cacheReq.reset();
 
-    // Get rid of the retrying packet if it was from this thread.
     if (retryTid == tid) {
         assert(cacheBlocked);
         for (auto it : retryPkt) {
@@ -1347,7 +1381,7 @@ Fetch::doSquash(PCStateBase &new_pc, const DynInstPtr squashInst, const InstSeqN
         }
         retryPkt.clear();
         retryTid = InvalidThreadID;
-        cacheBlocked = false;   // clear cache blocked
+        cacheBlocked = false;
     }
 
     if (squashInst && !squashInst->isControl()) {
@@ -2072,7 +2106,6 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
         fetch_pc + 4 > threads[tid].startPC + fetchBufferSize) {
         DPRINTF(Fetch, "[tid:%i] PC %#x outside fetch buffer range [%#x, %#x), stalling on ICache\n",
                 tid, fetch_pc, threads[tid].startPC, threads[tid].startPC + fetchBufferSize);
-        // Force issuing a new I-cache request.
         threads[tid].valid = false;
         return StallReason::IcacheStall;
     }

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -787,13 +787,35 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
         run_out = fall_thru >= stream.predEndPC;
     }
 
+    bool do_2fetch = false;
+
     // Track how many dynamic instructions were fetched for this (legacy) FTQ/FSQ entry.
     ftqEntryFetchedInsts[tid]++;
     if (run_out) {
+        if (predict_taken && dbpbtb->is2FetchEnabled() && dbpbtb->ftqHasNext(tid)) {
+            const Addr target_pc = stream.predBranchInfo.target;
+            const auto &next_stream = dbpbtb->ftqNext(tid);
+            const Addr span = next_stream.predEndPC - stream.startPC;
+            const unsigned max_bytes = dbpbtb->getMaxFetchBytesPerCycle();
+            const bool target_in_buffer =
+                target_pc >= threads[tid].startPC &&
+                target_pc + 4 <= threads[tid].startPC + fetchBufferSize;
+
+            if (target_pc == next_stream.startPC && span <= max_bytes && target_in_buffer) {
+                do_2fetch = true;
+                DPRINTF(DecoupleBP,
+                        "2Fetch: extend in-cycle to next FSQ entry (cur [%#lx, %#lx), next [%#lx, %#lx), span=%lu, "
+                        "max=%u)\n",
+                        stream.startPC, stream.predEndPC, next_stream.startPC, next_stream.predEndPC, span, max_bytes);
+            }
+        }
+
         dbpbtb->consumeFetchTarget(ftqEntryFetchedInsts[tid], tid);
         ftqEntryFetchedInsts[tid] = 0;
-        threads[tid].valid = false;
-        DPRINTF(DecoupleBP, "Used up fetch targets.\n");
+        if (!do_2fetch) {
+            threads[tid].valid = false;
+            DPRINTF(DecoupleBP, "Used up fetch targets.\n");
+        }
     }
 
     inst->setLoopIteration(currentLoopIter);
@@ -819,7 +841,7 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
         ++fetchStats.predictedBranches;
     }
 
-    return predict_taken;
+    return predict_taken && !do_2fetch;
 }
 
 bool
@@ -1796,6 +1818,8 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
         fetch_pc + 4 > threads[tid].startPC + fetchBufferSize) {
         DPRINTF(Fetch, "[tid:%i] PC %#x outside fetch buffer range [%#x, %#x), stalling on ICache\n",
                 tid, fetch_pc, threads[tid].startPC, threads[tid].startPC + fetchBufferSize);
+        // Force issuing a new I-cache request.
+        threads[tid].valid = false;
         return StallReason::IcacheStall;
     }
 
@@ -1818,7 +1842,7 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
                                StaticInstPtr &curMacroop)
 {
     auto *dec_ptr = decoder[tid];
-    bool predictedBranch = false;
+    bool stopFetchThisCycle = false;
     bool newMacroop = false;
 
     // Create a copy of the current PC state to calculate the next PC.
@@ -1875,16 +1899,17 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
     set(next_pc, pc);
 
     // Handle branch prediction and update next_pc for both modes
-    predictedBranch = lookupAndUpdateNextPC(instruction, *next_pc);
+    stopFetchThisCycle = lookupAndUpdateNextPC(instruction, *next_pc);
+    const bool predictedTaken = instruction->readPredTaken();
 
-    if (predictedBranch) {
+    if (predictedTaken) {
         DPRINTF(Fetch, "[tid:%i] Branch detected with PC = %s, target = %s\n",
                 instruction->threadNumber, pc, *next_pc);
     }
 
     if (isTraceMode()) {
         assert(traceFetch);
-        traceFetch->postBranchPredict(tid, instruction, traceForThisInst, pc, *next_pc, predictedBranch);
+        traceFetch->postBranchPredict(tid, instruction, traceForThisInst, pc, *next_pc, predictedTaken);
     }
 
     // A new macro-op also begins if the PC changes discontinuously.
@@ -1909,7 +1934,7 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
         delete vpPredMetaData;
     }
 
-    return predictedBranch;
+    return stopFetchThisCycle;
 }
 
 void
@@ -1927,7 +1952,7 @@ Fetch::performInstructionFetch(ThreadID tid)
     StaticInstPtr &curMacroop = macroop[tid];
 
     // Control flags for main fetch loop
-    bool predictedBranch = false;
+    bool stopFetchThisCycle = false;
 
     DPRINTF(Fetch, "[tid:%i] Adding instructions to queue to decode.\n", tid);
 
@@ -1935,7 +1960,7 @@ Fetch::performInstructionFetch(ThreadID tid)
     // For decoupled frontend (including trace mode), check FTQ availability
     StallReason stall = StallReason::NoStall;
     while (numInst < fetchWidth && fetchQueue[tid].size() < fetchQueueSize &&
-           !predictedBranch && !ftqEmpty(tid) && !waitForVsetvl) {
+           !stopFetchThisCycle && !ftqEmpty(tid) && !waitForVsetvl) {
 
         // Check memory needs and supply bytes to decoder if required
         stall = checkMemoryNeeds(tid, pc_state, curMacroop);
@@ -1948,7 +1973,7 @@ Fetch::performInstructionFetch(ThreadID tid)
         // into multiple micro-ops.
         do {
             // Process a single instruction, from decoding to PC update.
-            predictedBranch = processSingleInstruction(tid, pc_state, curMacroop);
+            stopFetchThisCycle = processSingleInstruction(tid, pc_state, curMacroop);
 
         } while (curMacroop &&
                  numInst < fetchWidth &&
@@ -1967,7 +1992,7 @@ Fetch::performInstructionFetch(ThreadID tid)
     }
 
     // Log why fetch stopped
-    if (predictedBranch) {
+    if (stopFetchThisCycle) {
         DPRINTF(Fetch, "[tid:%i] Done fetching, predicted branch instruction encountered.\n", tid);
     } else if (numInst >= fetchWidth) {
         DPRINTF(Fetch, "[tid:%i] Done fetching, reached fetch bandwidth for this cycle.\n", tid);

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -1098,6 +1098,44 @@ class Fetch
         statistics::Scalar twoFetchNotTakenSpanTooLarge;
         /** 2Fetch not used because target is not fully covered by fetch buffer. */
         statistics::Scalar twoFetchNotTakenTargetNotInBuffer;
+        /** 2Fetch failure caused only by missing next stream. */
+        statistics::Scalar twoFetchFailOnlyNoNext;
+        /** 2Fetch failure caused only by non-taken stream end. */
+        statistics::Scalar twoFetchFailOnlyNotPredTaken;
+        /** 2Fetch failure caused only by span exceeding max bytes per cycle. */
+        statistics::Scalar twoFetchFailOnlySpanTooLarge;
+        /** 2Fetch failure caused only by target falling outside current fetch buffer. */
+        statistics::Scalar twoFetchFailOnlyTargetNotInBuffer;
+        /** 2Fetch failure caused by both span and target-in-buffer checks. */
+        statistics::Scalar twoFetchFailBothSpanAndTargetNotInBuffer;
+        /** 2Fetch target falls before current fetch buffer start. */
+        statistics::Scalar twoFetchTargetBeforeBuffer;
+        /** 2Fetch target falls after current fetch buffer end. */
+        statistics::Scalar twoFetchTargetAfterBuffer;
+        /** 2Fetch next stream starts at or after current stream start. */
+        statistics::Scalar twoFetchNextStreamForward;
+        /** 2Fetch next stream starts before current stream start. */
+        statistics::Scalar twoFetchNextStreamBackward;
+        /** 2Fetch next stream predicted end is at or after current stream start. */
+        statistics::Scalar twoFetchSpanForwardOrZero;
+        /** 2Fetch next stream predicted end is before current stream start. */
+        statistics::Scalar twoFetchSpanBackward;
+        /** Target offset from fetch buffer start for 2Fetch opportunities. */
+        statistics::Distribution twoFetchTargetOffsetFromBufferStart;
+        /** Distance from target to current fetch buffer start when target is before it. */
+        statistics::Distribution twoFetchTargetDistanceBeforeBufferStart;
+        /** Amount by which target exceeds current fetch buffer end when it does. */
+        statistics::Distribution twoFetchTargetDistancePastBufferEnd;
+        /** Span in bytes from current stream start to next stream predicted end. */
+        statistics::Distribution twoFetchSpanBytes;
+        /** Backward span distance when next stream predicted end precedes current stream start. */
+        statistics::Distribution twoFetchBackwardSpanDistance;
+        /** Delta from current stream start to next stream start. */
+        statistics::Distribution twoFetchNextStartDelta;
+        /** Backward start delta when next stream starts before current stream start. */
+        statistics::Distribution twoFetchBackwardNextStartDistance;
+        /** Offset of predicted control PC within current stream at run-out. */
+        statistics::Distribution twoFetchRunOutBranchOffset;
         /** Number of cycles with fetched instructions but without 2Fetch. */
         statistics::Scalar singleFetchCycleCount;
         /** Total number of fetched instructions in cycles without 2Fetch. */

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -957,6 +957,9 @@ class Fetch
     // Used to explicitly notify the BPU when an entry is consumed (Phase5 prep).
     unsigned ftqEntryFetchedInsts[MaxThreads]{};
 
+    // Per-cycle aggregate state for additional fetch instrumentation.
+    bool cycleUsed2Fetch = false;
+
     /** fetch stall reasons */
     std::vector<StallReason> stallReason;
 
@@ -1063,6 +1066,50 @@ class Fetch
         statistics::Scalar tlbSquashes;
         /** Distribution of number of instructions fetched each cycle. */
         statistics::Distribution nisnDist;
+        /** Total number of performInstructionFetch calls. */
+        statistics::Scalar performIFCalls;
+        /** Number of performInstructionFetch calls that enter main while loop. */
+        statistics::Scalar performIFWhileEntered;
+        /** Total number of iterations spent in main fetch while loop. */
+        statistics::Scalar performIFWhileIterations;
+        /** Main while loop not entered because fetch width is exhausted. */
+        statistics::Scalar performIFWhileNotEnteredFetchWidth;
+        /** Main while loop not entered because fetch queue is full. */
+        statistics::Scalar performIFWhileNotEnteredFetchQueueFull;
+        /** Main while loop not entered because fetch already decided to stop. */
+        statistics::Scalar performIFWhileNotEnteredStopFetch;
+        /** Main while loop not entered because FTQ is empty. */
+        statistics::Scalar performIFWhileNotEnteredFtqEmpty;
+        /** Main while loop not entered because vector config blocks fetch. */
+        statistics::Scalar performIFWhileNotEnteredWaitForVsetvl;
+        /** Number of end-of-stream opportunities that can evaluate 2Fetch. */
+        statistics::Scalar twoFetchOpportunity;
+        /** Number of times 2Fetch succeeds. */
+        statistics::Scalar twoFetchTaken;
+        /** 2Fetch not used because stream ended without predicted taken branch. */
+        statistics::Scalar twoFetchNotTakenNotPredTaken;
+        /** 2Fetch not used because feature is disabled. */
+        statistics::Scalar twoFetchNotTakenDisabled;
+        /** 2Fetch not used because next FTQ stream is unavailable. */
+        statistics::Scalar twoFetchNotTakenNoNext;
+        /** 2Fetch not used because next stream target does not match branch target. */
+        statistics::Scalar twoFetchNotTakenTargetMismatch;
+        /** 2Fetch not used because merged span exceeds max fetch bytes per cycle. */
+        statistics::Scalar twoFetchNotTakenSpanTooLarge;
+        /** 2Fetch not used because target is not fully covered by fetch buffer. */
+        statistics::Scalar twoFetchNotTakenTargetNotInBuffer;
+        /** Number of cycles with fetched instructions but without 2Fetch. */
+        statistics::Scalar singleFetchCycleCount;
+        /** Total number of fetched instructions in cycles without 2Fetch. */
+        statistics::Scalar singleFetchCycleInsts;
+        /** Mean fetched instructions in cycles without 2Fetch. */
+        statistics::Formula singleFetchCycleInstMean;
+        /** Number of cycles with fetched instructions and with 2Fetch. */
+        statistics::Scalar doubleFetchCycleCount;
+        /** Total number of fetched instructions in cycles with 2Fetch. */
+        statistics::Scalar doubleFetchCycleInsts;
+        /** Mean fetched instructions in cycles with 2Fetch. */
+        statistics::Formula doubleFetchCycleInstMean;
         /** Rate of how often fetch was idle. */
         statistics::Formula idleRate;
         /** Number of branch fetches per cycle. */

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -357,7 +357,8 @@ class Fetch
      * Looks up the branch predictor, gets a prediction, and updates the PC.
      * @param inst The dynamic instruction object.
      * @param next_pc The PC state to update with the prediction.
-     * @return true if a branch was predicted taken.
+     * @return true if fetch should stop this cycle due to a predicted-taken
+     * branch (2Fetch may override and return false).
      */
     bool lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc);
 
@@ -543,7 +544,7 @@ class Fetch
      * @param tid The thread ID of the instruction.
      * @param pc The current program counter state (will be updated).
      * @param curMacroop The current macro-op being processed (if any).
-     * @return true if a branch was predicted.
+     * @return true if fetch should stop this cycle.
      */
     bool
     processSingleInstruction(ThreadID tid, PCStateBase &pc,

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -413,6 +413,7 @@ class Fetch
      * @return true if requests were successfully initiated
      */
     bool handleMultiCacheLineFetch(Addr vaddr, ThreadID tid, Addr pc);
+    bool idealFillFetchBuffer(Addr vaddr, ThreadID tid, Addr pc);
 
     /** Process multi-cacheline fetch completion when both packets have arrived.
      * Merges data from both cache lines into the fetch buffer.
@@ -843,6 +844,7 @@ class Fetch
     *  make sure we could decode tail 4bytes if it is in [62, 66)
      */
     unsigned fetchBufferSize;
+    const bool idealFetchWindowFill;
 
     /**
      * Fetch buffer structure to encapsulate instruction fetch data.

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1207,5 +1207,6 @@ class DecoupledBPUWithBTB(BranchPredictor):
     bpDBSwitches = VectorParam.String([], "Enable which traces in the form of database")
     resolveBlockThreshold = Param.Unsigned(8, "Consecutive resolve dequeue failures before blocking prediction once")
 
+    enable2Taken = Param.Bool(True, "Enable 2taken feature")
     enable2Fetch = Param.Bool(False, "Enable 2fetch feature")
     maxFetchBytesPerCycle = Param.Unsigned(64, "Maximum fetch bytes per cycle for 2fetch")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1206,3 +1206,6 @@ class DecoupledBPUWithBTB(BranchPredictor):
 
     bpDBSwitches = VectorParam.String([], "Enable which traces in the form of database")
     resolveBlockThreshold = Param.Unsigned(8, "Consecutive resolve dequeue failures before blocking prediction once")
+
+    enable2Fetch = Param.Bool(False, "Enable 2fetch feature")
+    maxFetchBytesPerCycle = Param.Unsigned(64, "Maximum fetch bytes per cycle for 2fetch")

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -48,6 +48,7 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       ftq(2, p.ftq_size),
       historyManager(16), // TODO: fix this
       resolveBlockThreshold(p.resolveBlockThreshold),
+      enable2Taken(p.enable2Taken),
       enable2Fetch(p.enable2Fetch),
       maxFetchBytesPerCycle(p.maxFetchBytesPerCycle),
       dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
@@ -145,7 +146,7 @@ DecoupledBPUWithBTB::tick()
         return;
     }
 
-    int predsRemainsToBeMade = enableTwoTaken ? 2 : 1;
+    int predsRemainsToBeMade = enable2Taken ? 2 : 1;
     while (predsRemainsToBeMade > 0) {
         // 1. Request new prediction if FSQ not full and we are idle
         if (!threads[curTid].validprediction && !ftq.full(curTid)) {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -48,6 +48,8 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       ftq(2, p.ftq_size),
       historyManager(16), // TODO: fix this
       resolveBlockThreshold(p.resolveBlockThreshold),
+      enable2Fetch(p.enable2Fetch),
+      maxFetchBytesPerCycle(p.maxFetchBytesPerCycle),
       dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
 {
     if (bpDBSwitches.size() > 0) {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -143,29 +143,32 @@ DecoupledBPUWithBTB::tick()
         return;
     }
 
-    // 1. Request new prediction if FSQ not full and we are idle
-    if (!threads[curTid].validprediction && !ftq.full(curTid)) {
-        if (threads[curTid].blockPredictionPending) {
-            DPRINTF(Override, "Prediction blocked to prioritize resolve update\n");
-            dbpBtbStats.predictionBlockedForUpdate++;
-            threads[curTid].blockPredictionPending = false;
-        } else {
-            requestNewPrediction(curTid);
+    int predsRemainsToBeMade = enableTwoTaken ? 2 : 1;
+    while (predsRemainsToBeMade > 0) {
+        // 1. Request new prediction if FSQ not full and we are idle
+        if (!threads[curTid].validprediction && !ftq.full(curTid)) {
+            if (threads[curTid].blockPredictionPending) {
+                DPRINTF(Override, "Prediction blocked to prioritize resolve update\n");
+                dbpBtbStats.predictionBlockedForUpdate++;
+                threads[curTid].blockPredictionPending = false;
+            } else {
+                requestNewPrediction(curTid);
+            }
         }
+
+        processNewPrediction(curTid);
+        predsRemainsToBeMade--;
     }
 
     for (int tid = 0; tid < numThreads; tid++) {
-        processNewPrediction(tid);
-
-        // Decrement override bubbles counter
         auto& numOverrideBubbles = threads[tid].numOverrideBubbles;
         if (numOverrideBubbles > 0) {
             numOverrideBubbles--;
             dbpBtbStats.overrideBubbleNum++;
-            DPRINTF(Override, "Consuming override bubble, %d remaining\n", numOverrideBubbles);
+            DPRINTF(Override, "Consuming override bubble, %d remaining\n",
+                    numOverrideBubbles);
         }
     }
-
     DPRINTF(Override, "Prediction cycle complete\n");
 }
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -146,12 +146,11 @@ class DecoupledBPUWithBTB : public BPredUnit
     const unsigned resolveBlockThreshold;
 
     ThreadID scheduleThread() { return 0; }
+    const bool enable2Taken;
     const bool enable2Fetch;
     const unsigned maxFetchBytesPerCycle;
 
     void processNewPrediction(ThreadID tid);
-    bool enableTwoTaken{true};
-
     FetchTarget createFetchTargetEntry(ThreadID tid);
 
     void updateHistoryForPrediction(FetchTarget &entry);

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -148,6 +148,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     ThreadID scheduleThread() { return 0; }
 
     void processNewPrediction(ThreadID tid);
+    bool enableTwoTaken{true};
 
     FetchTarget createFetchTargetEntry(ThreadID tid);
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -146,6 +146,8 @@ class DecoupledBPUWithBTB : public BPredUnit
     const unsigned resolveBlockThreshold;
 
     ThreadID scheduleThread() { return 0; }
+    const bool enable2Fetch;
+    const unsigned maxFetchBytesPerCycle;
 
     void processNewPrediction(ThreadID tid);
     bool enableTwoTaken{true};
@@ -176,6 +178,20 @@ class DecoupledBPUWithBTB : public BPredUnit
                  "%#lx-[%#lx, %#lx) --> %#lx, taken: %lu\n",
                  e.startPC, e.getBranchInfo().pc, e.getEndPC(),
                  e.getTakenTarget(), e.getTaken());
+    }
+
+    void printTargetFull(const FetchTarget &e)
+    {
+        // TODO: fix this
+        // DPRINTFR(
+        //     DecoupleBP,
+        //     "FSQ prediction:: %#lx-[%#lx, %#lx) --> %#lx\n",
+        //     e.startPC, e.predBranchPC, e.predEndPC, e.predTarget);
+        // DPRINTFR(
+        //     DecoupleBP,
+        //     "Resolved: %i, resolved target:: %#lx-[%#lx, %#lx) --> %#lx\n",
+        //     e.exeEnded, e.startPC, e.exeBranchPC, e.exeEndPC,
+        //     e.exeTarget);
     }
 
     /**
@@ -405,6 +421,19 @@ class DecoupledBPUWithBTB : public BPredUnit
     bool ftqHasFetching(ThreadID tid) const { return ftq.hasTarget(ftq.fetchId(tid), tid); }
     FetchTargetId ftqHeadId(ThreadID tid) const { assert(ftqHasFetching(tid)); return ftq.fetchId(tid); }
     const FetchTarget &ftqFetchingTarget(ThreadID tid) { assert(ftqHasFetching(tid)); return ftq.fetching(tid); }
+
+    bool ftqHasNext(ThreadID tid) const
+    {
+        return ftq.hasTarget(ftq.fetchId(tid) + 1, tid);
+    }
+    const FetchTarget &ftqNext(ThreadID tid)
+    {
+        assert(ftqHasNext(tid));
+        return ftq.get(ftq.fetchId(tid) + 1, tid);
+    }
+
+    bool is2FetchEnabled() const { return enable2Fetch; }
+    unsigned getMaxFetchBytesPerCycle() const { return maxFetchBytesPerCycle; }
 
     void dumpFsq(const char *when);
 


### PR DESCRIPTION
Change-Id: I39d54a0621d139cc00a156b02a6d7d888d9b15f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional two-fetch mode: perform up to two predictions per cycle when enabled.
  * New configuration: toggle two-fetch and set max fetch bytes per cycle.

* **Refactor**
  * Fetch and prediction flow reworked to support in-cycle two-fetch extension and updated fetch-loop/termination semantics.

* **Chores**
  * Example presets updated to enable two-fetch and reduce queue sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->