### PR TITLE
Fix mstatus

### DIFF
--- a/.github/workflows/gem5-ideal-btb-0.3c.yml
+++ b/.github/workflows/gem5-ideal-btb-0.3c.yml
@@ -6,11 +6,6 @@ on:
   # Removed pull_request trigger, only can be triggered use *-align branches
 
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch to test (leave empty for current branch)'
-        required: false
-        type: string
 
 jobs:
   perf_test:

--- a/.github/workflows/gem5-ideal-btb-perf.yml
+++ b/.github/workflows/gem5-ideal-btb-perf.yml
@@ -8,11 +8,6 @@ on:
   
   # Support manual trigger
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch to test (leave empty for current branch)'
-        required: false
-        type: string
 
 jobs:
   perf_test:

--- a/.github/workflows/gem5-perf.yml
+++ b/.github/workflows/gem5-perf.yml
@@ -5,11 +5,6 @@ on:
     branches: [ xs-dev ]
   # Removed pull_request trigger - use /run-spec for on-demand testing
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch to test (leave empty for current branch)'
-        required: false
-        type: string
 
 jobs:
   perf_test:

--- a/.github/workflows/gem5-vector.yml
+++ b/.github/workflows/gem5-vector.yml
@@ -5,11 +5,6 @@ on:
     branches: [ xs-dev ]
   # Removed pull_request trigger
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch to test (leave empty for current branch)'
-        required: false
-        type: string
 
 jobs:
   vector-test:

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -20,6 +20,8 @@ jobs:
     name: XS-GEM5 - Running test checkpoints
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: |
@@ -34,6 +36,8 @@ jobs:
     name: XS-GEM5 - Running h test checkpoints
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: |
@@ -47,6 +51,8 @@ jobs:
     name: XS-GEM5 - Check memory corruption
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 debug
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
@@ -62,6 +68,8 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCB
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -80,6 +88,8 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCBV
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
@@ -98,6 +108,8 @@ jobs:
     name: XS-GEM5 - Test Multi-core + RV64GCB
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - name: Build GEM5 opt
         run: |
           CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
@@ -117,6 +129,8 @@ jobs:
     name: XS-GEM5 - Test fix L2TLB bugs
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -135,6 +149,8 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCBH
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -6,11 +6,6 @@ on:
   # Removed pull_request trigger - moved to pr-quick-check.yml (Tier 1)
   # can be triggered manually
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch to test (leave empty for current branch)'
-        required: false
-        type: string
 
 jobs:
   paralel_cpt_test:
@@ -20,8 +15,6 @@ jobs:
     name: XS-GEM5 - Running test checkpoints
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: |
@@ -36,8 +29,6 @@ jobs:
     name: XS-GEM5 - Running h test checkpoints
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: |
@@ -51,8 +42,6 @@ jobs:
     name: XS-GEM5 - Check memory corruption
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 debug
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
@@ -68,8 +57,6 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCB
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -88,8 +75,6 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCBV
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
@@ -108,8 +93,6 @@ jobs:
     name: XS-GEM5 - Test Multi-core + RV64GCB
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - name: Build GEM5 opt
         run: |
           CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
@@ -129,8 +112,6 @@ jobs:
     name: XS-GEM5 - Test fix L2TLB bugs
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -149,8 +130,6 @@ jobs:
     name: XS-GEM5 - Test new simulation script on RV64GCBH
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch_name || github.ref }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -162,5 +141,4 @@ jobs:
           mkdir -p $GEM5_HOME/util/xs_scripts/test_h
           cd $GEM5_HOME/util/xs_scripts/test_h
           bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
-
 

--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -90,18 +90,10 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
                 bits(tc->readMiscReg(MISCREG_MIDELEG), _code) != 0) {
                 prv = PRV_S;
             }
-            if (pp == PRV_U &&
-                bits(tc->readMiscReg(MISCREG_SIDELEG), _code) != 0) {
-                prv = PRV_U;
-            }
         } else {
             if (pp != PRV_M &&
                 bits(tc->readMiscReg(MISCREG_MEDELEG), _code) != 0) {
                 prv = PRV_S;
-            }
-            if (pp == PRV_U &&
-                bits(tc->readMiscReg(MISCREG_SEDELEG), _code) != 0) {
-                prv = PRV_U;
             }
         }
 
