### PR TITLE
cpu-o3: using reverse ordered tick & refactor the stalls logic

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -583,7 +583,7 @@ def build_xiangshan_system(args):
         perfCCT_cmd += PerfRecord.vals[0] + " bigint unsigned NOT NULL"
         for i in range(1, len(PerfRecord.vals)):
             name = PerfRecord.vals[i]
-            type_str = "bigint unsigned" if name.lower().startswith(('at', 'pc')) else "char(20)"
+            type_str = "bigint unsigned" if name.lower().startswith(('at', 'pc', 'result')) else "char(20)"
             perfCCT_cmd += "," + name + " " + type_str + " NOT NULL"
         perfCCT_cmd += ");"
 

--- a/docs/Gem5_Docs/top/gem5_new_pipelilne.md
+++ b/docs/Gem5_Docs/top/gem5_new_pipelilne.md
@@ -1,0 +1,655 @@
+# O3 Reverse Tick 与新版阻塞机制说明
+
+## 1. 文档目标
+
+本文档用于解释最近这组 O3 流水线重构的设计意图与核心机制，重点回答下面几个问题：
+
+1. 这个 PR 到底想解决什么问题。
+2. 新版流水线里 `TimeBuffer`、本地 buffer、`StallSignals` 分别负责什么。
+3. 这套机制和 RTL 中常见的 `valid-ready`、级间寄存器、FIFO 分别是什么对应关系。
+4. 后续开发者在修改代码时，应该把什么信息放进 `TimeBuffer`，什么逻辑放进 `StallSignals`。
+5. 这套重构为什么更适合后续做 SMT 的分级阻塞。
+
+本文档描述的主改动主要来自以下提交：
+
+- `d966055b9d`: `cpu-o3: using reverse ordered tick & refactor the stalls logic`
+- `fdba12d73e`: `cpu-o3: fix reverse ordered tick`
+
+`e6d58acd5e` 主要是 perfCCT 记录增强，不是本文的重点。
+
+---
+
+## 2. 一句话总结这个 PR
+
+这个 PR 的核心不是修改某个预测器或某个调度算法，而是**重构 O3 流水线的时序建模方式**。
+
+可以用一句话概括：
+
+- 指令仍然沿着 `Fetch -> Decode -> Rename -> IEW -> Commit` 向前流动。
+- 阻塞/背压则改成沿着 `Commit -> IEW -> Rename -> Decode -> Fetch` 同拍反向传播。
+
+也就是说，这个 PR 想做的是：
+
+- 让后级先决定“我这拍能不能接收”
+- 再让前级在同一拍立即感知这个结果
+- 从而减少旧模型中大量 `block / unblock / skidBuffer / state machine` 的补偿逻辑
+
+这套结构的一个重要目标，是为后续 SMT 下的按线程阻塞和仲裁打基础。
+
+---
+
+## 3. O3 流水线的基本背景
+
+这个 O3 CPU 的主链路可以先粗略理解为：
+
+```text
+Fetch -> Decode -> Rename -> IEW -> Commit
+```
+
+各级职责大致如下：
+
+- `Fetch`
+  - 取指
+  - 与分支预测器、FTQ、Icache 交互
+- `Decode`
+  - 解码
+  - 做部分早期控制流检查
+  - 做部分指令融合
+- `Rename`
+  - 进行物理寄存器分配与重命名
+  - 处理 rename map / history buffer 等资源
+- `IEW`
+  - 分发到 IQ / LSQ
+  - 发射、执行、写回
+- `Commit`
+  - 通过 ROB 按程序序退休
+  - 处理 trap、squash、精确异常等
+
+CPU 的顶层 tick 入口在 `src/cpu/o3/cpu.cc`。
+
+---
+
+## 4. 旧模型与新模型的最重要区别
+
+### 4.1 旧模型的 tick 顺序
+
+在这个 PR 之前，CPU 的 tick 顺序基本是：
+
+```text
+fetch -> decode -> rename -> iew -> commit
+```
+
+这意味着：
+
+- 前端先运行
+- 后端后运行
+- 如果后端在这一拍才发现资源满、需要 squash 或者需要阻塞，那么前端往往已经把这一拍干完了
+
+因此旧模型需要维护很多额外状态来“补时序差”，例如：
+
+- `Blocked`
+- `Unblocking`
+- `Squashing`
+- `SerializeStall`
+- `skidBuffer`
+- block/unblock 握手信号
+
+这些东西并不是无意义的，它们是在旧 tick 顺序下为了保持行为正确而产生的。
+
+### 4.2 新模型的 tick 顺序
+
+这个 PR 之后，tick 顺序改成：
+
+```text
+commit -> iew -> rename -> decode -> fetch
+```
+
+注意，这并不表示“指令反向流动”。
+
+真正变化的是：
+
+- 软件模拟时，后级先更新自己的状态
+- 然后前级在同一拍根据后级状态决定是否推进
+
+所以新模型下更自然的背压链是：
+
+```text
+Commit -> IEW -> Rename -> Decode -> Fetch
+```
+
+也就是：
+
+1. `Commit` 先判断自己是否还能接收新的 rename 结果、ROB 是否还能插入
+2. `IEW` 根据 commit 的反馈决定是否继续向前接收
+3. `Rename` 根据 IEW/资源情况决定是否继续 rename
+4. `Decode` 根据 rename 是否能继续推进来决定是否阻塞 fetch
+5. `Fetch` 最后在这一拍就能知道自己能不能继续往前送
+
+这就是所谓的 reverse ordered tick。
+
+---
+
+## 5. `TimeBuffer` 到底是什么
+
+### 5.1 不要把它简单理解成“普通变量”
+
+`TimeBuffer` 不是普通共享变量，它更像“带显式时间偏移的环形缓冲”。
+
+关键语义如下：
+
+- `getWire(0)`：访问当前时刻的槽位
+- `getWire(-delay)`：读取延迟 `delay` 拍后才可见的槽位
+- `advance()`：在周期边界推进整个时间窗口
+
+因此，它的主要用途不是“简单共享一块数据”，而是**显式建模 stage 间传播延迟**。
+
+实现见：
+
+- `src/cpu/timebuf.hh`
+
+### 5.2 `TimeBuffer` 不是 RTL 意义上的“自动保值级间寄存器”
+
+这点非常重要。
+
+在 RTL 里，我们通常会这样想：
+
+- 上一级把 `valid + data` 放在级间寄存器或 FIFO 中
+- 如果下一级 `ready=0` 没收走，那么这个寄存器/FIFO 里的值会继续保持
+
+而在这个 gem5 O3 重构里，语义被拆开了：
+
+1. `TimeBuffer`
+   - 主要负责“这个信息跨多少拍可见”
+   - 更像“带延迟的链路”或“时间总线”
+2. 本地 buffer / 队列 / ROB / LSQ
+   - 主要负责“这个数据如果本拍没被处理，要继续留着”
+3. `StallSignals`
+   - 主要负责“这一拍是否允许上游继续推进”
+
+所以一句话记忆就是：
+
+**`TimeBuffer` 更像延迟总线，而不是永远替你保值的流水寄存器。**
+
+### 5.3 那 `TimeBuffer` 会不会覆盖旧值
+
+会。
+
+`TimeBuffer` 随着每拍 `advance()` 会推进时间窗口，并重建未来槽位。也就是说：
+
+- 它的内容不是“只要没人消费就一直保留”
+- 它本质上是按时间流动的
+
+因此，**真正需要长期保留的数据，不能只依赖 `TimeBuffer` 保存**。
+
+如果某一级已经收到数据但暂时处理不了，正确做法应该是：
+
+- 先把数据搬入该 stage 的本地 buffer
+- 然后由本地 buffer 持有这些数据直到后续周期继续处理
+
+这也是这次 PR 中大量引入 `fixedbuffer` 的直接原因。
+
+---
+
+## 6. 新模型下有哪些“存储/传输”层次
+
+为了理解新版阻塞机制，最好的方法是把整个流水线拆成三层看。
+
+### 6.1 第一层：链路延迟层
+
+负责表达“这个信息多少拍后才能被对面看到”。
+
+对应机制：
+
+- `TimeBuffer<TimeStruct>`
+- `fetchTimebuffer`
+- `decodeTimebuffer`
+- `renameTimebuffer`
+- `iewTimebuffer`
+
+它们表达的是：
+
+- 前向指令流的级间延迟
+- squash / redirect / doneSeqNum 等反馈控制信息的延迟
+
+### 6.2 第二层：本地保存层
+
+负责表达“这条数据已经到我这里了，但我这拍不一定能处理完”。
+
+对应结构：
+
+- `Decode::fixedbuffer`
+- `Rename::fixedbuffer`
+- `IEW::fixedbuffer`
+- `Commit::fixedbuffer`
+- 以及更传统的 `fetchQueue`、`ROB`、`LSQ`、`IQ`
+
+这一层最接近 RTL 里“寄存器/FIFO 保值”的语义。
+
+### 6.3 第三层：同拍背压层
+
+负责表达“我这一拍到底准不准继续推进”。
+
+对应结构：
+
+- `StallSignals`
+  - `blockFetch`
+  - `blockDecode`
+  - `blockRename`
+  - `blockIEW`
+
+这一层最接近 RTL 里 `ready/allowin` 那一半的语义。
+
+---
+
+## 7. `StallSignals` 是什么
+
+### 7.1 它的本质
+
+`StallSignals` 是这次 PR 新增的“快速背压通道”。
+
+它不是用来装复杂 payload 的，也不是用来表达多拍传播的，而是用来表达：
+
+- 后级这拍能不能接收
+- 上游这拍是不是该停
+
+它是这条同拍背压链的载体：
+
+```text
+Commit -> IEW -> Rename -> Decode -> Fetch
+```
+
+### 7.2 为什么它存在
+
+如果仍然让“阻塞信息”完全通过 `TimeBuffer` 传播，那么由于 `TimeBuffer` 是按拍延迟可见的，前级会晚一拍知道后级已经堵住。
+
+一旦晚一拍，就又需要：
+
+- block / unblock 状态机
+- skid buffer
+- 额外的中间状态
+
+也就是说，`StallSignals` 的存在，就是为了把“是否准许推进”这类必须同拍生效的控制，从 `TimeBuffer` 中分离出来。
+
+### 7.3 它是不是握手信号
+
+可以说它**类似 RTL `valid-ready` 协议中 `ready/allowin` 的那一半**，但并不是完整的 `valid-ready` 通道抽象。
+
+原因如下：
+
+1. 这里没有一个统一的 `valid` 信号字段
+   - 是否有数据，通常由 `size`、队列是否为空、本地 buffer 是否为空等方式表达
+2. `ready` 也没有被统一抽象成一个接口
+   - 而是拆成了 `blockFetch / blockDecode / blockRename / blockIEW`
+3. 数据保持不靠通道本身完成
+   - 而是靠各级自己的本地 buffer / ROB / LSQ 来完成
+
+所以更准确地说：
+
+- `StallSignals` 是“同拍背压”的建模机制
+- 它与 RTL 中的 `ready/allowin` 很相似
+- 但它不是完整 `valid-ready` 协议的一比一翻版
+
+---
+
+## 8. 与 RTL `valid-ready` / FIFO / 级间寄存器的对应关系
+
+这一节最容易帮助硬件背景的开发者建立直觉。
+
+### 8.1 RTL 中的典型模型
+
+在 RTL 中，一个级间通道通常同时具备三层含义：
+
+1. **数据通道**
+   - `data`
+2. **有效性**
+   - `valid`
+3. **可接收性**
+   - `ready`
+
+握手条件一般是：
+
+```text
+valid && ready
+```
+
+一旦握手成功：
+
+- 数据向下一级推进
+
+如果握手不成功：
+
+- 数据保持在当前级间寄存器/FIFO 中
+- 等待后续周期重试
+
+### 8.2 新版 gem5 O3 中的对应关系
+
+可以用下面这张表理解：
+
+| RTL 概念 | 新版 gem5 O3 对应物 | 说明 |
+| --- | --- | --- |
+| 级间链路延迟 | `TimeBuffer` | 表达“几拍后可见” |
+| 级间寄存器/FIFO 中的数据保持 | 各 stage 的 `fixedbuffer`、`fetchQueue`、`ROB`、`LSQ` 等 | 表达“已收到但暂未消费的数据继续保留” |
+| `ready/allowin` 背压 | `StallSignals` | 表达“这一拍能不能继续往前推” |
+| `valid` | `size`、队列非空、buffer 非空等隐式条件 | 没有统一字段，分散在具体结构里 |
+| payload 控制信息 | `TimeStruct` / 前向 Struct | squash、redirect、doneSeqNum 等 |
+
+### 8.3 一个更直观的类比
+
+如果用硬件设计语言来类比，新模型更像下面这种结构：
+
+```text
+前向链路: 有延迟的数据通道
+本地级内: 有输入缓冲 / FIFO / 寄存器保存未消费数据
+反向链路: 有组合式 allowin / backpressure
+```
+
+而不是一个统一的“每一级都只靠一组 valid-ready 寄存器”的极简模型。
+
+### 8.4 这和“寄存器保值”的关系
+
+RTL 中你会说：
+
+- 级间寄存器保值
+
+新版 gem5 O3 中更合适的说法是：
+
+- **接收级自己的本地 buffer 保值**
+
+也就是说，不是 `TimeBuffer` 帮你 hold 住数据，而是：
+
+- 下一级先把输入搬进自己的本地 buffer
+- 如果这拍处理不完，本地 buffer 继续保留
+- 上游则通过 `StallSignals` 被挡住，不再继续注入更多数据
+
+这是和 RTL 直觉最像、但实现手法不同的地方。
+
+---
+
+## 9. 这次 PR 中各机制分别承担什么责任
+
+### 9.1 `TimeBuffer` / `TimeStruct`
+
+适合承载：
+
+- 带 payload 的控制信息
+- 明确需要跨拍延迟传播的信息
+- stage 间前向传递的指令包
+
+典型例子：
+
+- squash
+- redirect PC
+- `doneSeqNum`
+- `doneMemSeqNum`
+- resolved CFI
+- 各级向下一阶段发送的指令 bundle
+
+### 9.2 本地 `fixedbuffer`
+
+适合承载：
+
+- 已经到达本 stage，但本拍还没处理完的数据
+- 需要跨拍继续保留的输入
+
+典型场景：
+
+- Decode 已经收到了来自 Fetch 的若干指令，但这拍只能处理一部分
+- Rename 已经收到了来自 Decode 的指令，但这拍资源不够
+- IEW 已经收到了来自 Rename 的指令，但 IQ / LSQ / dispatch 带宽不足
+- Commit 已经收到了来自 Rename 的指令，但这拍不一定能全部插入 ROB
+
+### 9.3 `StallSignals`
+
+适合承载：
+
+- 这一拍是否允许上游继续推进
+- 没有复杂 payload 的简单 backpressure
+
+典型语义：
+
+- `blockIEW`：commit 告诉 IEW，这一拍不要再继续向前推进到自己这里
+- `blockRename`：IEW 告诉 rename，这一拍别再往下送
+- `blockDecode`：rename 告诉 decode，这一拍别再往下送
+- `blockFetch`：decode 告诉 fetch，这一拍别再继续出队/送指令
+
+---
+
+## 10. 为什么 `TimeBuffer` 和 `StallSignals` 不能简单视为同一种东西
+
+这是后续维护最容易混淆的点。
+
+### 10.1 它们解决的是两类不同问题
+
+`TimeBuffer` 解决的是：
+
+- 延迟传播
+- 历史/未来时间槽位
+- 带 payload 的信息移动
+
+`StallSignals` 解决的是：
+
+- 同拍背压
+- 不需要等待 `advance()`
+- 通常不带复杂 payload
+
+### 10.2 为什么不能简单“全都塞进 `TimeBuffer`”
+
+如果把同拍背压也塞回 `TimeBuffer`，会重新出现旧问题：
+
+- 前级晚一拍知道后级阻塞
+- 需要恢复 block/unblock 状态机来补时序差
+
+### 10.3 为什么也不能简单“全都改成 `StallSignals`”
+
+如果把 squash、redirect、doneSeqNum、payload 丰富的控制也都改成 `StallSignals`，会出现另一个问题：
+
+- 这些信息本来就具有明确的多拍传播语义
+- 且往往需要携带复杂数据
+- 仅靠一个简单的 block 信号无法表达
+
+因此两者在语义上是分工明确的。
+
+---
+
+## 11. 那有没有机会把两者“合并”
+
+### 11.1 结论
+
+**可以考虑做接口层统一抽象，但不建议简单把当前实现硬合并。**
+
+### 11.2 为什么“真正合并”很难
+
+因为语义上它们仍然是两类东西：
+
+- 一类是 delayed payload channel
+- 一类是 same-cycle backpressure
+
+即使未来要统一成一个更抽象的 `Channel` 类，内部通常也仍然需要区分：
+
+- 是否带延迟
+- 是否需要 payload
+- 是否负责 buffering
+- 是否负责 backpressure
+
+换句话说：
+
+- **实现接口可以统一**
+- **语义层面依然需要分层**
+
+### 11.3 更合理的长期方向
+
+如果后续 SMT 和通道复杂度继续上升，可以考虑做更高层的抽象，例如：
+
+- `DelayedPayloadChannel`
+- `BackpressureChannel`
+- `BufferedStageInput`
+
+但在当前阶段，更重要的是：
+
+1. 先把语义边界写清楚
+2. 先避免后续开发者误用
+3. 再考虑是否值得抽象统一
+
+---
+
+## 12. 这一版设计为什么更适合 SMT
+
+这个 PR 不是完整 SMT 支持，但它在结构上更适合未来做 SMT。
+
+原因包括：
+
+1. `StallSignals` 本身就是按线程数组组织的
+2. 多个 stage 先把输入搬入本地 buffer，再决定消费多少，这更接近 per-thread arbitration 的思路
+3. 背压链显式化后，更容易按线程分析“是哪个下游线程/资源导致了阻塞”
+
+因此更准确地说：
+
+- 这不是“SMT 已经实现完成”
+- 而是“流水线控制结构更适合后续 SMT 开发”
+
+---
+
+## 13. 一次典型周期里会发生什么
+
+下面用一个典型例子说明新模型的直觉。
+
+假设这一拍后端资源紧张，Commit 或 IEW 已经接近满载。
+
+### 周期内顺序
+
+1. `Commit` 先 tick
+   - 判断 ROB 是否还能接收、是否正在 squashing
+   - 设置 `blockIEW`
+2. `IEW` 再 tick
+   - 读取 `blockIEW`
+   - 决定自己是否还能继续从 Rename 接收
+   - 必要时设置 `blockRename`
+3. `Rename` 再 tick
+   - 读取 `blockRename`
+   - 决定这拍是否继续 rename
+   - 必要时设置 `blockDecode`
+4. `Decode` 再 tick
+   - 读取 `blockDecode`
+   - 决定是否阻塞 Fetch
+   - 设置 `blockFetch`
+5. `Fetch` 最后 tick
+   - 读取 `blockFetch`
+   - 决定是否继续向 Decode 发送指令
+6. 周期末统一 `advance()` 各类 `TimeBuffer`
+
+### 需要注意的点
+
+在这个过程中：
+
+- 指令本身的前向传播，仍然依赖前向 `TimeBuffer`
+- 某一级已经收到但本拍处理不完的数据，会保存在该级本地 buffer 中
+- 是否允许上游继续推进，则由 `StallSignals` 同拍决定
+
+---
+
+## 14. 开发者修改代码时的判断准则
+
+后续如果要继续修改这套流水线代码，建议始终按下面的准则判断。
+
+### 14.1 什么时候应该用 `StallSignals`
+
+当你想表达的是：
+
+- “这一拍我能不能接收”
+- “上游这一拍应不应该继续推”
+- “这个决策需要同拍生效”
+
+此时优先考虑 `StallSignals`。
+
+### 14.2 什么时候应该用 `TimeBuffer`
+
+当你想表达的是：
+
+- “这个信息需要延迟若干拍后可见”
+- “这个信息不是简单 bool，而是带 payload”
+- “这是一个控制事件，而不是简单 backpressure”
+
+此时优先考虑 `TimeBuffer` / `TimeStruct`。
+
+### 14.3 什么时候应该放进本地 buffer
+
+当你想表达的是：
+
+- “数据已经到达本级”
+- “但这拍没处理完”
+- “需要跨拍继续保留”
+
+此时应该放进本级的 `fixedbuffer` 或其他局部队列/结构，而不是指望 `TimeBuffer` 自动保值。
+
+---
+
+## 15. 后续维护最容易踩的坑
+
+### 15.1 把“应当同拍生效”的信号误放进 `TimeBuffer`
+
+后果：
+
+- 信号晚一拍
+- 前级多推进一拍
+- 又要重新引入复杂 block/unblock 补偿逻辑
+
+### 15.2 把“应当带 payload/带延迟”的控制误简化成 `StallSignals`
+
+后果：
+
+- squash / redirect / doneSeq 等复杂语义表达不完整
+- 时序语义变得含糊
+
+### 15.3 误以为 `TimeBuffer` 会自动替 stage 持有未消费数据
+
+后果：
+
+- 数据保留逻辑写错
+- 修改后很容易出现“本拍看起来没问题、下拍数据没了”的问题
+
+### 15.4 把本地 buffer 和上游背压脱钩
+
+如果一个 stage 已经出现局部积压，但没有及时通过 `StallSignals` 阻止上游继续输入，就容易出现：
+
+- 带宽模型失真
+- buffer overflow
+- 行为与真实流水线不一致
+
+---
+
+## 16. 推荐的阅读路径
+
+如果后续开发者要读这套逻辑，建议按下面顺序看：
+
+1. `src/cpu/o3/cpu.cc`
+   - 先看 `CPU::tick()` 的新顺序
+2. `src/cpu/timebuf.hh`
+   - 理解 `TimeBuffer` 的真正语义
+3. `src/cpu/o3/comm.hh`
+   - 理解 `TimeStruct` 和 `StallSignals` 的职责边界
+4. `src/cpu/o3/commit.cc`
+   - 看 `blockIEW` 和 squash 源头
+5. `src/cpu/o3/iew.cc`
+   - 看 `blockRename`、dispatch、本地 buffer
+6. `src/cpu/o3/rename.cc`
+   - 看 `blockDecode`、本地 buffer、rename 资源约束
+7. `src/cpu/o3/decode.cc`
+   - 看 `blockFetch`
+8. `src/cpu/o3/fetch.cc`
+   - 看 fetch 最终如何消费背压和控制反馈
+
+---
+
+## 17. 最后一句总结
+
+这次重构之后，理解新版流水线最有效的方式不是问：
+
+- “为什么 `TimeBuffer` 不像 RTL 寄存器那样自动 hold 数据？”
+
+而是要改成下面这个三层心智模型：
+
+1. **`TimeBuffer` 负责延迟传播**
+2. **本地 buffer / ROB / LSQ 负责保存未消费数据**
+3. **`StallSignals` 负责同拍背压**
+
+如果始终用这三层模型来读代码，后续对新版阻塞逻辑、reverse tick 和 SMT 扩展方向都会更容易理解。

--- a/docs/tools/topdown/reverseTickRootCauseTopdown.md
+++ b/docs/tools/topdown/reverseTickRootCauseTopdown.md
@@ -1,0 +1,193 @@
+# Reverse Tick 下的 Root-Cause Topdown 口径说明
+
+## 1. 目标
+
+本文档用于说明新版 reverse ordered tick 流水线下，`fetchStallReason`、`decodeStallReason`、`renameStallReason`、`dispatchStallReason` 这几组 topdown 统计应该如何理解，以及为什么需要把根因按口径 B 从后向前传播。
+
+本文档假设：
+
+- `dispatchStallReason` 是最接近真实后端瓶颈的位置
+- 前端与中端的 stall reason 不是为了替代 `dispatchStallReason`
+- 而是为了描述同一个根因向前传播后，在不同流水级造成了多少停顿与空槽
+
+---
+
+## 2. 推荐口径：口径 B（根因归因）
+
+这里采用的口径是：
+
+- 如果真正的瓶颈发生在后端，则应该把这个根因沿着背压链一路向前传播
+- 前面的 stage 在被动停住时，不应该把问题重新归因为“本级无事可做”
+
+也就是说：
+
+- `dispatchStallReason` 负责回答“真正的病灶在哪里”
+- `fetch/decode/rename StallReason` 负责回答“这个病灶向前传播后，分别压住了哪些 stage”
+
+---
+
+## 3. 四级统计各自的角色
+
+### 3.1 `dispatchStallReason`
+
+这是最重要的一组统计。
+
+它最接近实际资源瓶颈发生的位置，适合用于定位真正的优化方向，例如：
+
+- IQ 满
+- LQ / SQ 满
+- serialize
+- ROB head not ready
+- 长执行延迟
+- memory bound
+
+因此：
+
+- `dispatchStallReason` 应作为最终根因锚点
+- 后续性能分析优先看这一组
+
+### 3.2 `renameStallReason`
+
+这一组统计表示：
+
+- 后端根因已经传播到 rename
+- rename 这一拍因为下游原因或资源约束而无法继续推进
+
+它的作用是帮助判断：
+
+- 后端瓶颈是否已经明显压到了 rename
+- rename 的停顿有多少是“本级资源不足”，有多少是“被后端反压”
+
+### 3.3 `decodeStallReason`
+
+这一组统计表示：
+
+- 同一个根因继续往前传播后，对 decode 造成了多少影响
+
+它的价值主要在于：
+
+- 判断 decode 空槽到底是 frontend 自己的问题，还是下游反压造成的
+
+### 3.4 `fetchStallReason`
+
+这一组统计表示：
+
+- 最终反映到前端 delivery 上的停顿原因
+
+它非常适合区分两类情况：
+
+1. 真正的 frontend 问题
+   - `IcacheStall`
+   - `ITlbStall`
+   - `FTQBubble`
+   - 其他本级取指问题
+2. 后端根因一路反压到前端
+   - 例如某类 memory bound、serialize、commit squash、长执行等
+
+因此：
+
+- `fetchStallReason` 不应直接替代 `dispatchStallReason`
+- 它的主要价值是区分“前端真的有问题”还是“前端只是被后端压住了”
+
+---
+
+## 4. 为什么这不是重复统计
+
+表面上看，四级都可能记录同一个 `StallReason`，但它们不是在统计同一个事件，而是在统计：
+
+- 同一个根因在不同 stage 上造成的影响范围
+
+例如，真实根因是 `LoadL2Bound`：
+
+1. `dispatchStallReason=LoadL2Bound`
+2. rename 因为 dispatch 不再前推，也记录 `LoadL2Bound`
+3. decode 因为 rename 被压住，也记录 `LoadL2Bound`
+4. fetch 因为 decode 不再接收，也记录 `LoadL2Bound`
+
+这四条统计放在一起的含义是：
+
+- 问题源头在后端 load miss
+- 并且这个问题已经足够严重，向前压住了整条流水线
+
+---
+
+## 5. Root-cause 传播规则
+
+为了让统计口径稳定，推荐采用如下规则。
+
+### 规则 1：本级真实原因优先
+
+如果本级确实发生了明确的本级 stall，就应该优先记录本级原因。
+
+例如：
+
+- fetch 确实遭遇 `IcacheStall`
+- decode 确实发生 `InstMisPred`
+
+此时不应盲目覆盖成下游原因。
+
+### 规则 2：本级只是被下游反压时，转发下游根因
+
+如果本级自身没有新的更直接原因，只是因为下游不再接收而停住，那么应该继续转发下游根因。
+
+这是口径 B 的核心。
+
+### 规则 3：同拍 reason 与同拍 block 一起传播
+
+reverse tick 下，`StallSignals` 已经承担同拍背压的传播职责。
+
+如果 reason 仍然只走延迟 `TimeBuffer`，那么 bool 型 block 和 root cause 就会错拍。
+
+因此：
+
+- 同拍 block 的 root cause 也应通过同拍 sideband 一起传播
+- `TimeBuffer` 继续承载延迟控制事件与 payload
+- `StallSignals` 则承载同拍背压及其根因元数据
+
+---
+
+## 6. 新版实现中的推荐职责划分
+
+### `dispatchStallReason`
+
+- 最终根因
+- 最重要
+- 用于真正定位要优化的结构
+
+### `renameStallReason`
+
+- 后端根因向前传播到 rename 的投影
+
+### `decodeStallReason`
+
+- 同一个根因继续传播到 decode 的投影
+
+### `fetchStallReason`
+
+- 该根因最终在 frontend delivery 上体现出的停顿
+
+---
+
+## 7. 修复方向
+
+为了让口径 B 在 reverse tick 下成立，建议做以下修复：
+
+1. 同拍 block 与同拍 root cause 一起传播
+2. 提前返回路径也必须发布当前拍的 reason
+3. 本级无新原因时，不要留下 stale reason
+4. 前级在被 block 时，应直接读取同拍 block root cause，而不是依赖延迟路径的旧值
+
+---
+
+## 8. 最后总结
+
+推荐的理解方式是：
+
+- `dispatchStallReason`：最终根因
+- `fetch/decode/rename StallReason`：这个根因在更前级造成的影响
+
+因此，修好 root-cause 传播以后：
+
+- `dispatchStallReason` 仍然是最主要的分析依据
+- `fetchStallReason` 也会重新变得有参考价值
+- 二者不是互相替代，而是互相补充

--- a/docs/tools/topdown/reverseTickRootCauseTopdown.md
+++ b/docs/tools/topdown/reverseTickRootCauseTopdown.md
@@ -179,7 +179,31 @@ reverse tick 下，`StallSignals` 已经承担同拍背压的传播职责。
 
 ---
 
