### PR TITLE
Feat despacito stream add perf counter

### DIFF
--- a/src/mem/cache/prefetch/despacito_stream.cc
+++ b/src/mem/cache/prefetch/despacito_stream.cc
@@ -47,7 +47,6 @@ DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
     }
 
     if (timestamp % sampleRate == 0) {
-        stats.nlSampleInsertTimes++;// Analyze insert times
         SamplerEntry *evict_sampler_entry = sampler.findVictim(block_index);
         updatePatternTable(evict_sampler_entry);
         stats.nlSampleVictimTouchedTrueTimes += evict_sampler_entry->touched ? 1 : 0; // Analyze victim touched times
@@ -67,7 +66,7 @@ DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
         evict_sampler_entry->pc = pfi.getPC();
         evict_sampler_entry->touched = false;
         sampler.insertEntry(block_index, false, evict_sampler_entry);
-
+    }
     timestamp++;
 }
 
@@ -179,7 +178,7 @@ DespacitoStreamPrefetcher::DespacitoStats::DespacitoStats(statistics::Group *par
             ADD_STAT(nlSampleVictimTouchedFalseTimes, statistics::units::Count::get(),
              "Number of times sample victim touched false times"),
 
-            /* pattern table */
+            /* pattern */
             ADD_STAT(nlPatternTrainTimes, statistics::units::Count::get(),
              "Number of times pattern table was trained"),
             ADD_STAT(nlPatternReplaceTimes, statistics::units::Count::get(), "Number of patterns replaced in table"),
@@ -205,12 +204,7 @@ DespacitoStreamPrefetcher::DespacitoStats::DespacitoStats(statistics::Group *par
              "Number of times a pattern's pc hit a valid entry with Sat==0"),
 
             /* prefetch */
-            ADD_STAT(nlTimeSampleCountResetTimes, statistics::units::Count::get(),
-            "Total number of samples processed"),
-            ADD_STAT(nlTimeSampleCountOverTimes, statistics::units::Count::get(),
-            "Number of times sample count exceeded threshold"),
-            ADD_STAT(nlTransmitPrefetchReqTimes, statistics::units::Count::get(), "Number of prefetches sent"),
-            ADD_STAT(nlFilterHits, statistics::units::Count::get(), "Number of prefetches skipped due to filter")
+            ADD_STAT(nlTransmitPrefetchReqTimes, statistics::units::Count::get(), "Number of prefetches sent")
 {}
 
 }

--- a/src/mem/cache/prefetch/despacito_stream.cc
+++ b/src/mem/cache/prefetch/despacito_stream.cc
@@ -19,9 +19,12 @@ DespacitoStreamPrefetcher::DespacitoStreamPrefetcher(const DespacitoStreamPrefet
               SamplerEntry()),
       patterns(p.patterns_entries, p.patterns_entries, p.patterns_indexing_policy, p.patterns_replacement_policy,
                PatternEntry(SatCounter8(2, 1))),
-      timestamp(0)
+      timestamp(0),
+      stats(this)
 {
 }
+
+
 
 void
 DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
@@ -29,24 +32,41 @@ DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
     Addr block_index = blockIndex(pfi.getAddr());
 
     SamplerEntry *sampler_entry = sampler.findEntry(block_index - 1, false);
-
+    stats.nlSampleTrainTimes++;
     if (sampler_entry) {
         if (timestamp > sampler_entry->timestamp + minDistance &&
             timestamp <= sampler_entry->timestamp + maxDistance) {
             sampler_entry->touched = true;
+            stats.nlSampleUpdateTimes++;
+        } else {
+            stats.nlSampleUpdateReqHitOverBoardTimes++; // Hit but not within the update range
         }
         sampler.accessEntry(sampler_entry);
+    }else{
+        stats.nlSampleUpdateReqNotHitTimes++; // If not present, it means no hit
     }
 
     if (timestamp % sampleRate == 0) {
+        stats.nlSampleInsertTimes++;// Analyze insert times
         SamplerEntry *evict_sampler_entry = sampler.findVictim(block_index);
         updatePatternTable(evict_sampler_entry);
+        stats.nlSampleVictimTouchedTrueTimes += evict_sampler_entry->touched ? 1 : 0; // Analyze victim touched times
+        stats.nlSampleVictimTouchedFalseTimes += evict_sampler_entry->touched ? 0 : 1;
+            
+        // if an existing entry is present in the victim slot, snapshot it
+        if (evict_sampler_entry->pc) {
+            stats.nlSampleReplaceTimes++;
+        } else {
+            // empty slot -> will be insertion
+            stats.nlSampleInsertTimes++;
+        }
+
+        // now write new sampler contents into the slot
         evict_sampler_entry->timestamp = timestamp;
         evict_sampler_entry->address = block_index;
         evict_sampler_entry->pc = pfi.getPC();
         evict_sampler_entry->touched = false;
         sampler.insertEntry(block_index, false, evict_sampler_entry);
-    }
 
     timestamp++;
 }
