### PR TITLE
cpu: Align BTBTAGE update reread and bank conflicts

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -93,9 +93,9 @@ tageStats(this, p.numPredictors, p.numBanks)
 {
     this->needMoreHistories = p.needMoreHistories;
 
-    // Warn if updateOnRead is disabled (RTL-like dynamic reread policy needs it enabled)
+    // Warn if updateOnRead is disabled (bank simulation works better with it enabled)
     if (!p.updateOnRead) {
-        warn("BTBTAGE: RTL-like update reread policy is best modeled with updateOnRead=true");
+        warn("BTBTAGE: Bank simulation works better with updateOnRead=true");
     }
 #endif
     tageTable.resize(numPredictors);
@@ -418,16 +418,7 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
 }
 
 bool
-BTBTAGE::isControlMispredForEntry(const FetchTarget &stream,
-                                  const BTBEntry &entry) const
-{
-    return stream.squashType == SquashType::SQUASH_CTRL &&
-           stream.squashPC == entry.pc;
-}
-
-bool
 BTBTAGE::needRereadForUpdateEntry(const BTBEntry &entry,
-                                  const FetchTarget &stream,
                                   const std::shared_ptr<TageMeta> &predMeta,
                                   TagePrediction *metaPred,
                                   bool *hasMetaPred) const
@@ -454,25 +445,22 @@ BTBTAGE::needRereadForUpdateEntry(const BTBEntry &entry,
         *metaPred = it->second;
     }
 
-    // Legacy mode: keep metadata-only update behavior if updateOnRead is disabled.
+    // Legacy mode: if update-on-read is disabled, never reread.
     if (!updateOnRead) {
         return false;
     }
 
-    // RTL alignment: only provider-used and non-mispred entries can skip update-time re-read.
-    const auto &pred = it->second;
-    bool use_provider = pred.mainInfo.found && !pred.useAlt;
-    bool mispred = isControlMispredForEntry(stream, entry);
-    return !(use_provider && !mispred);
+    // Alignment experiment:
+    // only when alt/base path is used do we reread and potentially incur bank conflicts.
+    return it->second.useAlt;
 }
 
 bool
