### PR TITLE
cpu-o3: update target in UBTB entry if different from takenEntry

### DIFF
--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -264,12 +264,16 @@ void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, con
         } else if (oldEntryIter != ubtb.end() && takenEntry.valid) {
             ubtbStats.s1Hits3Taken++;
             // both S0 and S3 predict taken
-            if (oldEntryIter->pc != takenEntry.pc || oldEntryIter->target != takenEntry.target) {
+            if (oldEntryIter->pc != takenEntry.pc ) {
                 // S0 and S3 predict different branch instruction
                 updateUCtr(oldEntryIter->uctr, false);
                 if (oldEntryIter->uctr == 0) {
                     // replace the old entry with the new one
                     replaceOldEntry(oldEntryIter, takenEntry, startAddr);
+                }
+                if (oldEntryIter->target != takenEntry.target) {
+                    // update target if different
+                    oldEntryIter->target = takenEntry.target;
                 }
             } else {
                 // S0 and S3 predict the same (brpc and target)


### PR DESCRIPTION
Change-Id: I6067a18288c0f36b1e83a775560a8c23dc4ef0b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized branch target buffer update logic to improve branch prediction accuracy and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->