-## 8. 最后总结
+## 8. 新增的结构性背压原因
+
+在这次 reverse tick 统计修复之后，原本容易被吞到 `OtherStall` 里的两类结构性背压，被显式拆成了独立原因：
+
+### `RegFull`
+
+- 含义：rename 本级因为物理寄存器资源不足，无法继续向前推进
+- 位置：根因首先发生在 rename
+- 传播：如果这个原因继续向前反压，则 `rename/decode/fetch StallReason` 都可以看到 `RegFull`
+
+它不属于“未知 stall”，而是明确的 rename 资源瓶颈。
+
+### `ROBFull`
+
+- 含义：commit 侧因为 ROB 剩余空间不足，无法继续吸收来自 rename 的输入
+- 位置：根因首先体现为 commit 对上游的容量背压
+- 传播：如果这个原因沿着背压链向前扩散，则 `rename/decode/fetch StallReason` 都可以看到 `ROBFull`
+
+这里的 `ROBFull` 更接近“ROB 容量背压”，而不是“ROB head 对应指令的执行根因”。
+
+因此，这两个 reason 的引入，主要是为了把原本模糊的 `OtherStall` 拆解成更有解释力的结构性原因，而不是改变一级 topdown 行为。
+
+---
+
+## 9. 最后总结
 
 推荐的理解方式是：
 

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -66,7 +66,7 @@ class PerfRecord(ScopedEnum):
         # position tick
         'AtFetch', 'AtDecode', 'AtRename', 'AtDispQue', 'AtIssueQue', 'AtIssueArb', 'AtIssueReadReg',
         'AtFU', 'AtBypassVal', 'AtWriteVal', 'AtCommit',
-        'DisAsm', 'PC'
+        'Result', 'DisAsm', 'PC'
     ]
 
 class BaseO3CPU(BaseCPU):

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -219,29 +219,17 @@ struct TimeStruct
         StallReason blockReason;
     };
 
-    DecodeComm decodeInfo[MaxThreads];
+    DecodeComm decodeInfo[MaxThreads]; // decode to fetch
 
     struct RenameComm
     {
         StallReason blockReason;
     };
 
-    RenameComm renameInfo[MaxThreads];
+    RenameComm renameInfo[MaxThreads]; // rename to decode
 
     struct IewComm
     {
-        // Also eventually include skid buffer space.
-        unsigned freeLQEntries;
-        unsigned freeSQEntries;
-        unsigned dispatchedToLQ;
-        unsigned dispatchedToSQ;
-
-        unsigned ldstqCount;
-
-        unsigned dispatched;
-        bool usedIQ;
-        bool usedLSQ;
-
         StallReason robHeadStallReason;
         StallReason blockReason;
         StallReason lqHeadStallReason;
@@ -256,7 +244,7 @@ struct TimeStruct
         std::vector<ResolvedCFIEntry> resolvedCFIs;  // *F
     };
 
-    IewComm iewInfo[MaxThreads];
+    IewComm iewInfo[MaxThreads]; // iew to rename, fetch
 
     struct CommitComm
     {
@@ -300,12 +288,11 @@ struct TimeStruct
 
         InstSeqNum doneMemSeqNum;
 
+        InstSeqNum robheadNotReadySeqNum;
+
         uint64_t doneFtqId; // F
         uint64_t squashedTargetId; // F
         unsigned squashedLoopIter; // F
-
-        /// Tell Rename how many free entries it has in the ROB
-        unsigned freeROBEntries; // *R
 
         bool isTrapSquash;
         bool squash; // *F, D, R, I
@@ -336,15 +323,19 @@ struct TimeStruct
 
     };
 
-    CommitComm commitInfo[MaxThreads];
-
-    bool decodeBlock[MaxThreads];
-    bool decodeUnblock[MaxThreads];
-    bool renameBlock[MaxThreads];
-    bool renameUnblock[MaxThreads];
-    bool iewBlock[MaxThreads];
-    bool iewUnblock[MaxThreads];
+    CommitComm commitInfo[MaxThreads];// commit to iew, rename, fetch
 };
+
+
+struct StallSignals
+{
+
+    bool blockFetch[MaxThreads];// decode to fetch
+    bool blockDecode[MaxThreads];// rename to decode
+    bool blockRename[MaxThreads];// iew to rename (if iew is stalling, rename all threads would be stalled)
+    bool blockIEW[MaxThreads];// commit to iew
+};
+
 
 } // namespace o3
 } // namespace gem5

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -329,11 +329,28 @@ struct TimeStruct
 
 struct StallSignals
 {
+    StallSignals()
+    {
+        for (int i = 0; i < MaxThreads; ++i) {
+            blockFetch[i] = false;
+            blockDecode[i] = false;
+            blockRename[i] = false;
+            blockIEW[i] = false;
+            fetchBlockReason[i] = StallReason::NoStall;
+            decodeBlockReason[i] = StallReason::NoStall;
+            renameBlockReason[i] = StallReason::NoStall;
+            iewBlockReason[i] = StallReason::NoStall;
+        }
+    }
 
     bool blockFetch[MaxThreads];// decode to fetch
     bool blockDecode[MaxThreads];// rename to decode
     bool blockRename[MaxThreads];// iew to rename (if iew is stalling, rename all threads would be stalled)
     bool blockIEW[MaxThreads];// commit to iew
+    StallReason fetchBlockReason[MaxThreads];// decode to fetch root cause
+    StallReason decodeBlockReason[MaxThreads];// rename to decode root cause
+    StallReason renameBlockReason[MaxThreads];// iew to rename root cause
+    StallReason iewBlockReason[MaxThreads];// commit to iew root cause
 };
 
 

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -101,6 +101,8 @@ enum StallReason {
     ScalarReadyButNotIssued,  // B
     ResumeUnblock,  // B
     CommitSquash,  // BS
+    ROBFull,  // B
+    RegFull,  // B
     OtherStall,  // B
     NumStallReasons
 };

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -288,7 +288,7 @@ struct TimeStruct
 
         InstSeqNum doneMemSeqNum;
 
-        InstSeqNum robheadNotReadySeqNum;
+        InstSeqNum robheadSeqNum;
 
         uint64_t doneFtqId; // F
         uint64_t squashedTargetId; // F

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1863,7 +1863,7 @@ Commit::moveInstsToBuffer()
         } else if (block) {
             block_reason = robInfoFromIEW->iewInfo[i].robHeadStallReason;
             if (block_reason == StallReason::NoStall) {
-                block_reason = StallReason::OtherStall;
+                block_reason = StallReason::ROBFull;
             }
         }
         DPRINTF(Commit, "Thread %i: block %i robblock %i active %i\n", i, block, robblock, active);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1401,7 +1401,9 @@ Commit::commitInsts()
                     Addr load_addr = head_inst->physEffAddr;
                     char buffer[8] = {0};
                     if (head_inst->memData) {
-                        std::memcpy(buffer, head_inst->memData, head_inst->effSize);
+                        std::memcpy(buffer, head_inst->memData,
+                                    std::min<size_t>(head_inst->effSize,
+                                                     sizeof(buffer)));
                     }
                     Addr load_value = *((uint64_t *)buffer);
                     bool hit = loadTripleCounter.update(load_pc, load_addr, load_value);
@@ -1855,9 +1857,19 @@ Commit::moveInstsToBuffer()
         bool robblock = commitStatus[i] == ROBSquashing || commitStatus[i] == TrapPending;
         bool block = (rob->getMaxEntries(i) - rob->getThreadEntries(i) < fixedbuffer[i].size()) || robblock;
         bool active = !block && !fixedbuffer[i].empty();
+        StallReason block_reason = StallReason::NoStall;
+        if (robblock) {
+            block_reason = StallReason::CommitSquash;
+        } else if (block) {
+            block_reason = robInfoFromIEW->iewInfo[i].robHeadStallReason;
+            if (block_reason == StallReason::NoStall) {
+                block_reason = StallReason::OtherStall;
+            }
+        }
         DPRINTF(Commit, "Thread %i: block %i robblock %i active %i\n", i, block, robblock, active);
 
         stallSig->blockIEW[i] = block;
+        stallSig->iewBlockReason[i] = block ? block_reason : StallReason::NoStall;
         if (active) {
             if (tid == InvalidThreadID) tid = i;
             else {

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1204,10 +1204,21 @@ Commit::commitInsts()
 
         // ThreadID commit_thread = getCommittingThread();
 
-        if (commit_thread == -1 || !rob->isHeadGroupReady(commit_thread))
+        if (commit_thread == -1)
             break;
 
         head_inst = rob->readHeadInst(commit_thread);
+
+        if (!rob->isHeadGroupReady(commit_thread)) {
+            if (debug::Commit && head_inst->readyToCommit()) {
+                InstSeqNum seqnum = rob->getHeadGroupLastDoneSeq(commit_thread);
+                DPRINTF(
+                    Commit,
+                    "[sn:%llu] Head is ready to commit, but the group is not all ready, last done inst [sn:%llu]\n",
+                    head_inst->seqNum, seqnum);
+            }
+            break;
+        }
 
         ThreadID tid = head_inst->threadNumber;
 
@@ -1502,7 +1513,12 @@ Commit::commitInsts()
     for (int tid = 0; tid < MaxThreads; tid++) {
         toIEW->commitInfo[tid].doneMemSeqNum =
             std::max(toIEW->commitInfo[tid].doneSeqNum, rob->getHeadGroupLastDoneSeq(tid));
-        toIEW->commitInfo[tid].robheadNotReadySeqNum = rob->getHeadGroupLastNotReadySeq(tid);
+
+        InstSeqNum robheadSeqNum = 0;
+        if (auto& it = rob->readHeadInst(tid)) {
+            robheadSeqNum = it->seqNum;
+        }
+        toIEW->commitInfo[tid].robheadSeqNum = robheadSeqNum;
     }
 
     DPRINTF(CommitRate, "%i\n", num_committed);
@@ -1828,9 +1844,7 @@ Commit::moveInstsToBuffer()
         for (int i = 0; i < insts_from_rename; ++i) {
             const DynInstPtr &inst = fromRename->insts[i];
             assert(inst->threadNumber == tid);
-            if (localSquashVer.largerThan(inst->getVersion())) {
-                inst->setSquashed();
-            }
+            if (!inst->isSquashed())
             fixedbuffer[tid].push_back(inst);
         }
     }
@@ -1864,11 +1878,6 @@ Commit::moveInstsToBuffer()
     int insts_to_process = fixedbuffer[tid].size();
     for (int inst_num = 0; inst_num < insts_to_process; ++inst_num) {
         const DynInstPtr &inst = fixedbuffer[tid].front();
-
-        if (localSquashVer.largerThan(inst->getVersion())) {
-            inst->setSquashed();
-        }
-
         if (!inst->isSquashed() &&
             commitStatus[tid] != ROBSquashing &&
             commitStatus[tid] != TrapPending) {
@@ -1902,17 +1911,15 @@ void
 Commit::squashInflightAndUpdateVersion(ThreadID tid)
 {
     DPRINTF(Commit, "Squashing in-flight renamed instructions\n");
-    int cycle = 0;  // Mark instructions renamed this cycle as squashed
-    auto tb_ptr = renameQueue->getWire(cycle);
-    DPRINTF(Commit, "%u insts in flight at cycle %d\n", tb_ptr->size,
-            cycle);
-    for (unsigned i_idx = 0; i_idx < tb_ptr->size; i_idx++) {
-        const DynInstPtr &inst = tb_ptr->insts[i_idx];
+    for (unsigned i_idx = 0; i_idx < fromRename->size; i_idx++) {
+        const DynInstPtr &inst = fromRename->insts[i_idx];
         DPRINTF(Commit, "[tid:%i] [sn:%llu] Squashing in-flight "
                 "instruction PC %s\n",
                 inst->threadNumber, inst->seqNum, inst->pcState());
         inst->setSquashed();
     }
+
+    fixedbuffer[tid].clear();
 
     localSquashVer.update(localSquashVer.nextVersion());
     toIEW->commitInfo[tid].squashVersion = localSquashVer;

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1241,6 +1241,10 @@ Commit::commitInsts()
 
             if (commit_success) {
                 cpu->perfCCT->updateInstPos(head_inst->seqNum, PerfRecord::AtCommit);
+                auto res = head_inst->getResult();
+                if (res.is<RegVal>()) {
+                    cpu->perfCCT->updateInstMeta(head_inst->seqNum, InstDetail::Result, res.as<RegVal>());
+                }
                 cpu->perfCCT->commitMeta(head_inst->seqNum);
 
                 DPRINTF(CommitTrace, "CT: %s\n", head_inst->genDisassembly());
@@ -1710,9 +1714,9 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 cause = cpu->readMiscReg(
                     RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
             }
-            auto exception_no =inst_fault->exception();
+            auto exception_no = inst_fault->exception();
             if (faultNum.find(exception_no) != faultNum.end()) {
-                DPRINTF(Commit, "Force to raise No.%lu exception at page fault\n", inst_fault);
+                DPRINTF(Commit, "Force to raise No.%lu exception at page fault\n", exception_no);
                 cpu->setExceptionGuideExecInfo(
                     exception_no, cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MTVAL, tid),
                     cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_STVAL, tid), false, 0, tid);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -129,7 +129,7 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
                 "--debug-start=%llu --debug-end=%llu\n",
                 lastCommitCycle, cpu->curCycle(),
                 cpu->cyclesToTicks(Cycles(lastCommitCycle - 200)),
-                cpu->cyclesToTicks(Cycles(lastCommitCycle + 50)));
+                cpu->cyclesToTicks(Cycles(lastCommitCycle + 200)));
         }
         cpu->schedule(this->stuckCheckEvent, cpu->clockEdge(Cycles(40010)));
       }, "CommitStuckCheckEvent"),
@@ -165,7 +165,9 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
         }
     }
 
-    for (ThreadID tid = 0; tid < MaxThreads; tid++) {
+    assert(renameToROBDelay == 1);
+
+    for (ThreadID tid = 0; tid < numThreads; tid++) {
         commitStatus[tid] = Idle;
         changedROBNumEntries[tid] = false;
         trapSquash[tid] = false;
@@ -181,6 +183,7 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
         htmStarts[tid] = 0;
         htmStops[tid] = 0;
         traceCommitIndex[tid] = 0;
+        fixedbuffer[tid] = boost::circular_buffer<DynInstPtr>(renameWidth);
     }
     interrupt = NoFault;
 
@@ -461,7 +464,6 @@ Commit::startupStage()
     // Broadcast the number of free entries.
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         toIEW->commitInfo[tid].usedROB = true;
-        toIEW->commitInfo[tid].freeROBEntries = rob->numFreeEntries(tid);
         toIEW->commitInfo[tid].emptyROB = true;
     }
 
@@ -1104,10 +1106,10 @@ Commit::commit()
         _nextStatus = Active;
     }
 
-    if (num_squashing_threads != numThreads) {
-        // If we're not currently squashing, then get instructions.
-        getInsts();
+    // If we're not currently squashing, then get instructions.
+    moveInstsToBuffer();
 
+    if (num_squashing_threads != numThreads) {
         // Try to commit any instructions.
         commitInsts();
     }
@@ -1120,7 +1122,6 @@ Commit::commit()
 
         if (changedROBNumEntries[tid]) {
             toIEW->commitInfo[tid].usedROB = true;
-            toIEW->commitInfo[tid].freeROBEntries = rob->numFreeEntries(tid);
 
             wroteToTimeBuffer = true;
             changedROBNumEntries[tid] = false;
@@ -1142,7 +1143,6 @@ Commit::commit()
             checkEmptyROB[tid] = false;
             toIEW->commitInfo[tid].usedROB = true;
             toIEW->commitInfo[tid].emptyROB = true;
-            toIEW->commitInfo[tid].freeROBEntries = rob->numFreeEntries(tid);
             wroteToTimeBuffer = true;
         }
 
@@ -1242,7 +1242,9 @@ Commit::commitInsts()
             if (commit_success) {
                 cpu->perfCCT->updateInstPos(head_inst->seqNum, PerfRecord::AtCommit);
                 cpu->perfCCT->commitMeta(head_inst->seqNum);
-                head_inst->printDisassemblyAndResult(cpu->name());
+
+                DPRINTF(CommitTrace, "CT: %s\n", head_inst->genDisassembly());
+
                 if (ismispred) {
                     ismispred = false;
                     stats.recovery_bubble += (cpu->curCycle() - lastCommitCycle) * renameWidth;
@@ -1382,7 +1384,11 @@ Commit::commitInsts()
                 if (head_inst->isLoad()) {
                     Addr load_pc = head_inst->pcState().instAddr();
                     Addr load_addr = head_inst->physEffAddr;
-                    Addr load_value = head_inst->memData ? *((uint64_t *)head_inst->memData) : 0;
+                    char buffer[8] = {0};
+                    if (head_inst->memData) {
+                        std::memcpy(buffer, head_inst->memData, head_inst->effSize);
+                    }
+                    Addr load_value = *((uint64_t *)buffer);
                     bool hit = loadTripleCounter.update(load_pc, load_addr, load_value);
                     if (hit) {
                         // same PC && same addr && same value
@@ -1492,6 +1498,7 @@ Commit::commitInsts()
     for (int tid = 0; tid < MaxThreads; tid++) {
         toIEW->commitInfo[tid].doneMemSeqNum =
             std::max(toIEW->commitInfo[tid].doneSeqNum, rob->getHeadGroupLastDoneSeq(tid));
+        toIEW->commitInfo[tid].robheadNotReadySeqNum = rob->getHeadGroupLastNotReadySeq(tid);
     }
 
     DPRINTF(CommitRate, "%i\n", num_committed);
@@ -1806,16 +1813,53 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
 }
 
 void
-Commit::getInsts()
+Commit::moveInstsToBuffer()
 {
     DPRINTF(Commit, "Getting instructions from Rename stage.\n");
+    int insts_from_rename = fromRename->size;
+    if (insts_from_rename != 0) {
+        // move to buffer
+        ThreadID tid = fromRename->insts[0]->threadNumber;
+        assert(fixedbuffer[tid].empty());
+        for (int i = 0; i < insts_from_rename; ++i) {
+            const DynInstPtr &inst = fromRename->insts[i];
+            assert(inst->threadNumber == tid);
+            if (localSquashVer.largerThan(inst->getVersion())) {
+                inst->setSquashed();
+            }
+            fixedbuffer[tid].push_back(inst);
+        }
+    }
+
+    // check threads stall & status
+    ThreadID tid = InvalidThreadID;
+    for (int i = 0; i < numThreads; i++) {
+        bool robblock = commitStatus[i] == ROBSquashing || commitStatus[i] == TrapPending;
+        bool block = (rob->getMaxEntries(i) - rob->getThreadEntries(i) < fixedbuffer[i].size()) || robblock;
+        bool active = !block && !fixedbuffer[i].empty();
+        DPRINTF(Commit, "Thread %i: block %i robblock %i active %i\n", i, block, robblock, active);
+
+        stallSig->blockIEW[i] = block;
+        if (active) {
+            if (tid == InvalidThreadID) tid = i;
+            else {
+                // if there are multiple active threads, must exhaust all threads first
+                // to avoid starvation of other threads and also avoid resource conflict
+                stallSig->blockIEW[tid] = true;
+                stallSig->blockIEW[i] = true;
+                DPRINTF(IEW, "Multiple active threads detected, blocking all threads\n");
+            }
+        }
+    }
+    if (tid == InvalidThreadID) {
+        DPRINTF(Commit, "No instructions from Rename stage.\n");
+        return;
+    }
 
     // Read any renamed instructions and place them into the ROB.
-    int insts_to_process = std::min((int)renameWidth, fromRename->size);
-
+    int insts_to_process = fixedbuffer[tid].size();
     for (int inst_num = 0; inst_num < insts_to_process; ++inst_num) {
-        const DynInstPtr &inst = fromRename->insts[inst_num];
-        ThreadID tid = inst->threadNumber;
+        const DynInstPtr &inst = fixedbuffer[tid].front();
 
         if (localSquashVer.largerThan(inst->getVersion())) {
             inst->setSquashed();
@@ -1839,6 +1883,13 @@ Commit::getInsts()
                     "Instruction PC %s was squashed, skipping.\n",
                     tid, inst->seqNum, inst->pcState());
         }
+
+        fixedbuffer[tid].pop_front();
+    }
+
+    if (!fixedbuffer[tid].empty()) {
+        stallSig->blockIEW[tid] = true;
+        DPRINTF(Commit, "Not all instructions from Rename stage could be processed, blocking thread %i\n", tid);
     }
 }
 
@@ -1873,14 +1924,18 @@ Commit::markCompletedInsts()
     for (int inst_num = 0; inst_num < fromIEW->size; ++inst_num) {
         assert(fromIEW->insts[inst_num]);
         if (!fromIEW->insts[inst_num]->isSquashed()) {
-            DPRINTF(Commit, "[tid:%i] Marking PC %s, [sn:%llu] ready "
+            DPRINTF(Commit,
+                    "[tid:%i] Marking PC %s, [sn:%llu] ready "
                     "within ROB.\n",
-                    fromIEW->insts[inst_num]->threadNumber,
-                    fromIEW->insts[inst_num]->pcState(),
+                    fromIEW->insts[inst_num]->threadNumber, fromIEW->insts[inst_num]->pcState(),
                     fromIEW->insts[inst_num]->seqNum);
 
             // Mark the instruction as ready to commit.
             fromIEW->insts[inst_num]->setCanCommit();
+            auto &inst = fromIEW->insts[inst_num];
+
+            panic_if(!rob->findInst(0, inst->seqNum), "[sn:%llu] Committed instruction not found in ROB",
+                     inst->seqNum);
         }
     }
 }
@@ -1901,10 +1956,7 @@ Commit::updateComInstStats(const DynInstPtr &inst)
         cpu->instDone(tid, inst);
     }
 
-    //
     //  Control Instructions
-    //
-    //
     if (inst->isControl()) {
         bool mispred = inst->mispredicted();
         std::unique_ptr<PCStateBase> tmp_next_pc(inst->pcState().clone());

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -144,7 +144,7 @@ private:
     uint64_t totalCount = 0;
 };
 
- class Commit
+class Commit
 {
   public:
     /** Overall commit status. Used to determine if the CPU can deschedule
@@ -175,6 +175,10 @@ private:
     std::set<uint64_t> faultNum;
     /** Per-thread status. */
     ThreadStatus commitStatus[MaxThreads];
+
+    boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
+
+    StallSignals* stallSig;
 
     bool robSquashHolding{false};
     /** Commit policy used in SMT mode. */
@@ -233,6 +237,8 @@ private:
     void setIEWStage(IEW *iew_stage);
 
     void setDecodeStage(Decode *decode_stage);
+
+    void setStallSignals(StallSignals* stall_signals) { stallSig = stall_signals; }
 
     /** The pointer to the IEW stage. Used solely to ensure that
      * various events (traps, interrupts, syscalls) do not occur until
@@ -373,7 +379,7 @@ private:
     bool commitHead(const DynInstPtr &head_inst, unsigned inst_num);
 
     /** Gets instructions from rename and inserts them into the ROB. */
-    void getInsts();
+    void moveInstsToBuffer();
 
     /** Squash instructions in the rename to ROB TimeBuffer. */
     void squashInflightAndUpdateVersion(ThreadID tid);

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -114,10 +114,10 @@ CPU::CPU(const BaseO3CPUParams &params)
       isa(numThreads, NULL),
 
       timeBuffer(params.backComSize, params.forwardComSize),
-      fetchQueue(params.backComSize, params.forwardComSize),
-      decodeQueue(params.backComSize, params.forwardComSize),
-      renameQueue(params.backComSize, params.forwardComSize),
-      iewQueue(params.backComSize, params.forwardComSize),
+      fetchTimebuffer(params.backComSize, params.forwardComSize),
+      decodeTimebuffer(params.backComSize, params.forwardComSize),
+      renameTimebuffer(params.backComSize, params.forwardComSize),
+      iewTimebuffer(params.backComSize, params.forwardComSize),
       activityRec(name(), NumStages,
                   params.backComSize + params.forwardComSize,
                   params.activity),
@@ -179,22 +179,28 @@ CPU::CPU(const BaseO3CPUParams &params)
     commit.setTimeBuffer(&timeBuffer);
 
     // Also setup each of the stages' queues.
-    fetch.setFetchQueue(&fetchQueue);
-    decode.setFetchQueue(&fetchQueue);
-    commit.setFetchQueue(&fetchQueue);
-    decode.setDecodeQueue(&decodeQueue);
-    rename.setDecodeQueue(&decodeQueue);
-    rename.setRenameQueue(&renameQueue);
-    iew.setRenameQueue(&renameQueue);
-    iew.setIEWQueue(&iewQueue);
-    commit.setIEWQueue(&iewQueue);
-    commit.setRenameQueue(&renameQueue);
+    fetch.setFetchQueue(&fetchTimebuffer);
+    decode.setFetchQueue(&fetchTimebuffer);
+    commit.setFetchQueue(&fetchTimebuffer);
+    decode.setDecodeQueue(&decodeTimebuffer);
+    rename.setDecodeQueue(&decodeTimebuffer);
+    rename.setRenameQueue(&renameTimebuffer);
+    iew.setRenameQueue(&renameTimebuffer);
+    iew.setIEWQueue(&iewTimebuffer);
+    commit.setIEWQueue(&iewTimebuffer);
+    commit.setRenameQueue(&renameTimebuffer);
 
     decode.setFetchStage(&fetch);
     commit.setIEWStage(&iew);
     commit.setDecodeStage(&decode);
     rename.setIEWStage(&iew);
     rename.setCommitStage(&commit);
+
+    fetch.setStallSignals(&stallSignals);
+    decode.setStallSignals(&stallSignals);
+    rename.setStallSignals(&stallSignals);
+    iew.setStallSignals(&stallSignals);
+    commit.setStallSignals(&stallSignals);
 
     ThreadID active_threads;
     if (FullSystem) {
@@ -572,23 +578,18 @@ CPU::tick()
 //    activity = false;
 
     //Tick each of the stages
-    fetch.tick();
-
-    decode.tick();
-
-    rename.tick();
-
-    iew.tick();
 
     commit.tick();
+    iew.tick();
+    rename.tick();
+    decode.tick();
+    fetch.tick();
 
-    // Now advance the time buffers
+    fetchTimebuffer.advance();
+    decodeTimebuffer.advance();
+    renameTimebuffer.advance();
+    iewTimebuffer.advance();
     timeBuffer.advance();
-
-    fetchQueue.advance();
-    decodeQueue.advance();
-    renameQueue.advance();
-    iewQueue.advance();
 
     activityRec.advance();
 
@@ -855,10 +856,10 @@ CPU::removeThread(ThreadID tid)
     // Flush out any old data from the time buffers.
     for (int i = 0; i < timeBuffer.getSize(); ++i) {
         timeBuffer.advance();
-        fetchQueue.advance();
-        decodeQueue.advance();
-        renameQueue.advance();
-        iewQueue.advance();
+        fetchTimebuffer.advance();
+        decodeTimebuffer.advance();
+        renameTimebuffer.advance();
+        iewTimebuffer.advance();
     }
 
     assert(iew.ldstQueue.getCount(tid) == 0);
@@ -978,10 +979,10 @@ CPU::drain()
         // test in isCpuDrained().
         for (int i = 0; i < timeBuffer.getSize(); ++i) {
             timeBuffer.advance();
-            fetchQueue.advance();
-            decodeQueue.advance();
-            renameQueue.advance();
-            iewQueue.advance();
+            fetchTimebuffer.advance();
+            decodeTimebuffer.advance();
+            renameTimebuffer.advance();
+            iewTimebuffer.advance();
         }
 
         drainSanityCheck();
@@ -1422,8 +1423,7 @@ CPU::removeFrontInst(const DynInstPtr &inst)
 
     removeInstsThisCycle = true;
 
-    // Remove the front instruction.
-    removeList.push(inst->getInstListIt());
+    instList.erase(inst->getInstListIt());
 }
 
 void
@@ -1458,9 +1458,7 @@ CPU::removeInstsNotInROB(ThreadID tid)
     while (inst_it != end_it) {
         assert(!instList.empty());
 
-        squashInstIt(inst_it, tid);
-
-        inst_it--;
+        inst_it = squashInstIt(inst_it, tid);
     }
 
     // If the ROB was empty, then we actually need to remove the first
@@ -1489,17 +1487,15 @@ CPU::removeInstsUntil(const InstSeqNum &seq_num, ThreadID tid)
 
         bool break_loop = (inst_iter == instList.begin());
 
-        squashInstIt(inst_iter, tid);
-
-        inst_iter--;
+        inst_iter = squashInstIt(inst_iter, tid);
 
         if (break_loop)
             break;
     }
 }
 
-void
-CPU::squashInstIt(const ListIt &instIt, ThreadID tid)
+CPU::ListIt
+CPU::squashInstIt(ListIt &instIt, ThreadID tid)
 {
     if ((*instIt)->threadNumber == tid) {
         DPRINTF(O3CPU, "Squashing instruction, "
@@ -1514,8 +1510,9 @@ CPU::squashInstIt(const ListIt &instIt, ThreadID tid)
         // @todo: Formulate a consistent method for deleting
         // instructions from the instruction list
         // Remove the instruction from the list.
-        removeList.push(instIt);
+        instIt = instList.erase(instIt);
     }
+    return --instIt;
 }
 
 void
@@ -1537,7 +1534,7 @@ CPU::cleanUpRemovedInsts()
 
         instList.erase(removeList.front());
 
-        removeList.pop();
+        removeList.pop_front();
     }
 
     removeInstsThisCycle = false;
@@ -1759,7 +1756,7 @@ CPU::readArchIntReg(int reg_idx, ThreadID tid)
     PhysRegIdPtr phys_reg =
         commitRenameMap[tid].lookup(RegId(IntRegClass, reg_idx)).PhyReg();
 
-    DPRINTF(Commit, "Get map: x%i -> p%i\n", reg_idx, phys_reg->flatIndex());
+    DPRINTF(Scoreboard, "Get map: x%i -> p%i\n", reg_idx, phys_reg->flatIndex());
 
     return regFile.getReg(phys_reg);
 }