-BTBTAGE::needRereadForUpdate(const FetchTarget &stream,
-                             const std::shared_ptr<TageMeta> &predMeta,
+BTBTAGE::needRereadForUpdate(const std::shared_ptr<TageMeta> &predMeta,
                              const std::vector<BTBEntry> &entries) const
 {
     for (const auto &entry : entries) {
-        if (needRereadForUpdateEntry(entry, stream, predMeta)) {
+        if (needRereadForUpdateEntry(entry, predMeta)) {
             return true;
         }
     }
@@ -702,19 +690,14 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
     auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
-
-    if (!predMeta) {
-        DPRINTF(TAGE, "canResolveUpdate: no prediction meta, skip bank conflict check\n");
-        return true;
-    }
-
     auto entries_to_update = prepareUpdateEntries(stream);
-    if (entries_to_update.empty()) {
-        DPRINTF(TAGE, "canResolveUpdate: no update entries, skip bank conflict check\n");
+
+    if (!predMeta || entries_to_update.empty()) {
+        DPRINTF(TAGE, "canResolveUpdate: no valid update entries/meta, skip conflict check\n");
         return true;
     }
-    bool need_reread = needRereadForUpdate(stream, predMeta, entries_to_update);
 
+    bool need_reread = needRereadForUpdate(predMeta, entries_to_update);
     if (!need_reread) {
         DPRINTF(TAGE, "canResolveUpdate: no reread needed, skip bank conflict check\n");
         return true;
@@ -785,10 +768,10 @@ BTBTAGE::update(const FetchTarget &stream) {
         TagePrediction meta_pred;
         bool has_meta_pred = false;
         bool need_reread = needRereadForUpdateEntry(
-            btb_entry, stream, predMeta, &meta_pred, &has_meta_pred);
+            btb_entry, predMeta, &meta_pred, &has_meta_pred);
 
         if (need_reread) {
-            // Re-read providers using snapshot (do not rely on prediction-time provider/alt).
+            // Re-read providers using snapshot.
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
             if (has_meta_pred && recomputed.taken != meta_pred.taken) {
                 hasRecomputedVsOriginalDiff = true;

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -93,9 +93,9 @@ tageStats(this, p.numPredictors, p.numBanks)
 {
     this->needMoreHistories = p.needMoreHistories;
 
-    // Warn if updateOnRead is disabled (bank simulation works better with it enabled)
+    // Warn if updateOnRead is disabled (RTL-like dynamic reread policy needs it enabled)
     if (!p.updateOnRead) {
-        warn("BTBTAGE: Bank simulation works better with updateOnRead=true");
+        warn("BTBTAGE: RTL-like update reread policy is best modeled with updateOnRead=true");
     }
 #endif
     tageTable.resize(numPredictors);
@@ -417,6 +417,68 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     return all_entries;
 }
 
+bool
+BTBTAGE::isControlMispredForEntry(const FetchTarget &stream,
+                                  const BTBEntry &entry) const
+{
+    return stream.squashType == SquashType::SQUASH_CTRL &&
+           stream.squashPC == entry.pc;
+}
+
+bool
+BTBTAGE::needRereadForUpdateEntry(const BTBEntry &entry,
+                                  const FetchTarget &stream,
+                                  const std::shared_ptr<TageMeta> &predMeta,
+                                  TagePrediction *metaPred,
+                                  bool *hasMetaPred) const
+{
+    if (!predMeta) {
+        if (hasMetaPred) {
+            *hasMetaPred = false;
+        }
+        return true;
+    }
+
+    auto it = predMeta->preds.find(entry.pc);
+    bool has_pred = it != predMeta->preds.end();
+    if (hasMetaPred) {
+        *hasMetaPred = has_pred;
+    }
+
+    if (!has_pred) {
+        DPRINTF(TAGE, "update: missing pred meta for pc %#lx, forcing reread\n", entry.pc);
+        return true;
+    }
+
+    if (metaPred) {
+        *metaPred = it->second;
+    }
+
+    // Legacy mode: keep metadata-only update behavior if updateOnRead is disabled.
+    if (!updateOnRead) {
+        return false;
+    }
+
+    // RTL alignment: only provider-used and non-mispred entries can skip update-time re-read.
+    const auto &pred = it->second;
+    bool use_provider = pred.mainInfo.found && !pred.useAlt;
+    bool mispred = isControlMispredForEntry(stream, entry);
+    return !(use_provider && !mispred);
+}
+
+bool
+BTBTAGE::needRereadForUpdate(const FetchTarget &stream,
+                             const std::shared_ptr<TageMeta> &predMeta,
+                             const std::vector<BTBEntry> &entries) const
+{
+    for (const auto &entry : entries) {
+        if (needRereadForUpdateEntry(entry, stream, predMeta)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /**
  * @brief Update predictor state for a single entry
  * 
@@ -639,6 +701,24 @@ bool
 BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
+    auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
+
+    if (!predMeta) {
+        DPRINTF(TAGE, "canResolveUpdate: no prediction meta, skip bank conflict check\n");
+        return true;
+    }
+
+    auto entries_to_update = prepareUpdateEntries(stream);
+    if (entries_to_update.empty()) {
+        DPRINTF(TAGE, "canResolveUpdate: no update entries, skip bank conflict check\n");
+        return true;
+    }
+    bool need_reread = needRereadForUpdate(stream, predMeta, entries_to_update);
+
+    if (!need_reread) {
+        DPRINTF(TAGE, "canResolveUpdate: no reread needed, skip bank conflict check\n");
+        return true;
+    }
 
 #ifndef UNIT_TEST
     // Record attempted update access per bank (even if it conflicts)
@@ -702,16 +782,20 @@ BTBTAGE::update(const FetchTarget &stream) {
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
         TagePrediction recomputed;
-        if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
-            // Re-read providers using snapshot (do not rely on prediction-time main/alt)
+        TagePrediction meta_pred;
+        bool has_meta_pred = false;
+        bool need_reread = needRereadForUpdateEntry(
+            btb_entry, stream, predMeta, &meta_pred, &has_meta_pred);
+
+        if (need_reread) {
+            // Re-read providers using snapshot (do not rely on prediction-time provider/alt).
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
-            // Track differences for statistics
-            auto it = predMeta->preds.find(btb_entry.pc);
-            if (it != predMeta->preds.end() && recomputed.taken != it->second.taken) {
+            if (has_meta_pred && recomputed.taken != meta_pred.taken) {
                 hasRecomputedVsOriginalDiff = true;
             }
-        } else { // otherwise, use the prediction from the prediction-time main/alt
-            recomputed = predMeta->preds[btb_entry.pc];
+        } else {
+            // Provider was already recorded in metadata and can be used directly.
+            recomputed = meta_pred;
         }
         if (recomputed.taken != actual_taken) {
             hasRecomputedVsActualDiff = true;

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -298,7 +298,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
-    // When prediction and update access the same bank in one cycle, update is dropped
+    // Conflict is modeled only when update needs a table re-read.
     const unsigned numBanks;         // Number of banks (e.g., 4)
     const unsigned bankIdWidth;      // log2(numBanks), computed in constructor
     const unsigned blockWidth;       // floorLog2(blockSize), e.g., 5 for 32B blocks
@@ -424,6 +424,22 @@ private:
                                  bool actual_taken,
                                  const TagePrediction &pred,
                                  const FetchTarget &stream);
+
+    // Decide whether this entry requires update-time table re-read.
+    bool needRereadForUpdateEntry(const BTBEntry &entry,
+                                  const FetchTarget &stream,
+                                  const std::shared_ptr<TageMeta> &predMeta,
+                                  TagePrediction *metaPred = nullptr,
+                                  bool *hasMetaPred = nullptr) const;
+
+    // Decide whether this stream contains any entry that requires re-read.
+    bool needRereadForUpdate(const FetchTarget &stream,
+                             const std::shared_ptr<TageMeta> &predMeta,
+                             const std::vector<BTBEntry> &entries) const;
+
+    // Whether this entry is the control-mispred branch of current fetch block.
+    bool isControlMispredForEntry(const FetchTarget &stream,
+                                  const BTBEntry &entry) const;
 
     // Helper method to handle new entry allocation
     bool handleNewEntryAllocation(const Addr &startPC,

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -298,7 +298,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
-    // Conflict is modeled only when update needs a table re-read.
+    // When prediction and update access the same bank in one cycle, update is dropped
     const unsigned numBanks;         // Number of banks (e.g., 4)
     const unsigned bankIdWidth;      // log2(numBanks), computed in constructor
     const unsigned blockWidth;       // floorLog2(blockSize), e.g., 5 for 32B blocks
@@ -426,20 +426,15 @@ private:
                                  const FetchTarget &stream);
 
     // Decide whether this entry requires update-time table re-read.
+    // Current policy: only when prediction used alt/base path (useAlt).
     bool needRereadForUpdateEntry(const BTBEntry &entry,
-                                  const FetchTarget &stream,
                                   const std::shared_ptr<TageMeta> &predMeta,
                                   TagePrediction *metaPred = nullptr,
                                   bool *hasMetaPred = nullptr) const;
 
-    // Decide whether this stream contains any entry that requires re-read.
-    bool needRereadForUpdate(const FetchTarget &stream,
-                             const std::shared_ptr<TageMeta> &predMeta,
+    // Decide whether this stream contains any entry requiring re-read.
+    bool needRereadForUpdate(const std::shared_ptr<TageMeta> &predMeta,
                              const std::vector<BTBEntry> &entries) const;
-
-    // Whether this entry is the control-mispred branch of current fetch block.
-    bool isControlMispredForEntry(const FetchTarget &stream,
-                                  const BTBEntry &entry) const;
 
     // Helper method to handle new entry allocation
     bool handleNewEntryAllocation(const Addr &startPC,

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -948,6 +948,31 @@ TEST_F(BTBTAGETest, BankConflict) {
     }
 }
 
+TEST_F(BTBTAGETest, BankConflictOnlyWhenRereadNeeded) {
+    BTBTAGE *bankTage = new BTBTAGE(4, 2, 1024, 4);
+    boost::dynamic_bitset<> testHistory(128);
+    std::vector<FullBTBPrediction> testStagePreds(5);
+
+    bankTage->enableBankConflict = true;
+    bankTage->updateOnRead = true;
+
+    // Force a strong provider so update can use meta without reread.
+    BTBEntry entry = createBTBEntry(0x20);
+    setupTageEntry(bankTage, 0x20, 3, 2, false);
+
+    testStagePreds[1].btbEntries = {entry};
+    bankTage->putPCHistory(0x20, testHistory, testStagePreds);
+    auto meta = bankTage->getPredictionMeta();
+
+    FetchTarget stream = createStream(0x20, entry, true, meta);
+    uint64_t conflicts_before = bankTage->tageStats.updateBankConflict;
+    bool can_update = bankTage->canResolveUpdate(stream);
+
+    EXPECT_TRUE(can_update) << "Provider+correct path should not trigger bank conflict";
+    EXPECT_EQ(bankTage->tageStats.updateBankConflict, conflicts_before);
+
+}
+
 
 }  // namespace test
 


### PR DESCRIPTION
Change-Id: I39cbd80ec9fcf1bcaa443814e62cee39b5ed163a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smarter per-entry decision for when table re-reads are needed during prediction updates, reducing unnecessary recomputation.
  * Bank conflicts are only reported when an update actually requires a re-read, improving conflict accuracy.

* **Tests**
  * Added test coverage for bank-conflict behavior when re-reads are/aren’t required.

* **Chores**
  * Updated simulator guidance message to recommend the RTL-like update reread policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->