### PR TITLE
Feat despacito stream add perf counter

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -55,9 +55,10 @@ def create_prefetcher(cpu, cache_level, options):
             prefetcher.stream_pf_ahead = False
         if options.kmh_align:
             prefetcher.enable_berti = False
-            prefetcher.enable_sstride = True
+            prefetcher.enable_sstride = False
             prefetcher.enable_activepage = False
-            prefetcher.enable_xsstream = True
+            prefetcher.enable_xsstream = False
+            prefetcher.enable_pht = False
 
     if cache_level == 'l2':
         if options.classic_l2:
@@ -80,15 +81,15 @@ def create_prefetcher(cpu, cache_level, options):
     if cache_level == 'l2_wrapper':
         if not options.classic_l2:
             if hasattr(prefetcher, 'enable_bop'):
-                prefetcher.enable_bop = True
+                prefetcher.enable_bop = False
             if options.kmh_align:
                 assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
                 prefetcher.enable_cmc = False
-                prefetcher.enable_bop = True
+                prefetcher.enable_bop = False
                 prefetcher.enable_cdp = False
-                prefetcher.enable_despacito_stream = False
-                prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
-                prefetcher.bop_small = XSPhysicalSmallBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
+                prefetcher.enable_despacito_stream = True
+                prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=False,enable_adaptoffset=False)
+                prefetcher.bop_small = XSPhysicalSmallBOP(is_sub_prefetcher=False,enable_adaptoffset=False)
             if options.l1_to_l2_pf_hint:
                 prefetcher.queue_size = 64
                 prefetcher.max_prefetch_requests_with_pending_translation = 128

--- a/src/mem/cache/prefetch/despacito_stream.cc
+++ b/src/mem/cache/prefetch/despacito_stream.cc
@@ -1,6 +1,7 @@
 #include "mem/cache/prefetch/despacito_stream.hh"
 
 #include "base/output.hh"
+#include "cpu/pred/general_arch_db.hh"
 #include "debug/DespacitoStreamPrefetcher.hh"
 #include "mem/cache/base.hh"
 #include "mem/cache/prefetch/associative_set_impl.hh"