@@ -1770,7 +1767,7 @@ CPU::readArchFloatReg(int reg_idx, ThreadID tid)
     cpuStats.fpRegfileReads++;
     PhysRegIdPtr phys_reg =
         commitRenameMap[tid].lookup(RegId(FloatRegClass, reg_idx)).PhyReg();
-    DPRINTF(Commit, "Get map: f%i -> p%i\n", reg_idx, phys_reg->flatIndex());
+    DPRINTF(Scoreboard, "Get map: f%i -> p%i\n", reg_idx, phys_reg->flatIndex());
 
     return regFile.getReg(phys_reg);
 }
@@ -1781,7 +1778,7 @@ CPU::readArchVecReg(int reg_idx, uint64_t *val,ThreadID tid)
     cpuStats.vecRegfileReads++;
     PhysRegIdPtr phys_reg =
         commitRenameMap[tid].lookup(RegId(VecRegClass, reg_idx)).PhyReg();
-    DPRINTF(Commit, "Get map: v%i -> p%i\n", reg_idx, phys_reg->flatIndex());
+    DPRINTF(Scoreboard, "Get map: v%i -> p%i\n", reg_idx, phys_reg->flatIndex());
 
     regFile.getReg(phys_reg, val);
 }

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -413,7 +413,7 @@ class CPU : public BaseCPU
     void removeInstsUntil(const InstSeqNum &seq_num, ThreadID tid);
 
     /** Removes the instruction pointed to by the iterator. */
-    void squashInstIt(const ListIt &instIt, ThreadID tid);
+    ListIt squashInstIt(ListIt &instIt, ThreadID tid);
 
     // flush fetch buffer while flushing tlb
     void flushTLBs() override;
@@ -451,7 +451,7 @@ class CPU : public BaseCPU
     /** List of all the instructions that will be removed at the end of this
      *  cycle.
      */
-    std::queue<ListIt> removeList;
+    std::deque<ListIt> removeList;
 
 #ifdef DEBUG
     /** Debug structure to keep track of the sequence numbers still in
@@ -526,20 +526,24 @@ class CPU : public BaseCPU
         NumStages
     };
 
+    StallSignals stallSignals;
+
     /** The main time buffer to do backwards communication. */
     TimeBuffer<TimeStruct> timeBuffer;
 
     /** The fetch stage's instruction queue. */
-    TimeBuffer<FetchStruct> fetchQueue;
+    TimeBuffer<FetchStruct> fetchTimebuffer;
 
     /** The decode stage's instruction queue. */
-    TimeBuffer<DecodeStruct> decodeQueue;
+    TimeBuffer<DecodeStruct> decodeTimebuffer;
 
     /** The rename stage's instruction queue. */
-    TimeBuffer<RenameStruct> renameQueue;
+    TimeBuffer<RenameStruct> renameTimebuffer;
 
     /** The IEW stage's instruction queue. */
-    TimeBuffer<IEWStruct> iewQueue;
+    TimeBuffer<IEWStruct> iewTimebuffer;
+
+    StallSignals stallSig;
 
   private:
     /** The activity recorder; used to tell if the CPU has any

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -83,18 +83,15 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
              decodeWidth, static_cast<int>(MaxWidth));
 
     // @todo: Make into a parameter
-    skidBufferMax = (fetchToDecodeDelay + 1) *  params.fetchWidth;
-    for (int tid = 0; tid < MaxThreads; tid++) {
-        stalls[tid] = {false};
-        decodeStatus[tid] = Idle;
-        bdelayDoneSeqNum[tid] = 0;
-        squashInst[tid] = nullptr;
-        squashAfterDelaySlot[tid] = 0;
+    for (int i=0;i<numThreads;i++) {
+        fixedbuffer[i] = boost::circular_buffer<DynInstPtr>(decodeWidth);
     }
+    stallBuffer = boost::circular_buffer<DynInstPtr>(decodeWidth * (fetchToDecodeDelay + 1));
+    eachstallSize = boost::circular_buffer<int>(fetchToDecodeDelay + 1);
+
 
     decodeStalls.resize(decodeWidth, StallReason::NoStall);
-
-   statistics::registerDumpCallback([this]() {
+    statistics::registerDumpCallback([this]() {
         int idx = 0;
         for (auto it : this->fusionType) {
             this->stats.fusedInsts.subname(idx, it.first);
@@ -114,21 +111,13 @@ Decode::startupStage()
 void
 Decode::clearStates(ThreadID tid)
 {
-    decodeStatus[tid] = Idle;
-    stalls[tid].rename = false;
+
 }
 
 void
 Decode::resetStage()
 {
     _status = Inactive;
-
-    // Setup status, make sure stall signals are clear.
-    for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        decodeStatus[tid] = Idle;
-
-        stalls[tid].rename = false;
-    }
 }
 
 std::string
@@ -226,8 +215,7 @@ void
 Decode::drainSanityCheck() const
 {
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        assert(insts[tid].empty());
-        assert(skidBuffer[tid].empty());
+        assert(fixedbuffer[tid].empty());
     }
 }
 
@@ -235,8 +223,7 @@ bool
 Decode::isDrained() const
 {
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        if (!insts[tid].empty() || !skidBuffer[tid].empty() ||
-                (decodeStatus[tid] != Running && decodeStatus[tid] != Idle))
+        if (!fixedbuffer[tid].empty())
             return false;
     }
     return true;
@@ -247,10 +234,6 @@ Decode::checkStall(ThreadID tid) const
 {
     bool ret_val = false;
 
-    if (stalls[tid].rename) {
-        DPRINTF(Decode,"[tid:%i] Stall fom Rename stage detected.\n", tid);
-        ret_val = true;
-    }
 
     return ret_val;
 }
@@ -261,55 +244,8 @@ Decode::fetchInstsValid()
     return fromFetch->size > 0;
 }
 
-bool
-Decode::block(ThreadID tid)
-{
-    DPRINTF(Decode, "[tid:%i] Blocking.\n", tid);
-
-    // Add the current inputs to the skid buffer so they can be
-    // reprocessed when this stage unblocks.
-    skidInsert(tid);
-
-    // If the decode status is blocked or unblocking then decode has not yet
-    // signalled fetch to unblock. In that case, there is no need to tell
-    // fetch to block.
-    if (decodeStatus[tid] != Blocked) {
-        // Set the status to Blocked.
-        decodeStatus[tid] = Blocked;
-
-        if (toFetch->decodeUnblock[tid]) {
-            toFetch->decodeUnblock[tid] = false;
-        } else {
-            toFetch->decodeBlock[tid] = true;
-            wroteToTimeBuffer = true;
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-bool
-Decode::unblock(ThreadID tid)
-{
-    // Decode is done unblocking only if the skid buffer is empty.
-    if (skidBuffer[tid].empty()) {
-        DPRINTF(Decode, "[tid:%i] Done unblocking.\n", tid);
-        toFetch->decodeUnblock[tid] = true;
-        wroteToTimeBuffer = true;
-
-        decodeStatus[tid] = Running;
-        return true;
-    }
-
-    DPRINTF(Decode, "[tid:%i] Currently unblocking.\n", tid);
-
-    return false;
-}
-
 void
-Decode::squash(const DynInstPtr &inst, ThreadID tid)
+Decode::selfSquash(const DynInstPtr &inst, ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] [sn:%llu] Squashing due to incorrect branch "
             "prediction detected at decode.\n", tid, inst->seqNum);
@@ -348,30 +284,23 @@ Decode::squash(const DynInstPtr &inst, ThreadID tid)
 
     InstSeqNum squash_seq_num = inst->seqNum;
 
-    // Might have to tell fetch to unblock.
-    if (decodeStatus[tid] == Blocked ||
-        decodeStatus[tid] == Unblocking) {
-        toFetch->decodeUnblock[tid] = 1;
-    }
+    stallSig->blockFetch[tid] = true; // tell fetch don't send new insts
 
-    // Set status to squashing.
-    decodeStatus[tid] = Squashing;
+    fixedbuffer[tid].clear();
 
-    for (int i=0; i<fromFetch->size; i++) {
-        if (fromFetch->insts[i]->threadNumber == tid &&
-            fromFetch->insts[i]->seqNum > squash_seq_num) {
-            fromFetch->insts[i]->setSquashed();
+    auto delIt = stallBuffer.begin();
+    for (auto it0 = eachstallSize.begin(); it0 != eachstallSize.end();) {
+        int size = *it0;
+        auto start_it = delIt;
+        auto end_it = start_it + size;
+        if ((*start_it)->threadNumber == tid) {
+            delIt = stallBuffer.erase(start_it, end_it);
+            it0 = eachstallSize.erase(it0);
         }
-    }
-
-    // Clear the instruction list and skid buffer in case they have any
-    // insts in them.
-    while (!insts[tid].empty()) {
-        insts[tid].pop();
-    }
-
-    while (!skidBuffer[tid].empty()) {
-        skidBuffer[tid].pop();
+        else {
+            delIt = end_it;
+            it0++;
+        }
     }
 
     // Squash instructions up until this one
@@ -383,89 +312,28 @@ Decode::squash(ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] Squashing.\n",tid);
 
-    if (decodeStatus[tid] == Blocked ||
-        decodeStatus[tid] == Unblocking) {
-        if (FullSystem) {
-            toFetch->decodeUnblock[tid] = 1;
-        } else {
-            // In syscall emulation, we can have both a block and a squash due
-            // to a syscall in the same cycle.  This would cause both signals
-            // to be high.  This shouldn't happen in full system.
-            // @todo: Determine if this still happens.
-            if (toFetch->decodeBlock[tid])
-                toFetch->decodeBlock[tid] = 0;
-            else
-                toFetch->decodeUnblock[tid] = 1;
+    fixedbuffer[tid].clear();
+
+    auto delIt = stallBuffer.begin();
+    for (auto it0 = eachstallSize.begin(); it0 != eachstallSize.end();) {
+        int size = *it0;
+        auto start_it = delIt;
+        auto end_it = start_it + size;
+        if ((*start_it)->threadNumber == tid) {
+            delIt = stallBuffer.erase(start_it, end_it);
+            it0 = eachstallSize.erase(it0);
+        }
+        else {
+            delIt = end_it;
+            it0++;
         }
     }
 
-    // Set status to squashing.
-    decodeStatus[tid] = Squashing;
-
-    // Go through incoming instructions from fetch and squash them.
-    unsigned squash_count = 0;
-
-    for (int i=0; i<fromFetch->size; i++) {
-        if (fromFetch->insts[i]->threadNumber == tid) {
-            fromFetch->insts[i]->setSquashed();
-            squash_count++;
-        }
-    }
-
-    // Clear the instruction list and skid buffer in case they have any
-    // insts in them.
-    while (!insts[tid].empty()) {
-        insts[tid].pop();
-    }
-
-    while (!skidBuffer[tid].empty()) {
-        skidBuffer[tid].pop();
-    }
-
-    return squash_count;
+    return 0;
 }
 
 void
-Decode::skidInsert(ThreadID tid)
-{
-    DynInstPtr inst = NULL;
-
-    while (!insts[tid].empty()) {
-        inst = insts[tid].front();
-
-        insts[tid].pop();
-
-        assert(tid == inst->threadNumber);
-
-        skidBuffer[tid].push(inst);
-
-        DPRINTF(Decode, "Inserting [tid:%d][sn:%lli] PC: %s into decode "
-                "skidBuffer %i\n", inst->threadNumber, inst->seqNum,
-                inst->pcState(), skidBuffer[tid].size());
-    }
-
-    // @todo: Eventually need to enforce this by not letting a thread
-    // fetch past its skidbuffer
-    assert(skidBuffer[tid].size() <= skidBufferMax);
-}
-
-bool
-Decode::skidsEmpty()
-{
-    list<ThreadID>::iterator threads = activeThreads->begin();
-    list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-        if (!skidBuffer[tid].empty())
-            return false;
-    }
-
-    return true;
-}
-
-void
-Decode::updateStatus()
+Decode::updateActivate()
 {
     bool any_unblocking = false;
 
@@ -475,7 +343,7 @@ Decode::updateStatus()
     while (threads != end) {
         ThreadID tid = *threads++;
 
-        if (decodeStatus[tid] == Unblocking) {
+        if (!stallSig->blockDecode[tid]) {
             any_unblocking = true;
             break;
         }
@@ -503,144 +371,126 @@ Decode::updateStatus()
 }
 
 void
-Decode::sortInsts()
+Decode::moveInstsToBuffer()
 {
+    // do not support mixed thread instructions in one fetch group
     int insts_from_fetch = fromFetch->size;
+    if (insts_from_fetch != 0) {
+        ThreadID tid = fromFetch->insts[0]->threadNumber;
+
+        // move to stallbuffer
+        panic_if(eachstallSize.full(), "Decode stallbuffer overflow, has %d stalls\n", eachstallSize.size() + 1);
+        eachstallSize.push_back(insts_from_fetch);
+        for (int i = 0; i < insts_from_fetch; i++) {
+            stallBuffer.push_back(fromFetch->insts[i]);
+        }
+    }
+
+    DPRINTF(Decode, "Decode stall buffer has %d stalls\n",
+            eachstallSize.size());
+
+    if (stallBuffer.empty()) {
+        return;
+    }
+    // stallbuffer move to fixedbuffer
+    ThreadID tid = stallBuffer.front()->threadNumber;
+    if (!fixedbuffer[tid].empty())
+        return;
+    insts_from_fetch = eachstallSize.front();
+    eachstallSize.pop_front();
     for (int i = 0; i < insts_from_fetch; ++i) {
-        const DynInstPtr &inst = fromFetch->insts[i];
+        const DynInstPtr &inst = stallBuffer.front();
+        assert(tid == inst->threadNumber);
         if (localSquashVer.largerThan(inst->getVersion())) {
             inst->setSquashed();
         }
-        insts[inst->threadNumber].push(inst);
+        assert(!fixedbuffer[inst->threadNumber].full());
+        fixedbuffer[inst->threadNumber].push_back(inst);
+        stallBuffer.pop_front();
     }
+
 }
 
 void
-Decode::readStallSignals(ThreadID tid)
+Decode::checkSquash()
 {
-    if (fromRename->renameBlock[tid]) {
-        stalls[tid].rename = true;
+    for (int i = 0;i < numThreads; i++) {
+        if (fromCommit->commitInfo[i].squash) {
+            DPRINTF(Decode, "[tid:%i] Squashing instructions due to squash "
+                    "from commit.\n", i);
+            squash(i);
+            localSquashVer.update(fromCommit->commitInfo[i].squashVersion.getVersion());
+            DPRINTF(Decode, "Updating squash version to %u\n",
+                    localSquashVer.getVersion());
+        }
     }
-
-    if (fromRename->renameUnblock[tid]) {
-        assert(stalls[tid].rename);
-        stalls[tid].rename = false;
-    }
-}
-
-bool
-Decode::checkSignalsAndUpdate(ThreadID tid)
-{
-    // Check if there's a squash signal, squash if there is.
-    // Check stall signals, block if necessary.
-    // If status was blocked
-    //     Check if stall conditions have passed
-    //         if so then go to unblocking
-    // If status was Squashing
-    //     check if squashing is not high.  Switch to running this cycle.
-
-    // Update the per thread stall statuses.
-    readStallSignals(tid);
-
-    // Check squash signals from commit.
-    if (fromCommit->commitInfo[tid].squash) {
-
-        DPRINTF(Decode, "[tid:%i] Squashing instructions due to squash "
-                "from commit.\n", tid);
-
-        squash(tid);
-
-        localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
-        DPRINTF(Decode, "Updating squash version to %u\n",
-                localSquashVer.getVersion());
-
-        return true;
-    }
-
-    if (checkStall(tid)) {
-        blockReason = fromRename->renameInfo[tid].blockReason;
-        return block(tid);
-    }
-
-    if (decodeStatus[tid] == Blocked) {
-        DPRINTF(Decode, "[tid:%i] Done blocking, switching to unblocking.\n",
-                tid);
-
-        decodeStatus[tid] = Unblocking;
-
-        unblock(tid);
-
-        return true;
-    }
-
-    if (decodeStatus[tid] == Squashing) {
-        // Switch status to running if decode isn't being told to block or
-        // squash this cycle.
-        DPRINTF(Decode, "[tid:%i] Done squashing, switching to running.\n",
-                tid);
-
-        decodeStatus[tid] = Running;
-
-        return false;
-    }
-
-    // If we've reached this point, we have not gotten any signals that
-    // cause decode to change its status.  Decode remains the same as before.
-    return false;
 }
 
 void
 Decode::tick()
 {
     toRename->fetchStallReason = fromFetch->fetchStallReason;
-
     wroteToTimeBuffer = false;
-
     bool status_change = false;
-
     toRenameIndex = 0;
 
-    list<ThreadID>::iterator threads = activeThreads->begin();
-    list<ThreadID>::iterator end = activeThreads->end();
+    moveInstsToBuffer();
 
-    sortInsts();
+    checkSquash();
 
-    //Check stall and squash signals.
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    // check threads stall & status
+    ThreadID tid = InvalidThreadID;
+    for (int i = 0; i < numThreads; i++) {
+        bool block = stallSig->blockDecode[i];
+        bool active = !block && !fixedbuffer[i].empty();
 
-        DPRINTF(Decode,"Processing [tid:%i]\n",tid);
-        status_change =  checkSignalsAndUpdate(tid) || status_change;
-
-        decode(status_change, tid);
-
-        toFetch->decodeInfo[tid].blockReason = blockReason;
-    }
-
-    if (status_change) {
-        updateStatus();
-    }
-
-    ThreadID tid = *threads;
-    if (stalls[tid].rename) {
-        // stall from rename, pass rename stall
-        setAllStalls(fromRename->renameInfo[tid].blockReason);
-    } else if (toRenameIndex == 0) {
-        if (decodeStalls[0] != StallReason::NoStall) {
-            setAllStalls(decodeStalls[0]);
-        } else {
-            // warn("decode have other Stall Reason!");
-        }
-    } else {
-        // no stall from decode, pass fetch stall(no stall/FetchFragStall/fetch all stall)
-        for (int i = 0; i < decodeStalls.size(); i++) {
-            if (i < toRenameIndex) {    // decode success, no stall
-                decodeStalls.at(i) = StallReason::NoStall;
-            } else {    // no insts to decode, pass fetch frag stall
-                decodeStalls.at(i) = fromFetch->fetchStallReason.at(i);
+        stallSig->blockFetch[i] = block;
+        if (active) {
+            if (tid == InvalidThreadID)
+                tid = i;
+            else {
+                // if there are multiple active threads, must exhaust all threads first
+                // to avoid starvation of other threads and also avoid resource conflict
+                stallSig->blockFetch[tid] = true;
+                stallSig->blockFetch[i] = true;
+                DPRINTF(Decode, "Multiple active threads detected, blocking all threads\n");
             }
         }
     }
+    if (tid == InvalidThreadID) {
+        // all threads are stalled, no need to process
+        return;
+    }
+    DPRINTF(Decode,"Processing [tid:%i]\n",tid);
+
+    decodeInsts(tid);
+    ++stats.runCycles;
+
+    toFetch->decodeInfo[tid].blockReason = blockReason;
+
+    if (status_change) {
+        updateActivate();
+    }
+
+    // if (stalls[tid].rename) {
+    //     // stall from rename, pass rename stall
+    //     setAllStalls(fromRename->renameInfo[tid].blockReason);
+    // } else if (toRenameIndex == 0) {
+    //     if (decodeStalls[0] != StallReason::NoStall) {
+    //         setAllStalls(decodeStalls[0]);
+    //     } else {
+    //         // warn("decode have other Stall Reason!");
+    //     }
+    // } else {
+    //     // no stall from decode, pass fetch stall(no stall/FetchFragStall/fetch all stall)
+    //     for (int i = 0; i < decodeStalls.size(); i++) {
+    //         if (i < toRenameIndex) {    // decode success, no stall
+    //             decodeStalls.at(i) = StallReason::NoStall;
+    //         } else {    // no insts to decode, pass fetch frag stall
+    //             decodeStalls.at(i) = fromFetch->fetchStallReason.at(i);
+    //         }
+    //     }
+    // }
 
     toRename->decodeStallReason = decodeStalls;
 
@@ -652,58 +502,11 @@ Decode::tick()
 }
 
 void
-Decode::decode(bool &status_change, ThreadID tid)
-{
-    // If status is Running or idle,
-    //     call decodeInsts()
-    // If status is Unblocking,
-    //     buffer any instructions coming from fetch
-    //     continue trying to empty skid buffer
-    //     check if stall conditions have passed
-
-    if (decodeStatus[tid] == Blocked) {
-        ++stats.blockedCycles;
-        setAllStalls(blockReason);
-    } else if (decodeStatus[tid] == Squashing) {
-        ++stats.squashCycles;
-        setAllStalls(StallReason::SquashStall);
-    }
-
-    // Decode should try to decode as many instructions as its bandwidth
-    // will allow, as long as it is not currently blocked.
-    if (decodeStatus[tid] == Running ||
-        decodeStatus[tid] == Idle) {
-        DPRINTF(Decode, "[tid:%i] Not blocked, so attempting to run "
-                "stage.\n",tid);
-
-        decodeInsts(tid);
-    } else if (decodeStatus[tid] == Unblocking) {
-        // Make sure that the skid buffer has something in it if the
-        // status is unblocking.
-        assert(!skidsEmpty());
-
-        // If the status was unblocking, then instructions from the skid
-        // buffer were used.  Remove those instructions and handle
-        // the rest of unblocking.
-        decodeInsts(tid);
-
-        if (fetchInstsValid()) {
-            // Add the current inputs to the skid buffer so they can be
-            // reprocessed when this stage unblocks.
-            skidInsert(tid);
-        }
-
-        status_change = unblock(tid) || status_change;
-    }
-}
-
-void
 Decode::decodeInsts(ThreadID tid)
 {
     // Instructions can come either from the skid buffer or the list of
     // instructions coming from fetch, depending on decode's status.
-    int insts_available = decodeStatus[tid] == Unblocking ?
-        skidBuffer[tid].size() : insts[tid].size();
+    int insts_available = fixedbuffer[tid].size();
 
     std::queue<StallReason> decode_stalls;
 
@@ -724,17 +527,9 @@ Decode::decodeInsts(ThreadID tid)
         }
         setAllStalls(stall);
         return;
-    } else if (decodeStatus[tid] == Unblocking) {
-        DPRINTF(Decode, "[tid:%i] Unblocking, removing insts from skid "
-                "buffer.\n",tid);
-        ++stats.unblockCycles;
-    } else if (decodeStatus[tid] == Running) {
-        ++stats.runCycles;
     }
 
-    std::queue<DynInstPtr>
-        &insts_to_decode = decodeStatus[tid] == Unblocking ?
-        skidBuffer[tid] : insts[tid];
+    auto& insts_to_decode = fixedbuffer[tid];
 
     DPRINTF(Decode, "[tid:%i] Sending instruction to rename.\n",tid);
 
@@ -754,7 +549,7 @@ Decode::decodeInsts(ThreadID tid)
 
         DynInstPtr inst = std::move(insts_to_decode.front());
 
-        insts_to_decode.pop();
+        insts_to_decode.pop_front();
 
         DPRINTF(Decode, "[tid:%i] Processing instruction [sn:%lli] with "
                 "PC %s\n", tid, inst->seqNum, inst->pcState());
@@ -808,7 +603,7 @@ Decode::decodeInsts(ThreadID tid)
 
             // Might want to set some sort of boolean and just do
             // a check at the end
-            squash(inst, inst->threadNumber);
+            selfSquash(inst, inst->threadNumber);
 
             decode_stalls.push(StallReason::InstMisPred);
             breakDecode = StallReason::InstMisPred;
@@ -871,7 +666,7 @@ Decode::decodeInsts(ThreadID tid)
 
                 // Might want to set some sort of boolean and just do
                 // a check at the end
-                squash(inst, inst->threadNumber);
+                selfSquash(inst, inst->threadNumber);
 
                 decode_stalls.push(StallReason::InstMisPred);
                 breakDecode = StallReason::InstMisPred;
@@ -900,7 +695,7 @@ Decode::decodeInsts(ThreadID tid)
             inst->setPredTaken(true);
             inst->setPredTarg(*target);
             // must squash after setting inst real target because it cannot be computed from static inst
-            squash(inst, inst->threadNumber);
+            selfSquash(inst, inst->threadNumber);
             break;
         }
         if (inst->isNonSpeculative() && inst->readPredTaken()) {
@@ -911,9 +706,13 @@ Decode::decodeInsts(ThreadID tid)
             inst->setPredTarg(*npc);
         }
     }
-
     for (auto &fused_inst : fusionInst) {
         toRename->insts[toRename->size++] = fused_inst;
+    }
+
+    if (insts_available) {
+        // current cycle insts was not all processed, need to block fetch in next cycle
+        stallSig->blockFetch[tid] = true;
     }
 
     // this stage is totally stalled, set all decode stalls
@@ -928,7 +727,6 @@ Decode::decodeInsts(ThreadID tid)
     // and put all those instructions into the skid buffer.
     if (!insts_to_decode.empty()) {
         blockReason = breakDecode;
-        block(tid);
     }
 
     // Record that decode has written to the time buffer for activity

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -431,8 +431,9 @@ Decode::tick()
 {
     toRename->fetchStallReason = fromFetch->fetchStallReason;
     wroteToTimeBuffer = false;
-    bool status_change = false;
     toRenameIndex = 0;
+    blockReason = StallReason::NoStall;
+    setAllStalls(StallReason::NoStall);
 
     moveInstsToBuffer();
 
@@ -440,11 +441,15 @@ Decode::tick()
 
     // check threads stall & status
     ThreadID tid = InvalidThreadID;
+    ThreadID blocked_tid = InvalidThreadID;
     for (int i = 0; i < numThreads; i++) {
         bool block = stallSig->blockDecode[i];
         bool active = !block && !fixedbuffer[i].empty();
 
         stallSig->blockFetch[i] = block;
+        stallSig->fetchBlockReason[i] =
+            block ? stallSig->decodeBlockReason[i] : StallReason::NoStall;
+        toFetch->decodeInfo[i].blockReason = stallSig->fetchBlockReason[i];
         if (active) {
             if (tid == InvalidThreadID)
                 tid = i;
@@ -455,22 +460,39 @@ Decode::tick()
                 stallSig->blockFetch[i] = true;
                 DPRINTF(Decode, "Multiple active threads detected, blocking all threads\n");
             }
+        } else if (block && blocked_tid == InvalidThreadID) {
+            blocked_tid = i;
         }
     }
     if (tid == InvalidThreadID) {
         // all threads are stalled, no need to process
+        if (blocked_tid != InvalidThreadID) {
+            setAllStalls(stallSig->fetchBlockReason[blocked_tid]);
+            blockReason = stallSig->fetchBlockReason[blocked_tid];
+        }
+        toRename->decodeStallReason = decodeStalls;
+        updateActivate();
         return;
     }
     DPRINTF(Decode,"Processing [tid:%i]\n",tid);
 
     decodeInsts(tid);
     ++stats.runCycles;
-
-    toFetch->decodeInfo[tid].blockReason = blockReason;
-
-    if (status_change) {
-        updateActivate();
+    if (stallSig->blockDecode[tid]) {
+        setAllStalls(stallSig->decodeBlockReason[tid]);
+    } else if (toRenameIndex > 0 && decodeStalls[0] == StallReason::NoStall) {
+        for (int i = 0; i < decodeStalls.size(); i++) {
+            if (i < toRenameIndex) {
+                decodeStalls.at(i) = StallReason::NoStall;
+            } else {
+                decodeStalls.at(i) = fromFetch->fetchStallReason.at(i);
+            }
+        }
     }
+    stallSig->fetchBlockReason[tid] =
+        stallSig->blockFetch[tid] ? blockReason : StallReason::NoStall;
+    toFetch->decodeInfo[tid].blockReason = stallSig->fetchBlockReason[tid];
+    updateActivate();
 
     // if (stalls[tid].rename) {
     //     // stall from rename, pass rename stall
@@ -713,6 +735,9 @@ Decode::decodeInsts(ThreadID tid)
     if (insts_available) {
         // current cycle insts was not all processed, need to block fetch in next cycle
         stallSig->blockFetch[tid] = true;
+        if (breakDecode == StallReason::NoStall) {
+            breakDecode = StallReason::OtherFragStall;
+        }
     }
 
     // this stage is totally stalled, set all decode stalls

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -289,7 +289,7 @@ class Decode
 
     std::unordered_map<const char*, uint64_t> fusionType;
 
-    StallReason blockReason;
+    StallReason blockReason{NoStall};
 
     void setAllStalls(StallReason decodeStall);
 

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -41,7 +41,7 @@
 #ifndef __CPU_O3_DECODE_HH__
 #define __CPU_O3_DECODE_HH__
 
-#include <queue>
+#include <boost/circular_buffer.hpp>
 
 #include "base/statistics.hh"
 #include "cpu/o3/comm.hh"
@@ -79,23 +79,9 @@ class Decode
         Inactive
     };
 
-    /** Individual thread status. */
-    enum ThreadStatus
-    {
-        Running,
-        Idle,
-        StartSquash,
-        Squashing,
-        Blocked,
-        Unblocking
-    };
-
   private:
     /** Decode status. */
     DecodeStatus _status;