@@ -122,13 +114,7 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         int v = status.mprv ? status.mpv : tc->readMiscReg(MISCREG_VIRMODE);
         switch (prv) {
           case PRV_U:
-            cause = MISCREG_UCAUSE;
-            epc = MISCREG_UEPC;
-            tvec = MISCREG_UTVEC;
-            tval = MISCREG_UTVAL;
-
-            status.upie = status.uie;
-            status.uie = 0;
+            panic("Delegating interrupt to user mode is removed.");
             break;
           case PRV_S:
               if (prvh == PRV_HS) {

--- a/src/arch/riscv/faults.hh
+++ b/src/arch/riscv/faults.hh
@@ -90,13 +90,10 @@ enum ExceptionCode : uint64_t
     STORE_G_PAGE = 23,
     AMO_G_PAGE = 23,
 
-    INT_SOFTWARE_USER = 0,
     INT_SOFTWARE_SUPER = 1,
     INT_SOFTWARE_MACHINE = 3,
-    INT_TIMER_USER = 4,
     INT_TIMER_SUPER = 5,
     INT_TIMER_MACHINE = 7,
-    INT_EXT_USER = 8,
     INT_EXT_SUPER = 9,
     INT_EXT_MACHINE = 11,
     NumInterruptTypes

--- a/src/arch/riscv/gdb-xml/riscv-64bit-csr.xml
+++ b/src/arch/riscv/gdb-xml/riscv-64bit-csr.xml
@@ -10,17 +10,7 @@
 <feature name="org.gnu.gdb.riscv.csr">
   <reg name="cycle" bitsize="64"/>
   <reg name="time" bitsize="64"/>
-  <reg name="ustatus" bitsize="64"/>
-  <reg name="uie" bitsize="64"/>
-  <reg name="utvec" bitsize="64"/>
-  <reg name="uscratch" bitsize="64"/>
-  <reg name="uepc" bitsize="64"/>
-  <reg name="ucause" bitsize="64"/>
-  <reg name="utval" bitsize="64"/>
-  <reg name="uip" bitsize="64"/>
   <reg name="sstatus" bitsize="64"/>
-  <reg name="sedeleg" bitsize="64"/>
-  <reg name="sideleg" bitsize="64"/>
   <reg name="sie" bitsize="64"/>
   <reg name="stvec" bitsize="64"/>
   <reg name="scounteren" bitsize="64"/>

--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -70,18 +70,11 @@ class Interrupts : public BaseInterrupts
         INTERRUPT mask = 0;
         STATUS status = tc->readMiscReg(MISCREG_STATUS);
         INTERRUPT mideleg = tc->readMiscReg(MISCREG_MIDELEG);
-        INTERRUPT sideleg = tc->readMiscReg(MISCREG_SIDELEG);
         PrivilegeMode prv = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
         switch (prv) {
             case PRV_U:
-                mask.mei = (!sideleg.mei) | (sideleg.mei & status.uie);
-                mask.mti = (!sideleg.mti) | (sideleg.mti & status.uie);
-                mask.msi = (!sideleg.msi) | (sideleg.msi & status.uie);
-                mask.sei = (!sideleg.sei) | (sideleg.sei & status.uie);
-                mask.sti = (!sideleg.sti) | (sideleg.sti & status.uie);
-                mask.ssi = (!sideleg.ssi) | (sideleg.ssi & status.uie);
-                if (status.uie)
-                    mask.uei = mask.uti = mask.usi = 1;
+                mask.mei = mask.mti = mask.msi = 1;
+                mask.sei = mask.sti = mask.ssi = 1;
                 break;
             case PRV_S:
                 mask.mei = (!mideleg.mei) | (mideleg.mei & status.sie);
@@ -89,13 +82,11 @@ class Interrupts : public BaseInterrupts
                 mask.msi = (!mideleg.msi) | (mideleg.msi & status.sie);
                 if (status.sie)
                     mask.sei = mask.sti = mask.ssi = 1;
-                mask.uei = mask.uti = mask.usi = 0;
                 break;
             case PRV_M:
                 if (status.mie)
                      mask.mei = mask.mti = mask.msi = 1;
                 mask.sei = mask.sti = mask.ssi = 0;
-                mask.uei = mask.uti = mask.usi = 0;
                 break;
             default:
                 panic("Unknown privilege mode %d.", prv);
@@ -126,8 +117,7 @@ class Interrupts : public BaseInterrupts
         std::bitset<NumInterruptTypes> mask = globalMask();
         const std::vector<int> interrupt_order {
             INT_EXT_MACHINE, INT_TIMER_MACHINE, INT_SOFTWARE_MACHINE,
-            INT_EXT_SUPER, INT_TIMER_SUPER, INT_SOFTWARE_SUPER,
-            INT_EXT_USER, INT_TIMER_USER, INT_SOFTWARE_USER
+            INT_EXT_SUPER, INT_TIMER_SUPER, INT_SOFTWARE_SUPER
         };
         for (const int &id : interrupt_order)
             if (checkInterrupt(id) && mask[id])

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -210,8 +210,8 @@ namespace RiscvISA
     [MISCREG_PMPADDR14]     = "PMPADDR14",
     [MISCREG_PMPADDR15]     = "PMPADDR15",
 
-    [MISCREG_SEDELEG]       = "SEDELEG",
-    [MISCREG_SIDELEG]       = "SIDELEG",
+    [MISCREG_RESERVED01]    = "",
+    [MISCREG_RESERVED02]    = "",
     [MISCREG_STVEC]         = "STVEC",
     [MISCREG_SCOUNTEREN]    = "SCOUNTEREN",
     [MISCREG_SSCRATCH]      = "SSCRATCH",
@@ -220,11 +220,11 @@ namespace RiscvISA
     [MISCREG_STVAL]         = "STVAL",
     [MISCREG_SATP]          = "SATP",
 
-    [MISCREG_UTVEC]         = "UTVEC",
-    [MISCREG_USCRATCH]      = "USCRATCH",
-    [MISCREG_UEPC]          = "UEPC",
-    [MISCREG_UCAUSE]        = "UCAUSE",
-    [MISCREG_UTVAL]         = "UTVAL",
+    [MISCREG_RESERVED03]    = "",
+    [MISCREG_RESERVED04]    = "",
+    [MISCREG_RESERVED05]    = "",
+    [MISCREG_RESERVED06]    = "",
+    [MISCREG_RESERVED07]    = "",
     [MISCREG_FFLAGS]        = "FFLAGS",
     [MISCREG_FRM]           = "FRM",
 

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -729,14 +729,10 @@ ISA::setMiscReg(int misc_reg, RegVal val)
             break;
           case MISCREG_STATUS:
             {
-                // SXL and UXL are hard-wired to 64 bit
+                // Match NEMU CSR semantics: only writable MSTATUS fields update.
                 auto cur = readMiscRegNoEffect(misc_reg);
-                DPRINTF(RiscvMisc, "Value before and: %#lx\n", val);
-                val &= ~(STATUS_SXL_MASK | STATUS_UXL_MASK);
-                DPRINTF(RiscvMisc, "Value before or: %#lx\n", val);
-                val |= cur & (STATUS_SXL_MASK | STATUS_UXL_MASK);
-                DPRINTF(RiscvMisc, "Value after or: %#lx\n", val);
-                STATUS mstatus = val;
+                STATUS mstatus =
+                    ((cur & ~(NEMU_MSTATUS_WMASK)) | (val & NEMU_MSTATUS_WMASK));
                 mstatus.sd = mstatus.fs == 0x3 || mstatus.vs == 0x3;
                 setMiscRegNoEffect(misc_reg, mstatus);
             }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -55,14 +55,20 @@ decode QUADRANT {
                 if (status.fs == FPUStatus::OFF) {
                     return std::make_shared<IllegalInstFault>("FPU is off",
                                                                machInst);
-                } else {
-                    status.fs = 3;
-                    //xc->setMiscReg(MISCREG_STATUS,status);
-                    if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
-                        STATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
-                        vsstatus.fs = 3;
-                        xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
+                }
+                if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    if (vsstatus.fs == FPUStatus::OFF) {
+                        return std::make_shared<IllegalInstFault>(
+                                "FPU is off in virtual mode", machInst);
                     }
+                }
+                status.fs = 3;
+                //xc->setMiscReg(MISCREG_STATUS,status);
+                if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    vsstatus.fs = 3;
+                    xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
                 }
 
                 Fp2_bits = Mem;
@@ -137,6 +143,13 @@ decode QUADRANT {
                 if (status.fs == FPUStatus::OFF)
                     return std::make_shared<IllegalInstFault>("FPU is off",
                                                                machInst);
+                if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    if (vsstatus.fs == FPUStatus::OFF) {
+                        return std::make_shared<IllegalInstFault>(
+                                "FPU is off in virtual mode", machInst);
+                    }
+                }
 
                 Mem = Fp2_bits;
             }}, {{
@@ -346,14 +359,20 @@ decode QUADRANT {
                 if (status.fs == FPUStatus::OFF) {
                     return std::make_shared<IllegalInstFault>("FPU is off",
                                                           machInst);
-                } else {
-                    status.fs = 3;
-                    xc->setMiscReg(MISCREG_STATUS,status);
-                    if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
-                        STATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
-                        vsstatus.fs = 3;
-                        xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
+                }
+                if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    if (vsstatus.fs == FPUStatus::OFF) {
+                        return std::make_shared<IllegalInstFault>(
+                                "FPU is off in virtual mode", machInst);
                     }
+                }
+                status.fs = 3;
+                xc->setMiscReg(MISCREG_STATUS,status);
+                if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    vsstatus.fs = 3;
+                    xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
                 }
                 Fc1_bits = Mem;
             }}, {{
@@ -431,6 +450,17 @@ decode QUADRANT {
                 offset = CIMM6<5:3> << 3 |
                          CIMM6<2:0> << 6;
             }}, {{
+                STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                if (status.fs == FPUStatus::OFF)
+                    return std::make_shared<IllegalInstFault>("FPU is off",
+                                                               machInst);
+                if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                    VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                    if (vsstatus.fs == FPUStatus::OFF) {
+                        return std::make_shared<IllegalInstFault>(
+                                "FPU is off in virtual mode", machInst);
+                    }
+                }
                 Mem_ud = Fc2_bits;
             }}, {{
                 EA = sp + offset;
@@ -487,6 +517,13 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF)
                         return std::make_shared<IllegalInstFault>(
                                     "FPU is off", machInst);
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
+                        }
+                    }
                     freg_t fd;
                     fd = freg(f16(Mem_uh));
                     Fd_bits = fd.v;
