### PR TITLE
cpu-o3: Add replayed load completion counter

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -252,6 +252,9 @@ class DynInst : public ExecContext, public RefCounted
     /* replay type of this instruction */
     std::optional<LdStReplayType> replayType;
 
+    // Track whether this instruction has ever been replayed.
+    bool _everReplayed = false;
+
     bool _hasProducerStorePC = false;
     Addr _producerStorePC = 0;
 
@@ -1054,7 +1057,9 @@ class DynInst : public ExecContext, public RefCounted
     void setReplay(LdStReplayType type) {
         setNeedReplay();
         replayType = type;
+        _everReplayed = true;
     }
+    bool everReplayed() const { return _everReplayed; }
     std::optional<LdStReplayType> getReplayType() const {
         return replayType;
     }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -789,7 +789,14 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(RAWQueueFull, "Number of times RAW queue was full"),
       ADD_STAT(RAWQueueReplay, "Number of instructions replayed from RAW queue"),
       ADD_STAT(RAWQueueLatency, statistics::units::Cycle::get(), "RAW queue latency distribution"),
-      ADD_STAT(loadReplayEvents, statistics::units::Count::get(), "event distribution of load replay")
+      ADD_STAT(loadReplayEvents, statistics::units::Count::get(), "event distribution of load replay"),
+      ADD_STAT(replayedLoadIssueToPipe, statistics::units::Count::get(),
+               "Number of replayed loads that enter the load pipeline"),
+      ADD_STAT(replayedLoadReadyToFinish, statistics::units::Count::get(),
+               "Number of replayed loads that finish execution"),
+      ADD_STAT(replayedLoadFinishRate, statistics::units::Ratio::get(),
+               "Replay load finish rate",
+               replayedLoadReadyToFinish / replayedLoadIssueToPipe)
 {
     loadToUse
         .init(0, 299, 10)
@@ -811,6 +818,8 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
     for (int i = 0; i < LdStReplayTypeCount; i++) {
         loadReplayEvents.subname(i, load_store_replay_event_str[static_cast<LdStReplayType>(i)]);
     }
+
+    replayedLoadFinishRate.precision(6);
 }
 
 void
@@ -1220,6 +1229,10 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
     loadPipeSx[0]->insts[idx] = inst;
     loadPipeSx[0]->size++;
 
+    if (inst->everReplayed()) {
+        stats.replayedLoadIssueToPipe++;
+    }
+
     DPRINTF(LoadPipeline, "issueToLoadPipe: [sn:%llu]\n", inst->seqNum);
 }
 
@@ -1605,7 +1618,12 @@ LSQUnit::executeLoadPipeSx()
             }
 
             if (i == loadPipeStages - 1 && !inst->needReplay()) {
-                if (inst->isNormalLd() || !inst->readMemAccPredicate()) iewStage->readyToFinish(inst);
+                if (inst->isNormalLd() || !inst->readMemAccPredicate()) {
+                    if (inst->everReplayed()) {
+                        stats.replayedLoadReadyToFinish++;
+                    }
+                    iewStage->readyToFinish(inst);
+                }
                 iewStage->activityThisCycle();
                 inst->endPipelining();
                 DPRINTF(LoadPipeline, "Load [sn:%llu] ready to finish\n",

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -911,6 +911,13 @@ class LSQUnit
         statistics::Distribution RAWQueueLatency;
 
         statistics::Vector loadReplayEvents;
+
+        /** Number of replayed loads that enter the load pipeline. */
+        statistics::Scalar replayedLoadIssueToPipe;
+        /** Number of replayed loads that finish execution. */
+        statistics::Scalar replayedLoadReadyToFinish;
+        /** Ratio of replayed load finishes to replayed load issues. */
+        statistics::Formula replayedLoadFinishRate;
     } stats;
 
     void bankConflictReplay();


### PR DESCRIPTION
Add a load instruction replay success rate counter to evaluate the effectiveness of replay behavior and provide a reference for RTL.

Change-Id: I78887a7eb4d90ad5b5a3a870977ff9aabd621468