@@ -20,7 +21,76 @@ DespacitoStreamPrefetcher::DespacitoStreamPrefetcher(const DespacitoStreamPrefet
       patterns(p.patterns_entries, p.patterns_entries, p.patterns_indexing_policy, p.patterns_replacement_policy,
                PatternEntry(SatCounter8(2, 1))),
       timestamp(0)
+    , stats(this)
 {
+    // Enable DB tracing by default (will save to "despacito_stream.db" on exit).
+    // This makes it easy to collect traces without extra Python plumbing.
+    initDB(true, "despacito_stream.db");
+}
+
+void
+DespacitoStreamPrefetcher::initDB(bool enable, const std::string &filename)
+{
+    enableDB = enable;
+    if (!enableDB)
+        return;
+
+    db.init_db();
+    std::vector<std::pair<std::string, gem5::DataType>> fields = {
+        std::make_pair(std::string("pc"), gem5::UINT64),
+        std::make_pair(std::string("vaddr"), gem5::UINT64),
+        std::make_pair(std::string("timeSample"), gem5::UINT64),
+        std::make_pair(std::string("sampleTrainEn"), gem5::UINT64),
+        std::make_pair(std::string("sampleHit"), gem5::UINT64),
+        // victim (old) snapshot
+        std::make_pair(std::string("victim_timestamp"), gem5::UINT64),
+        std::make_pair(std::string("victim_addr"), gem5::UINT64),
+        std::make_pair(std::string("victim_pc"), gem5::UINT64),
+        std::make_pair(std::string("victim_touched"), gem5::UINT64),
+        // inserted (new) snapshot
+        std::make_pair(std::string("insert_timestamp"), gem5::UINT64),
+        std::make_pair(std::string("insert_addr"), gem5::UINT64),
+        std::make_pair(std::string("insert_pc"), gem5::UINT64),
+        std::make_pair(std::string("insert_touched"), gem5::UINT64),
+        // update (touched) snapshot
+        std::make_pair(std::string("update_timestamp"), gem5::UINT64),
+        std::make_pair(std::string("update_addr"), gem5::UINT64),
+        std::make_pair(std::string("update_pc"), gem5::UINT64),
+        std::make_pair(std::string("update_touched"), gem5::UINT64),
+        // pattern snapshots
+        std::make_pair(std::string("patternTrain_conf"), gem5::UINT64),
+        std::make_pair(std::string("patternTrain_pc"), gem5::UINT64),
+        std::make_pair(std::string("patternUpdate_conf"), gem5::UINT64),
+        std::make_pair(std::string("patternUpdate_pc"), gem5::UINT64),
+        std::make_pair(std::string("patternInsert_conf"), gem5::UINT64),
+        std::make_pair(std::string("patternInsert_pc"), gem5::UINT64),
+        std::make_pair(std::string("event"), gem5::TEXT),
+    };
+
+    despacitoTrace = db.addAndGetTrace("DESPACITOSTREAMTRACE", fields);
+    despacitoTrace->init_table();
+
+    // Save DB on simulator exit
+    registerExitCallback([this, filename]() {
+        if (enableDB) {
+            db.save_db(simout.resolve(filename).c_str());
+        }
+    });
+}
+
+void
+DespacitoStreamPrefetcher::writeDespacitoAggregate(uint64_t pc, uint64_t vaddr, uint64_t timeSample,
+    uint64_t sampleTrainEn, uint64_t sampleHit,
+    const SamplerSnapshot *victim, const SamplerSnapshot *inserted,
+    const SamplerSnapshot *updated,
+    const PatternSnapshot *patternTrain, const PatternSnapshot *patternUpdate,
+    const PatternSnapshot *patternInsert)
+{
+    if (!enableDB || !despacitoTrace)
+        return;
+    DespacitoTraceRecord rec(pc, vaddr, timeSample, sampleTrainEn, sampleHit,
+                             victim, inserted, updated, patternTrain, patternUpdate, patternInsert);
+    despacitoTrace->write_record(rec);
 }
 
 void
@@ -29,45 +99,139 @@ DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
     Addr block_index = blockIndex(pfi.getAddr());
 
     SamplerEntry *sampler_entry = sampler.findEntry(block_index - 1, false);
-
+    stats.nlSampleTrainTimes++;
     if (sampler_entry) {
         if (timestamp > sampler_entry->timestamp + minDistance &&
             timestamp <= sampler_entry->timestamp + maxDistance) {
             sampler_entry->touched = true;
+            stats.nlSampleUpdateTimes++;
+            // record update snapshot (will be included in aggregated record)
+            // populate update snapshot below
+        } else {
+            stats.nlSampleUpdateReqHitOverBoardTimes++; // Hit but not within the update range
         }
         sampler.accessEntry(sampler_entry);
+    }else{
+    stats.nlSampleUpdateReqNotHitTimes++; // If not present, it means no hit
     }
 
     if (timestamp % sampleRate == 0) {
+    stats.nlSampleInsertTimes++;// Analyze insert times
         SamplerEntry *evict_sampler_entry = sampler.findVictim(block_index);
-        updatePatternTable(evict_sampler_entry);
+    stats.nlSampleVictimTouchedTrueTimes += evict_sampler_entry->touched ? 1 : 0; // Analyze victim touched times
+    stats.nlSampleVictimTouchedFalseTimes += evict_sampler_entry->touched ? 0 : 1;
+        // create local snapshots to capture victim/insert data for aggregated record
+        SamplerSnapshot victimSnap;
+        bool haveVictim = false;
+        SamplerSnapshot insertSnap;
+        bool haveInsert = false;
+        SamplerSnapshot updateSnap;
+        bool haveUpdate = false;
+
+        // if an existing entry is present in the victim slot, snapshot it
+        if (evict_sampler_entry->pc) {
+            victimSnap.timestamp = evict_sampler_entry->timestamp;
+            victimSnap.address = evict_sampler_entry->address;
+            victimSnap.pc = evict_sampler_entry->pc;
+            victimSnap.touched = evict_sampler_entry->touched;
+            haveVictim = true;
+            stats.nlSampleReplaceTimes++;
+        } else {
+            // empty slot -> will be insertion
+            stats.nlSampleInsertTimes++;
+        }
+
+    PatternSnapshot patternTrainSnap;
+    PatternSnapshot patternUpdateSnap;
+    PatternSnapshot patternInsertSnap;
+    updatePatternTable(evict_sampler_entry, &patternTrainSnap, &patternUpdateSnap, &patternInsertSnap);
+
+        // now write new sampler contents into the slot
         evict_sampler_entry->timestamp = timestamp;
         evict_sampler_entry->address = block_index;
         evict_sampler_entry->pc = pfi.getPC();
         evict_sampler_entry->touched = false;
         sampler.insertEntry(block_index, false, evict_sampler_entry);
+
+        // snapshot the newly inserted data
+        insertSnap.timestamp = evict_sampler_entry->timestamp;
+        insertSnap.address = evict_sampler_entry->address;
+        insertSnap.pc = evict_sampler_entry->pc;
+        insertSnap.touched = evict_sampler_entry->touched;
+        haveInsert = true;
+
+        // if we earlier touched an existing sampler_entry (update path), snapshot it
+        if (sampler_entry && timestamp > sampler_entry->timestamp + minDistance &&
+            timestamp <= sampler_entry->timestamp + maxDistance) {
+            updateSnap.timestamp = sampler_entry->timestamp;
+            updateSnap.address = sampler_entry->address;
+            updateSnap.pc = sampler_entry->pc;
+            updateSnap.touched = sampler_entry->touched;
+            haveUpdate = true;
+        }
+
+    // Record trace to db
+    writeDespacitoAggregate(pfi.getPC(), block_index, timestamp, 0, 0,
+                haveVictim ? &victimSnap : nullptr,
+                haveInsert ? &insertSnap : nullptr,
+                haveUpdate ? &updateSnap : nullptr,
+                patternTrainSnap.valid ? &patternTrainSnap : nullptr,
+                patternUpdateSnap.valid ? &patternUpdateSnap : nullptr,
+                patternInsertSnap.valid ? &patternInsertSnap : nullptr);
     }
 
     timestamp++;
 }
 
 void