@@ -496,14 +533,20 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF) {
                         return std::make_shared<IllegalInstFault>(
                                     "FPU is off", machInst);
-                    } else {
-                        status.fs = 3;
-                        xc->setMiscReg(MISCREG_STATUS,status);
-                        if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
-                            STATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
-                            vsstatus.fs = 3;
-                            xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
+                    }
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
                         }
+                    }
+                    status.fs = 3;
+                    xc->setMiscReg(MISCREG_STATUS,status);
+                    if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        vsstatus.fs = 3;
+                        xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
                     }
                     freg_t fd;
                     fd = freg(f32(Mem_uw));
@@ -514,14 +557,20 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF) {
                         return std::make_shared<IllegalInstFault>(
                                     "FPU is off", machInst);
-                    } else {
-                        status.fs = 3;
-                       // xc->setMiscReg(MISCREG_STATUS,status);
-                        if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
-                            STATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
-                            vsstatus.fs = 3;
-                            xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
+                    }
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
                         }
+                    }
+                    status.fs = 3;
+                   // xc->setMiscReg(MISCREG_STATUS,status);
+                    if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        vsstatus.fs = 3;
+                        xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
                     }
                     freg_t fd;
                     fd = freg(f64(Mem));
@@ -747,6 +796,13 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF)
                         return std::make_shared<IllegalInstFault>(
                                 "FPU is off", machInst);
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
+                        }
+                    }
 
                     Mem_uh = (uint16_t)Fs2_bits;
                 }}, inst_flags=[IsSplitStoreAddr, IsOper16, FloatMemWriteOp]);