-
-    /** Per-thread status. */
-    ThreadStatus decodeStatus[MaxThreads];
 
     Addr ignoreFusionPC = 0;
 
@@ -118,6 +104,8 @@ class Decode
 
     /** Sets the main backwards communication time buffer pointer. */
     void setTimeBuffer(TimeBuffer<TimeStruct> *tb_ptr);
+
+    void setStallSignals(StallSignals* stall_signals) { stallSig = stall_signals; }
 
     /** Sets pointer to time buffer used to communicate to the next stage. */
     void setDecodeQueue(TimeBuffer<DecodeStruct> *dq_ptr);
@@ -142,13 +130,6 @@ class Decode
      */
     void tick();
 
-    /** Determines what to do based on decode's current status.
-     * @param status_change decode() sets this variable if there was a status
-     * change (ie switching from from blocking to unblocking).
-     * @param tid Thread id to decode instructions from.
-     */
-    void decode(bool &status_change, ThreadID tid);
-
     /** Processes instructions from fetch and passes them on to rename.
      * Decoding of instructions actually happens when they are created in
      * fetch, so this function mostly checks if PC-relative branches are
@@ -162,27 +143,15 @@ class Decode
 
     void checkAndFuseInsts(std::vector<DynInstPtr> &vec, DynInstPtr& cur);
 
-    /** Inserts a thread's instructions into the skid buffer, to be decoded
-     * once decode unblocks.
-     */
-    void skidInsert(ThreadID tid);
-
-    /** Returns if all of the skid buffers are empty. */
-    bool skidsEmpty();
-
     /** Updates overall decode status based on all of the threads' statuses. */
-    void updateStatus();
+    void updateActivate();
 
     /** Separates instructions from fetch into individual lists of instructions
      * sorted by thread.
      */
-    void sortInsts();
+    void moveInstsToBuffer();
 
-    /** Reads all stall signals from the backwards communication timebuffer. */
-    void readStallSignals(ThreadID tid);
-
-    /** Checks all input signals and updates decode's status appropriately. */
-    bool checkSignalsAndUpdate(ThreadID tid);
+    void checkSquash();
 
     /** Checks all stall signals, and returns if any are true. */
     bool checkStall(ThreadID tid) const;
@@ -190,22 +159,10 @@ class Decode
     /** Returns if there any instructions from fetch on this cycle. */
     bool fetchInstsValid();
 
-    /** Switches decode to blocking, and signals back that decode has
-     * become blocked.
-     * @return Returns true if there is a status change.
-     */
-    bool block(ThreadID tid);
-
-    /** Switches decode to unblocking if the skid buffer is empty, and
-     * signals back that decode has unblocked.
-     * @return Returns true if there is a status change.
-     */
-    bool unblock(ThreadID tid);
-
     /** Squashes if there is a PC-relative branch that was predicted
      * incorrectly. Sends squash information back to fetch.
      */
-    void squash(const DynInstPtr &inst, ThreadID tid);
+    void selfSquash(const DynInstPtr &inst, ThreadID tid);
 
   public:
     /** Squashes due to commit signalling a squash. Changes status to
@@ -225,6 +182,8 @@ class Decode
 
     /** Fetch interface. */
     Fetch *fetch_ptr;
+
+    StallSignals* stallSig;
 
     /** Time buffer interface. */
     TimeBuffer<TimeStruct> *timeBuffer;
@@ -255,24 +214,15 @@ class Decode
     TimeBuffer<FetchStruct>::wire fromFetch;
 
     /** Queue of all instructions coming from fetch this cycle. */
-    std::queue<DynInstPtr> insts[MaxThreads];
+    boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
 
-    /** Skid buffer between fetch and decode. */
-    std::queue<DynInstPtr> skidBuffer[MaxThreads];
+    boost::circular_buffer<DynInstPtr> stallBuffer;
+    boost::circular_buffer<int> eachstallSize;
 
     /** Variable that tracks if decode has written to the time buffer this
      * cycle. Used to tell CPU if there is activity this cycle.
      */
     bool wroteToTimeBuffer;
-
-    /** Source of possible stalls. */
-    struct Stalls
-    {
-        bool rename;
-    };
-
-    /** Tracks which stages are telling decode to stall. */
-    Stalls stalls[MaxThreads];
 
     /** Rename to decode delay. */
     Cycles renameToDecodeDelay;
@@ -297,21 +247,6 @@ class Decode
 
     /** List of active thread ids */
     std::list<ThreadID> *activeThreads;
-
-    /** Maximum size of the skid buffer. */
-    unsigned skidBufferMax;
-
-    /** SeqNum of Squashing Branch Delay Instruction (used for MIPS)*/
-    Addr bdelayDoneSeqNum[MaxThreads];
-
-    /** Instruction used for squashing branch (used for MIPS)*/
-    DynInstPtr squashInst[MaxThreads];
-
-    /** Tells when their is a pending delay slot inst. to send
-     *  to rename. If there is, then wait squash after the next
-     *  instruction (used for MIPS).
-     */
-    bool squashAfterDelaySlot[MaxThreads];
 
     bool enableLoadFusion;
 

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -862,9 +862,6 @@ class DynInst : public ExecContext, public RefCounted
     /** Clears the serializeAfter part of this instruction.*/
     void clearSerializeAfter() { status.reset(SerializeAfter); }
 
-    /** Checks if this serializeAfter is only temporarily set. */
-    bool isTempSerializeAfter() { return status[SerializeAfter]; }
-
     /** Sets the serialization part of this instruction as handled. */
     void setSerializeHandled() { status.set(SerializeHandled); }
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1317,7 +1317,7 @@ Fetch::sendInstructionsToDecode()
     if (stallSig->blockFetch[tid]) {
         // If decode stalled, use decode's stall reason
         DPRINTF(Fetch, "[tid:%i] Fetch stalled\n", tid);
-        setAllFetchStalls(fromDecode->decodeInfo[tid].blockReason);
+        setAllFetchStalls(stallSig->fetchBlockReason[tid]);
     }
 
     int insts_to_decode = 0;

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1221,6 +1221,7 @@ Fetch::initializeTickState()
     bool status_change = false;
 
     wroteToTimeBuffer = false;
+    setAllFetchStalls(StallReason::NoStall);
 
     // get the distribution of fetch status
     fetchStats.fetchStatusDist[fetchStatus[0]]++;