@@ -54,20 +74,29 @@ DespacitoStreamPrefetcher::updateSampler(const PrefetchInfo &pfi)
 void
 DespacitoStreamPrefetcher::updatePatternTable(SamplerEntry *sampler_entry)
 {
+    stats.nlPatternTrainTimes++;
     if (sampler_entry->pc) {
+    stats.nlPatternUpdateTimes++;// Here we check the PC, when findVictim returns an entry, it sets valid to false
         PatternEntry *pattern_entry = patterns.findEntry(sampler_entry->pc, false);
         if (pattern_entry) {
             patterns.accessEntry(pattern_entry);
             if (sampler_entry->touched) {
                 pattern_entry->conf++;
+               stats.nlPatternUpdateTouchedTrueTimes++;
             } else {
                 pattern_entry->conf--;
+                stats.nlPatternUpdateTouchedFalseTimes++;
             }
         } else {
             if (sampler_entry->touched) {
                 pattern_entry = patterns.findVictim(sampler_entry->pc);
+                bool was_valid = pattern_entry->isValid();
                 pattern_entry->conf.reset();
                 patterns.insertEntry(sampler_entry->pc, false, pattern_entry);
+                if (was_valid)
+                    stats.nlPatternReplaceTimes++;
+                else
+                    stats.nlPatternInsertTimes++;
             }
         }
     }
@@ -86,9 +115,24 @@ DespacitoStreamPrefetcher::calculatePrefetch(const PrefetchInfo &pfi, std::vecto
 
     PatternEntry *pattern_entry = patterns.findEntry(pc, false);
 
+    if (pattern_entry) {
+    stats.nlPatternPcHitTimes++;
+    stats.nlPatternPcHitValidEntryTimes++;
+        if (pattern_entry->conf.isSaturated()){
+            stats.nlPatternPcHitValidEntrySatEq3Times++;
+        } else if (pattern_entry->conf.rawCounter() == 2) {
+            stats.nlPatternPcHitValidEntrySatEq2Times++;
+        } else if (pattern_entry->conf.rawCounter() == 1) {
+            stats.nlPatternPcHitValidEntrySatEq1Times++;
+        }else{
+            stats.nlPatternPcHitValidEntrySatEq0Times++;
+        }
+    }
+
     if (pattern_entry && pattern_entry->conf.isSaturated()) {
         Addr pf_addr = block_addr + blkSize;
         sendPFWithFilter(pfi, pf_addr, addresses, 32, PrefetchSourceType::DespacitoStream);
+    stats.nlTransmitPrefetchReqTimes++;
     }
 
     updateSampler(pfi);
@@ -113,6 +157,61 @@ DespacitoStreamPrefetcher::sendPFWithFilter(const PrefetchInfo &pfi, Addr addr, 
         return true;
     }
 }
+
+DespacitoStreamPrefetcher::DespacitoStats::DespacitoStats(statistics::Group *parent)
+        : statistics::Group(parent),
+            /* sampler */
+            ADD_STAT(nlSampleTrainTimes, statistics::units::Count::get(), "Number of times sampler was trained"),
+            ADD_STAT(nlSampleInsertTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were inserted"),
+            ADD_STAT(nlSampleReplaceTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were replaced"),
+
+            ADD_STAT(nlSampleUpdateTimes, statistics::units::Count::get(),
+             "Number of times sampler entries were updated"),
+            ADD_STAT(nlSampleUpdateReqNotHitTimes, statistics::units::Count::get(),
+            "update request not hit times"),
+            ADD_STAT(nlSampleUpdateReqHitOverBoardTimes, statistics::units::Count::get(),
+             "update request hit but over board times"),
+
+            ADD_STAT(nlSampleVictimTouchedTrueTimes, statistics::units::Count::get(),
+             "Number of times sample victim touched true times"),
+            ADD_STAT(nlSampleVictimTouchedFalseTimes, statistics::units::Count::get(),
+             "Number of times sample victim touched false times"),
+
+            /* pattern table */
+            ADD_STAT(nlPatternTrainTimes, statistics::units::Count::get(),
+             "Number of times pattern table was trained"),
+            ADD_STAT(nlPatternReplaceTimes, statistics::units::Count::get(), "Number of patterns replaced in table"),
+            ADD_STAT(nlPatternInsertTimes, statistics::units::Count::get(), "Number of patterns inserted into table"),
+
+            ADD_STAT(nlPatternUpdateTimes, statistics::units::Count::get(),
+            "Number of times a pattern's confidence changed"),
+            ADD_STAT(nlPatternUpdateTouchedTrueTimes, statistics::units::Count::get(),
+            "Number of times a pattern's training data was touched"),
+            ADD_STAT(nlPatternUpdateTouchedFalseTimes, statistics::units::Count::get(),
+            "Number of times a pattern's training data was not touched"),
+
+            ADD_STAT(nlPatternPcHitTimes, statistics::units::Count::get(), "Number of times a pattern's pc was hit"),
+            ADD_STAT(nlPatternPcHitValidEntryTimes, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq3Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==3"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq2Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==2"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq1Times, statistics::units::Count::get(),
+            "Number of times a pattern's pc hit a valid entry with Sat==1"),
+            ADD_STAT(nlPatternPcHitValidEntrySatEq0Times, statistics::units::Count::get(),
+             "Number of times a pattern's pc hit a valid entry with Sat==0"),
+
+            /* prefetch */
+            ADD_STAT(nlTimeSampleCountResetTimes, statistics::units::Count::get(),
+            "Total number of samples processed"),
+            ADD_STAT(nlTimeSampleCountOverTimes, statistics::units::Count::get(),
+            "Number of times sample count exceeded threshold"),
+            ADD_STAT(nlTransmitPrefetchReqTimes, statistics::units::Count::get(), "Number of prefetches sent"),
+            ADD_STAT(nlFilterHits, statistics::units::Count::get(), "Number of prefetches skipped due to filter")
+{}
 
 }
 }

--- a/src/mem/cache/prefetch/despacito_stream.hh
+++ b/src/mem/cache/prefetch/despacito_stream.hh
@@ -1,6 +1,8 @@
 #ifndef __MEM_CACHE_PREFETCH_DESPACITO_STREAM_HH__
 #define __MEM_CACHE_PREFETCH_DESPACITO_STREAM_HH__
 
+#include <cstdint>
+#include <string>
 #include <vector>
 
 #include <boost/compute/detail/lru_cache.hpp>
@@ -75,6 +77,48 @@ class DespacitoStreamPrefetcher : public Queued
     void updateSampler(const PrefetchInfo &pfi);
 
     void updatePatternTable(SamplerEntry *sampler_entry);
+
+
+  struct DespacitoStats : public statistics::Group
+  {
+    DespacitoStats(statistics::Group *parent);
+
+    // Sampler stats
+    statistics::Scalar nlSampleTrainTimes;
+
+    statistics::Scalar nlSampleInsertTimes;
+    statistics::Scalar nlSampleReplaceTimes;
+
+    statistics::Scalar nlSampleUpdateTimes;
+    statistics::Scalar nlSampleUpdateReqNotHitTimes;
+    statistics::Scalar nlSampleUpdateReqHitOverBoardTimes;
+
+    statistics::Scalar nlSampleVictimTouchedTrueTimes;
+    statistics::Scalar nlSampleVictimTouchedFalseTimes;
+
+
+    // Pattern table stats
+    statistics::Scalar nlPatternTrainTimes;
+    statistics::Scalar nlPatternReplaceTimes;
+    statistics::Scalar nlPatternInsertTimes;
+
+    statistics::Scalar nlPatternUpdateTimes;
+    statistics::Scalar nlPatternUpdateTouchedTrueTimes;
+    statistics::Scalar nlPatternUpdateTouchedFalseTimes;
+
+    statistics::Scalar nlPatternPcHitTimes;
+    statistics::Scalar nlPatternPcHitValidEntryTimes;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq3Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq2Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq1Times;
+    statistics::Scalar nlPatternPcHitValidEntrySatEq0Times;
+
+    // Prefetch stats
+    statistics::Scalar nlTimeSampleCountResetTimes; // total samples processed
+    statistics::Scalar nlTimeSampleCountOverTimes;
+    statistics::Scalar nlTransmitPrefetchReqTimes;
+    statistics::Scalar nlFilterHits;
+  } stats;
 
   public:
     boost::compute::detail::lru_cache<Addr, Addr> *filter;

--- a/src/mem/cache/prefetch/despacito_stream.hh
+++ b/src/mem/cache/prefetch/despacito_stream.hh
@@ -114,10 +114,7 @@ class DespacitoStreamPrefetcher : public Queued
     statistics::Scalar nlPatternPcHitValidEntrySatEq0Times;
 
     // Prefetch stats
-    statistics::Scalar nlTimeSampleCountResetTimes; // total samples processed
-    statistics::Scalar nlTimeSampleCountOverTimes;
     statistics::Scalar nlTransmitPrefetchReqTimes;
-    statistics::Scalar nlFilterHits;
   } stats;
 
   public:


### PR DESCRIPTION
Add performance counters for the despacito stream on Gem5 and synchronize the counters with the RTL design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability by introducing comprehensive statistics collection and performance monitoring across prefetch operations, including sampler, pattern matching, and request handling metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->