@@ -755,6 +811,13 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF)
                         return std::make_shared<IllegalInstFault>(
                                 "FPU is off", machInst);
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
+                        }
+                    }
 
                     Mem_uw = (uint32_t)Fs2_bits;
                 }}, inst_flags=[IsSplitStoreAddr, IsOper32, FloatMemWriteOp]);
@@ -763,6 +826,13 @@ decode QUADRANT {
                     if (status.fs == FPUStatus::OFF)
                         return std::make_shared<IllegalInstFault>(
                                 "FPU is off", machInst);
+                    if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                        VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                        if (vsstatus.fs == FPUStatus::OFF) {
+                            return std::make_shared<IllegalInstFault>(
+                                    "FPU is off in virtual mode", machInst);
+                        }
+                    }
 
                     Mem_ud = Fs2_bits;
                 }}, inst_flags=[IsSplitStoreAddr, IsOper64, FloatMemWriteOp]);

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2129,13 +2129,6 @@ decode QUADRANT {
                             return std::make_shared<BreakpointFault>(
                                 xc->pcState());
                         }}, IsSerializeAfter, IsNonSpeculative, No_OpClass);
-                        0x2: uret({{
-                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                            status.uie = status.upie;
-                            status.upie = 1;
-                            xc->setMiscReg(MISCREG_STATUS, status);
-                            NPC = xc->readMiscReg(MISCREG_UEPC);
-                        }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                     }
                     0x8: decode RS2 {
                         0x2: sret({{

--- a/src/arch/riscv/isa/formats/fp.isa
+++ b/src/arch/riscv/isa/formats/fp.isa
@@ -39,6 +39,13 @@ def template FloatExecute {{
         STATUS status = xc->readMiscReg(MISCREG_STATUS);
         if (status.fs == FPUStatus::OFF)
             return std::make_shared<IllegalInstFault>("FPU is off", machInst);
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+            if (vsstatus.fs == FPUStatus::OFF) {
+                return std::make_shared<IllegalInstFault>(
+                        "FPU is off in virtual mode", machInst);
+            }
+        }
 
         %(op_decl)s;
         %(op_rd)s;

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -460,8 +460,7 @@ def template CSRExecute {{
                 break;
               case CSR_MIP: case CSR_MIE:
               case CSR_SIP: case CSR_SIE:
-              case CSR_UIP: case CSR_UIE:
-              case CSR_MSTATUS: case CSR_SSTATUS: case CSR_USTATUS:
+              case CSR_MSTATUS: case CSR_SSTATUS:
               case CSR_HSTATUS:
                 if (newdata_all != olddata_all) {
                     xc->setMiscReg(midx, newdata_all);

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -355,6 +355,44 @@ def template CSRExecute {{
 
         auto* isa = dynamic_cast<RiscvISA::ISA*>(xc->tcBase()->getIsaPtr());
         switch (csr) {
+          case CSR_FFLAGS:
+          case CSR_FRM:
+          case CSR_FCSR: {
+            STATUS status = xc->readMiscReg(MISCREG_STATUS);
+            if (status.fs == FPUStatus::OFF) {
+                return std::make_shared<IllegalInstFault>(
+                        "FPU CSR access with FS off\n", machInst);
+            }
+            if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                if (vsstatus.fs == FPUStatus::OFF) {
+                    return std::make_shared<IllegalInstFault>(
+                            "FPU CSR access with VS FS off\n", machInst);
+                }
+            }
+            break;
+          }
+          case CSR_VSTART:
+          case CSR_VXSAT:
+          case CSR_VXRM:
+          case CSR_VCSR:
+          case CSR_VL:
+          case CSR_VTYPE:
+          case CSR_VLENB: {
+            STATUS status = xc->readMiscReg(MISCREG_STATUS);
+            if (status.vs == 0) {
+                return std::make_shared<IllegalInstFault>(
+                        "Vector CSR access with VS off\n", machInst);
+            }
+            if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                if (vsstatus.vs == 0) {
+                    return std::make_shared<IllegalInstFault>(
+                            "Vector CSR access with VS VS off\n", machInst);
+                }
+            }
+            break;
+          }
           case CSR_SATP: {
             STATUS status = xc->readMiscReg(MISCREG_STATUS);
             if (pm == PRV_S && status.tvm == 1) {

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -204,8 +204,8 @@ enum MiscRegIndex
     MISCREG_PMPADDR14,
     MISCREG_PMPADDR15,
 
-    MISCREG_SEDELEG,
-    MISCREG_SIDELEG,
+    MISCREG_RESERVED01, // MISCREG_SEDELEG,
+    MISCREG_RESERVED02, // MISCREG_SIDELEG,
     MISCREG_STVEC,
     MISCREG_SCOUNTEREN,
     MISCREG_SSCRATCH,
@@ -214,11 +214,11 @@ enum MiscRegIndex
     MISCREG_STVAL,
     MISCREG_SATP,
 
-    MISCREG_UTVEC,
-    MISCREG_USCRATCH,
-    MISCREG_UEPC,
-    MISCREG_UCAUSE,
-    MISCREG_UTVAL,
+    MISCREG_RESERVED03, // MISCREG_UTVEC,
+    MISCREG_RESERVED04, // MISCREG_USCRATCH,
+    MISCREG_RESERVED05, // MISCREG_UEPC,
+    MISCREG_RESERVED06, // MISCREG_UCAUSE,
+    MISCREG_RESERVED07, // MISCREG_UTVAL,
     MISCREG_FFLAGS,
     MISCREG_FRM,
 
@@ -270,14 +270,6 @@ enum MiscRegIndex
 
 enum CSRIndex
 {
-    CSR_USTATUS = 0x000,
-    CSR_UIE = 0x004,
-    CSR_UTVEC = 0x005,
-    CSR_USCRATCH = 0x040,
-    CSR_UEPC = 0x041,
-    CSR_UCAUSE = 0x042,
-    CSR_UTVAL = 0x043,
-    CSR_UIP = 0x044,
     CSR_FFLAGS = 0x001,
     CSR_FRM = 0x002,
     CSR_FCSR = 0x003,
@@ -316,8 +308,6 @@ enum CSRIndex
     // HPMCOUNTERH rv32 only
 
     CSR_SSTATUS = 0x100,
-    CSR_SEDELEG = 0x102,
-    CSR_SIDELEG = 0x103,
     CSR_SIE = 0x104,
     CSR_STVEC = 0x105,
     CSR_SCOUNTEREN = 0x106,
@@ -507,14 +497,6 @@ struct CSRMetadata
 };
 
 const std::map<int, CSRMetadata> CSRData = {
-    {CSR_USTATUS, {"ustatus", MISCREG_STATUS}},
-    {CSR_UIE, {"uie", MISCREG_IE}},
-    {CSR_UTVEC, {"utvec", MISCREG_UTVEC}},
-    {CSR_USCRATCH, {"uscratch", MISCREG_USCRATCH}},
-    {CSR_UEPC, {"uepc", MISCREG_UEPC}},
-    {CSR_UCAUSE, {"ucause", MISCREG_UCAUSE}},
-    {CSR_UTVAL, {"utval", MISCREG_UTVAL}},
-    {CSR_UIP, {"uip", MISCREG_IP}},
     {CSR_FFLAGS, {"fflags", MISCREG_FFLAGS}},
     {CSR_FRM, {"frm", MISCREG_FRM}},
     {CSR_FCSR, {"fcsr", MISCREG_FFLAGS}}, // Actually FRM << 5 | FFLAGS
@@ -581,8 +563,6 @@ const std::map<int, CSRMetadata> CSRData = {
     {CSR_HPMCOUNTER31, {"hpmcounter31", MISCREG_HPMCOUNTER31}},
 
     {CSR_SSTATUS, {"sstatus", MISCREG_STATUS}},
-    {CSR_SEDELEG, {"sedeleg", MISCREG_SEDELEG}},
-    {CSR_SIDELEG, {"sideleg", MISCREG_SIDELEG}},
     {CSR_SIE, {"sie", MISCREG_IE}},
     {CSR_STVEC, {"stvec", MISCREG_STVEC}},
     {CSR_SCOUNTEREN, {"scounteren", MISCREG_SCOUNTEREN}},
@@ -765,10 +745,8 @@ BitUnion64(STATUS)
     Bitfield<8> spp;
     Bitfield<7> mpie;
     Bitfield<5> spie;
-    Bitfield<4> upie;
     Bitfield<3> mie;
     Bitfield<1> sie;
-    Bitfield<0> uie;
 EndBitUnion(STATUS)
 
 BitUnion64(HSTATUS)
@@ -845,13 +823,10 @@ EndBitUnion(HGATP)
 BitUnion64(INTERRUPT)
     Bitfield<11> mei;
     Bitfield<9> sei;
-    Bitfield<8> uei;
     Bitfield<7> mti;
     Bitfield<5> sti;
-    Bitfield<4> uti;
     Bitfield<3> msi;
     Bitfield<1> ssi;
-    Bitfield<0> usi;
 EndBitUnion(INTERRUPT)
 
 const off_t MXL_OFFSET = (sizeof(uint64_t) * 8 - 2);
@@ -917,10 +892,8 @@ const RegVal STATUS_VS_MASK = 3ULL << VS_OFFSET;
 const RegVal STATUS_SPP_MASK = 1ULL << 8;
 const RegVal STATUS_MPIE_MASK = 1ULL << 7;
 const RegVal STATUS_SPIE_MASK = 1ULL << 5;
-const RegVal STATUS_UPIE_MASK = 1ULL << 4;
 const RegVal STATUS_MIE_MASK = 1ULL << 3;
 const RegVal STATUS_SIE_MASK = 1ULL << 1;
-const RegVal STATUS_UIE_MASK = 1ULL << 0;
 const RegVal MSTATUS_WMASK_FS = 0x3UL << 13;
 const RegVal MSTATUS_WMASK_RVH = 3UL << 38;
 const RegVal MSTATUS_WMASK_RVV = 3UL << 9;
@@ -932,25 +905,16 @@ const RegVal SSTATUS_MASK = STATUS_SD_MASK | STATUS_UXL_MASK |
                             STATUS_XS_MASK | STATUS_FS_MASK |
                             STATUS_VS_MASK |
                             STATUS_SPP_MASK | STATUS_SPIE_MASK |
-                            STATUS_UPIE_MASK | STATUS_SIE_MASK |
-                            STATUS_UIE_MASK;
-const RegVal USTATUS_MASK = STATUS_SD_MASK | STATUS_MXR_MASK |
-                            STATUS_SUM_MASK | STATUS_XS_MASK |
-                            STATUS_FS_MASK | STATUS_VS_MASK |
-                            STATUS_UPIE_MASK | STATUS_UIE_MASK;
+                            STATUS_SIE_MASK;
 
 const RegVal MEI_MASK = 1ULL << 11;
 const RegVal SEI_MASK = 1ULL << 9;
-const RegVal UEI_MASK = 1ULL << 8;
 const RegVal MTI_MASK = 1ULL << 7;
 const RegVal STI_MASK = 1ULL << 5;
-const RegVal UTI_MASK = 1ULL << 4;
 const RegVal MSI_MASK = 1ULL << 3;
 const RegVal SSI_MASK = 1ULL << 1;
-const RegVal USI_MASK = 1ULL << 0;
 const RegVal NEMU_MIP_MASK =  ((1 << 9) | (1 << 5) | (1 << 2) |(1 << 1));
 const RegVal SI_MASK = SEI_MASK | STI_MASK | SSI_MASK;
-const RegVal UI_MASK = UEI_MASK | UTI_MASK | USI_MASK;
 const RegVal FFLAGS_MASK = (1 << FRM_OFFSET) - 1;
 const RegVal FRM_MASK = 0x7;
 const RegVal NEMU_MIE_MASK_BASE = 0xaaa;
@@ -959,9 +923,6 @@ const RegVal NEMU_LCOFI = 0;
 const RegVal NEMU_MIE_MASK = NEMU_MIE_MASK_BASE | NEMU_MIE_MASK_H | NEMU_LCOFI;
 
 const std::map<int, RegVal> CSRMasks = {
-    {CSR_USTATUS, USTATUS_MASK},
-    {CSR_UIE, UI_MASK},
-    {CSR_UIP, UI_MASK},
     {CSR_FFLAGS, FFLAGS_MASK},
     {CSR_FRM, FRM_MASK},
     {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},

--- a/src/arch/riscv/remote_gdb.cc
+++ b/src/arch/riscv/remote_gdb.cc
@@ -212,31 +212,9 @@ RemoteGDB::RiscvGdbRegCache::getRegs(ThreadContext *context)
     r.time = context->readMiscRegNoEffect(
         CSRData.at(CSR_TIME).physIndex);
 
-    // U mode CSR
-    r.ustatus = context->readMiscRegNoEffect(
-        CSRData.at(CSR_USTATUS).physIndex) & CSRMasks.at(CSR_USTATUS);
-    r.uie = context->readMiscReg(
-        CSRData.at(CSR_UIE).physIndex) & CSRMasks.at(CSR_UIE);
-    r.utvec = context->readMiscRegNoEffect(
-        CSRData.at(CSR_UTVEC).physIndex);
-    r.uscratch = context->readMiscRegNoEffect(
-        CSRData.at(CSR_USCRATCH).physIndex);
-    r.uepc = context->readMiscRegNoEffect(
-        CSRData.at(CSR_UEPC).physIndex);
-    r.ucause = context->readMiscRegNoEffect(
-        CSRData.at(CSR_UCAUSE).physIndex);
-    r.utval = context->readMiscRegNoEffect(
-        CSRData.at(CSR_UTVAL).physIndex);
-    r.uip = context->readMiscReg(
-        CSRData.at(CSR_UIP).physIndex) & CSRMasks.at(CSR_UIP);
-
     // S mode CSR
     r.sstatus = context->readMiscRegNoEffect(
         CSRData.at(CSR_SSTATUS).physIndex) & CSRMasks.at(CSR_SSTATUS);
-    r.sedeleg = context->readMiscRegNoEffect(
-        CSRData.at(CSR_SEDELEG).physIndex);
-    r.sideleg = context->readMiscRegNoEffect(
-        CSRData.at(CSR_SIDELEG).physIndex);
     r.sie = context->readMiscReg(
         CSRData.at(CSR_SIE).physIndex) & CSRMasks.at(CSR_SIE);
     r.stvec = context->readMiscRegNoEffect(
@@ -337,36 +315,6 @@ RemoteGDB::RiscvGdbRegCache::setRegs(ThreadContext *context) const
     context->setMiscRegNoEffect(
         CSRData.at(CSR_TIME).physIndex, r.time);
 
-    // U mode CSR
-    oldVal = context->readMiscRegNoEffect(
-        CSRData.at(CSR_USTATUS).physIndex);
-    mask = CSRMasks.at(CSR_USTATUS);
-    newVal = (oldVal & ~mask) | (r.ustatus & mask);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_USTATUS).physIndex, newVal);
-    oldVal = context->readMiscReg(
-        CSRData.at(CSR_UIE).physIndex);
-    mask = CSRMasks.at(CSR_UIE);
-    newVal = (oldVal & ~mask) | (r.uie & mask);
-    context->setMiscReg(
-        CSRData.at(CSR_UIE).physIndex, newVal);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_UTVEC).physIndex, r.utvec);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_USCRATCH).physIndex, r.uscratch);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_UEPC).physIndex, r.uepc);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_UCAUSE).physIndex, r.ucause);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_UTVAL).physIndex, r.utval);
-    oldVal = context->readMiscReg(
-        CSRData.at(CSR_UIP).physIndex);
-    mask = CSRMasks.at(CSR_UIP);
-    newVal = (oldVal & ~mask) | (r.uip & mask);
-    context->setMiscReg(
-        CSRData.at(CSR_UIP).physIndex, newVal);
-
     // S mode CSR
     oldVal = context->readMiscRegNoEffect(
         CSRData.at(CSR_SSTATUS).physIndex);
@@ -374,10 +322,6 @@ RemoteGDB::RiscvGdbRegCache::setRegs(ThreadContext *context) const
     newVal = (oldVal & ~mask) | (r.sstatus & mask);
     context->setMiscRegNoEffect(
         CSRData.at(CSR_SSTATUS).physIndex, newVal);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_SEDELEG).physIndex, r.sedeleg);
-    context->setMiscRegNoEffect(
-        CSRData.at(CSR_SIDELEG).physIndex, r.sideleg);
     oldVal = context->readMiscReg(
         CSRData.at(CSR_SIE).physIndex);
     mask = CSRMasks.at(CSR_SIE);

--- a/src/arch/riscv/remote_gdb.hh
+++ b/src/arch/riscv/remote_gdb.hh
@@ -82,17 +82,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint32_t placeholder;
             uint64_t cycle;
             uint64_t time;
-            uint64_t ustatus;
-            uint64_t uie;
-            uint64_t utvec;
-            uint64_t uscratch;
-            uint64_t uepc;
-            uint64_t ucause;
-            uint64_t utval;
-            uint64_t uip;
             uint64_t sstatus;
-            uint64_t sedeleg;
-            uint64_t sideleg;
             uint64_t sie;
             uint64_t stvec;
             uint64_t scounteren;

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1697,10 +1697,11 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 cause = cpu->readMiscReg(
                     RiscvISA::MiscRegIndex::MISCREG_SCAUSE, tid);
             } else {
-                DPRINTF(Commit, "Force to raise exception at user mode\n");
+                DPRINTF(Commit,
+                        "Trap ended in unexpected PRV_U, fallback to MCAUSE\n");
                 assert(priv == RiscvISA::PRV_U);
                 cause = cpu->readMiscReg(
-                    RiscvISA::MiscRegIndex::MISCREG_UCAUSE, tid);
+                    RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
             }
             auto exception_no =inst_fault->exception();
             if (faultNum.find(exception_no) != faultNum.end()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter checks now block FPU/vector CSR access and related instructions when FPU/vector state is disabled or in virtual mode.

* **Refactor**
  * Status register writes now only update writable fields via a centralized writable-mask, preserving derived status bits.

* **Chores**
  * Visible user-mode CSRs and delegation registers removed; user-mode interrupt delegation eliminated and remote-debugger CSR visibility reduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->