### PR TITLE
cpu-o3: clean up RISC-V ISA and TLB handling to align NEMU

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -320,8 +320,6 @@ void ISA::clear()
 
     miscRegFile[MISCREG_PRV] = PRV_M;
     miscRegFile[MISCREG_ISA] = 0x80000000003411af;
-    miscRegFile[MISCREG_VENDORID] = 0;
-    miscRegFile[MISCREG_ARCHID] = 0;
     miscRegFile[MISCREG_IMPID] = 0;
     miscRegFile[MISCREG_MIDELEG] = ((1 << 12) | (1 << 10) | (1 << 6) | (1 << 2));
     if (FullSystem) {
@@ -344,7 +342,7 @@ void ISA::clear()
     miscRegFile[MISCREG_HSTATUS] = (uint64_t)2<<32;
     miscRegFile[MISCREG_VSSTATUS] = miscRegFile[MISCREG_STATUS] & NEMU_SSTATUS_RMASK;
     miscRegFile[MISCREG_ARCHID] = 0x19;
-
+    miscRegFile[MISCREG_VENDORID] = (16ULL << 7) | 0x6FULL;
 }
 
 bool

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1840,7 +1840,17 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
 {
     delayed = false;
     SATP satp = tc->readMiscReg(MISCREG_SATP);
-    Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
+    // RISC-V Sv39/Sv48 require a canonical (sign-extended) virtual address.
+    // If the incoming vaddr is non-canonical, it must raise a page fault and
+    // STVAL should contain the *original* (non-canonical) vaddr.
+    const Addr raw_vaddr = req->getVaddr();
+    Addr vaddr = VADDR_SEXT(satp.mode, raw_vaddr);
+    if ((satp.mode == AddrXlateMode::SV39 || satp.mode == AddrXlateMode::SV48) &&
+        vaddr != raw_vaddr) {
+        DPRINTF(TLB, "Non-canonical vaddr %#lx (canon %#lx), mode %d\n",
+                raw_vaddr, vaddr, satp.mode);
+        return createPagefault(raw_vaddr, 0, mode, false);
+    }
     Addr vaddr_trace = (vaddr >> (PageShift + L2TLB_BLK_OFFSET)) << (PageShift + L2TLB_BLK_OFFSET);
     if (((vaddr_trace != lastVaddr) || (req->getPC() != lastPc)) &&
         is_dtlb) {


### PR DESCRIPTION
- Aligned vendor CSR; NEMU commit: 0860de24253ef2097663fe64095b0fc329515489
- Enhanced TLB translation to handle non-canonical virtual addresses, raising page faults as necessary.

This improves the clarity and correctness of the RISC-V implementation.

Change-Id: I4801512f6add7ee9ccd3f7d8182658c7ecbbac4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved RISC-V virtual address translation to properly handle non-canonical addresses in Sv39/Sv48 modes, returning appropriate page faults for invalid addresses.
  * Updated RISC-V processor identification values for improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->