@@ -1304,8 +1305,21 @@ Fetch::sendInstructionsToDecode()
     }
     if (!any_thread_active) {
         // All threads are blocked, no instructions to send
+        ThreadID blocked_tid = InvalidThreadID;
         for (int i = 0; i < numThreads; i++) {
-            updateStallReasons(0, i);
+            if (stallSig->blockFetch[i]) {
+                blocked_tid = i;
+                break;
+            }
+        }
+
+        if (blocked_tid != InvalidThreadID) {
+            setAllFetchStalls(stallSig->fetchBlockReason[blocked_tid]);
+        }
+
+        toDecode->fetchStallReason = stallReason;
+
+        for (int i = 0; i < numThreads; i++) {
             measureFrontendBubbles(0, i);
         }
         return;
@@ -1350,7 +1364,9 @@ Fetch::sendInstructionsToDecode()
 void
 Fetch::updateStallReasons(unsigned insts_to_decode, ThreadID tid)
 {
-    if (insts_to_decode == 0) {
+    if (stallSig->blockFetch[tid]) {
+        setAllFetchStalls(stallSig->fetchBlockReason[tid]);
+    } else if (insts_to_decode == 0) {
         // fetch stalled
         if (stallReason[0] != StallReason::NoStall) {
             // previously set stall reason

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1464,6 +1464,7 @@ Fetch::handleIEWSignals()
     }
 
     auto &incoming = fromIEW->iewInfo->resolvedCFIs;
+    const bool had_pending_resolve = !resolveQueue.empty();
     uint8_t enqueueSize = fromIEW->iewInfo->resolvedCFIs.size();
     uint8_t enqueueCount = 0;
 
@@ -1497,7 +1498,10 @@ Fetch::handleIEWSignals()
 
     fetchStats.resolveQueueOccupancy.sample(resolveQueue.size());
 
-    if (!resolveQueue.empty()) {
+    // Process only entries that were already pending before this cycle.
+    // This preserves a cycle of separation between IEW producing resolved CFIs
+    // and fetch consuming them as predictor resolved updates.
+    if (had_pending_resolve && !resolveQueue.empty()) {
         auto &entry = resolveQueue.front();
         unsigned int stream_id = entry.resolvedFTQId;
         dbpbtb->prepareResolveUpdateEntries(stream_id);

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -127,7 +127,6 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         pc[i].reset(params.isa[0]->newPCState());
         macroop[i] = nullptr;
         delayedCommit[i] = false;
-        stalls[i] = {false, false};
         lastIcacheStall[i] = 0;
     }
 
@@ -416,8 +415,6 @@ Fetch::clearStates(ThreadID tid)
     macroop[tid] = NULL;
     delayedCommit[tid] = false;
     cacheReq[tid].reset();
-    stalls[tid].decode = false;
-    stalls[tid].drain = false;
     fetchBuffer[tid].reset();
     fetchQueue[tid].clear();
 
@@ -442,9 +439,6 @@ Fetch::resetStage()
 
         delayedCommit[tid] = false;
         cacheReq[tid].reset();
-
-        stalls[tid].decode = false;
-        stalls[tid].drain = false;
 
         fetchBuffer[tid].reset();
         ftqEntryFetchedInsts[tid] = 0;
@@ -646,22 +640,13 @@ Fetch::processCacheCompletion(PacketPtr pkt)
 
     switchToActive();
 
-    // Complete cache request and transition to appropriate state
-    if (checkStall(tid)) {
-        setThreadStatus(tid, Blocked);
-    } else {
-        // Transition from WaitingCache back to Running when cache access completes
-        setThreadStatus(tid, Running);
-    }
+    // Transition from WaitingCache back to Running when cache access completes
+    setThreadStatus(tid, Running);
 }
 
 void
 Fetch::drainResume()
 {
-    for (ThreadID i = 0; i < numThreads; ++i) {
-        stalls[i].decode = false;
-        stalls[i].drain = false;
-    }
 }
 
 void
@@ -675,7 +660,7 @@ Fetch::drainSanityCheck() const
 
     for (ThreadID i = 0; i < numThreads; ++i) {
         assert(cacheReq[i].packets.empty());
-        assert(fetchStatus[i] == Idle || stalls[i].drain);
+        assert(fetchStatus[i] == Idle);
     }
 
     branchPred->drainSanityCheck();
@@ -697,10 +682,7 @@ Fetch::isDrained() const
 
         // Return false if not idle or drain stalled
         if (fetchStatus[i] != Idle) {
-            if (fetchStatus[i] == Blocked && stalls[i].drain)
-                continue;
-            else
-                return false;
+            return false;
         }
     }
 
@@ -722,10 +704,6 @@ Fetch::takeOverFrom()
 void
 Fetch::drainStall(ThreadID tid)
 {
-    assert(cpu->isDraining());
-    assert(!stalls[tid].drain);
-    DPRINTF(Drain, "%i: Thread drained.\n", tid);
-    stalls[tid].drain = true;
 }
 
 void
@@ -1167,20 +1145,6 @@ Fetch::squashFromDecode(PCStateBase &new_pc, const DynInstPtr squashInst,
     cpu->removeInstsUntil(seq_num, tid);
 }
 
-bool
-Fetch::checkStall(ThreadID tid) const
-{
-    bool ret_val = false;
-
-    if (stalls[tid].drain) {
-        assert(cpu->isDraining());
-        DPRINTF(Fetch,"[tid:%i] Drain stall detected.\n",tid);
-        ret_val = true;
-    }
-
-    return ret_val;
-}
-
 Fetch::FetchStatus
 Fetch::updateFetchStatus()
 {
@@ -1191,7 +1155,7 @@ Fetch::updateFetchStatus()
     while (threads != end) {
         ThreadID tid = *threads++;
 
-        if ((canFetchInstructions(tid) && !checkStall(tid)) || fetchStatus[tid] == Squashing ||
+        if (canFetchInstructions(tid) || fetchStatus[tid] == Squashing ||
             cacheReq[tid].getOverallStatus() == AccessComplete) {
 
             if (_status == Inactive) {
@@ -1327,50 +1291,45 @@ Fetch::handleInterrupts()
 void
 Fetch::sendInstructionsToDecode()
 {
-    // Send instructions enqueued into the fetch queue to decode.
-    // Limit rate by fetchWidth.  Stall if decode is stalled.
-    unsigned insts_to_decode = 0;
-    unsigned available_insts = 0;
-
-    // Count available instructions across all active threads
-    for (auto tid : *activeThreads) {
-        if (!stalls[tid].decode) {
-            available_insts += fetchQueue[tid].size();
+    bool any_thread_active = false;
+    for (int i = 0; i < numThreads; i++) {
+        if (!stallSig->blockFetch[i]) {
+            any_thread_active = true;
+            break;
         }
     }
+    if (!any_thread_active) {
+        // All threads are blocked, no instructions to send
+        return;
+    }
+    ThreadID tid = 0; // TODO: smt support
 
-    // Pick a random thread to start trying to grab instructions from
-    auto tid_itr = activeThreads->begin();
-    std::advance(tid_itr,
-            random_mt.random<uint8_t>(0, activeThreads->size() - 1));
+    // fetch totally stalled
+    if (stallSig->blockFetch[tid]) {
+        // If decode stalled, use decode's stall reason
+        DPRINTF(Fetch, "[tid:%i] Fetch stalled\n", tid);
+        setAllFetchStalls(fromDecode->decodeInfo[tid].blockReason);
+    }
 
-    // Collect instructions from fetch queues until decode width is reached
-    while (available_insts != 0 && insts_to_decode < decodeWidth) {
-        ThreadID tid = *tid_itr;
-        if (!stalls[tid].decode && !fetchQueue[tid].empty()) {
-            const auto& inst = fetchQueue[tid].front();
-            toDecode->insts[toDecode->size++] = inst;
-            DPRINTF(Fetch, "[tid:%i] [sn:%llu] Sending instruction to decode "
-                    "from fetch queue. Fetch queue size: %i.\n",
-                    tid, inst->seqNum, fetchQueue[tid].size());
+    int insts_to_decode = 0;
+    auto& insts = fetchQueue[tid];
+    while (!insts.empty() && insts_to_decode < decodeWidth) {
+        const auto& inst = insts.front();
+        toDecode->insts[toDecode->size++] = inst;
+        DPRINTF(Fetch, "[tid:%i] [sn:%llu] Sending instruction to decode "
+                "from fetch queue. Fetch queue size: %i.\n",
+                tid, inst->seqNum, insts.size());
 
-            wroteToTimeBuffer = true;
-            fetchQueue[tid].pop_front();
-            insts_to_decode++;
-            available_insts--;
-        }
-
-        tid_itr++;
-        // Wrap around if at end of active threads list
-        if (tid_itr == activeThreads->end())
-            tid_itr = activeThreads->begin();
+        wroteToTimeBuffer = true;
+        insts.pop_front();
+        insts_to_decode++;
     }
 
     // Update stall reasons based on fetch/decode status
-    updateStallReasons(insts_to_decode, *tid_itr);
+    updateStallReasons(insts_to_decode, tid);
 
     // Intel TopDown method for measuring frontend bubbles
-    measureFrontendBubbles(insts_to_decode, *tid_itr);
+    measureFrontendBubbles(insts_to_decode, tid);
 
     // If there was activity this cycle, inform the CPU of it
     if (wroteToTimeBuffer) {
@@ -1385,11 +1344,7 @@ Fetch::sendInstructionsToDecode()
 void
 Fetch::updateStallReasons(unsigned insts_to_decode, ThreadID tid)
 {
-    // fetch totally stalled
-    if (stalls[tid].decode) {
-        // If decode stalled, use decode's stall reason
-        setAllFetchStalls(fromDecode->decodeInfo[tid].blockReason);
-    } else if (insts_to_decode == 0) {
+    if (insts_to_decode == 0) {
         // fetch stalled
         if (stallReason[0] != StallReason::NoStall) {
             // previously set stall reason
@@ -1419,7 +1374,7 @@ Fetch::measureFrontendBubbles(unsigned insts_to_decode, ThreadID tid)
     // For N-wide machine, if frontend supplies 0 instructions:
     // - fetchBubbles += N (count total empty slots)
     // - fetchBubbles_max += 1 (count occurrence of all slots being empty)
-    if (!stalls[tid].decode && !fromCommit->commitInfo[tid].robSquashing) {
+    if (!stallSig->blockFetch[tid] && !fromCommit->commitInfo[tid].robSquashing) {
         // backend not stalled
         int unused_slots = decodeWidth - insts_to_decode;
         if (unused_slots > 0) {
@@ -1432,7 +1387,7 @@ Fetch::measureFrontendBubbles(unsigned insts_to_decode, ThreadID tid)
         }
     }
 
-    if (stalls[tid].decode) {
+    if (stallSig->blockFetch[tid]) {
         fetchStats.decodeStalls++;
     }
 }
@@ -1440,17 +1395,6 @@ Fetch::measureFrontendBubbles(unsigned insts_to_decode, ThreadID tid)
 bool
 Fetch::checkSignalsAndUpdate(ThreadID tid)
 {
-    // Update the per thread stall statuses.
-    if (fromDecode->decodeBlock[tid]) {
-        stalls[tid].decode = true;
-    }
-
-    if (fromDecode->decodeUnblock[tid]) {
-        assert(stalls[tid].decode);
-        assert(!fromDecode->decodeBlock[tid]);
-        stalls[tid].decode = false;
-    }
-
     // Check squash signals from commit.
     bool commitSquashed = handleCommitSignals(tid);
 
@@ -1461,14 +1405,6 @@ Fetch::checkSignalsAndUpdate(ThreadID tid)
     }
 
     if (handleDecodeSquash(tid)) {
-        return true;
-    }
-
-    if (checkStall(tid) && !hasPendingCacheRequests(tid)) {
-        DPRINTF(Fetch, "[tid:%i] Setting to blocked\n",tid);
-
-        setThreadStatus(tid, Blocked);
-
         return true;
     }
 
@@ -1736,7 +1672,7 @@ Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
 ThreadID
 Fetch::selectFetchThread()
 {
-    ThreadID tid = getFetchingThread();
+    ThreadID tid = 0; // TODO: smt support
 
     assert(!cpu->switchedOut());
 
@@ -2096,145 +2032,6 @@ Fetch::recvReqRetry()
     }
 }
 
-///////////////////////////////////////
-//                                   //
-//  SMT FETCH POLICY MAINTAINED HERE //
-//                                   //
-///////////////////////////////////////
-ThreadID
-Fetch::getFetchingThread()
-{
-    if (numThreads > 1) {
-        switch (fetchPolicy) {
-          case SMTFetchPolicy::RoundRobin:
-            return roundRobin();
-          case SMTFetchPolicy::IQCount:
-            return iqCount();
-          case SMTFetchPolicy::LSQCount:
-            return lsqCount();
-          case SMTFetchPolicy::Branch:
-            return branchCount();
-          default:
-            return InvalidThreadID;
-        }
-    } else {
-        std::list<ThreadID>::iterator thread = activeThreads->begin();
-        if (thread == activeThreads->end()) {
-            return InvalidThreadID;
-        }
-
-        ThreadID tid = *thread;
-
-        if (canFetchInstructions(tid) || fetchStatus[tid] == Idle) {
-            return tid;
-        } else {
-            return InvalidThreadID;
-        }
-    }
-}
-
-
-ThreadID
-Fetch::roundRobin()
-{
-    std::list<ThreadID>::iterator pri_iter = priorityList.begin();
-    std::list<ThreadID>::iterator end      = priorityList.end();
-
-    ThreadID high_pri;
-
-    while (pri_iter != end) {
-        high_pri = *pri_iter;
-
-        assert(high_pri <= numThreads);
-
-        if (canFetchInstructions(high_pri) || fetchStatus[high_pri] == Idle) {
-
-            priorityList.erase(pri_iter);
-            priorityList.push_back(high_pri);
-
-            return high_pri;
-        }
-
-        pri_iter++;
-    }
-
-    return InvalidThreadID;
-}
-
-ThreadID
-Fetch::iqCount()
-{
-    //sorted from lowest->highest
-    std::priority_queue<unsigned, std::vector<unsigned>,
-                        std::greater<unsigned> > PQ;
-    std::map<unsigned, ThreadID> threadMap;
-
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-        unsigned iqCount = cpu->getIQInsts();
-
-        //we can potentially get tid collisions if two threads
-        //have the same iqCount, but this should be rare.
-        PQ.push(iqCount);
-        threadMap[iqCount] = tid;
-    }
-
-    while (!PQ.empty()) {
-        ThreadID high_pri = threadMap[PQ.top()];
-
-        if (canFetchInstructions(high_pri) || fetchStatus[high_pri] == Idle)
-            return high_pri;
-        else
-            PQ.pop();
-
-    }
-
-    return InvalidThreadID;
-}
-
-ThreadID
-Fetch::lsqCount()
-{
-    //sorted from lowest->highest
-    std::priority_queue<unsigned, std::vector<unsigned>,
-                        std::greater<unsigned> > PQ;
-    std::map<unsigned, ThreadID> threadMap;
-
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-        unsigned ldstqCount = fromIEW->iewInfo[tid].ldstqCount;
-
-        //we can potentially get tid collisions if two threads
-        //have the same iqCount, but this should be rare.
-        PQ.push(ldstqCount);
-        threadMap[ldstqCount] = tid;
-    }
-
-    while (!PQ.empty()) {
-        ThreadID high_pri = threadMap[PQ.top()];
-
-        if (canFetchInstructions(high_pri) || fetchStatus[high_pri] == Idle)
-            return high_pri;
-        else
-            PQ.pop();
-    }
-
-    return InvalidThreadID;
-}
-
-ThreadID
-Fetch::branchCount()
-{
-    panic("Branch Count Fetch policy unimplemented\n");
-    return InvalidThreadID;
-}
-
 void
 Fetch::profileStall(ThreadID tid)
 {
@@ -2242,10 +2039,7 @@ Fetch::profileStall(ThreadID tid)
 
     // @todo Per-thread stats
 
-    if (stalls[tid].drain) {
-        ++fetchStats.pendingDrainCycles;
-        DPRINTF(Fetch, "Fetch is waiting for a drain!\n");
-    } else if (activeThreads->empty()) {
+    if (activeThreads->empty()) {
         ++fetchStats.noActiveThreadStallCycles;
         DPRINTF(Fetch, "Fetch has no active thread!\n");
     } else if (fetchStatus[tid] == Blocked) {

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1291,6 +1291,10 @@ Fetch::handleInterrupts()
 void
 Fetch::sendInstructionsToDecode()
 {
+
+    // Reset the number of instructions we've fetched
+    numInst = 0;
+
     bool any_thread_active = false;
     for (int i = 0; i < numThreads; i++) {
         if (!stallSig->blockFetch[i]) {
@@ -1300,8 +1304,13 @@ Fetch::sendInstructionsToDecode()
     }
     if (!any_thread_active) {
         // All threads are blocked, no instructions to send
+        for (int i = 0; i < numThreads; i++) {
+            updateStallReasons(0, i);
+            measureFrontendBubbles(0, i);
+        }
         return;
     }
+
     ThreadID tid = 0; // TODO: smt support
 
     // fetch totally stalled
@@ -1336,9 +1345,6 @@ Fetch::sendInstructionsToDecode()
         DPRINTF(Activity, "Activity this cycle.\n");
         cpu->activityThisCycle();
     }
-
-    // Reset the number of instructions we've fetched
-    numInst = 0;
 }
 
 void

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -247,6 +247,8 @@ class Fetch
     /** Sets the main backwards communication time buffer pointer. */
     void setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer);
 
+    void setStallSignals(StallSignals* stall_signals) { stallSig = stall_signals; }
+
     /** Sets pointer to list of active threads. */
     void setActiveThreads(std::list<ThreadID> *at_ptr);
 
@@ -435,9 +437,6 @@ class Fetch
                           const DynInstPtr squashInst,
                           const InstSeqNum seq_num, ThreadID tid);
 
-    /** Checks if a thread is stalled. */
-    bool checkStall(ThreadID tid) const;
-
     /** Updates overall fetch stage status; to be called at the end of each
      * cycle. */
     FetchStatus updateFetchStatus();
@@ -505,22 +504,6 @@ class Fetch
     DynInstPtr buildInst(ThreadID tid, StaticInstPtr staticInst,
             StaticInstPtr curMacroop, const PCStateBase &this_pc,
             const PCStateBase &next_pc, bool trace);
-
-    /** Returns the appropriate thread to fetch, given the fetch policy. */
-    ThreadID getFetchingThread();
-
-    /** Returns the appropriate thread to fetch using a round robin policy. */
-    ThreadID roundRobin();
-
-    /** Returns the appropriate thread to fetch using the IQ count policy. */
-    ThreadID iqCount();
-
-    /** Returns the appropriate thread to fetch using the LSQ count policy. */
-    ThreadID lsqCount();
-
-    /** Returns the appropriate thread to fetch using the branch count
-     * policy. */
-    ThreadID branchCount();
 
     /** Pipeline the next I-cache access to the current one. */
     void pipelineIcacheAccesses(ThreadID tid);
@@ -655,7 +638,7 @@ class Fetch
     };
 
     /** Tracks which stages are telling fetch to stall. */
-    Stalls stalls[MaxThreads];
+    StallSignals* stallSig;
 
     /** Decode to fetch delay. */
     Cycles decodeToFetchDelay;

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -303,6 +303,8 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::Atomic,"Atomic"},
         {StallReason::ResumeUnblock, "ResumeUnblock"},
         {StallReason::CommitSquash, "CommitSquash"},
+        {StallReason::ROBFull, "ROBFull"},
+        {StallReason::RegFull, "RegFull"},
         {StallReason::OtherStall, "OtherStall"},
         {StallReason::OtherFetchStall, "OtherFetchStall"},
         {StallReason::FTQBubble, "FTQBubble"},

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -826,10 +826,21 @@ IEW::dispatchInsts()
     // check threads stall & status
     ThreadID tid = InvalidThreadID;
     for (int i = 0; i < numThreads; i++) {
-        bool block = stallSig->blockIEW[i] || !canInsertLDSTQue(i);
+        bool ldst_block = !canInsertLDSTQue(i);
+        bool block = stallSig->blockIEW[i] || ldst_block;
         bool active = !block && !fixedbuffer[i].empty();
+        StallReason block_reason = StallReason::NoStall;
+        if (stallSig->blockIEW[i]) {
+            block_reason = stallSig->iewBlockReason[i];
+        } else if (ldst_block) {
+            block_reason = checkDispatchStall(i, NumDQ, nullptr, -1);
+            if (block_reason == StallReason::NoStall) {
+                block_reason = StallReason::OtherStall;
+            }
+        }
 
         stallSig->blockRename[i] = block;
+        stallSig->renameBlockReason[i] = block ? block_reason : StallReason::NoStall;
         if (active) {
             if (tid == InvalidThreadID) tid = i;
             else {
@@ -1645,6 +1656,7 @@ IEW::writebackInsts()
 void
 IEW::tick()
 {
+    blockReason = StallReason::NoStall;
     for (int i = 0;i < fromRename->fetchStallReason.size();i++) {
         iewStats.fetchStallReason[fromRename->fetchStallReason[i]]++;
     }

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -111,10 +111,12 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
     // Instruction queue needs the queue between issue and execute.
     instQueue.setIssueToExecuteQueue(&issueToExecQueue);
 
-    for (ThreadID tid = 0; tid < MaxThreads; tid++) {
-        dispatchStatus[tid] = Running;
+    for (ThreadID tid = 0; tid < numThreads; tid++) {
         fetchRedirect[tid] = false;
+        serializeOnNextInst[tid] = false;
     }
+
+    assert(renameToIEWDelay == 1);
 
     updateLSQNextCycle = false;
 
@@ -375,16 +377,6 @@ IEW::IEWStats::ExecutedInstStats::ExecutedInstStats(CPU *cpu)
 void
 IEW::startupStage()
 {
-    for (ThreadID tid = 0; tid < numThreads; tid++) {
-        toRename->iewInfo[tid].usedIQ = true;
-
-        toRename->iewInfo[tid].usedLSQ = true;
-        toRename->iewInfo[tid].freeLQEntries =
-            ldstQueue.numFreeLoadEntries(tid);
-        toRename->iewInfo[tid].freeSQEntries =
-            ldstQueue.numFreeStoreEntries(tid);
-    }
-
     // Initialize the checker's dcache port here
     if (cpu->checker) {
         cpu->checker->setDcachePort(&ldstQueue.getDataPort());
@@ -396,11 +388,6 @@ IEW::startupStage()
 void
 IEW::clearStates(ThreadID tid)
 {
-    toRename->iewInfo[tid].usedIQ = true;
-
-    toRename->iewInfo[tid].usedLSQ = true;
-    toRename->iewInfo[tid].freeLQEntries = ldstQueue.numFreeLoadEntries(tid);
-    toRename->iewInfo[tid].freeSQEntries = ldstQueue.numFreeStoreEntries(tid);
 }
 
 void
@@ -440,7 +427,7 @@ IEW::setIEWQueue(TimeBuffer<IEWStruct> *iq_ptr)
     // position [-1] (via fromIEW) in the same cycle, achieving zero-cycle latency for
     // IEW→Commit communication. This allows Commit to immediately arbitrate squash
     // signals from IEW (e.g., branch mispredictions) before forwarding to Fetch.
-    toCommit = iewQueue->getWire(-iewToCommitDelay);
+    toCommit = iewQueue->getWire(0);
 }
 
 void
@@ -462,17 +449,17 @@ bool
 IEW::isDrained() const
 {
     bool drained = ldstQueue.isDrained() && instQueue.isDrained();
+    if (!drained) {
+        DPRINTF(Drain, "LDSTQ or IQ not drained.\n");
+        return false;
+    }
 
-    for (ThreadID tid = 0; tid < numThreads; tid++) {
-        if (!insts[tid].empty()) {
-            DPRINTF(Drain, "%i: Insts not empty.\n", tid);
+    for (int i=0;i<numThreads;i++) {
+        if (!fixedbuffer[i].empty()) {
+            DPRINTF(Drain, "%i: Insts not empty.\n", i);
             drained = false;
+            break;
         }
-        if (!skidBuffer[tid].empty()) {
-            DPRINTF(Drain, "%i: Skid buffer not empty.\n", tid);
-            drained = false;
-        }
-        drained = drained && dispatchStatus[tid] == Running;
     }
 
     return drained;
@@ -502,7 +489,6 @@ IEW::takeOverFrom()
     cpu->activityThisCycle();
 
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        dispatchStatus[tid] = Running;
         fetchRedirect[tid] = false;
     }
 
@@ -533,27 +519,15 @@ IEW::squash(ThreadID tid)
     ldstQueue.squash(fromCommit->commitInfo[tid].doneSeqNum, tid);
     updatedQueues = true;
 
+    fixedbuffer[tid].clear();
+
+    stallSig->blockRename[tid] = true;
+
     // Clear the skid buffer in case it has any data in it.
     DPRINTF(IEW,
             "Removing skidbuffer instructions until "
             "[sn:%llu] [tid:%i]\n",
             fromCommit->commitInfo[tid].doneSeqNum, tid);
-
-    while (!skidBuffer[tid].empty()) {
-        if (skidBuffer[tid].front()->isLoad()) {
-            toRename->iewInfo[tid].dispatchedToLQ++;
-        }
-        if (skidBuffer[tid].front()->isStore() ||
-            skidBuffer[tid].front()->isAtomic()) {
-            toRename->iewInfo[tid].dispatchedToSQ++;
-        }
-
-        toRename->iewInfo[tid].dispatched++;
-
-        skidBuffer[tid].pop_front();
-    }
-
-    emptyRenameInsts(tid);
 }
 
 void
@@ -563,8 +537,7 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
             " PC: %s "
             "\n", tid, inst->seqNum, inst->pcState() );
 
-    if (!toCommit->squash[tid] ||
-            inst->seqNum < toCommit->squashedSeqNum[tid]) {
+    if (!toCommit->squash[tid] || inst->seqNum < toCommit->squashedSeqNum[tid]) {
         toCommit->squash[tid] = true;
         toCommit->squashedSeqNum[tid] = inst->seqNum;
         toCommit->squashedTargetId[tid] = inst->getFtqId();
@@ -587,6 +560,7 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
                 toCommit->squashedLoopIter[tid]);
     }
 
+    stallSig->blockRename[tid] = true;
 }
 
 void
@@ -600,8 +574,7 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
     // case the memory violator should take precedence over the branch
     // misprediction because it requires the violator itself to be included in
     // the squash.
-    if (!toCommit->squash[tid] ||
-            inst->seqNum <= toCommit->squashedSeqNum[tid]) {
+    if (!toCommit->squash[tid] || inst->seqNum <= toCommit->squashedSeqNum[tid]) {
         toCommit->squash[tid] = true;
 
         toCommit->squashedSeqNum[tid] = inst->seqNum;
@@ -621,43 +594,9 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
                 toCommit->pc[tid]->instAddr(),
                 toCommit->squashedTargetId[tid],
                 toCommit->squashedLoopIter[tid]);
-
-
-    }
-}
-
-void
-IEW::block(ThreadID tid)
-{
-    DPRINTF(IEW, "[tid:%i] Blocking.\n", tid);
-
-    if (dispatchStatus[tid] != Blocked &&
-        dispatchStatus[tid] != Unblocking) {
-        toRename->iewBlock[tid] = true;
-        wroteToTimeBuffer = true;
     }
 
-    // Add the current inputs to the skid buffer so they can be
-    // reprocessed when this stage unblocks.
-    skidInsert(tid);
-
-    dispatchStatus[tid] = Blocked;
-}
-
-void
-IEW::unblock(ThreadID tid)
-{
-    DPRINTF(IEW, "[tid:%i] Reading instructions out of the skid "
-            "buffer %u.\n",tid, tid);
-
-    // If the skid bufffer is empty, signal back to previous stages to unblock.
-    // Also switch status to running.
-    if (skidBuffer[tid].empty()) {
-        toRename->iewUnblock[tid] = true;
-        wroteToTimeBuffer = true;
-        DPRINTF(IEW, "[tid:%i] Done unblocking.\n",tid);
-        dispatchStatus[tid] = Running;
-    }
+    stallSig->blockRename[tid] = true;
 }
 
 void
@@ -734,76 +673,9 @@ IEW::readyToFinish(const DynInstPtr& inst)
 }
 
 void
-IEW::skidInsert(ThreadID tid)
-{
-    DynInstPtr inst = NULL;
-
-    while (!insts[tid].empty()) {
-        inst = insts[tid].front();
-
-        insts[tid].pop_front();
-
-        DPRINTF(IEW,"[tid:%i] Inserting [sn:%lli] PC:%s into "
-                "dispatch skidBuffer %i\n",tid, inst->seqNum,
-                inst->pcState(),tid);
-
-        skidBuffer[tid].push_back(inst);
-    }
-
-    assert(skidBuffer[tid].size() <= skidBufferMax &&
-           "Skidbuffer Exceeded Max Size");
-}
-
-int
-IEW::skidCount()
-{
-    int max=0;
-
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-        unsigned thread_count = skidBuffer[tid].size();
-        if (max < thread_count)
-            max = thread_count;
-    }
-
-    return max;
-}
-
-bool
-IEW::skidsEmpty()
-{
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        if (!skidBuffer[tid].empty())
-            return false;
-    }
-
-    return true;
-}
-
-void
-IEW::updateStatus()
+IEW::updateActivate()
 {
     bool any_unblocking = false;
-
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        if (dispatchStatus[tid] == Unblocking) {
-            any_unblocking = true;
-            break;
-        }
-    }
 
     // If there are no ready instructions waiting to be scheduled by the IQ,
     // and there's no stores waiting to write back, and dispatch is not
@@ -829,21 +701,28 @@ IEW::updateStatus()
 }
 
 bool
-IEW::checkStall(ThreadID tid)
+IEW::checkSerialize(const DynInstPtr& inst)
 {
-    bool ret_val(false);
+    ThreadID tid = inst->threadNumber;
+    bool skipserialize = fromCommit->commitInfo[tid].robheadNotReadySeqNum == inst->seqNum;
 
-    if (fromCommit->commitInfo[tid].robSquashing) {
-        DPRINTF(IEW,"[tid:%i] Stall from Commit stage detected.\n",tid);
-        ret_val = true;
-        blockReason = StallReason::CommitSquash;
+    if (serializeOnNextInst[tid]) {
+        inst->setSerializeBefore();
+        serializeOnNextInst[tid] = false;
     }
 
-    return ret_val;
+    if (inst->isSerializeBefore() && !skipserialize) {
+        return true;
+    } else if (inst->isStoreConditional() || inst->isSerializeAfter()) {
+        serializeOnNextInst[tid] = true;
+        return false;
+    }
+
+    return false;
 }
 
 void
-IEW::checkSignalsAndUpdate(ThreadID tid)
+IEW::checkSquash()
 {
     // Check if there's a squash signal, squash if there is
     // Check stall signals, block if there is.
@@ -852,101 +731,46 @@ IEW::checkSignalsAndUpdate(ThreadID tid)
     // If status was Squashing
     //     check if squashing is not high.  Switch to running this cycle.
 
-    if (fromCommit->commitInfo[tid].squash) {
-        squash(tid);
-        localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
-        DPRINTF(IEW, "Updating squash version to %u\n",
-                localSquashVer.getVersion());
+    for (int i = 0; i < numThreads; i++) {
+        if (fromCommit->commitInfo[i].squash) {
+            squash(i);
+            localSquashVer.update(fromCommit->commitInfo[i].squashVersion.getVersion());
+            DPRINTF(IEW, "Updating squash version to %u\n", localSquashVer.getVersion());
 
-        if (dispatchStatus[tid] == Blocked ||
-            dispatchStatus[tid] == Unblocking) {
-            toRename->iewUnblock[tid] = true;
-            wroteToTimeBuffer = true;
+            fetchRedirect[i] = false;
+            iewStats.stallEvents[ROBWalk]++;
+            setAllStalls(StallReason::CommitSquash);
+            return;
         }
 
-        dispatchStatus[tid] = Squashing;
-        fetchRedirect[tid] = false;
-        iewStats.stallEvents[ROBWalk]++;
-        setAllStalls(StallReason::CommitSquash);
-        return;
-    }
+        if (fromCommit->commitInfo[i].robSquashing) {
+            DPRINTF(IEW, "[tid:%i] ROB is still squashing.\n", i);
 
-    if (fromCommit->commitInfo[tid].robSquashing) {
-        DPRINTF(IEW, "[tid:%i] ROB is still squashing.\n", tid);
-
-        dispatchStatus[tid] = Squashing;
-        emptyRenameInsts(tid);
-        wroteToTimeBuffer = true;
-        iewStats.stallEvents[ROBWalk]++;
-        setAllStalls(StallReason::CommitSquash);
-    }
-
-    if (checkStall(tid)) {
-        block(tid);
-        dispatchStatus[tid] = Blocked;
-        return;
-    }
-
-    if (dispatchStatus[tid] == Blocked) {
-        // Status from previous cycle was blocked, but there are no more stall
-        // conditions.  Switch over to unblocking.
-        DPRINTF(IEW, "[tid:%i] Done blocking, switching to unblocking.\n",
-                tid);
-
-        dispatchStatus[tid] = Unblocking;
-
-        unblock(tid);
-
-        return;
-    }
-
-    if (dispatchStatus[tid] == Squashing) {
-        // Switch status to running if rename isn't being told to block or
-        // squash this cycle.
-        DPRINTF(IEW, "[tid:%i] Done squashing, switching to running.\n",
-                tid);
-
-        dispatchStatus[tid] = Running;
-
-        return;
+            wroteToTimeBuffer = true;
+            iewStats.stallEvents[ROBWalk]++;
+            setAllStalls(StallReason::CommitSquash);
+        }
     }
 }
 
 void
-IEW::sortInsts()
+IEW::moveInstsToBuffer()
 {
     int insts_from_rename = fromRename->size;
-#ifdef DEBUG
-    for (ThreadID tid = 0; tid < numThreads; tid++)
-        assert(insts[tid].empty());
-#endif
+    if (insts_from_rename == 0) {
+        DPRINTF(IEW, "No instructions from rename to move to buffer.\n");
+        return;
+    }
+    ThreadID tid = fromRename->insts[0]->threadNumber;
+    assert(fixedbuffer[tid].empty());
     for (int i = 0; i < insts_from_rename; ++i) {
         const DynInstPtr &inst = fromRename->insts[i];
+        assert(inst->threadNumber == tid);
         if (localSquashVer.largerThan(inst->getVersion())) {
             inst->setSquashed();
+        } else {
+            fixedbuffer[tid].push_back(inst);
         }
-        insts[fromRename->insts[i]->threadNumber].push_back(inst);
-    }
-}
-
-void
-IEW::emptyRenameInsts(ThreadID tid)
-{
-    DPRINTF(IEW, "[tid:%i] Removing incoming rename instructions\n", tid);
-
-    while (!insts[tid].empty()) {
-
-        if (insts[tid].front()->isLoad()) {
-            toRename->iewInfo[tid].dispatchedToLQ++;
-        }
-        if (insts[tid].front()->isStore() ||
-            insts[tid].front()->isAtomic()) {
-            toRename->iewInfo[tid].dispatchedToSQ++;
-        }
-
-        toRename->iewInfo[tid].dispatched++;
-
-        insts[tid].pop_front();
     }
 }
 
@@ -977,63 +801,68 @@ IEW::deactivateStage()
     cpu->deactivateStage(CPU::IEWIdx);
 }
 
-void
-IEW::dispatch(ThreadID tid)
+bool
+IEW::canInsertLDSTQue(ThreadID tid)
 {
-    // If status is Running or idle,
-    //     call dispatchInsts()
-    // If status is Unblocking,
-    //     buffer any instructions coming from rename
-    //     continue trying to empty skid buffer
-    //     check if stall conditions have passed
+    int freeLQEntries = ldstQueue.getFreeLQEntries(tid);
+    int freeSQEntries = ldstQueue.getFreeSQEntries(tid);
 
-    if (dispatchStatus[tid] == Blocked) {
-        ++iewStats.blockCycles;
-        setAllStalls(blockReason);
-
-    } else if (dispatchStatus[tid] == Squashing) {
-        ++iewStats.squashCycles;
-        setAllStalls(StallReason::CommitSquash);
+    int lastClockLQPopEntries = ldstQueue.getAndResetLastLQPopEntries(tid);
+    int lastClockSQPopEntries = ldstQueue.getAndResetLastSQPopEntries(tid);
+    if (freeLQEntries >= renameWidth + lastClockLQPopEntries &&
+        freeSQEntries >= renameWidth + lastClockSQPopEntries) {
+        return true;
     }
-
-    // Dispatch should try to dispatch as many instructions as its bandwidth
-    // will allow, as long as it is not currently blocked.
-    if (dispatchStatus[tid] == Running ||
-        dispatchStatus[tid] == Idle) {
-        DPRINTF(IEW, "[tid:%i] Not blocked, so attempting to run "
-                "dispatch.\n", tid);
-
-        dispatchInsts(tid);
-    } else if (dispatchStatus[tid] == Unblocking) {
-        // Make sure that the skid buffer has something in it if the
-        // status is unblocking.
-        assert(!skidsEmpty());
-
-        // If the status was unblocking, then instructions from the skid
-        // buffer were used.  Remove those instructions and handle
-        // the rest of unblocking.
-        dispatchInsts(tid);
-
-        ++iewStats.unblockCycles;
-
-        if (fromRename->size != 0) {
-            // Add the current inputs to the skid buffer so they can be
-            // reprocessed when this stage unblocks.
-            skidInsert(tid);
-        }
-
-        unblock(tid);
-    }
+    return false;
 }
 
 void
-IEW::dispatchInsts(ThreadID tid)
+IEW::dispatchInsts()
 {
     if (enableDispatchStage) {
-        dispatchInstFromDispQue(tid);
-        classifyInstToDispQue(tid);
-    } else {
-        dispatchInstFromRename(tid);
+        dispatchInstFromDispQue();
+    }
+
+    // check threads stall & status
+    ThreadID tid = InvalidThreadID;
+    for (int i = 0; i < numThreads; i++) {
+        bool block = stallSig->blockIEW[i] || !canInsertLDSTQue(i);
+        bool active = !block && !fixedbuffer[i].empty();
+
+        stallSig->blockRename[i] = block;
+        if (active) {
+            if (tid == InvalidThreadID) tid = i;
+            else {
+                // if there are multiple active threads, must exhaust all threads first
+                // to avoid starvation of other threads and also avoid resource conflict
+                stallSig->blockRename[tid] = true;
+                stallSig->blockRename[i] = true;
+                DPRINTF(IEW, "Multiple active threads detected, blocking all threads\n");
+            }
+        }
+    }
+
+    if (tid != InvalidThreadID) {
+        DPRINTF(IEW,"Processing [tid:%i]\n",tid);
+
+        // dispatch to IQ
+        if (enableDispatchStage) {
+            classifyInstToDispQue(tid);
+        } else {
+            dispatchInstFromRename(tid);
+        }
+        // check stall again
+        if (!fixedbuffer[tid].empty()) {
+            stallSig->blockRename[tid] = true;
+            DPRINTF(IEW, "Dispatch bandwidth full, blocking thread %i\n", tid);
+        }
+
+        toRename->iewInfo[tid].robHeadStallReason = checkDispatchStall(tid, NumDQ, nullptr, -1);
+        toRename->iewInfo[tid].lqHeadStallReason =
+            ldstQueue.lqEmpty() ? StallReason::NoStall : checkLSQStall(tid, true);
+        toRename->iewInfo[tid].sqHeadStallReason =
+            ldstQueue.sqEmpty() ? StallReason::NoStall : checkLSQStall(tid, false);
+        toRename->iewInfo[tid].blockReason = blockReason;
     }
 }
 
@@ -1042,16 +871,7 @@ IEW::dispatchInstFromRename(ThreadID tid)
 {
     DynInstPtr inst;
 
-    std::deque<DynInstPtr> &insts_to_dispatch =
-    dispatchStatus[tid] == Unblocking ?
-    skidBuffer[tid] : insts[tid];
-
-    bool canDispatch = true;
-
-    if ((ldstQueue.getFreeLQEntries(tid) < (renameWidth + lastClockLQPopEntries[tid])) ||
-        (ldstQueue.getFreeSQEntries(tid) < (renameWidth + lastClockSQPopEntries[tid]))) {
-        canDispatch = false;
-    }
+    auto &insts_to_dispatch = fixedbuffer[tid];
 
     bool emptyROB = fromCommit->commitInfo[tid].emptyROB;
 
@@ -1061,159 +881,148 @@ IEW::dispatchInstFromRename(ThreadID tid)
 
     unsigned dispatched = 0;
     int disp_seq = -1;
-    if (canDispatch) {
-        scheduler->lookahead(insts_to_dispatch);
-        while (!insts_to_dispatch.empty()) {
-            bool add_to_iq = false;
-            auto &inst = insts_to_dispatch.front();
-            disp_seq++;
-            int ins = cpu->cpuStats.committedInsts.total();
-            if (cpu->hasHintDownStream() && ins % 10000 == 1) {
-                cpu->hintDownStream->notifyIns(ins);
-            }
 
-            if (inst->isSquashed()) {
-                ++iewStats.dispSquashedInsts;
-                // Tell Rename That An Instruction has been processed
-                if (inst->isLoad()) {
-                    toRename->iewInfo[tid].dispatchedToLQ++;
-                }
-                if (inst->isStore() || inst->isAtomic()) {
-                    toRename->iewInfo[tid].dispatchedToSQ++;
-                }
-                toRename->iewInfo[tid].dispatched++;
-                insts_to_dispatch.pop_front();
-
-                dispatch_stalls.push(StallReason::InstSquashed);
-                continue;
-            }
-
-            if ((inst->isSerializeBefore() && !inst->isSerializeHandled()) ? !emptyROB : false) {
-                dispatch_stalls.push(StallReason::SerializeStall);
-                breakDispatch = StallReason::SerializeStall;
-                blockReason = breakDispatch;
-                break;
-            }
-
-            // Check LSQ if inst is LD/ST
-            if ((inst->isAtomic() && ldstQueue.sqFull(tid)) || (inst->isLoad() && ldstQueue.lqFull(tid)) ||
-                (inst->isStore() && ldstQueue.sqFull(tid))) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: %s has become full.\n", tid, inst->isLoad() ? "LQ" : "SQ");
-
-                iewStats.stallEvents[LSQFull]++;
-
-                ++iewStats.lsqFullEvents;
-                dispatch_stalls.push(checkDispatchStall(tid, NumDQ, inst, disp_seq));
-                breakDispatch = dispatch_stalls.back();
-                blockReason = breakDispatch;
-                break;
-            }
-
-            if (!scheduler->ready(inst, disp_seq)) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: IQ is full or bwFull.\n", tid);
-                iewStats.stallEvents[IQFull]++;
-                ++iewStats.iqFullEvents;
-
-                dispatch_stalls.push(checkDispatchStall(tid, NumDQ, inst, disp_seq));
-                breakDispatch = dispatch_stalls.back();
-                blockReason = breakDispatch;
-                break;
-            }
-
-            const int numHtmStarts = ldstQueue.numHtmStarts(tid);
-            const int numHtmStops = ldstQueue.numHtmStops(tid);
-            const int htmDepth = numHtmStarts - numHtmStops;
-            if (htmDepth > 0) {
-                inst->setHtmTransactionalState(ldstQueue.getLatestHtmUid(tid), htmDepth);
-            } else {
-                inst->clearHtmTransactionalState();
-            }
-
-            if (!inst->isNop() && !inst->isEliminated()) {
-                scheduler->addProducer(inst);
-            }
-
-            if (inst->isAtomic()) {
-                DPRINTF(IEW,
-                        "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n",
-                        tid);
-                ++iewStats.dispStoreInsts;
-                ++iewStats.dispNonSpecInsts;
-                toRename->iewInfo[tid].dispatchedToSQ++;
-
-                ldstQueue.insertStore(inst);
-                inst->setCanCommit();
-                instQueue.insertNonSpec(inst);
-                add_to_iq = false;
-            } else if (inst->isLoad()) {
-                DPRINTF(IEW,
-                        "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n",
-                        tid);
-                ++iewStats.dispLoadInsts;
-                toRename->iewInfo[tid].dispatchedToLQ++;
-
-                ldstQueue.insertLoad(inst);
-                add_to_iq = true;
-            } else if (inst->isStore()) {
-                DPRINTF(IEW,
-                        "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n",
-                        tid);
-                ++iewStats.dispStoreInsts;
-
-                ldstQueue.insertStore(inst);
-                if (inst->isStoreConditional()) {
-                    ++iewStats.dispNonSpecInsts;
-                    inst->setCanCommit();
-                    instQueue.insertNonSpec(inst);
-                    add_to_iq = false;
-                } else {
-                    add_to_iq = true;
-                }
-                toRename->iewInfo[tid].dispatchedToSQ++;
-            } else if (inst->isReadBarrier() || inst->isWriteBarrier()) {
-                inst->setCanCommit();
-                instQueue.insertBarrier(inst);
-                add_to_iq = false;
-            } else if (inst->isNop() || inst->isEliminated()) {
-                DPRINTF(IEW,
-                        "[tid:%i] Dispatch: Nop instruction [sn:%llu] encountered, "
-                        "skipping.\n",
-                        tid, inst->seqNum);
-                inst->setIssued();
-                inst->setExecuted();
-                inst->setCanCommit();
-                iewStats.executedInstStats.numNop[tid]++;
-                add_to_iq = false;
-            } else {
-                assert(!inst->isExecuted());
-                add_to_iq = true;
-            }
-
-            if (add_to_iq && inst->isNonSpeculative()) {
-                DPRINTF(IEW,
-                        "[tid:%i] Dispatch: Nonspeculative instruction "
-                        "encountered, skipping.\n",
-                        tid);
-                inst->setCanCommit();
-                instQueue.insertNonSpec(inst);
-                add_to_iq = false;
-            }
-
-            if (add_to_iq) {
-                instQueue.insert(inst, disp_seq);
-            }
-            ppDispatch->notify(inst);
-
-            toRename->iewInfo[tid].dispatched++;
-            ++iewStats.dispatchedInsts;
-
-            insts_to_dispatch.pop_front();
-            dispatched++;
+    scheduler->lookahead(insts_to_dispatch);
+    while (!insts_to_dispatch.empty()) {
+        bool add_to_iq = false;
+        auto &inst = insts_to_dispatch.front();
+        disp_seq++;
+        int ins = cpu->cpuStats.committedInsts.total();
+        if (cpu->hasHintDownStream() && ins % 10000 == 1) {
+            cpu->hintDownStream->notifyIns(ins);
         }
+
+        if (inst->isSquashed()) {
+            ++iewStats.dispSquashedInsts;
+            insts_to_dispatch.pop_front();
+
+            dispatch_stalls.push(StallReason::InstSquashed);
+            continue;
+        }
+
+        if (checkSerialize(inst)) {
+            DPRINTF(IEW, "[tid:%i] [sn:%llu] Dispatch: Serialize instruction encountered.\n", tid, inst->seqNum);
+            dispatch_stalls.push(checkDispatchStall(tid, NumDQ, inst, disp_seq));
+            breakDispatch = dispatch_stalls.back();
+            blockReason = breakDispatch;
+            break;
+        }
+
+        // Check LSQ if inst is LD/ST
+        if ((inst->isAtomic() && ldstQueue.sqFull(tid)) || (inst->isLoad() && ldstQueue.lqFull(tid)) ||
+            (inst->isStore() && ldstQueue.sqFull(tid))) {
+            DPRINTF(IEW, "[tid:%i] Dispatch: %s has become full.\n", tid, inst->isLoad() ? "LQ" : "SQ");
+
+            iewStats.stallEvents[LSQFull]++;
+
+            ++iewStats.lsqFullEvents;
+            dispatch_stalls.push(checkDispatchStall(tid, NumDQ, inst, disp_seq));
+            breakDispatch = dispatch_stalls.back();
+            blockReason = breakDispatch;
+            break;
+        }
+
+        if (!scheduler->ready(inst, disp_seq)) {
+            DPRINTF(IEW, "[tid:%i] Dispatch: IQ is full or bwFull.\n", tid);
+            iewStats.stallEvents[IQFull]++;
+            ++iewStats.iqFullEvents;
+
+            dispatch_stalls.push(checkDispatchStall(tid, NumDQ, inst, disp_seq));
+            breakDispatch = dispatch_stalls.back();
+            blockReason = breakDispatch;
+            break;
+        }
+
+        const int numHtmStarts = ldstQueue.numHtmStarts(tid);
+        const int numHtmStops = ldstQueue.numHtmStops(tid);
+        const int htmDepth = numHtmStarts - numHtmStops;
+        if (htmDepth > 0) {
+            inst->setHtmTransactionalState(ldstQueue.getLatestHtmUid(tid), htmDepth);
+        } else {
+            inst->clearHtmTransactionalState();
+        }
+
+        if (!inst->isNop() && !inst->isEliminated()) {
+            scheduler->addProducer(inst);
+        }
+
+        if (inst->isAtomic()) {
+            DPRINTF(IEW,
+                    "[tid:%i] Dispatch: Memory instruction "
+                    "encountered, adding to LSQ.\n",
+                    tid);
+            ++iewStats.dispStoreInsts;
+            ++iewStats.dispNonSpecInsts;
+
+            ldstQueue.insertStore(inst);
+            inst->setCanCommit();
+            instQueue.insertNonSpec(inst);
+            add_to_iq = false;
+        } else if (inst->isLoad()) {
+            DPRINTF(IEW,
+                    "[tid:%i] Dispatch: Memory instruction "
+                    "encountered, adding to LSQ.\n",
+                    tid);
+            ++iewStats.dispLoadInsts;
+
+            ldstQueue.insertLoad(inst);
+            add_to_iq = true;
+        } else if (inst->isStore()) {
+            DPRINTF(IEW,
+                    "[tid:%i] Dispatch: Memory instruction "
+                    "encountered, adding to LSQ.\n",
+                    tid);
+            ++iewStats.dispStoreInsts;
+
+            ldstQueue.insertStore(inst);
+            if (inst->isStoreConditional()) {
+                ++iewStats.dispNonSpecInsts;
+                inst->setCanCommit();
+                instQueue.insertNonSpec(inst);
+                add_to_iq = false;
+            } else {
+                add_to_iq = true;
+            }
+        } else if (inst->isReadBarrier() || inst->isWriteBarrier()) {
+            inst->setCanCommit();
+            instQueue.insertBarrier(inst);
+            add_to_iq = false;
+        } else if (inst->isNop() || inst->isEliminated()) {
+            DPRINTF(IEW,
+                    "[tid:%i] Dispatch: Nop instruction [sn:%llu] encountered, "
+                    "skipping.\n",
+                    tid, inst->seqNum);
+            inst->setIssued();
+            inst->setExecuted();
+            inst->setCanCommit();
+            iewStats.executedInstStats.numNop[tid]++;
+            add_to_iq = false;
+        } else {
+            assert(!inst->isExecuted());
+            add_to_iq = true;
+        }
+
+        if (add_to_iq && inst->isNonSpeculative()) {
+            DPRINTF(IEW,
+                    "[tid:%i] Dispatch: Nonspeculative instruction "
+                    "encountered, skipping.\n",
+                    tid);
+            inst->setCanCommit();
+            instQueue.insertNonSpec(inst);
+            add_to_iq = false;
+        }
+
+        if (add_to_iq) {
+            instQueue.insert(inst, disp_seq);
+        }
+        ppDispatch->notify(inst);
+
+        ++iewStats.dispatchedInsts;
+
+        insts_to_dispatch.pop_front();
+        dispatched++;
     }
+
     iewStats.dispDist.sample(dispatched);
 
     if (!dispatch_stalls.empty()) {
@@ -1244,17 +1053,8 @@ IEW::dispatchInstFromRename(ThreadID tid)
 
     if (!insts_to_dispatch.empty()) {
         DPRINTF(IEW,"[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
-        block(tid);
-        iewStats.stallEvents[DispBWFull]++;
-        toRename->iewUnblock[tid] = false;
-        disp_stall = true;
-    } else {
-        disp_stall = false;
-    }
 
-    if (dispatchStatus[tid] == Idle && insts_to_add) {
-        dispatchStatus[tid] = Running;
-        updatedQueues = true;
+        iewStats.stallEvents[DispBWFull]++;
     }
 
 }
@@ -1262,9 +1062,7 @@ IEW::dispatchInstFromRename(ThreadID tid)
 void
 IEW::classifyInstToDispQue(ThreadID tid)
 {
-    std::deque<DynInstPtr> &insts_to_dispatch =
-        dispatchStatus[tid] == Unblocking ?
-        skidBuffer[tid] : insts[tid];
+    auto &insts_to_dispatch = fixedbuffer[tid];
 
     bool emptyROB = fromCommit->commitInfo[tid].emptyROB;
 
@@ -1282,24 +1080,14 @@ IEW::classifyInstToDispQue(ThreadID tid)
         if (dispQue[id].size() < dqSize[id]) {
             if (inst->isSquashed()) {
                 ++iewStats.dispSquashedInsts;
-                //Tell Rename That An Instruction has been processed
-                if (inst->isLoad()) {
-                    toRename->iewInfo[tid].dispatchedToLQ++;
-                }
-                if (inst->isStore() || inst->isAtomic()) {
-                    toRename->iewInfo[tid].dispatchedToSQ++;
-                }
-                toRename->iewInfo[tid].dispatched++;
                 insts_to_dispatch.pop_front();
 
                 dispatch_stalls.push(StallReason::InstSquashed);
                 continue;
             }
 
-            if ((inst->isSerializeBefore() && !inst->isSerializeHandled()) ? !emptyROB : false) {
-                dispatch_stalls.push(StallReason::SerializeStall);
-                breakDispatch = StallReason::SerializeStall;
-                blockReason = breakDispatch;
+            if (checkSerialize(inst)) {
+                DPRINTF(IEW, "[tid:%i] [sn:%llu] Dispatch: Serialize instruction encountered.\n", tid, inst->seqNum);
                 break;
             }
 
@@ -1318,18 +1106,14 @@ IEW::classifyInstToDispQue(ThreadID tid)
             if (inst->isAtomic()) {
                 ++iewStats.dispStoreInsts;
                 ++iewStats.dispNonSpecInsts;
-                toRename->iewInfo[tid].dispatchedToSQ++;
             } else if (inst->isLoad()) {
                 ++iewStats.dispLoadInsts;
-                toRename->iewInfo[tid].dispatchedToLQ++;
             } else if (inst->isStore()) {
                 ++iewStats.dispStoreInsts;
                 if (inst->isStoreConditional()) {
                     ++iewStats.dispNonSpecInsts;
                 }
-                toRename->iewInfo[tid].dispatchedToSQ++;
             }
-            toRename->iewInfo[tid].dispatched++;
             ++iewStats.dispatchedInsts;
             dispQue[id].push_back(inst);
 
@@ -1378,25 +1162,14 @@ IEW::classifyInstToDispQue(ThreadID tid)
 
     if (!insts_to_dispatch.empty()) {
         DPRINTF(IEW,"[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
-        block(tid);
         iewStats.stallEvents[DispBWFull]++;
-        toRename->iewUnblock[tid] = false;
-        disp_stall = true;
-    } else {
-        disp_stall = false;
-    }
-
-    if (dispatchStatus[tid] == Idle && insts_to_add) {
-        dispatchStatus[tid] = Running;
-        updatedQueues = true;
     }
 }
 
 void
-IEW::dispatchInstFromDispQue(ThreadID tid)
+IEW::dispatchInstFromDispQue()
 {
     DynInstPtr inst;
-    bool add_to_iq = false;
     int dis_num_inst = 0;
 
     for (int i = 0; i < NumDQ; i++) {
@@ -1405,12 +1178,13 @@ IEW::dispatchInstFromDispQue(ThreadID tid)
         scheduler->lookahead(dispQue[i]);
         while (!dispQue[i].empty() && dispatched < dispWidth[i]) {
             inst = dispQue[i].front();
+            ThreadID tid = inst->threadNumber;
             disp_seq++;
 
             // Check for squashed instructions.
             if (inst->isSquashed()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Squashed instruction encountered, "
-                        "not adding to IQ.\n", tid);
+                DPRINTF(IEW, "[tid:%i] [sn:%llu] Dispatch: Squashed instruction encountered, "
+                        "not adding to IQ.\n", tid, inst->seqNum);
 
                 dispQue[i].pop_front();
                 continue;
@@ -1438,6 +1212,7 @@ IEW::dispatchInstFromDispQue(ThreadID tid)
                 break;
             }
 
+            bool add_to_iq = false;
             // Otherwise issue the instruction just fine.
             if (inst->isAtomic()) {
                 DPRINTF(IEW, "[tid:%i] Dispatch: Memory instruction "
@@ -1704,6 +1479,9 @@ IEW::executeInsts()
             // commit any squashed instructions.  I like the latter a bit more.
             inst->setCanCommit();
 
+            // avoid "not a load cancel" for using the squashed instruction's data
+            scheduler->bypassWriteback(inst);
+
             ++iewStats.executedInstStats.numSquashedInsts;
 
             continue;
@@ -1771,10 +1549,6 @@ IEW::executeInsts()
         }
 
         updateExeInstStats(inst);
-
-        if (debug::IEW) {
-            inst->printDisassemblyAndResult(cpu->name());
-        }
 
         // Check if branch prediction was correct, if not then we need
         // to tell commit to squash in flight instructions.  Only
@@ -1874,11 +1648,9 @@ IEW::tick()
     for (int i = 0;i < fromRename->fetchStallReason.size();i++) {
         iewStats.fetchStallReason[fromRename->fetchStallReason[i]]++;
     }
-
     for (int i = 0;i < fromRename->decodeStallReason.size();i++) {
         iewStats.decodeStallReason[fromRename->decodeStallReason[i]]++;
     }
-
     for (int i = 0;i < fromRename->renameStallReason.size();i++) {
         iewStats.renameStallReason[fromRename->renameStallReason[i]]++;
     }
@@ -1892,34 +1664,17 @@ IEW::tick()
     scheduler->tick();
     ldstQueue.tick();
 
-    sortInsts();
+    // dispatch
+    moveInstsToBuffer();
+    checkSquash();
+    dispatchInsts();
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    // Check stall and squash signals, dispatch any instructions.
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        DPRINTF(IEW,"Issue: Processing [tid:%i]\n",tid);
-        lastClockLQPopEntries[tid] = ldstQueue.getAndResetLastLQPopEntries(tid);
-        lastClockSQPopEntries[tid] = ldstQueue.getAndResetLastSQPopEntries(tid);
-        checkSignalsAndUpdate(tid);
-        dispatch(tid);
-
-        toRename->iewInfo[tid].robHeadStallReason = checkDispatchStall(tid, NumDQ, nullptr, -1);
-        toRename->iewInfo[tid].lqHeadStallReason =
-            ldstQueue.lqEmpty() ? StallReason::NoStall : checkLSQStall(tid, true);
-        toRename->iewInfo[tid].sqHeadStallReason =
-            ldstQueue.sqEmpty() ? StallReason::NoStall : checkLSQStall(tid, false);
-        toRename->iewInfo[tid].blockReason = blockReason;
-    }
     for (int i = 0;i < dispatchStalls.size();i++) {
         iewStats.dispatchStallReason[dispatchStalls[i]]++;
     }
+
+    // update the LSQ and scheduler before we check for ready instructions to execute
     ldstQueue.writebackStoreBuffer();
-
-
     if (exeStatus != Squashing) {
         instQueue.scheduleReadyInsts();
 
@@ -1927,7 +1682,6 @@ IEW::tick()
 
         writebackInsts();
     }
-
     scheduler->issueAndSelect();
 
     bool broadcast_free_entries = false;
@@ -1946,11 +1700,11 @@ IEW::tick()
     // nonspeculative instruction.
     // This is pretty inefficient...
 
-    threads = activeThreads->begin();
-    while (threads != end) {
+    auto threads = activeThreads->begin();
+    while (threads != activeThreads->end()) {
         ThreadID tid = (*threads++);
 
-        DPRINTF(IEW,"Processing [tid:%i]\n",tid);
+        DPRINTF(IEW,"Commit processing [tid:%i]\n",tid);
 
         if (fromCommit->commitInfo[tid].doneMemSeqNum != 0 &&
             !fromCommit->commitInfo[tid].squash &&
@@ -1987,28 +1741,14 @@ IEW::tick()
         }
 
         if (broadcast_free_entries) {
-            toFetch->iewInfo[tid].ldstqCount =
-                ldstQueue.getCount(tid);
-
-            toRename->iewInfo[tid].usedIQ = true;
-            toRename->iewInfo[tid].usedLSQ = true;
-
-            toRename->iewInfo[tid].freeLQEntries =
-                ldstQueue.numFreeLoadEntries(tid);
-            toRename->iewInfo[tid].freeSQEntries =
-                ldstQueue.numFreeStoreEntries(tid);
-
             wroteToTimeBuffer = true;
         }
-
-        DPRINTF(IEW, "[tid:%i], Dispatch dispatched %i instructions.\n",
-                tid, toRename->iewInfo[tid].dispatched);
     }
 
     DPRINTF(IEW,"LQ has %i free entries. SQ has %i free entries.\n",
             ldstQueue.numFreeLoadEntries(), ldstQueue.numFreeStoreEntries());
 
-    updateStatus();
+    updateActivate();
 
     if (wroteToTimeBuffer) {
         DPRINTF(Activity, "Activity this cycle.\n");

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -704,7 +704,7 @@ bool
 IEW::checkSerialize(const DynInstPtr& inst)
 {
     ThreadID tid = inst->threadNumber;
-    bool skipserialize = fromCommit->commitInfo[tid].robheadNotReadySeqNum == inst->seqNum;
+    bool skipserialize = fromCommit->commitInfo[tid].robheadSeqNum >= inst->seqNum;
 
     if (serializeOnNextInst[tid]) {
         inst->setSerializeBefore();

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -48,6 +48,8 @@
 #include <set>
 #include <vector>
 
+#include <boost/circular_buffer.hpp>
+
 #include "base/statistics.hh"
 #include "cpu/o3/comm.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
@@ -139,12 +141,12 @@ class IEW
 
     /** Overall stage status. */
     Status _status;
-    /** Dispatch status. */
-    StageStatus dispatchStatus[MaxThreads];
     /** Execute status. */
     StageStatus exeStatus;
     /** Writeback status. */
     StageStatus wbStatus;
+
+    bool serializeOnNextInst[MaxThreads];
 
     /** Probe points. */
     ProbePointArg<DynInstPtr> *ppMispredict;
@@ -154,7 +156,7 @@ class IEW
     /** To probe when instruction execution is complete. */
     ProbePointArg<DynInstPtr> *ppToCommit;
 
-    bool disp_stall = false;
+    StallSignals* stallSig;
 
   public:
     /** Constructs a IEW with the given parameters. */
@@ -222,17 +224,8 @@ class IEW
     /** Inst is ready to finish (The last cycle in FU) */
     void readyToFinish(const DynInstPtr &inst);
 
-    /** Inserts unused instructions of a thread into the skid buffer. */
-    void skidInsert(ThreadID tid);
-
-    /** Returns the max of the number of entries in all of the skid buffers. */
-    int skidCount();
-
-    /** Returns if all of the skid buffers are empty. */
-    bool skidsEmpty();
-
     /** Updates overall IEW status based on all of the stages' statuses. */
-    void updateStatus();
+    void updateActivate();
 
     /** Resets entries of the IQ and the LSQ. */
     void resetEntries();
@@ -304,9 +297,7 @@ class IEW
 
     uint32_t getIQInsts();
 
-    bool dispStall() {
-      return disp_stall;
-    }
+    void setStallSignals(StallSignals* stall_signals) { stallSig = stall_signals; }
 
   private:
     /** Sends commit proper information for a squash due to a branch
@@ -319,19 +310,10 @@ class IEW
      */
     void squashDueToMemOrder(const DynInstPtr &inst, ThreadID tid);
 
-    /** Sets Dispatch to blocked, and signals back to other stages to block. */
-    void block(ThreadID tid);
-
-    /** Unblocks Dispatch if the skid buffer is empty, and signals back to
-     * other stages to unblock.
-     */
-    void unblock(ThreadID tid);
-
-    /** Determines proper actions to take given Dispatch's status. */
-    void dispatch(ThreadID tid);
+    bool canInsertLDSTQue(ThreadID tid);
 
     /** Dispatches instructions to IQ and LSQ. */
-    void dispatchInsts(ThreadID tid);
+    void dispatchInsts();
 
     void dispatchInstFromRename(ThreadID tid);
 
@@ -339,7 +321,7 @@ class IEW
      *  first, dispatch the inst from DispatchQueue to IQ
      *  second, receive new inst from rename, store it to DQ
      */
-    void dispatchInstFromDispQue(ThreadID tid);
+    void dispatchInstFromDispQue();
     void classifyInstToDispQue(ThreadID tid);
 
     /** Executes instructions. In the case of memory operations, it informs the
@@ -355,17 +337,13 @@ class IEW
      */
     void writebackInsts();
 
-    /** Checks if any of the stall conditions are currently true. */
-    bool checkStall(ThreadID tid);
+    bool checkSerialize(const DynInstPtr& inst);
 
     /** Processes inputs and changes state accordingly. */
-    void checkSignalsAndUpdate(ThreadID tid);
-
-    /** Removes instructions from rename from a thread's instruction list. */
-    void emptyRenameInsts(ThreadID tid);
+    void checkSquash();
 
     /** Sorts instructions coming from rename into lists separated by thread. */
-    void sortInsts();
+    void moveInstsToBuffer();
 
   public:
     /** Ticks IEW stage, causing Dispatch, the IQ, the LSQ, Execute, and
@@ -411,10 +389,7 @@ class IEW
     TimeBuffer<IEWStruct>::wire toCommit;
 
     /** Queue of all instructions coming from rename this cycle. */
-    std::deque<DynInstPtr> insts[MaxThreads];
-
-    /** Skid buffer between rename and IEW. */
-    std::deque<DynInstPtr> skidBuffer[MaxThreads];
+    std::deque<DynInstPtr> fixedbuffer[MaxThreads];
 
     std::deque<DynInstPtr> dispQue[3];
 
@@ -442,8 +417,6 @@ class IEW
     Scheduler* getScheduler() { return scheduler; }
     /** Instruction queue. */
     InstructionQueue instQueue;
-    unsigned lastClockLQPopEntries[MaxThreads];
-    unsigned lastClockSQPopEntries[MaxThreads];
 
     /** Load / store queue. */
     LSQ ldstQueue;

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -640,7 +640,6 @@ InstructionQueue::scheduleReadyInsts()
 
         if (issued_inst->isSquashed()) {
             ++iqStats.squashedInstsIssued;
-            continue;
         }
 
         if (issued_inst->isFloating()) {

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -328,7 +328,7 @@ IssueQue::checkScoreboard(const DynInstPtr& inst)
         if (!scheduler->bypassScoreboard[src->flatIndex()]) [[unlikely]] {
             auto dst_inst = scheduler->getInstByDstReg(src->flatIndex());
             assert(dst_inst);
-            if (!dst_inst->isLoad()) panic("dst[sn:%llu] is not load", dst_inst->seqNum);
+            if (!dst_inst->isLoad()) panic("dst[sn:%llu] is not load, src[sn:%llu]", dst_inst->seqNum, inst->seqNum);
             warn_once(
                 "Tt's should not happen on classic cache, it may be wrong delay of load wake or missed loadcancel in "
                 "lsq\n");
@@ -1193,7 +1193,7 @@ Scheduler::insert(const DynInstPtr& inst, int disp_seq)
         iqs[dispSeqVec.at(disp_seq)]->insert(inst);
     }
 
-    DPRINTF(Schedule, "[sn:%llu] dispatch: %s\n", inst->seqNum, inst->staticInst->disassemble(0));
+    DPRINTF(Schedule, "[sn:%llu] scheduler insert: %s\n", inst->seqNum, inst->staticInst->disassemble(0));
 }
 
 void

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1661,10 +1661,15 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
     // All responses received in 1 cycle are cache hit.
     bool cacheHit = LSQRequest::_inst->getCpuPtr()->ticksToCycles(curTick() - pkt->sendTick) <= 1;
     // Dump inst num, request addr, and packet addr
-    DPRINTF(LSQ, "Single Req::recvTimingResp: inst: %llu, pkt: %#lx, isLoad: %d, "
-                "isLLSC: %d, isUncache: %d, isCachehit: %d, data: %d\n",
-                pkt->req->getReqInstSeqNum(), pkt->getAddr(), isLoad(), mainReq()->isLLSC(),
-                mainReq()->isUncacheable(), cacheHit, *(pkt->getPtr<uint64_t*>()));
+    if (debug::LSQ) {
+        char buffer[8];
+        std::memcpy(buffer, pkt->getPtr<char>(), pkt->getSize());
+        DPRINTF(LSQ, "Single Req::recvTimingResp: inst: %llu, pkt: %#lx, isLoad: %d, "
+                    "isLLSC: %d, isUncache: %d, isCachehit: %d, data: %d\n",
+                    pkt->req->getReqInstSeqNum(), pkt->getAddr(), isLoad(), mainReq()->isLLSC(),
+                    mainReq()->isUncacheable(), cacheHit, *((uint64_t*)buffer));
+    }
+
 
     if (isLoad()) {
         auto it = std::find(lsqUnit()->inflightLoads.begin(), lsqUnit()->inflightLoads.end(), this);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1194,6 +1194,8 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
             inst->setExecuted();
         }
     }
+    DPRINTF(LSQ, "[sn:%llu] isTranslationComplete %d, isMemAccessRequired %d, falut %d\n",
+        inst->seqNum, request->isTranslationComplete(), request->isMemAccessRequired(), inst->faulted());
 
     if (inst->traceData)
         inst->traceData->setMem(addr, size, flags);

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1910,7 +1910,6 @@ LSQUnit::commitLoad()
                 inst->lastWakeDependents - inst->firstIssue);
             stats.loadToUse.sample(load_to_use);
             if (((uint64_t) load_to_use) > 2000) {
-                inst->printDisassemblyAndResult(cpu->name());
                 DPRINTF(CommitTrace,
                         "Inst[sn:%lu] load2use = %lu, translation lat = %lu\n",
                         inst->seqNum, load_to_use, translation_lat);
@@ -2572,8 +2571,14 @@ LSQUnit::writebackReg(const DynInstPtr &inst, PacketPtr pkt)
         return;
     }
 
-    DPRINTF(LoadPipeline, "WritebackReg: %s [sn:%lli] data: %#lx\n", enums::OpClassStrings[inst->opClass()], inst->seqNum,
-        inst->memData ? *((uint64_t *)inst->memData) : 0);
+    if (debug::LoadPipeline) {
+        char buffer[8] = {0};
+        if (inst->memData)
+            std::memcpy(buffer, inst->memData, inst->effSize);
+        DPRINTF(LoadPipeline, "WritebackReg: %s [sn:%lli] data: %#lx\n", enums::OpClassStrings[inst->opClass()],
+                inst->seqNum, ((uint64_t *)buffer));
+    }
+
 
     if (!inst->isExecuted()) {
         inst->setExecuted();
@@ -3238,7 +3243,8 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
 
     // Check the SQ for any previous stores that might lead to forwarding
     auto store_it = load_inst->sqIt;
-    assert (store_it >= storeWBIt);
+    panic_if(store_it < storeWBIt, "[sn:%llu] Load instruction's store index is younger than store writeback index",
+             load_inst->seqNum);
     // End once we've reached the top of the LSQ
     while (store_it != storeWBIt && !load_inst->isDataPrefetch()) {
         // Move the index to one younger
@@ -3372,9 +3378,15 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                     }
                 }
 
-                DPRINTF(LoadPipeline, "Forwarding from store [sn:%llu] to load [sn:%llu] "
-                        "addr %#x, data: %#lx\n", store_it->instruction()->seqNum, load_inst->seqNum,
-                        request->mainReq()->getPaddr(), *((uint64_t*)load_inst->memData));
+                if (debug::LoadPipeline) {
+                    char buffer[8] = {0};
+                    if (load_inst->memData) std::memcpy(buffer, load_inst->memData, load_inst->effSize);
+                    DPRINTF(LoadPipeline, "Forwarding from store [sn:%llu] to load [sn:%llu] "
+                            "addr %#x, data: %#lx\n", store_it->instruction()->seqNum, load_inst->seqNum,
+                            request->mainReq()->getPaddr(), *((uint64_t*)buffer));
+                }
+
+
 
                 load_inst->setFullForward();
 
@@ -3439,8 +3451,12 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                 }
 
                 load_inst->setFullForward();
-                DPRINTF(LoadPipeline, "Load [sn:%llu] forward from sbuffer, data: %lx\n",
-                        load_inst->seqNum, *((uint64_t*)load_inst->memData));
+                if (debug::LoadPipeline) {
+                    char buffer[8] = {0};
+                    if (load_inst->memData) std::memcpy(buffer, load_inst->memData, load_inst->effSize);
+                    DPRINTF(LoadPipeline, "Load [sn:%llu] forward from sbuffer, data: %lx\n",
+                            load_inst->seqNum, *((uint64_t*)buffer));
+                }
 
                 return NoFault;
             }

--- a/src/cpu/o3/perfCCT.cc
+++ b/src/cpu/o3/perfCCT.cc
@@ -14,6 +14,7 @@ InstMeta::reset(const DynInstPtr inst)
     posTick.resize((int)PerfRecord::AtCommit + 1, 0);
     disasm = inst->staticInst->disassemble(inst->pcState().instAddr());
     pc = inst->pcState().instAddr();
+    value = 0;
 
     isload = inst->isLoad();
     vaddr = 0;
@@ -76,6 +77,10 @@ PerfCCT::updateInstMeta(InstSeqNum sn, const InstDetail detail, const uint64_t v
     }
     auto meta = getMeta(sn);
     switch (detail) {
+    case InstDetail::Result: {
+        meta->value = val;
+        break;
+    }
     case InstDetail::VAddress: {
         meta->vaddr = val;
         break;
@@ -109,8 +114,9 @@ PerfCCT::commitMeta(InstSeqNum sn)
     for (auto it = meta->posTick.begin() + 1; it != meta->posTick.end(); it++) {
         ss << "," << *it;
     }
+    ss << "," << (meta->value & 0x0fffffffffffffffllu);
     ss << ",\'" << meta->disasm << "\'";
-    ss << "," << meta->pc;
+    ss << "," << (meta->pc & 0x0fffffffffffffffllu);
     ss << ");";
     archdb->execmd(ss.str());
     ss.str(std::string());

--- a/src/cpu/o3/perfCCT.hh
+++ b/src/cpu/o3/perfCCT.hh
@@ -15,6 +15,7 @@ namespace o3
 
 enum class InstDetail
 {
+    Result,
     VAddress,
     PAddress,
     LastReplay,
@@ -53,6 +54,7 @@ class InstMeta
     std::vector<Tick> posTick;
     std::string disasm;
     Addr pc;
+    uint64_t value;
 
     bool isload;
     Addr vaddr;
@@ -67,7 +69,7 @@ class InstMeta
 // performanceCounter commitTrace
 class PerfCCT
 {
-    const int MaxMetas = 1500;  // same as MaxNum of DynInst
+    const int MaxMetas = 3000;  // same as MaxNum of DynInst
     bool enableCCT;
     ArchDBer* archdb;
     std::string sql_insert_cmd;

--- a/src/cpu/o3/regfile.hh
+++ b/src/cpu/o3/regfile.hh
@@ -48,11 +48,9 @@
 #include "arch/generic/isa.hh"
 #include "arch/vecregs.hh"
 #include "base/trace.hh"
-#include "config/the_isa.hh"
-#include "cpu/o3/comm.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/regfile.hh"
-#include "debug/IEW.hh"
+#include "debug/Scoreboard.hh"
 
 namespace gem5
 {
@@ -272,22 +270,22 @@ class PhysRegFile
         switch (type) {
           case IntRegClass:
             val = intRegFile.reg(idx);
-            DPRINTF(IEW, "RegFile: Access to int register %i, has data %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Access to int register %i, has data %#x\n",
                     idx, val);
             return val;
           case FloatRegClass:
             val = floatRegFile.reg(idx);
-            DPRINTF(IEW, "RegFile: Access to float register %i has data %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Access to float register %i has data %#x\n",
                     idx, val);
             return val;
           case VecElemClass:
             val = vectorElemRegFile.reg(idx);
-            DPRINTF(IEW, "RegFile: Access to vector element register %i "
+            DPRINTF(Scoreboard, "RegFile: Access to vector element register %i "
                     "has data %#x\n", idx, val);
             return val;
           case CCRegClass:
             val = ccRegFile.reg(idx);
-            DPRINTF(IEW, "RegFile: Access to cc register %i has data %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Access to cc register %i has data %#x\n",
                     idx, val);
             return val;
           case RMiscRegClass:
@@ -307,7 +305,7 @@ class PhysRegFile
         const RegClassType type = virt_reg.PhyReg()->classValue();
         const RegIndex idx = virt_reg.PhyReg()->index();
 
-        DPRINTF(IEW, "RegFile: trying to access %s register %i \n", type, idx);
+        DPRINTF(Scoreboard, "RegFile: trying to access %s register %i \n", type, idx);
         return virt_reg.correct(getReg(virt_reg.PhyReg()));
     }
 
@@ -326,7 +324,7 @@ class PhysRegFile
             break;
           case VecRegClass:
             vectorRegFile.get(idx, val);
-            DPRINTF(IEW, "RegFile: Access to vector register %i, has "
+            DPRINTF(Scoreboard, "RegFile: Access to vector register %i, has "
                     "data %s\n", idx, vectorRegFile.regClass.valString(val));
             break;
           case VecElemClass:
@@ -334,7 +332,7 @@ class PhysRegFile
             break;
           case VecPredRegClass:
             vecPredRegFile.get(idx, val);
-            DPRINTF(IEW, "RegFile: Access to predicate register %i, has "
+            DPRINTF(Scoreboard, "RegFile: Access to predicate register %i, has "
                     "data %s\n", idx, vecPredRegFile.regClass.valString(val));
             break;
           case CCRegClass:
@@ -375,22 +373,22 @@ class PhysRegFile
             break;
           case IntRegClass:
             intRegFile.reg(idx) = val;
-            DPRINTF(IEW, "RegFile: Setting int register %i to %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Setting int register %i to %#x\n",
                     idx, val);
             break;
           case FloatRegClass:
             floatRegFile.reg(idx) = val;
-            DPRINTF(IEW, "RegFile: Setting float register %i to %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Setting float register %i to %#x\n",
                     idx, val);
             break;
           case VecElemClass:
             vectorElemRegFile.reg(idx) = val;
-            DPRINTF(IEW, "RegFile: Setting vector element register %i to "
+            DPRINTF(Scoreboard, "RegFile: Setting vector element register %i to "
                     "%#x\n", idx, val);
             break;
           case CCRegClass:
             ccRegFile.reg(idx) = val;
-            DPRINTF(IEW, "RegFile: Setting cc register %i to %#x\n",
+            DPRINTF(Scoreboard, "RegFile: Setting cc register %i to %#x\n",
                     idx, val);
             break;
           case RMiscRegClass:
@@ -415,7 +413,7 @@ class PhysRegFile
             setReg(phys_reg, *(RegVal *)val);
             break;
           case VecRegClass:
-            DPRINTF(IEW, "RegFile: Setting vector register %i to %s\n",
+            DPRINTF(Scoreboard, "RegFile: Setting vector register %i to %s\n",
                     idx, vectorRegFile.regClass.valString(val));
             vectorRegFile.set(idx, val);
             break;
@@ -423,7 +421,7 @@ class PhysRegFile
             setReg(phys_reg, *(RegVal *)val);
             break;
           case VecPredRegClass:
-            DPRINTF(IEW, "RegFile: Setting predicate register %i to %s\n",
+            DPRINTF(Scoreboard, "RegFile: Setting predicate register %i to %s\n",
                     idx, vectorRegFile.regClass.valString(val));
             vecPredRegFile.set(idx, val);
             break;

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -50,7 +50,6 @@
 #include "debug/Activity.hh"
 #include "debug/O3PipeView.hh"
 #include "debug/Rename.hh"
-#include "debug/Counters.hh"
 #include "params/BaseO3CPU.hh"
 
 namespace gem5
@@ -74,20 +73,13 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              renameWidth, static_cast<int>(MaxWidth));
 
-    // @todo: Make into a parameter.
-    skidBufferMax = (decodeToRenameDelay + 1) * params.decodeWidth * 2;
     for (uint32_t tid = 0; tid < MaxThreads; tid++) {
-        renameStatus[tid] = Idle;
+        fixedbuffer[tid] = boost::circular_buffer<DynInstPtr>(renameWidth);
         renameMap[tid] = nullptr;
-        instsInProgress[tid] = 0;
-        loadsInProgress[tid] = 0;
-        storesInProgress[tid] = 0;
-        freeEntries[tid] = {0, 0, 0};
-        emptyROB[tid] = true;
         stalls[tid] = {false, false};
-        serializeInst[tid] = nullptr;
-        serializeOnNextInst[tid] = false;
     }
+
+    assert(decodeToRenameDelay == 1);
 
     renameStalls.resize(renameWidth, StallReason::NoStall);
 }
@@ -254,49 +246,19 @@ Rename::startupStage()
 void
 Rename::clearStates(ThreadID tid)
 {
-    renameStatus[tid] = Idle;
-
-    freeEntries[tid].lqEntries = iew_ptr->ldstQueue.numFreeLoadEntries(tid);
-    freeEntries[tid].sqEntries = iew_ptr->ldstQueue.numFreeStoreEntries(tid);
-    freeEntries[tid].robEntries = commit_ptr->numROBFreeEntries(tid);
-    emptyROB[tid] = true;
-
     stalls[tid].iew = false;
-    serializeInst[tid] = NULL;
-
-    instsInProgress[tid] = 0;
-    loadsInProgress[tid] = 0;
-    storesInProgress[tid] = 0;
-
-    serializeOnNextInst[tid] = false;
 }
 
 void
 Rename::resetStage()
 {
     _status = Inactive;
-
-    resumeSerialize = false;
     resumeUnblocking = false;
 
     // Grab the number of free entries directly from the stages.
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        renameStatus[tid] = Idle;
-        freeEntries[tid].lqEntries =
-            iew_ptr->ldstQueue.numFreeLoadEntries(tid);
-        freeEntries[tid].sqEntries =
-            iew_ptr->ldstQueue.numFreeStoreEntries(tid);
-        freeEntries[tid].robEntries = commit_ptr->numROBFreeEntries(tid);
-        emptyROB[tid] = true;
 
         stalls[tid].iew = false;
-        serializeInst[tid] = NULL;
-
-        instsInProgress[tid] = 0;
-        loadsInProgress[tid] = 0;
-        storesInProgress[tid] = 0;
-
-        serializeOnNextInst[tid] = false;
     }
 }
 
@@ -330,11 +292,8 @@ bool
 Rename::isDrained() const
 {
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        if (instsInProgress[tid] != 0 ||
-            !historyBuffer[tid].empty() ||
-            !skidBuffer[tid].empty() ||
-            !insts[tid].empty() ||
-            (renameStatus[tid] != Idle && renameStatus[tid] != Running))
+        if (!historyBuffer[tid].empty() ||
+            !fixedbuffer[tid].empty())
             return false;
     }
     return true;
@@ -351,9 +310,7 @@ Rename::drainSanityCheck() const
 {
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         assert(historyBuffer[tid].empty());
-        assert(insts[tid].empty());
-        assert(skidBuffer[tid].empty());
-        assert(instsInProgress[tid] == 0);
+        assert(fixedbuffer[tid].empty());
     }
 }
 
@@ -363,49 +320,7 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
     DPRINTF(Rename, "[tid:%i] [squash sn:%llu] Squashing instructions.\n",
         tid,squash_seq_num);
 
-    // Clear the stall signal if rename was blocked or unblocking before.
-    // If it still needs to block, the blocking should happen the next
-    // cycle and there should be space to hold everything due to the squash.
-    if (renameStatus[tid] == Blocked ||
-        renameStatus[tid] == Unblocking) {
-        toDecode->renameUnblock[tid] = 1;
-
-        resumeSerialize = false;
-        serializeInst[tid] = NULL;
-    } else if (renameStatus[tid] == SerializeStall) {
-        if (serializeInst[tid]->seqNum <= squash_seq_num) {
-            DPRINTF(Rename, "[tid:%i] [squash sn:%llu] "
-                "Rename will resume serializing after squash\n",
-                tid,squash_seq_num);
-            resumeSerialize = true;
-            assert(serializeInst[tid]);
-        } else {
-            resumeSerialize = false;
-            toDecode->renameUnblock[tid] = 1;
-
-            serializeInst[tid] = NULL;
-        }
-    }
-
-    // Set the status to Squashing.
-    renameStatus[tid] = Squashing;
-
-    // Squash any instructions from decode.
-    for (int i=0; i<fromDecode->size; i++) {
-        if (fromDecode->insts[i]->threadNumber == tid &&
-            fromDecode->insts[i]->seqNum > squash_seq_num) {
-            fromDecode->insts[i]->setSquashed();
-            wroteToTimeBuffer = true;
-        }
-
-    }
-
-    // Clear the instruction list and skid buffer in case they have any
-    // insts in them.
-    insts[tid].clear();
-
-    // Clear the skid buffer in case it has any data in it.
-    skidBuffer[tid].clear();
+    fixedbuffer[tid].clear();
 
     doSquash(squash_seq_num, tid);
 }
@@ -418,187 +333,96 @@ Rename::tick()
 
     wroteToTimeBuffer = false;
 
-    blockThisCycle = false;
-
     bool status_change = false;
 
-    toIEWIndex = 0;
+    moveInstsToBuffer();
 
-    sortInsts();
+    checkSquash();
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
+    releasePhysRegs();
 
-    // Check stall and squash signals.
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    // check threads stall & status
+    ThreadID tid = InvalidThreadID;
+    for (int i = 0; i < numThreads; i++) {
+        bool block = stallSig->blockRename[i] || !canRename(i);
+        bool active = !block && !fixedbuffer[i].empty();
+        DPRINTF(Rename, "[tid:%i] blockRename: %i, canRename: %i, block: %i, active: %i\n",
+                i, stallSig->blockRename[i], canRename(i), block, active);
 
-        DPRINTF(Rename, "Processing [tid:%i]\n", tid);
-
-        status_change = checkSignalsAndUpdate(tid) || status_change;
-
-        rename(status_change, tid);
-
-        toDecode->renameInfo[tid].blockReason = blockReason;
-    }
-
-    if (stalls[*threads].iew) {
-        setAllStalls(fromIEW->iewInfo[*threads].blockReason);
-    } else if (toIEWIndex == 0) {
-        if (renameStalls[0] != StallReason::NoStall) {
-            setAllStalls(renameStalls[0]);
-        } else {
-            // warn("rename have other stall reason!");
-        }
-    } else {
-        // no stall from rename, pass decode stall(no stall or decode stall)
-        // assert(renamed_insts != 0);
-        for (int i = 0; i < renameStalls.size(); i++) {
-            if (i < toIEWIndex) {
-                renameStalls.at(i) = StallReason::NoStall;
-            } else {
-                renameStalls.at(i) = fromDecode->decodeStallReason.at(i);
+        // if rename has no insts, no need to block decode, even if rename is blocked for other reasons
+        stallSig->blockDecode[i] = block && !fixedbuffer[i].empty();
+        if (active) {
+            if (tid == InvalidThreadID) tid = i;
+            else {
+                // if there are multiple active threads, must exhaust all threads first
+                // to avoid starvation of other threads and also avoid resource conflict
+                stallSig->blockDecode[tid] = true;
+                stallSig->blockDecode[i] = true;
+                DPRINTF(Rename, "Multiple active threads detected, blocking all threads\n");
             }
         }
     }
 
+    if (tid == InvalidThreadID) {
+        // all threads are stalled, no need to process
+        return;
+    }
+    DPRINTF(Rename, "Processing [tid:%i]\n", tid);
+
+    renameInsts(tid);
+
+    toDecode->renameInfo[tid].blockReason = blockReason;
+
     toIEW->renameStallReason = renameStalls;
 
-    if (status_change) {
-        updateStatus();
-    }
+    updateActivate();
 
     if (wroteToTimeBuffer || releaseSeq < finalCommitSeq) {
         DPRINTF(Activity, "Activity this cycle.\n");
         cpu->activityThisCycle();
     }
+}
 
-    threads = activeThreads->begin();
-
+void
+Rename::releasePhysRegs()
+{
+    // Release physical registers up to releaseWidth
+    auto threads = activeThreads->begin();
     if (releaseSeq + releaseWidth < finalCommitSeq) {
         releaseSeq += releaseWidth;
     } else {
         releaseSeq = finalCommitSeq;
     }
-
-    while (threads != end) {
+    while (threads != activeThreads->end()) {
         ThreadID tid = *threads++;
 
         removeFromHistory(releaseSeq, tid);
-
         // If we committed this cycle then doneSeqNum will be > 0
         if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&
-            !fromCommit->commitInfo[tid].squash &&
-            renameStatus[tid] != Squashing) {
+            !fromCommit->commitInfo[tid].squash) {
 
             finalCommitSeq = fromCommit->commitInfo[tid].doneSeqNum;
             releaseSeq = historyBuffer->empty() ? 0 : historyBuffer[tid].back().instSeqNum;
         }
     }
-
-    // @todo: make into updateProgress function
-    for (ThreadID tid = 0; tid < numThreads; tid++) {
-        instsInProgress[tid] -= fromIEW->iewInfo[tid].dispatched;
-        loadsInProgress[tid] -= fromIEW->iewInfo[tid].dispatchedToLQ;
-        storesInProgress[tid] -= fromIEW->iewInfo[tid].dispatchedToSQ;
-        assert(loadsInProgress[tid] >= 0);
-        assert(storesInProgress[tid] >= 0);
-        assert(instsInProgress[tid] >=0);
-    }
-
-}
-
-void
-Rename::rename(bool &status_change, ThreadID tid)
-{
-    // If status is Running or idle,
-    //     call renameInsts()
-    // If status is Unblocking,
-    //     buffer any instructions coming from decode
-    //     continue trying to empty skid buffer
-    //     check if stall conditions have passed
-
-    if (renameStatus[tid] == Blocked) {
-        ++stats.blockCycles;
-        setAllStalls(blockReason);
-    } else if (renameStatus[tid] == Squashing) {
-        ++stats.squashCycles;
-        setAllStalls(StallReason::SquashStall);
-    } else if (renameStatus[tid] == SerializeStall) {
-        ++stats.serializeStallCycles;
-        setAllStalls(StallReason::SerializeStall);
-        // If we are currently in SerializeStall and resumeSerialize
-        // was set, then that means that we are resuming serializing
-        // this cycle.  Tell the previous stages to block.
-        if (resumeSerialize) {
-            resumeSerialize = false;
-            blockReason = StallReason::SerializeStall;
-            block(tid);
-            toDecode->renameUnblock[tid] = false;
-        }
-    } else if (renameStatus[tid] == Unblocking) {
-        if (resumeUnblocking) {
-            blockReason = StallReason::ResumeUnblock;
-            block(tid);
-            resumeUnblocking = false;
-            toDecode->renameUnblock[tid] = false;
-        }
-    }
-
-    if (renameStatus[tid] == Running ||
-        renameStatus[tid] == Idle) {
-        DPRINTF(Rename,
-                "[tid:%i] "
-                "Not blocked, so attempting to run stage.\n",
-                tid);
-
-        renameInsts(tid);
-    } else if (renameStatus[tid] == Unblocking) {
-        renameInsts(tid);
-
-        if (validInsts()) {
-            // Add the current inputs to the skid buffer so they can be
-            // reprocessed when this stage unblocks.
-            skidInsert(tid);
-        }
-
-        // If we switched over to blocking, then there's a potential for
-        // an overall status change.
-        status_change = unblock(tid) || status_change || blockThisCycle;
-    }
 }
 
 bool
-Rename::canRename(ThreadID tid, int num_insts)
+Rename::canRename(ThreadID tid)
 {
     std::vector<int> demand_phy_regs(RMiscRegClass + 1, 0);
-    InstQueue &insts_to_rename = renameStatus[tid] == Unblocking ?
-        skidBuffer[tid] : insts[tid];
+    auto& insts_to_rename = fixedbuffer[tid];
+    int num_insts = insts_to_rename.size();
 
     // calculate physical registers needed by these `num_insts` instructions
     for (int i = 0; i < num_insts; i++) {
         DynInstPtr inst = insts_to_rename.at(i);
-        if (inst->isLoad()) {
-            if (calcFreeLQEntries(tid) <= 0) {
-                break;
-            }
-        } else if (inst->isStore() || inst->isAtomic()) {
-            if (calcFreeSQEntries(tid) <= 0) {
-                break;
-            }
-        }
         if (inst->isSquashed()) {
             continue;
         }
-        if (inst->isSerializeBefore() && !inst->isSerializeHandled()) {
-            break;
-        }
+
         for (int j = 0; j < RMiscRegClass + 1 ; j++) {
             demand_phy_regs[j] += inst->numDestRegs((RegClassType)j);
-        }
-        if ((inst->isStoreConditional() || inst->isSerializeAfter()) &&
-            !inst->isSerializeHandled()) {
-            break;
         }
     }
 
@@ -622,6 +446,11 @@ Rename::canRename(ThreadID tid, int num_insts)
     // check if the demand registers can be satisfied or not
     for (int i = 0; i < RMiscRegClass + 1; i++) {
         if (demand_phy_regs[i] > renameMap[tid]->numFreeEntries((RegClassType)i)) {
+            DPRINTF(Rename,
+                    "[tid:%i] Cannot rename because demand for %s physical "
+                    "registers is %i, but only %i are free.\n",
+                    tid, RegId((RegClassType)i, 0).className(), demand_phy_regs[i],
+                    renameMap[tid]->numFreeEntries((RegClassType)i));
             return false;
         }
     }
@@ -633,173 +462,25 @@ Rename::renameInsts(ThreadID tid)
 {
     // Instructions can be either in the skid buffer or the queue of
     // instructions coming from decode, depending on the status.
-    int insts_available = renameStatus[tid] == Unblocking ?
-        skidBuffer[tid].size() : insts[tid].size();
-
-    int instsAvailable = insts_available;
-
-    // Check the decode queue to see if instructions are available.
-    // If there are no available instructions to rename, then do nothing.
-    if (insts_available == 0) {
-        DPRINTF(Rename, "[tid:%i] Nothing to do, breaking out early.\n",
-                tid);
-        // Should I change status to idle?
-        ++stats.idleCycles;
-
-        StallReason stall = StallReason::NoStall;
-        for (auto iter : fromDecode->decodeStallReason) {
-            if (iter != StallReason::NoStall) {
-                stall = iter;
-                break;
-            }
-        }
-        setAllStalls(stall);
-
-        return;
-    } else if (renameStatus[tid] == Unblocking) {
-        ++stats.unblockCycles;
-    } else if (renameStatus[tid] == Running) {
-        ++stats.runCycles;
-    }
-
-    // Will have to do a different calculation for the number of free
-    // entries.
-    int free_rob_entries = calcFreeROBEntries(tid);
-    int free_iq_entries  = calcFreeIQEntries(tid);
-    int min_free_entries = free_rob_entries;
-
-    DPRINTF(Rename, "free_rob_entries=%d, free_iq_entries=%d, insts_available=%d\n",
-            free_rob_entries, free_iq_entries, insts_available);
-
-    FullSource source = ROB;
-
-    if (free_iq_entries < min_free_entries) {
-        min_free_entries = free_iq_entries;
-        source = IQ;
-    }
-
-    // Check if there's any space left.
-    if (min_free_entries <= 0) {
-        DPRINTF(Rename,
-                "[tid:%i] Blocking due to no free ROB/IQ/ entries.\n"
-                "ROB has %i free entries.\n"
-                "IQ has %i free entries.\n",
-                tid, free_rob_entries, free_iq_entries);
-
-        blockThisCycle = true;
-
-        block(tid);
-
-        incrFullStat(source);
-
-        setAllStalls(checkRenameStallFromIEW(tid));
-
-        return;
-    } else if (min_free_entries < insts_available) {
-        DPRINTF(Rename,
-                "[tid:%i] "
-                "Will have to block this cycle. "
-                "%i insts available, "
-                "but only %i insts can be renamed due to ROB/IQ/LSQ limits.\n",
-                tid, insts_available, min_free_entries);
-
-        insts_available = min_free_entries;
-
-        blockThisCycle = true;
-
-        blockReason = checkRenameStallFromIEW(tid);
-
-        incrFullStat(source);
-    }
-
-    InstQueue &insts_to_rename = renameStatus[tid] == Unblocking ?
-        skidBuffer[tid] : insts[tid];
-
-    DPRINTF(Rename,
-            "[tid:%i] "
-            "%i available instructions to send iew.\n",
-            tid, insts_available);
-
-    DPRINTF(Rename,
-            "[tid:%i] "
-            "%i insts pipelining from Rename | "
-            "%i insts dispatched to IQ last cycle.\n",
-            tid, instsInProgress[tid], fromIEW->iewInfo[tid].dispatched);
-
-    // Handle serializing the next instruction if necessary.
-    if (serializeOnNextInst[tid]) {
-        if (emptyROB[tid] && instsInProgress[tid] == 0) {
-            // ROB already empty; no need to serialize.
-            serializeOnNextInst[tid] = false;
-        } else if (!insts_to_rename.empty()) {
-            insts_to_rename.front()->setSerializeBefore();
-        }
-    }
+    auto& insts_to_rename = fixedbuffer[tid];
+    int insts_available = insts_to_rename.size();
 
     int renamed_insts = 0;
+    int toIEWIndex = 0;
 
     std::queue<StallReason> rename_stalls;
 
     StallReason breakRename = StallReason::NoStall;
-
-    // Check here to make sure there are enough destination registers
-    // to rename to.  Otherwise block.
-    bool can_rename = canRename(tid, std::min((int)renameWidth, insts_available));
-    if (!can_rename) {
-        DPRINTF(Rename, "[tid:%i] Blocking due to no free physical registers to rename to.\n", tid);
-        blockThisCycle = true;
-        ++stats.fullRegistersEvents;
-    }
-
-    while (can_rename && insts_available > 0 &&  toIEWIndex < renameWidth) {
-        DPRINTF(Rename, "[tid:%i] Sending instructions to IEW.\n", tid);
+    while (insts_available > 0) {
 
         assert(!insts_to_rename.empty());
 
         DynInstPtr inst = insts_to_rename.front();
 
-        //For all kind of instructions, check ROB and IQ first For load
-        //instruction, check LQ size and take into account the inflight loads
-        //For store instruction, check SQ size and take into account the
-        //inflight stores
-
-        if (inst->isLoad()) {
-            if (calcFreeLQEntries(tid) <= 0) {
-                DPRINTF(Rename, "[tid:%i] Cannot rename due to no free LQ\n",
-                        tid);
-                source = LQ;
-                incrFullStat(source);
-                rename_stalls.push(checkRenameStallFromIEW(tid));
-                breakRename = checkRenameStallFromIEW(tid);
-                break;
-            }
-        }
-
-        if (inst->isStore() || inst->isAtomic()) {
-            if (calcFreeSQEntries(tid) <= 0) {
-                DPRINTF(Rename, "[tid:%i] Cannot rename due to no free SQ\n",
-                        tid);
-                source = SQ;
-                incrFullStat(source);
-                rename_stalls.push(checkRenameStallFromIEW(tid));
-                breakRename = checkRenameStallFromIEW(tid);
-                break;
-            }
-        }
-
         insts_to_rename.pop_front();
 
-        if (renameStatus[tid] == Unblocking) {
-            DPRINTF(Rename,
-                    "[tid:%i] "
-                    "Removing [sn:%llu] PC:%s from rename skidBuffer\n",
-                    tid, inst->seqNum, inst->pcState());
-        }
-
         if (inst->isSquashed()) {
-            DPRINTF(Rename,
-                    "[tid:%i] "
-                    "instruction %i with PC %s is squashed, skipping.\n",
+            DPRINTF(Rename, "[sn:%llu] instruction  with PC %s is squashed, skipping.\n",
                     tid, inst->seqNum, inst->pcState());
 
             ++stats.squashedInsts;
@@ -812,69 +493,16 @@ Rename::renameInsts(ThreadID tid)
             continue;
         }
 
-        DPRINTF(Rename,
-                "[tid:%i] "
-                "Processing instruction [sn:%llu] with PC %s.\n",
-                tid, inst->seqNum, inst->pcState());
-
         assert(renameMap[tid]->canRename(inst));
 
-        // Handle serializeAfter/serializeBefore instructions.
-        // serializeAfter marks the next instruction as serializeBefore.
-        // serializeBefore makes the instruction wait in rename until the ROB
-        // is empty.
+        DPRINTF(Rename, "[tid:%i] [sn:%llu] Renaming instruction with PC %s.\n",
+            tid, inst->seqNum, inst->pcState());
 
-        // In this model, IPR accesses are serialize before
-        // instructions, and store conditionals are serialize after
-        // instructions.  This is mainly due to lack of support for
-        // out-of-order operations of either of those classes of
-        // instructions.
-        if (inst->isSerializeBefore() && !inst->isSerializeHandled()) {
-            DPRINTF(Rename, "Serialize before instruction encountered.\n");
-
-            if (!inst->isTempSerializeBefore()) {
-                stats.serializing++;
-                inst->setSerializeHandled();
-            } else {
-                stats.tempSerializing++;
-            }
-
-            // Change status over to SerializeStall so that other stages know
-            // what this is blocked on.
-            renameStatus[tid] = SerializeStall;
-
-            serializeInst[tid] = inst;
-
-            blockThisCycle = true;
-
-            blockReason = StallReason::SerializeStall;
-
-            rename_stalls.push(StallReason::SerializeStall);
-
-            breakRename = StallReason::SerializeStall;
-
-            break;
-        } else if ((inst->isStoreConditional() || inst->isSerializeAfter()) &&
-                   !inst->isSerializeHandled()) {
-            DPRINTF(Rename, "Serialize after instruction encountered.\n");
-
-            stats.serializing++;
-
-            inst->setSerializeHandled();
-
-            serializeAfter(insts_to_rename, tid);
-        }
         renameSrcRegs(inst, inst->threadNumber);
 
         renameDestRegs(inst, inst->threadNumber);
 
         cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtRename);
-
-        if (inst->isAtomic() || inst->isStore()) {
-            storesInProgress[tid]++;
-        } else if (inst->isLoad()) {
-            loadsInProgress[tid]++;
-        }
 
         ++renamed_insts;
         // Notify potential listeners that source and destination registers for
@@ -892,78 +520,47 @@ Rename::renameInsts(ThreadID tid)
         --insts_available;
     }
 
+    // Check if there's any instructions left that haven't yet been renamed.
+    // If so then block.
+    if (!fixedbuffer[tid].empty()) {
+        stallSig->blockDecode[tid] = true;
+        blockReason = breakRename;
+        DPRINTF(Rename, "[tid:%i] Stalling because there are still instructions to "
+                "rename.\n", tid);
+    }
+
     if (!rename_stalls.empty()) {
         setAllStalls(rename_stalls.front());
         rename_stalls.pop();
     } else if (breakRename != StallReason::NoStall) {
         setAllStalls(breakRename);
     }
-
-    instsInProgress[tid] += renamed_insts;
     stats.renamedInsts += renamed_insts;
 
     // If we wrote to the time buffer, record this.
     if (toIEWIndex) {
         wroteToTimeBuffer = true;
     }
-
-    // Check if there's any instructions left that haven't yet been renamed.
-    // If so then block.
-    if (insts_available) {
-        blockThisCycle = true;
-        blockReason = breakRename;
-    }
-
-    if (blockThisCycle) {
-        block(tid);
-        toDecode->renameUnblock[tid] = false;
-    }
 }
 
 void
-Rename::skidInsert(ThreadID tid)
-{
-    DynInstPtr inst = NULL;
-
-    while (!insts[tid].empty()) {
-        inst = insts[tid].front();
-
-        insts[tid].pop_front();
-
-        assert(tid == inst->threadNumber);
-
-        DPRINTF(Rename, "[tid:%i] Inserting [sn:%llu] PC: %s into Rename "
-                "skidBuffer\n", tid, inst->seqNum, inst->pcState());
-
-        ++stats.skidInsts;
-
-        skidBuffer[tid].push_back(inst);
-    }
-
-    if (skidBuffer[tid].size() > skidBufferMax) {
-        InstQueue::iterator it;
-        warn("Skidbuffer contents:\n");
-        for (it = skidBuffer[tid].begin(); it != skidBuffer[tid].end(); it++) {
-            warn("[tid:%i] %s [sn:%llu].\n", tid,
-                    (*it)->staticInst->disassemble(
-                        inst->pcState().instAddr()),
-                    (*it)->seqNum);
-        }
-        panic("Skidbuffer Exceeded Max Size");
-    }
-}
-
-void
-Rename::sortInsts()
+Rename::moveInstsToBuffer()
 {
     int insts_from_decode = fromDecode->size;
+    if (insts_from_decode == 0) {
+        return;
+    }
+    ThreadID tid = fromDecode->insts[0]->threadNumber;
     for (int i = 0; i < insts_from_decode; ++i) {
         const DynInstPtr &inst = fromDecode->insts[i];
+        assert(inst->threadNumber == tid);
         if (localSquashVer.largerThan(inst->getVersion())) {
             inst->setSquashed();
         } else {
-            insts[inst->threadNumber].push_back(inst);
+            assert(!fixedbuffer[tid].full());
+            fixedbuffer[tid].push_back(inst);
         }
+
 #if TRACING_ON
         if (debug::O3PipeView) {
             inst->renameTick = curTick() - inst->fetchTick;
@@ -972,38 +569,27 @@ Rename::sortInsts()
     }
 }
 
-bool
-Rename::skidsEmpty()
+void
+Rename::checkSquash()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
+    for (int i = 0; i < numThreads; i++) {
+        if (fromCommit->commitInfo[i].squash) {
+            DPRINTF(Rename, "[tid:%i] Squashing instructions due to squash from "
+                    "commit.\n", i);
 
-    while (threads != end) {
-        ThreadID tid = *threads++;
+            squash(fromCommit->commitInfo[i].doneSeqNum, i);
 
-        if (!skidBuffer[tid].empty())
-            return false;
+            localSquashVer.update(fromCommit->commitInfo[i].squashVersion.getVersion());
+            DPRINTF(Rename, "Updating squash version to %u\n",
+                    localSquashVer.getVersion());
+        }
     }
-
-    return true;
 }
 
 void
-Rename::updateStatus()
+Rename::updateActivate()
 {
-    bool any_unblocking = false;
-
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        if (renameStatus[tid] == Unblocking) {
-            any_unblocking = true;
-            break;
-        }
-    }
+    bool any_unblocking = true;
 
     // Rename will have activity if it's unblocking.
     if (any_unblocking) {
@@ -1024,59 +610,6 @@ Rename::updateStatus()
             cpu->deactivateStage(CPU::RenameIdx);
         }
     }
-}
-
-bool
-Rename::block(ThreadID tid)
-{
-    DPRINTF(Rename, "[tid:%i] Blocking.\n", tid);
-
-    // Add the current inputs onto the skid buffer, so they can be
-    // reprocessed when this stage unblocks.
-    skidInsert(tid);
-
-    // Only signal backwards to block if the previous stages do not think
-    // rename is already blocked.
-    if (renameStatus[tid] != Blocked) {
-        // If resumeUnblocking is set, we unblocked during the squash,
-        // but now we're have unblocking status. We need to tell earlier
-        // stages to block.
-        if (resumeUnblocking || renameStatus[tid] != Unblocking) {
-            toDecode->renameBlock[tid] = true;
-            toDecode->renameUnblock[tid] = false;
-            wroteToTimeBuffer = true;
-        }
-
-        // Rename can not go from SerializeStall to Blocked, otherwise
-        // it would not know to complete the serialize stall.
-        if (renameStatus[tid] != SerializeStall) {
-            // Set status to Blocked.
-            renameStatus[tid] = Blocked;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool
-Rename::unblock(ThreadID tid)
-{
-    DPRINTF(Rename, "[tid:%i] Trying to unblock.\n", tid);
-
-    // Rename is done unblocking if the skid buffer is empty.
-    if (skidBuffer[tid].empty() && renameStatus[tid] != SerializeStall) {
-
-        DPRINTF(Rename, "[tid:%i] Done unblocking.\n", tid);
-
-        toDecode->renameUnblock[tid] = true;
-        wroteToTimeBuffer = true;
-
-        renameStatus[tid] = Running;
-        return true;
-    }
-
-    return false;
 }
 
 void
@@ -1356,262 +889,6 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
     }
 }
 
-int
-Rename::calcFreeROBEntries(ThreadID tid)
-{
-    int num_free = freeEntries[tid].robEntries -
-                  (instsInProgress[tid] - fromIEW->iewInfo[tid].dispatched);
-
-    //DPRINTF(Rename,"[tid:%i] %i rob free\n",tid,num_free);
-
-    return num_free;
-}
-
-int
-Rename::calcFreeIQEntries(ThreadID tid)
-{
-    return iew_ptr->dispStall() ? 0 : 100;
-}
-
-int
-Rename::calcFreeLQEntries(ThreadID tid)
-{
-        int num_free = freeEntries[tid].lqEntries -
-            (loadsInProgress[tid] - fromIEW->iewInfo[tid].dispatchedToLQ);
-        DPRINTF(Rename,
-                "calcFreeLQEntries: free lqEntries: %d, loadsInProgress: %d, "
-                "loads dispatchedToLQ: %d\n",
-                freeEntries[tid].lqEntries, loadsInProgress[tid],
-                fromIEW->iewInfo[tid].dispatchedToLQ);
-        return num_free;
-}
-
-int
-Rename::calcFreeSQEntries(ThreadID tid)
-{
-        int num_free = freeEntries[tid].sqEntries -
-            (storesInProgress[tid] - fromIEW->iewInfo[tid].dispatchedToSQ);
-        DPRINTF(Rename, "calcFreeSQEntries: free sqEntries: %d, "
-                "storesInProgress: %d, stores dispatchedToSQ: %d\n",
-                freeEntries[tid].sqEntries, storesInProgress[tid],
-                fromIEW->iewInfo[tid].dispatchedToSQ);
-        return num_free;
-}
-
-unsigned
-Rename::validInsts()
-{
-    unsigned inst_count = 0;
-
-    for (int i=0; i<fromDecode->size; i++) {
-        if (!fromDecode->insts[i]->isSquashed())
-            inst_count++;
-    }
-
-    return inst_count;
-}
-
-void
-Rename::readStallSignals(ThreadID tid)
-{
-    if (fromIEW->iewBlock[tid]) {
-        stalls[tid].iew = true;
-    }
-
-    if (fromIEW->iewUnblock[tid]) {
-        assert(stalls[tid].iew);
-        stalls[tid].iew = false;
-    }
-}
-
-bool
-Rename::checkStall(ThreadID tid)
-{
-    bool ret_val = false;
-
-    if (stalls[tid].iew) {
-        DPRINTF(Rename,"[tid:%i] Stall from IEW stage detected.\n", tid);
-
-        blockReason = fromIEW->iewInfo[tid].blockReason;
-        ret_val = true;
-    } else if (calcFreeROBEntries(tid) <= 0) {
-        DPRINTF(Rename,"[tid:%i] Stall: ROB has 0 free entries.\n", tid);
-        blockReason = checkRenameStallFromIEW(tid);
-        ret_val = true;
-    } else if (calcFreeIQEntries(tid) <= 0) {
-        DPRINTF(Rename,"[tid:%i] Stall: IQ has 0 free entries.\n", tid);
-        blockReason = checkRenameStallFromIEW(tid);
-        ret_val = true;
-    } else if (calcFreeLQEntries(tid) <= 0 && calcFreeSQEntries(tid) <= 0) {
-        DPRINTF(Rename,"[tid:%i] Stall: LSQ has 0 free entries.\n", tid);
-        blockReason = checkRenameStallFromIEW(tid);
-        ret_val = true;
-    } else if (renameMap[tid]->numFreeEntries() <= 0) {
-        DPRINTF(Rename,"[tid:%i] Stall: RenameMap has 0 free entries.\n", tid);
-        blockReason = checkRenameStallFromIEW(tid);
-        ret_val = true;
-    } else if (renameStatus[tid] == SerializeStall &&
-               (!emptyROB[tid] || instsInProgress[tid])) {
-        DPRINTF(Rename,"[tid:%i] Stall: Serialize stall and ROB is not "
-                "empty.\n",
-                tid);
-        blockReason = StallReason::SerializeStall;
-        ret_val = true;
-    }
-
-    return ret_val;
-}
-
-void
-Rename::readFreeEntries(ThreadID tid)
-{
-    if (fromIEW->iewInfo[tid].usedLSQ) {
-        freeEntries[tid].lqEntries = fromIEW->iewInfo[tid].freeLQEntries;
-        freeEntries[tid].sqEntries = fromIEW->iewInfo[tid].freeSQEntries;
-    }
-
-    if (fromCommit->commitInfo[tid].usedROB) {
-        freeEntries[tid].robEntries =
-            fromCommit->commitInfo[tid].freeROBEntries;
-        emptyROB[tid] = fromCommit->commitInfo[tid].emptyROB;
-        if (emptyROB[tid])
-            DPRINTF(Rename, "[tid:%i] ROB is empty now.\n", tid);
-    }
-
-    DPRINTF(Rename, "[tid:%i] Free ROB: %i, "
-                    "Free LQ: %i, Free SQ: %i, FreeRM %i(%i %i %i %i %i %i)\n",
-            tid,
-            freeEntries[tid].robEntries,
-            freeEntries[tid].lqEntries,
-            freeEntries[tid].sqEntries,
-            renameMap[tid]->numFreeEntries(),
-            renameMap[tid]->numFreeEntries(IntRegClass),
-            renameMap[tid]->numFreeEntries(FloatRegClass),
-            renameMap[tid]->numFreeEntries(VecRegClass),
-            renameMap[tid]->numFreeEntries(VecElemClass),
-            renameMap[tid]->numFreeEntries(VecPredRegClass),
-            renameMap[tid]->numFreeEntries(CCRegClass));
-
-    DPRINTF(Rename, "[tid:%i] %i instructions not yet in ROB\n",
-            tid, instsInProgress[tid]);
-}
-
-bool
-Rename::checkSignalsAndUpdate(ThreadID tid)
-{
-    // Check if there's a squash signal, squash if there is
-    // Check stall signals, block if necessary.
-    // If status was blocked
-    //     check if stall conditions have passed
-    //         if so then go to unblocking
-    // If status was Squashing
-    //     check if squashing is not high.  Switch to running this cycle.
-    // If status was serialize stall
-    //     check if ROB is empty and no insts are in flight to the ROB
-
-    readFreeEntries(tid);
-    readStallSignals(tid);
-
-    if (fromCommit->commitInfo[tid].squash) {
-        DPRINTF(Rename, "[tid:%i] Squashing instructions due to squash from "
-                "commit.\n", tid);
-
-        squash(fromCommit->commitInfo[tid].doneSeqNum, tid);
-
-        localSquashVer.update(fromCommit->commitInfo[tid].squashVersion.getVersion());
-        DPRINTF(Rename, "Updating squash version to %u\n",
-                localSquashVer.getVersion());
-
-        return true;
-    }
-
-    if (checkStall(tid)) {
-        return block(tid);
-    }
-
-    if (renameStatus[tid] == Blocked) {
-        DPRINTF(Rename, "[tid:%i] Done blocking, switching to unblocking.\n",
-                tid);
-
-        renameStatus[tid] = Unblocking;
-
-        unblock(tid);
-
-        return true;
-    }
-
-    if (renameStatus[tid] == Squashing) {
-        // Switch status to running if rename isn't being told to block or
-        // squash this cycle.
-        if (resumeSerialize) {
-            DPRINTF(Rename,
-                    "[tid:%i] Done squashing, switching to serialize.\n", tid);
-
-            renameStatus[tid] = SerializeStall;
-            return true;
-        } else if (resumeUnblocking) {
-            DPRINTF(Rename,
-                    "[tid:%i] Done squashing, switching to unblocking.\n",
-                    tid);
-            renameStatus[tid] = Unblocking;
-            return true;
-        } else {
-            DPRINTF(Rename, "[tid:%i] Done squashing, switching to running.\n",
-                    tid);
-            renameStatus[tid] = Running;
-            return false;
-        }
-    }
-
-    if (renameStatus[tid] == SerializeStall) {
-        // Stall ends once the ROB is free.
-        DPRINTF(Rename, "[tid:%i] Done with serialize stall, switching to "
-                "unblocking.\n", tid);
-
-        DynInstPtr serial_inst = serializeInst[tid];
-
-        renameStatus[tid] = Unblocking;
-
-        unblock(tid);
-
-        DPRINTF(Rename, "[tid:%i] Processing instruction [%lli] with "
-                "PC %s.\n", tid, serial_inst->seqNum, serial_inst->pcState());
-
-        // Put instruction into queue here.
-        serial_inst->clearSerializeBefore();
-
-        if (!skidBuffer[tid].empty()) {
-            skidBuffer[tid].push_front(serial_inst);
-        } else {
-            insts[tid].push_front(serial_inst);
-        }
-
-        DPRINTF(Rename, "[tid:%i] Instruction must be processed by rename."
-                " Adding to front of list.\n", tid);
-
-        serializeInst[tid] = NULL;
-
-        return true;
-    }
-
-    // If we've reached this point, we have not gotten any signals that
-    // cause rename to change its status.  Rename remains the same as before.
-    return false;
-}
-
-void
-Rename::serializeAfter(InstQueue &inst_list, ThreadID tid)
-{
-    if (inst_list.empty()) {
-        // Mark a bit to say that I must serialize on the next instruction.
-        serializeOnNextInst[tid] = true;
-        return;
-    }
-
-    // Set the next instruction as serializing.
-    inst_list.front()->setSerializeBefore();
-}
-
 void
 Rename::incrFullStat(const FullSource &source)
 {
@@ -1675,18 +952,19 @@ StallReason
 Rename::checkRenameStallFromIEW(ThreadID tid)
 {
     StallReason robHeadStallReason = fromIEW->iewInfo[tid].robHeadStallReason;
+    return robHeadStallReason;
 
-    if (robHeadStallReason == StallReason::NoStall) {
-        if (calcFreeLQEntries(tid) <= 0) {
-            return fromIEW->iewInfo[tid].lqHeadStallReason;
-        } else if (calcFreeSQEntries(tid) <= 0) {
-            return fromIEW->iewInfo[tid].sqHeadStallReason;
-        } else {
-            return robHeadStallReason;
-        }
-    } else {
-        return robHeadStallReason;
-    }
+    // if (robHeadStallReason == StallReason::NoStall) {
+    //     if (calcFreeLQEntries(tid) <= 0) {
+    //         return fromIEW->iewInfo[tid].lqHeadStallReason;
+    //     } else if (calcFreeSQEntries(tid) <= 0) {
+    //         return fromIEW->iewInfo[tid].sqHeadStallReason;
+    //     } else {
+    //         return robHeadStallReason;
+    //     }
+    // } else {
+    //     return robHeadStallReason;
+    // }
 }
 
 } // namespace o3

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -332,8 +332,8 @@ Rename::tick()
     toIEW->decodeStallReason = fromDecode->decodeStallReason;
 
     wroteToTimeBuffer = false;
-
-    bool status_change = false;
+    blockReason = StallReason::NoStall;
+    setAllStalls(StallReason::NoStall);
 
     moveInstsToBuffer();
 
@@ -343,14 +343,28 @@ Rename::tick()
 
     // check threads stall & status
     ThreadID tid = InvalidThreadID;
+    ThreadID blocked_tid = InvalidThreadID;
     for (int i = 0; i < numThreads; i++) {
-        bool block = stallSig->blockRename[i] || !canRename(i);
+        bool can_rename = canRename(i);
+        bool block = stallSig->blockRename[i] || !can_rename;
         bool active = !block && !fixedbuffer[i].empty();
+        StallReason block_reason = StallReason::NoStall;
+        if (stallSig->blockRename[i]) {
+            block_reason = stallSig->renameBlockReason[i];
+        } else if (!can_rename) {
+            block_reason = checkRenameStallFromIEW(i);
+            if (block_reason == StallReason::NoStall) {
+                block_reason = StallReason::OtherStall;
+            }
+        }
         DPRINTF(Rename, "[tid:%i] blockRename: %i, canRename: %i, block: %i, active: %i\n",
-                i, stallSig->blockRename[i], canRename(i), block, active);
+                i, stallSig->blockRename[i], can_rename, block, active);
 
         // if rename has no insts, no need to block decode, even if rename is blocked for other reasons
         stallSig->blockDecode[i] = block && !fixedbuffer[i].empty();
+        stallSig->decodeBlockReason[i] =
+            stallSig->blockDecode[i] ? block_reason : StallReason::NoStall;
+        toDecode->renameInfo[i].blockReason = stallSig->decodeBlockReason[i];
         if (active) {
             if (tid == InvalidThreadID) tid = i;
             else {
@@ -360,18 +374,39 @@ Rename::tick()
                 stallSig->blockDecode[i] = true;
                 DPRINTF(Rename, "Multiple active threads detected, blocking all threads\n");
             }
+        } else if (stallSig->blockDecode[i] && blocked_tid == InvalidThreadID) {
+            blocked_tid = i;
         }
     }
 
     if (tid == InvalidThreadID) {
         // all threads are stalled, no need to process
+        if (blocked_tid != InvalidThreadID) {
+            setAllStalls(stallSig->decodeBlockReason[blocked_tid]);
+            blockReason = stallSig->decodeBlockReason[blocked_tid];
+        }
+        toIEW->renameStallReason = renameStalls;
+        updateActivate();
         return;
     }
     DPRINTF(Rename, "Processing [tid:%i]\n", tid);
 
     renameInsts(tid);
+    if (stallSig->blockRename[tid]) {
+        setAllStalls(stallSig->renameBlockReason[tid]);
+    } else if (toIEW->size > 0 && renameStalls[0] == StallReason::NoStall) {
+        for (int i = 0; i < renameStalls.size(); i++) {
+            if (i < toIEW->size) {
+                renameStalls.at(i) = StallReason::NoStall;
+            } else {
+                renameStalls.at(i) = fromDecode->decodeStallReason.at(i);
+            }
+        }
+    }
 
-    toDecode->renameInfo[tid].blockReason = blockReason;
+    stallSig->decodeBlockReason[tid] =
+        stallSig->blockDecode[tid] ? blockReason : StallReason::NoStall;
+    toDecode->renameInfo[tid].blockReason = stallSig->decodeBlockReason[tid];
 
     toIEW->renameStallReason = renameStalls;
 
@@ -524,6 +559,12 @@ Rename::renameInsts(ThreadID tid)
     // If so then block.
     if (!fixedbuffer[tid].empty()) {
         stallSig->blockDecode[tid] = true;
+        if (breakRename == StallReason::NoStall) {
+            breakRename = checkRenameStallFromIEW(tid);
+            if (breakRename == StallReason::NoStall) {
+                breakRename = StallReason::OtherStall;
+            }
+        }
         blockReason = breakRename;
         DPRINTF(Rename, "[tid:%i] Stalling because there are still instructions to "
                 "rename.\n", tid);

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -354,7 +354,9 @@ Rename::tick()
         } else if (!can_rename) {
             block_reason = checkRenameStallFromIEW(i);
             if (block_reason == StallReason::NoStall) {
-                block_reason = StallReason::OtherStall;
+                block_reason = StallReason::RegFull;
+                ++stats.fullRegistersEvents;
+                stats.stallEvents[RegFull]++;
             }
         }
         DPRINTF(Rename, "[tid:%i] blockRename: %i, canRename: %i, block: %i, active: %i\n",
@@ -562,7 +564,9 @@ Rename::renameInsts(ThreadID tid)
         if (breakRename == StallReason::NoStall) {
             breakRename = checkRenameStallFromIEW(tid);
             if (breakRename == StallReason::NoStall) {
-                breakRename = StallReason::OtherStall;
+                breakRename = StallReason::RegFull;
+                ++stats.fullRegistersEvents;
+                stats.stallEvents[RegFull]++;
             }
         }
         blockReason = breakRename;
@@ -993,19 +997,21 @@ StallReason
 Rename::checkRenameStallFromIEW(ThreadID tid)
 {
     StallReason robHeadStallReason = fromIEW->iewInfo[tid].robHeadStallReason;
-    return robHeadStallReason;
+    if (robHeadStallReason != StallReason::NoStall) {
+        return robHeadStallReason;
+    }
 
-    // if (robHeadStallReason == StallReason::NoStall) {
-    //     if (calcFreeLQEntries(tid) <= 0) {
-    //         return fromIEW->iewInfo[tid].lqHeadStallReason;
-    //     } else if (calcFreeSQEntries(tid) <= 0) {
-    //         return fromIEW->iewInfo[tid].sqHeadStallReason;
-    //     } else {
-    //         return robHeadStallReason;
-    //     }
-    // } else {
-    //     return robHeadStallReason;
-    // }
+    StallReason lqHeadStallReason = fromIEW->iewInfo[tid].lqHeadStallReason;
+    if (lqHeadStallReason != StallReason::NoStall) {
+        return lqHeadStallReason;
+    }
+
+    StallReason sqHeadStallReason = fromIEW->iewInfo[tid].sqHeadStallReason;
+    if (sqHeadStallReason != StallReason::NoStall) {
+        return sqHeadStallReason;
+    }
+
+    return StallReason::NoStall;
 }
 
 } // namespace o3

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -444,7 +444,7 @@ class Rename
 
     std::vector<StallReason> renameStalls;
 
-    StallReason blockReason;
+    StallReason blockReason{NoStall};
 
     void setAllStalls(StallReason renameStall);
 

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -123,9 +123,6 @@ class Rename
     /** Rename status. */
     RenameStatus _status;
 
-    /** Per-thread status. */
-    ThreadStatus renameStatus[MaxThreads];
-
     /** Probe points. */
     typedef std::pair<InstSeqNum, PhysRegIdPtr> SeqNumRegPair;
     /** To probe when register renaming for an instruction is complete */
@@ -211,16 +208,11 @@ class Rename
     /** Debugging function used to dump history buffer of renamings. */
     void dumpHistory();
 
+    void setStallSignals(StallSignals* stall_signals) { stallSig = stall_signals; }
+
   private:
     /** Reset this pipeline stage */
     void resetStage();
-
-    /** Determines what to do based on rename's current status.
-     * @param status_change rename() sets this variable if there was a status
-     * change (ie switching from blocking to unblocking).
-     * @param tid Thread id to rename instructions from.
-     */
-    void rename(bool &status_change, ThreadID tid);
 
     /** Renames instructions for the given thread. Also handles serializing
      * instructions.
@@ -228,35 +220,19 @@ class Rename
     void renameInsts(ThreadID tid);
 
     /** Checks if the rename map can rename all the given number of instructions this cycle. */
-    bool canRename(ThreadID tid, int num_insts);
+    bool canRename(ThreadID tid);
 
-    /** Inserts unused instructions from a given thread into the skid buffer,
-     * to be renamed once rename unblocks.
-     */
-    void skidInsert(ThreadID tid);
+    void releasePhysRegs();
 
     /** Separates instructions from decode into individual lists of instructions
      * sorted by thread.
      */
-    void sortInsts();
+    void moveInstsToBuffer();
 
-    /** Returns if all of the skid buffers are empty. */
-    bool skidsEmpty();
+    void checkSquash();
 
     /** Updates overall rename status based on all of the threads' statuses. */
-    void updateStatus();
-
-    /** Switches rename to blocking, and signals back that rename has become
-     * blocked.
-     * @return Returns true if there is a status change.
-     */
-    bool block(ThreadID tid);
-
-    /** Switches rename to unblocking if the skid buffer is empty, and signals
-     * back that rename has unblocked.
-     * @return Returns true if there is a status change.
-     */
-    bool unblock(ThreadID tid);
+    void updateActivate();
 
     /** Executes actual squash, removing squashed instructions. */
     void doSquash(const InstSeqNum &squash_seq_num, ThreadID tid);
@@ -269,42 +245,6 @@ class Rename
 
     /** Renames the destination registers of an instruction. */
     void renameDestRegs(const DynInstPtr &inst, ThreadID tid);
-
-    /** Calculates the number of free ROB entries for a specific thread. */
-    int calcFreeROBEntries(ThreadID tid);
-
-    /** Calculates the number of free IQ entries for a specific thread. */
-    int calcFreeIQEntries(ThreadID tid);
-
-    /** Calculates the number of free LQ entries for a specific thread. */
-    int calcFreeLQEntries(ThreadID tid);
-
-    /** Calculates the number of free SQ entries for a specific thread. */
-    int calcFreeSQEntries(ThreadID tid);
-
-    /** Returns the number of valid instructions coming from decode. */
-    unsigned validInsts();
-
-    /** Reads signals telling rename to block/unblock. */
-    void readStallSignals(ThreadID tid);
-
-    /** Checks if any stages are telling rename to block. */
-    bool checkStall(ThreadID tid);
-
-    /** Gets the number of free entries for a specific thread. */
-    void readFreeEntries(ThreadID tid);
-
-    /** Checks the signals and updates the status. */
-    bool checkSignalsAndUpdate(ThreadID tid);
-
-    /** Either serializes on the next instruction available in the InstQueue,
-     * or records that it must serialize on the next instruction to enter
-     * rename.
-     * @param inst_list The list of younger, unprocessed instructions for the
-     * thread that has the serializeAfter instruction.
-     * @param tid The thread id.
-     */
-    void serializeAfter(InstQueue &inst_list, ThreadID tid);
 
     /** Holds the information for each destination register rename. It holds
      * the instruction's sequence number, the arch register, the old physical
@@ -370,10 +310,7 @@ class Rename
     TimeBuffer<DecodeStruct>::wire fromDecode;
 
     /** Queue of all instructions coming from decode this cycle. */
-    InstQueue insts[MaxThreads];
-
-    /** Skid buffer between rename and decode. */
-    InstQueue skidBuffer[MaxThreads];
+    boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
 
     /** Rename map interface. */
     UnifiedRenameMap *renameMap[MaxThreads];
@@ -387,46 +324,10 @@ class Rename
     /** Pointer to the scoreboard. */
     Scoreboard *scoreboard;
 
-    /** Count of instructions in progress that have been sent off to the IQ
-     * and ROB, but are not yet included in their occupancy counts.
-     */
-    int instsInProgress[MaxThreads];
-
-    /** Count of Load instructions in progress that have been sent off to the
-     * IQ and ROB, but are not yet included in their occupancy counts.
-     */
-    int loadsInProgress[MaxThreads];
-
-    /** Count of Store instructions in progress that have been sent off to the
-     * IQ and ROB, but are not yet included in their occupancy counts.
-     */
-    int storesInProgress[MaxThreads];
-
     /** Variable that tracks if decode has written to the time buffer this
      * cycle. Used to tell CPU if there is activity this cycle.
      */
     bool wroteToTimeBuffer;
-
-    /** Structures whose free entries impact the amount of instructions that
-     * can be renamed.
-     */
-    struct FreeEntries
-    {
-        unsigned robEntries;
-        unsigned lqEntries;
-        unsigned sqEntries;
-    };
-
-    /** Per-thread tracking of the number of free entries of back-end
-     * structures.
-     */
-    FreeEntries freeEntries[MaxThreads];
-
-    /** Records if the ROB is empty. In SMT mode the ROB may be dynamically
-     * partitioned between threads, so the ROB must tell rename when it is
-     * empty.
-     */
-    bool emptyROB[MaxThreads];
 
     /** Source of possible stalls. */
     struct Stalls
@@ -438,13 +339,7 @@ class Rename
     /** Tracks which stages are telling decode to stall. */
     Stalls stalls[MaxThreads];
 
-    /** The serialize instruction that rename has stalled on. */
-    DynInstPtr serializeInst[MaxThreads];
-
-    /** Records if rename needs to serialize on the next instruction for any
-     * thread.
-     */
-    bool serializeOnNextInst[MaxThreads];
+    StallSignals* stallSig;
 
     /** Delay between iew and rename, in ticks. */
     int iewToRenameDelay;
@@ -460,27 +355,12 @@ class Rename
 
     unsigned releaseWidth;
 
-    /** The index of the instruction in the time buffer to IEW that rename is
-     * currently using.
-     */
-    unsigned toIEWIndex;
-
-    /** Whether or not rename needs to block this cycle. */
-    bool blockThisCycle;
-
-    /** Whether or not rename needs to resume a serialize instruction
-     * after squashing. */
-    bool resumeSerialize;
-
     /** Whether or not rename needs to resume clearing out the skidbuffer
      * after squashing. */
     bool resumeUnblocking;
 
     /** The number of threads active in rename. */
     ThreadID numThreads;
-
-    /** The maximum skid buffer size. */
-    unsigned skidBufferMax;
 
     /** Enum to record the source of a structure full stall.  Can come from
      * either ROB, IQ, LSQ, and it is priortized in that order.

--- a/src/cpu/o3/rename_map.cc
+++ b/src/cpu/o3/rename_map.cc
@@ -108,16 +108,16 @@ SimpleRenameMap::rename(const RegId &arch_reg, const VirtRegId& bypass_reg)
         renamed_reg.PhyReg()->decrNumPinnedWrites();
     } else {
         renamed_reg.setPhyReg(freeList->getReg());
-        DPRINTF(Rename, "Get free reg p%i\n", renamed_reg.PhyReg()->flatIndex());
+        DPRINTF(Scoreboard, "Get free reg p%i\n", renamed_reg.PhyReg()->flatIndex());
         map[arch_reg.index()] = renamed_reg;
         renamed_reg.PhyReg()->setNumPinnedWrites(arch_reg.getNumPinnedWrites());
         renamed_reg.PhyReg()->setNumPinnedWritesToComplete(
             arch_reg.getNumPinnedWrites() + 1);
-        DPRINTF(Rename, "set refcnt of p%i to %i\n",
+        DPRINTF(Scoreboard, "set refcnt of p%i to %i\n",
                 renamed_reg.PhyReg()->flatIndex(), renamed_reg.PhyReg()->getRef());
     }
 
-    DPRINTF(Rename, "Renamed reg %d to physical reg %d (%d) old mapping was"
+    DPRINTF(Scoreboard, "Renamed reg %d to physical reg %d (%d) old mapping was"
             " %d (%d)\n",
             arch_reg, renamed_reg.PhyReg()->flatIndex(), renamed_reg.PhyReg()->flatIndex(),
             prev_reg.PhyReg()->flatIndex(), prev_reg.PhyReg()->flatIndex());

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -465,6 +465,24 @@ ROB::getHeadGroupLastDoneSeq(ThreadID tid)
     return 0;
 }
 
+InstSeqNum
+ROB::getHeadGroupLastNotReadySeq(ThreadID tid)
+{
+    if (!threadGroups[tid].empty() && threadGroups[tid].front() != 0) {
+        auto it = instList[tid].begin();
+        InstSeqNum seqnum = 0;
+        for (int i = 0; i < threadGroups[tid].front(); i++, it++) {
+            auto& inst = *it;
+            if (!inst->readyToCommit() || !inst->isExecuted() || inst->faulted()) {
+                seqnum = inst->seqNum;
+                break;
+            }
+        }
+        return seqnum;
+    }
+    return 0;
+}
+
 unsigned
 ROB::numFreeEntries(ThreadID tid)
 {
@@ -685,10 +703,10 @@ ROB::squash(InstSeqNum squash_num, ThreadID tid)
     if (!instList[tid].empty()) {
         InstIt tail_thread = instList[tid].end();
         tail_thread--;
-
         squashIt[tid] = tail_thread;
 
-        doSquash(tid);
+        // dont squash on current cycle
+        // doSquash(tid);
     }
 }
 
@@ -762,10 +780,10 @@ ROB::ROBStats::ROBStats(statistics::Group *parent)
 }
 
 DynInstPtr
-ROB::findInst(ThreadID tid, InstSeqNum squash_inst)
+ROB::findInst(ThreadID tid, InstSeqNum seqnum)
 {
     for (InstIt it = instList[tid].begin(); it != instList[tid].end(); it++) {
-        if ((*it)->seqNum == squash_inst) {
+        if ((*it)->seqNum == seqnum) {
             return *it;
         }
     }

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -436,8 +436,8 @@ ROB::isHeadGroupReady(ThreadID tid)
             }
 
             // if one group has barrier or non-speculative or fault
-            // this group must be committed
-            if (inst->readyToCommit() && (!inst->isExecuted() || inst->faulted())) {
+            // this group can commit directly.
+            if (inst->isNonSpeculative() || inst->isStoreConditional() || !inst->isExecuted() || inst->faulted()) {
                 return true;
             }
         }
@@ -459,24 +459,6 @@ ROB::getHeadGroupLastDoneSeq(ThreadID tid)
                 break;
             }
             seqnum = inst->seqNum;
-        }
-        return seqnum;
-    }
-    return 0;
-}
-
-InstSeqNum
-ROB::getHeadGroupLastNotReadySeq(ThreadID tid)
-{
-    if (!threadGroups[tid].empty() && threadGroups[tid].front() != 0) {
-        auto it = instList[tid].begin();
-        InstSeqNum seqnum = 0;
-        for (int i = 0; i < threadGroups[tid].front(); i++, it++) {
-            auto& inst = *it;
-            if (!inst->readyToCommit() || !inst->isExecuted() || inst->faulted()) {
-                seqnum = inst->seqNum;
-                break;
-            }
         }
         return seqnum;
     }

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -172,8 +172,6 @@ class ROB
 
     InstSeqNum getHeadGroupLastDoneSeq(ThreadID tid);
 
-    InstSeqNum getHeadGroupLastNotReadySeq(ThreadID tid);
-
     /** Re-adjust ROB partitioning. */
     void resetEntries();
 

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -142,7 +142,7 @@ class ROB
     /** Returns a pointer to the instruction with the given sequence if it is
      *  in the ROB.
      */
-    DynInstPtr findInst(ThreadID tid, InstSeqNum squash_inst);
+    DynInstPtr findInst(ThreadID tid, InstSeqNum seqnum);
 
     /** Returns pointer to the tail instruction within the ROB.  There is
      *  no guarantee as to the return value if the ROB is empty.
@@ -171,6 +171,8 @@ class ROB
     bool isHeadGroupReady(ThreadID tid);
 
     InstSeqNum getHeadGroupLastDoneSeq(ThreadID tid);
+
+    InstSeqNum getHeadGroupLastNotReadySeq(ThreadID tid);
 
     /** Re-adjust ROB partitioning. */
     void resetEntries();

--- a/src/cpu/reg_class.hh
+++ b/src/cpu/reg_class.hh
@@ -212,6 +212,9 @@ class RegId
     constexpr const char*
     className() const
     {
+        if (regClass == InvalidRegClass) {
+            return "InvalidRegClass";
+        }
         return regClassStrings[regClass];
     }
 


### PR DESCRIPTION
Change-Id: I9b599a4e0d704215ad1a3bf543dbd075384fe1f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Major pipeline rewrite: new time-buffered stage flow, consolidated per-thread local buffers, unified stall signaling, and reordered tick sequence for steadier instruction movement.

* **Bug Fixes**
  * Improved commit/ROB readiness and stall behavior to reduce starvation and incorrect ordering.
  * Safer load/memory handling and guarded diagnostics to avoid unsafe prints.

* **New Features**
  * Perf recording now captures per-instruction Result values for richer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->