-DespacitoStreamPrefetcher::updatePatternTable(SamplerEntry *sampler_entry)
+DespacitoStreamPrefetcher::updatePatternTable(SamplerEntry *sampler_entry,
+                                              PatternSnapshot *patternTrain,
+                                              PatternSnapshot *patternUpdate,
+                                              PatternSnapshot *patternInsert)
 {
+    stats.nlPatternTrainTimes++;
     if (sampler_entry->pc) {
+    stats.nlPatternUpdateTimes++;// Here we check the PC, when findVictim returns an entry, it sets valid to false
         PatternEntry *pattern_entry = patterns.findEntry(sampler_entry->pc, false);
         if (pattern_entry) {
+            // capture pre-update snapshot if requested
+            if (patternTrain) {
+                patternTrain->conf = pattern_entry->conf;
+                patternTrain->pc = pattern_entry->getTag();
+                patternTrain->valid = true;
+            }
+
             patterns.accessEntry(pattern_entry);
             if (sampler_entry->touched) {
                 pattern_entry->conf++;
+               stats.nlPatternUpdateTouchedTrueTimes++;
             } else {
                 pattern_entry->conf--;
+                stats.nlPatternUpdateTouchedFalseTimes++;
+            }
+            // capture post-update snapshot if requested
+            if (patternUpdate) {
+                patternUpdate->conf = pattern_entry->conf;
+                patternUpdate->pc = pattern_entry->getTag();
+                patternUpdate->valid = true;
             }
         } else {
             if (sampler_entry->touched) {
                 pattern_entry = patterns.findVictim(sampler_entry->pc);
+                bool was_valid = pattern_entry->isValid();
                 pattern_entry->conf.reset();
                 patterns.insertEntry(sampler_entry->pc, false, pattern_entry);
+                if (was_valid)
+                    stats.nlPatternReplaceTimes++;
+                else
+                    stats.nlPatternInsertTimes++;
+
+                // capture inserted snapshot
+                if (patternInsert) {
+                    patternInsert->conf = pattern_entry->conf;
+                    patternInsert->pc = pattern_entry->getTag();
+                    patternInsert->valid = true;
+                }
             }
         }
     }
@@ -86,9 +250,24 @@ DespacitoStreamPrefetcher::calculatePrefetch(const PrefetchInfo &pfi, std::vecto
 
     PatternEntry *pattern_entry = patterns.findEntry(pc, false);
 
+    if (pattern_entry) {
+    stats.nlPatternPcHitTimes++;
+    stats.nlPatternPcHitValidEntryTimes++;
+        if (pattern_entry->conf.isSaturated()){
+            stats.nlPatternPcHitValidEntrySatEq3Times++;
+        } else if (pattern_entry->conf.rawCounter() == 2) {
+            stats.nlPatternPcHitValidEntrySatEq2Times++;
+        } else if (pattern_entry->conf.rawCounter() == 1) {
+            stats.nlPatternPcHitValidEntrySatEq1Times++;
+        }else{
+            stats.nlPatternPcHitValidEntrySatEq0Times++;
+        }
+    }
+
     if (pattern_entry && pattern_entry->conf.isSaturated()) {
         Addr pf_addr = block_addr + blkSize;
         sendPFWithFilter(pfi, pf_addr, addresses, 32, PrefetchSourceType::DespacitoStream);
+    stats.nlTransmitPrefetchReqTimes++;
     }
 
     updateSampler(pfi);
@@ -113,6 +292,61 @@ DespacitoStreamPrefetcher::sendPFWithFilter(const PrefetchInfo &pfi, Addr addr, 
         return true;
     }
 }
+
+DespacitoStreamPrefetcher::DespacitoStats::DespacitoStats(statistics::Group *parent)
+        : statistics::Group(parent),
+            /* sampler */
+            ADD_STAT(nlSampleTrainTimes, statistics::units::Count::get(), "Number of times sampler was trained"),
+            ADD_STAT(nlSampleInsertTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were inserted"),
+            ADD_STAT(nlSampleReplaceTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were replaced"),
+
+            ADD_STAT(nlSampleUpdateTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were updated"),
+            ADD_STAT(nlSampleUpdateReqNotHitTimes, statistics::units::Count::get(),
+            "update request not hit times"),
+            ADD_STAT(nlSampleUpdateReqHitOverBoardTimes, statistics::units::Count::get(),
+             "update request hit but over board times"),
+
+            ADD_STAT(nlSampleVictimTouchedTrueTimes, statistics::units::Count::get(),
+             "Number of times sample victim touched true times"),
+            ADD_STAT(nlSampleVictimTouchedFalseTimes, statistics::units::Count::get(),
+             "Number of times sample victim touched false times"),
+
+            /* pattern table */
+            ADD_STAT(nlPatternTrainTimes, statistics::units::Count::get(),
+             "Number of times pattern table was trained"),
+            ADD_STAT(nlPatternReplaceTimes, statistics::units::Count::get(), "Number of patterns replaced in table"),
+            ADD_STAT(nlPatternInsertTimes, statistics::units::Count::get(), "Number of patterns inserted into table"),
+
+            ADD_STAT(nlPatternUpdateTimes, statistics::units::Count::get(),
+            "Number of times a pattern's confidence changed"),
+            ADD_STAT(nlPatternUpdateTouchedTrueTimes, statistics::units::Count::get(),
+            "Number of times a pattern's training data was touched"),
+            ADD_STAT(nlPatternUpdateTouchedFalseTimes, statistics::units::Count::get(),
+            "Number of times a pattern's training data was not touched"),
+
+            ADD_STAT(nlPatternPcHitTimes, statistics::units::Count::get(), "Number of times a pattern's pc was hit"),
+            ADD_STAT(nlPatternPcHitValidEntryTimes, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq3Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==3"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq2Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==2"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq1Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==1"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq0Times, statistics::units::Count::get(),
+             "Number of times a pattern's pc hit a valid entry with Sat==0"),
+
+            /* prefetch */
+            ADD_STAT(nlTimeSampleCountResetTimes, statistics::units::Count::get(),
+            "Total number of samples processed"),
+            ADD_STAT(nlTimeSampleCountOverTimes, statistics::units::Count::get(),
+            "Number of times sample count exceeded threshold"),
+            ADD_STAT(nlTransmitPrefetchReqTimes, statistics::units::Count::get(), "Number of prefetches sent"),
+            ADD_STAT(nlFilterHits, statistics::units::Count::get(), "Number of prefetches skipped due to filter")
+{}
 
 }
 }

--- a/src/mem/cache/prefetch/despacito_stream.hh
+++ b/src/mem/cache/prefetch/despacito_stream.hh
@@ -1,6 +1,8 @@
 #ifndef __MEM_CACHE_PREFETCH_DESPACITO_STREAM_HH__
 #define __MEM_CACHE_PREFETCH_DESPACITO_STREAM_HH__
 
+#include <cstdint>
+#include <string>
 #include <vector>
 
 #include <boost/compute/detail/lru_cache.hpp>
@@ -8,6 +10,7 @@
 #include "base/sat_counter.hh"
 #include "base/statistics.hh"
 #include "base/types.hh"
+#include "cpu/pred/general_arch_db.hh"
 #include "debug/DespacitoStreamPrefetcher.hh"
 #include "mem/cache/prefetch/associative_set.hh"
 #include "mem/cache/prefetch/queued.hh"
@@ -74,7 +77,174 @@ class DespacitoStreamPrefetcher : public Queued
 
     void updateSampler(const PrefetchInfo &pfi);
 
-    void updatePatternTable(SamplerEntry *sampler_entry);
+    /* Forward declare PatternSnapshot so it can be used in the updatePatternTable
+     * declaration which appears before the full PatternSnapshot definition. */
+    struct PatternSnapshot;
+
+    void updatePatternTable(SamplerEntry *sampler_entry,
+                            PatternSnapshot *patternTrain, PatternSnapshot *patternUpdate,
+                            PatternSnapshot *patternInsert);
+
+
+  struct DespacitoStats : public statistics::Group
+  {
+    DespacitoStats(statistics::Group *parent);
+
+    // Sampler stats
+    statistics::Scalar nlSampleTrainTimes;
+
+    statistics::Scalar nlSampleInsertTimes;
+    statistics::Scalar nlSampleReplaceTimes;
+
+    statistics::Scalar nlSampleUpdateTimes;
+    statistics::Scalar nlSampleUpdateReqNotHitTimes;
+    statistics::Scalar nlSampleUpdateReqHitOverBoardTimes;
+
+    statistics::Scalar nlSampleVictimTouchedTrueTimes;
+    statistics::Scalar nlSampleVictimTouchedFalseTimes;
+
+
+    // Pattern table stats
+    statistics::Scalar nlPatternTrainTimes;
+    statistics::Scalar nlPatternReplaceTimes;
+    statistics::Scalar nlPatternInsertTimes;
+
+    statistics::Scalar nlPatternUpdateTimes;
+    statistics::Scalar nlPatternUpdateTouchedTrueTimes;
+    statistics::Scalar nlPatternUpdateTouchedFalseTimes;
+
+    statistics::Scalar nlPatternPcHitTimes;
+    statistics::Scalar nlPatternPcHitValidEntryTimes;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq3Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq2Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq1Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq0Times;
+
+    // Prefetch stats
+    statistics::Scalar nlTimeSampleCountResetTimes; // total samples processed
+    statistics::Scalar nlTimeSampleCountOverTimes;
+    statistics::Scalar nlTransmitPrefetchReqTimes;
+    statistics::Scalar nlFilterHits;
+  } stats;
+
+  /* Database for tracing events related to DespacitoStreamPrefetcher.
+   * Usage:
+   *   // enable and set output filename (will be saved on simulator exit)
+   *   initDB(true, "despacito_stream.db");
+   *   // write an event at runtime
+   *   writeDespacitoTrace(pc, block_addr, "sample_insert");
+   */
+  bool enableDB = false;
+  gem5::DataBase db;
+  gem5::TraceManager *despacitoTrace = nullptr;
+
+
+  struct SamplerSnapshot
+  {
+    uint64_t timestamp = 0;
+    Addr address = 0;
+    Addr pc = 0;
+    bool touched = false;
+  };
+
+  struct PatternSnapshot
+  {
+    SatCounter8 conf;
+    Addr pc;
+    bool valid = false;
+    PatternSnapshot() : conf(2, 0), pc(0), valid(false) {}
+  };
+
+
+  struct DespacitoTraceRecord : public gem5::Record
+  {
+    DespacitoTraceRecord(uint64_t pc, uint64_t vaddr, uint64_t timeSample,
+                         uint64_t sampleTrainEn, uint64_t sampleHit,
+                         const SamplerSnapshot *victim, const SamplerSnapshot *inserted,
+                         const SamplerSnapshot *updated,
+                         const PatternSnapshot *patternTrain, const PatternSnapshot *patternUpdate,
+                         const PatternSnapshot *patternInsert) {
+      _tick = curTick();
+
+      _uint64_data["pc"] = pc;
+      _uint64_data["vaddr"] = vaddr;
+      _uint64_data["timeSample"] = timeSample;
+      _uint64_data["sampleTrainEn"] = sampleTrainEn;
+      _uint64_data["sampleHit"] = sampleHit;
+
+      if (victim) {
+        _uint64_data["victim_timestamp"] = victim->timestamp;
+        _uint64_data["victim_addr"] = victim->address;
+        _uint64_data["victim_pc"] = victim->pc;
+        _uint64_data["victim_touched"] = victim->touched ? 1 : 0;
+      } else {
+        _uint64_data["victim_timestamp"] = 0;
+        _uint64_data["victim_addr"] = 0;
+        _uint64_data["victim_pc"] = 0;
+        _uint64_data["victim_touched"] = 0;
+      }
+
+      if (inserted) {
+        _uint64_data["insert_timestamp"] = inserted->timestamp;
+        _uint64_data["insert_addr"] = inserted->address;
+        _uint64_data["insert_pc"] = inserted->pc;
+        _uint64_data["insert_touched"] = inserted->touched ? 1 : 0;
+      } else {
+        _uint64_data["insert_timestamp"] = 0;
+        _uint64_data["insert_addr"] = 0;
+        _uint64_data["insert_pc"] = 0;
+        _uint64_data["insert_touched"] = 0;
+      }
+
+      if (updated) {
+        _uint64_data["update_timestamp"] = updated->timestamp;
+        _uint64_data["update_addr"] = updated->address;
+        _uint64_data["update_pc"] = updated->pc;
+        _uint64_data["update_touched"] = updated->touched ? 1 : 0;
+      } else {
+        _uint64_data["update_timestamp"] = 0;
+        _uint64_data["update_addr"] = 0;
+        _uint64_data["update_pc"] = 0;
+        _uint64_data["update_touched"] = 0;
+      }
+
+      if (patternTrain && patternTrain->valid) {
+        _uint64_data["patternTrain_conf"] = static_cast<uint64_t>(patternTrain->conf);
+        _uint64_data["patternTrain_pc"] = patternTrain->pc;
+      } else {
+        _uint64_data["patternTrain_conf"] = 0;
+        _uint64_data["patternTrain_pc"] = 0;
+      }
+
+      if (patternUpdate && patternUpdate->valid) {
+        _uint64_data["patternUpdate_conf"] = static_cast<uint64_t>(patternUpdate->conf);
+        _uint64_data["patternUpdate_pc"] = patternUpdate->pc;
+      } else {
+        _uint64_data["patternUpdate_conf"] = 0;
+        _uint64_data["patternUpdate_pc"] = 0;
+      }
+
+      if (patternInsert && patternInsert->valid) {
+        _uint64_data["patternInsert_conf"] = static_cast<uint64_t>(patternInsert->conf);
+        _uint64_data["patternInsert_pc"] = patternInsert->pc;
+      } else {
+        _uint64_data["patternInsert_conf"] = 0;
+        _uint64_data["patternInsert_pc"] = 0;
+      }
+
+      _text_data["event"] = std::string("aggregated");
+    }
+  };
+
+  void initDB(bool enable, const std::string &filename = "despacito_stream.db");
+
+  void writeDespacitoAggregate(uint64_t pc, uint64_t vaddr, uint64_t timeSample,
+                               uint64_t sampleTrainEn ,uint64_t sampleHit,
+                              const SamplerSnapshot *victim, const SamplerSnapshot *inserted,
+                              const SamplerSnapshot *updated,
+                              const PatternSnapshot *patternTrain,const PatternSnapshot *patternUpdate,
+                              const PatternSnapshot *patternInsert
+                            );
 
   public:
     boost::compute::detail::lru_cache<Addr, Addr> *filter;

--- a/util/xs_scripts/kmh_v3_btb.sh
+++ b/util/xs_scripts/kmh_v3_btb.sh
@@ -7,4 +7,6 @@ for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
     checkForVariable $var
 done
 
-$gem5 $gem5_home/configs/example/kmhv3.py --generic-rv-cpt=$1
+$gem5 $gem5_home/configs/example/kmhv3.py --generic-rv-cpt=$1 \
+ --enable-arch-db \
+ --arch-db-file  "/nfs/home/zhengzhongqiang/Work/GEM5_NL/OnlyNLPerfDB/mcf_12253.db"

--- a/util/xs_scripts/parallel_sim.sh
+++ b/util/xs_scripts/parallel_sim.sh
@@ -121,7 +121,7 @@ export -f arg_wrapper
 export -f prepare_env
 
 # xsgem5_para_jobs define in docker compose
-num_threads=${xsgem5_para_jobs:-63}
+num_threads=${xsgem5_para_jobs:-148}
 function parallel_run() {
     # We use gnu parallel to control the parallelism.
     # If your server has 32 core and 64 SMT threads, we suggest to run with no more than 32 threads.


### PR DESCRIPTION
During the implementation of this prefetcher in XS RTL, many new performance counters have been added for the prefetcher, and currently, the alignment of performance counters is being carried out on Gem5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined prefetcher configurations to optimize cache performance under alignment conditions.

* **Chores**
  * Integrated database-backed tracing infrastructure for cache prefetchers with comprehensive statistics collection for detailed performance analysis.
  * Increased parallel simulation job capacity to improve testing throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->