### PR TITLE
bpu,configs: Add optional BTBTAGE upper-bound mode for kmhv3

### DIFF
--- a/.codex/skills/ci-perf-analysis/SKILL.md
+++ b/.codex/skills/ci-perf-analysis/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ci-perf-analysis
+description: 用于从 GitHub Actions 的 gem5 性能 CI 中定位 summary、score.txt 和归档目录，并结合本地 gem5_data_proc 对 spec06/spec17 结果做 weighted score、benchmark 子项对比和通用 stats 归因。适用于用户给出 run URL/run id、commit、workflow run，或要求分析 CI 跑分变化来源时。
+---
+
+# CI 性能分析
+
+## 概览
+
+这个 skill 只做一条固定链路：
+
+1. 用 `gh` 从 CI run 找到 summary 对应的 `score.txt` 和归档目录。
+2. 用本地 `gem5_data_proc/run.py` 把 `spec_all/` 处理成 `csv`、`weighted.csv`、`score.csv`。
+3. 对比 benchmark 级收益，并在需要时继续下钻到 `stats.txt` 或其他归档结果。
+
+## 快速开始
+
+### 1. 先拿 summary 和归档目录
+
+优先使用 bundled script：
+
+```bash
+python3 .codex/skills/ci-perf-analysis/scripts/ci_perf_info.py \
+  https://github.com/OpenXiangShan/GEM5/actions/runs/<run_id>
+```
+
+输出会包含：
+
+- `archive_path`
+- `spec_all` 目录
+- `score.txt` 的最后 42 行
+
+这和 workflow 在 GitHub summary 里展示的内容一致，因为 CI 本身就是把 `score.txt` 的最后 42 行写进 step summary。
+
+### 2. 优先使用本地 `gem5_data_proc`
+
+默认优先使用：
+
+```bash
+/nfs/home/yanyue/workspace/gem5_data_proc
+```
+
+如果用户本地没有，再执行：
+
+```bash
+git clone https://github.com/jensen-yan/gem5_data_proc
+# 设置环境变量 
+export $GEM5_DATA_PROC_HOME=xxx
+```
+
+
+### 3. 用 `gem5_data_proc` 处理整个归档
+
+```bash
+cd $GEM5_DATA_PROC_HOME
+python3 run.py /nfs/home/share/gem5_ci/performance_data/spec06-0.3c/<archive_dir> \
+  --out-dir /tmp/gem5_proc_runA \
+  --tag runA
+```
+
+关键输出：
+
+- `<tag>.csv`：point 级或 benchmark 聚合后的原始统计
+- `<tag>-weighted.csv`：按权重聚合后的 benchmark 统计
+- `<tag>-score.csv`：最终 score/time/coverage
+
+### 4. 对比两个 run
+
+最常见的是比较两次 CI：
+
+```bash
+python3 .codex/skills/ci-perf-analysis/scripts/ci_perf_info.py <runA>
+python3 .codex/skills/ci-perf-analysis/scripts/ci_perf_info.py <runB>
+
+cd $GEM5_DATA_PROC_HOME
+python3 run.py <archiveA> --out-dir /tmp/gem5_proc_A --tag A
+python3 run.py <archiveB> --out-dir /tmp/gem5_proc_B --tag B
+```
+
+然后用短 Python 片段读取两个 `*-score.csv` / `*-weighted.csv` 做对比。优先关注：
+
+- 总 score 变化
+- benchmark 级 `time` / `score` 变化
+- 用户关心的 stats 指标变化
+
+## 下钻分析
+
+### 1. 看 benchmark 级收益
+
+- 对两个归档分别运行 `run.py`
+- 比较 `*-score.csv` 里的 `time` 和 `score`
+- 按 `score_delta_pct` 或 `time_delta_pct` 排序
+
+### 2. 看 stats 指标变化
+
+- 先看 `*-weighted.csv` 里的通用统计
+- 如果用户已经给出重点指标，直接围绕这些指标对比
+- 如果用户没有指定，优先从 `time`、`cpi`、前端、后端、内存、分支等大类里挑变化最明显的项
+- 归因时优先描述“哪些 stats 在变”，再解释这些变化更像支持哪类根因
+
+### 3. 需要时再读归档里的其他文件
+
+- `stats.txt`：看原始统计，位置在
+    /nfs/home/share/gem5_ci/performance_data/spec06-0.3c/<archive_dir>/<spec_bmk>/m5out/stats.txt
+- `score.txt`：对照 summary
+- 其他 CSV 或日志：按用户问题决定是否下钻
+
+## 常用命令
+
+### 已知 run URL，直接拿 archive path
+
+```bash
+python3 .codex/skills/ci-perf-analysis/scripts/ci_perf_info.py <run_url_or_id>
+```
+
+### 已知 archive path，直接处理
+
+```bash
+cd $GEM5_DATA_PROC_HOME
+python3 run.py <archive_dir> --out-dir /tmp/gem5_proc --tag run
+```
+
+## 输出组织建议
+
+回答这类问题时，优先按下面的顺序组织：
+
+1. commit / run / workflow / 配置差异
+2. summary 里的总分变化
+3. benchmark 级主要收益和回退项
+4. 相关 stats 指标变化
+5. 对根因的判断
+
+结论要尽量区分：
+
+- “哪个 benchmark 涨了”
+- “哪些 stats 在变”
+- “这些 stats 更像支持哪类根因”
+
+## 资源
+
+### scripts/
+
+- `ci_perf_info.py`
+  - 输入 run URL 或 run id
+  - 输出 archive path、spec_all 路径和 `score.txt` tail
+
+### references/
+
+当前不需要额外参考文件。后续如果这套流程扩展到更多 workflow 或更多统计口径，再新增参考文档。

--- a/.codex/skills/ci-perf-analysis/scripts/ci_perf_info.py
+++ b/.codex/skills/ci-perf-analysis/scripts/ci_perf_info.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Locate archived CI performance data and print the score summary."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = "OpenXiangShan/GEM5"
+ARCHIVE_RE = re.compile(
+    r"Archiving performance data to "
+    r"(/nfs/home/share/gem5_ci/performance_data/\S+)"
+)
+
+
+def run_cmd(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or f"command failed: {' '.join(cmd)}")
+    return result.stdout
+
+
+def parse_run_id(text: str) -> str:
+    match = re.search(r"/actions/runs/(\d+)", text)
+    if match:
+        return match.group(1)
+    if text.isdigit():
+        return text
+    raise SystemExit(f"cannot parse run id from: {text}")
+
+
+def get_job_id(run_id: str) -> str:
+    output = run_cmd(["gh", "api", f"repos/{REPO}/actions/runs/{run_id}/jobs"])
+    data = json.loads(output)
+    jobs = data.get("jobs", [])
+    if not jobs:
+        raise SystemExit(f"no jobs found for run {run_id}")
+    return str(jobs[0]["id"])
+
+
+def get_archive_path(job_id: str) -> str:
+    log_text = run_cmd(["gh", "api", f"repos/{REPO}/actions/jobs/{job_id}/logs"])
+    match = ARCHIVE_RE.search(log_text)
+    if not match:
+        raise SystemExit(f"cannot find archive path in logs for job {job_id}")
+    return match.group(1)
+
+
+def print_score(score_path: Path, tail_lines: int) -> None:
+    if not score_path.is_file():
+        print(f"score.txt not found: {score_path}", file=sys.stderr)
+        return
+
+    lines = score_path.read_text().splitlines()
+    print(f"score.txt: {score_path}")
+    print(f"--- tail -n {tail_lines} ---")
+    for line in lines[-tail_lines:]:
+        print(line)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print CI archive path and score summary for a GEM5 perf run."
+    )
+    parser.add_argument("run", help="GitHub Actions run URL or run id")
+    parser.add_argument(
+        "--tail-lines",
+        type=int,
+        default=42,
+        help="how many trailing lines of score.txt to print",
+    )
+    args = parser.parse_args()
+
+    run_id = parse_run_id(args.run)
+    job_id = get_job_id(run_id)
+    archive_path = Path(get_archive_path(job_id))
+
+    print(f"run_id: {run_id}")
+    print(f"job_id: {job_id}")
+    print(f"archive_path: {archive_path}")
+    print(f"spec_all: {archive_path / 'spec_all'}")
+
+    score_path = archive_path / "score.txt"
+    print_score(score_path, args.tail_lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -718,6 +718,11 @@ def xiangshan_system_init():
         action="store_false",
         help="Use regular BTBTAGE instead of BTBTAGEUpperBound in kmhv3",
     )
+    parser.add_argument(
+        "--btb-tage-upper-bound-path-hash",
+        action="store_true",
+        help="Use path-hash history for BTBTAGEUpperBound instead of outcome history",
+    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -705,6 +705,19 @@ def xiangshan_system_init():
     Options.addCommonOptions(parser, configure_xiangshan=True)
     Options.addXiangshanFSOptions(parser)
     Options.addXiangshanTraceOptions(parser)
+    parser.set_defaults(btb_tage_upper_bound=True)
+    parser.add_argument(
+        "--btb-tage-upper-bound",
+        dest="btb_tage_upper_bound",
+        action="store_true",
+        help="Use BTBTAGEUpperBound in kmhv3 (enabled by default)",
+    )
+    parser.add_argument(
+        "--disable-btb-tage-upper-bound",
+        dest="btb_tage_upper_bound",
+        action="store_false",
+        help="Use regular BTBTAGE instead of BTBTAGEUpperBound in kmhv3",
+    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -705,7 +705,10 @@ def xiangshan_system_init():
     Options.addCommonOptions(parser, configure_xiangshan=True)
     Options.addXiangshanFSOptions(parser)
     Options.addXiangshanTraceOptions(parser)
-    parser.set_defaults(btb_tage_upper_bound=True)
+    parser.set_defaults(
+        btb_tage_upper_bound=True,
+        btb_tage_upper_bound_path_hash=True,
+    )
     parser.add_argument(
         "--btb-tage-upper-bound",
         dest="btb_tage_upper_bound",
@@ -720,8 +723,15 @@ def xiangshan_system_init():
     )
     parser.add_argument(
         "--btb-tage-upper-bound-path-hash",
+        dest="btb_tage_upper_bound_path_hash",
         action="store_true",
-        help="Use path-hash history for BTBTAGEUpperBound instead of outcome history",
+        help="Use path-hash history for BTBTAGEUpperBound (enabled by default)",
+    )
+    parser.add_argument(
+        "--disable-btb-tage-upper-bound-path-hash",
+        dest="btb_tage_upper_bound_path_hash",
+        action="store_false",
+        help="Use outcome history for BTBTAGEUpperBound instead of path-hash history",
     )
 
     # Add the ruby specific and protocol specific args

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -104,6 +104,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.microtage.enabled = False
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
+            cpu.branchPred.tage.useBranchPcForIndex = True
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -95,6 +95,10 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ftq_size = 64
             cpu.branchPred.fsq_size = 64
 
+            if args.btb_tage_upper_bound:
+                # Use the UB-S(outcome) probe by default for current CI study.
+                cpu.branchPred.tage = BTBTAGEUpperBound()
+
             cpu.branchPred.mbtb.resolvedUpdate = True
             cpu.branchPred.tage.resolvedUpdate = True
             cpu.branchPred.ittage.resolvedUpdate = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -105,6 +105,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.tage.useBranchPcForIndex = True
+            cpu.branchPred.tage.numWays = 8
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -104,9 +104,11 @@ def setKmhV3Params(args, system):
             cpu.branchPred.microtage.enabled = False
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
-            cpu.branchPred.tage.useBranchPcForIndex = True
-            cpu.branchPred.tage.numWays = 8
-            cpu.branchPred.tage.tableSizes = [8192] * 8
+            cpu.branchPred.tage.useBranchPcForIndex = False
+            cpu.branchPred.tage.usePositionForIndexMix = True
+            cpu.branchPred.tage.indexMixTables = 4
+            cpu.branchPred.tage.numWays = 2
+            cpu.branchPred.tage.tableSizes = [2048] * 8
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -96,8 +96,9 @@ def setKmhV3Params(args, system):
             cpu.branchPred.fsq_size = 64
 
             if args.btb_tage_upper_bound:
-                # Use the UB-S(outcome) probe by default for current CI study.
-                cpu.branchPred.tage = BTBTAGEUpperBound()
+                # Default to UB-S(outcome); optionally switch to UB-P(path-hash).
+                cpu.branchPred.tage = BTBTAGEUpperBound(
+                    usePathHashHistory=args.btb_tage_upper_bound_path_hash)
 
             cpu.branchPred.mbtb.resolvedUpdate = True
             cpu.branchPred.tage.resolvedUpdate = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -96,7 +96,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.fsq_size = 64
 
             if args.btb_tage_upper_bound:
-                # Default to UB-S(outcome); optionally switch to UB-P(path-hash).
+                # Default to UB-P(path-hash); optionally fall back to UB-S(outcome).
                 cpu.branchPred.tage = BTBTAGEUpperBound(
                     usePathHashHistory=args.btb_tage_upper_bound_path_hash)
 

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -106,6 +106,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.tage.useBranchPcForIndex = True
             cpu.branchPred.tage.numWays = 8
+            cpu.branchPred.tage.tableSizes = [8192] * cpu.branchPred.tage.numPredictors
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -106,7 +106,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.tage.useBranchPcForIndex = True
             cpu.branchPred.tage.numWays = 8
-            cpu.branchPred.tage.tableSizes = [8192] * cpu.branchPred.tage.numPredictors
+            cpu.branchPred.tage.tableSizes = [8192] * 8
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -105,7 +105,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
-            cpu.branchPred.mgsc.enabled = True
+            cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True
 
             # RTL alignment: only enable bias + path + IMLI tables, disable PC threshold

--- a/docs/Gem5_Docs/frontend/tage_index_capacity_exploration_20260305.md
+++ b/docs/Gem5_Docs/frontend/tage_index_capacity_exploration_20260305.md
@@ -1,0 +1,130 @@
+# BTB-TAGE 索引与容量探索记录（2026-03-05）
+
+## 1. 背景与目标
+
+在 SPEC06（重点 gobmk / sjeng）中，观察到大量误预测集中在**同一基本块（32B/64B）内的多条分支**。当前 BTB-TAGE 索引长期以 `startPC` 为主，导致同块内多分支更容易落到同一组，形成明显冲突。
+
+本次探索目标：
+
+1. 确认 `position`/`branch` 信息进入 index 是否有效。
+2. 确认在已有索引改进后，是否仍有容量收益空间。
+3. 找出容量收益主要来自低表还是高表。
+4. 评估“**不增加容量**”情况下的算法优化潜力。
+
+## 2. 核心假设
+
+1. 同块多分支冲突是当前 TAGE 误预测的重要来源之一。
+2. 将分支粒度信息引入 index（`branchPC` 或 `position`）可减轻冲突。
+3. 若低历史表（T0~T3）压力更大，则扩容收益应主要来自低表。
+
+## 3. 实验设置
+
+- 模式：本地 checkpoint，快速窗口
+- 指令长度：`--maxinsts=5000000 --warmup-insts-no-switch=0`
+- 统一开关：
+  - `system.cpu[0].branchPred.mgsc.enabled=False`
+  - `system.cpu[0].branchPred.tage.enableBankConflict=False`
+- 重点切片：
+  - `gobmk_nngs_18098`
+  - `sjeng_84999`
+
+## 4. 已验证改动与发现
+
+### 4.1 branchPC-index（已实现并验证）
+
+- 机制：索引使用 `branchPC` 替代 `startPC`。
+- 结果：
+  - gobmk：明显改善（mispredict 与 IPC 均提升）
+  - sjeng：小幅改善
+
+结论：方向正确，但不是最终上限。
+
+### 4.2 扩容（ways*4 / capacity*4）
+
+在 branchPC-index 基础上继续增大容量，收益仍明显，说明冲突问题并未被完全消除。
+
+典型结论（5M 快速窗）：
+
+- gobmk：`tableSizes` 4x 收益显著；`numWays` 4x 也有收益
+- sjeng：`tableSizes` 4x 稳定，`numWays` 4x 收益不稳定（有时 IPC 不升反降）
+
+### 4.3 容量收益来源定位（低表 vs 高表）
+
+在 `useBranchPcForIndex=True`、`numWays=2` 下做分层扩容：
+
+- base：`[2048 x 8]`
+- low4x：`[8192,8192,8192,8192,2048,2048,2048,2048]`
+- high4x：`[2048,2048,2048,2048,8192,8192,8192,8192]`
+- all4x：`[8192 x 8]`
+
+结果：
+
+1. **low4x ≈ all4x**（收益接近）
+2. **high4x 收益很小**
+3. `updateAllocFailure` 在 low4x/all4x 大幅下降（约 80% 级别）
+
+结论：容量瓶颈主要在**低历史表**，而非高历史表。
+
+## 5. 新算法原型：position-mix index（本次新增）
+
+### 5.1 设计动机
+
+考虑 RTL 约束下难以在 S1 直接拿到 `branchPC`，先在模型中验证：
+
+- 保持 `startPC` 作为 base
+- 仅在低表索引中混入 `position` 哈希
+- 可配置作用表数（`indexMixTables`）
+
+### 5.2 新增参数
+
+- `usePositionForIndexMix`（默认 `False`）
+- `indexMixTables`（默认 `4`）
+
+### 5.3 5M 快速结果（useBranchPcForIndex=False）
+
+gobmk（off -> mix2/mix4/mix8）：
+
+- IPC：`2.544804 -> 2.580220 / 2.583373 / 2.580409`
+- mispred：`44249 -> 42602 / 42686 / 42887`
+
+sjeng（off -> mix2/mix4/mix8）：
+
+- IPC：`2.116851 -> 2.120000 / 2.129908 / 2.124130`
+- mispred：`47856 -> 47515 / 47429 / 47691`
+
+结论：
+
+1. position-mix 确实有效。
+2. `mix4` 整体最稳。
+3. `mix8` 开始出现副作用（过度扰动）。
+
+## 6. 关键认识（本轮结论）
+
+1. `branchPC-index` 与 `position-mix` 方向一致，但并非完全相同机制。
+2. 仅靠索引去冲突仍不能完全替代容量；低表容量与去别名要协同。
+3. 如果追求“**不增容量**”的可行方案，`position-mix(low tables)` 是值得继续推进的候选。
+
+## 7. 当前分支提交链（CI触发）
+
+分支：`bigger-tage-align`
+
+1. `dc5faa5c3c` configs: Disable MGSC in align baseline
+2. `a068a5fb07` cpu,configs: Enable branch-PC index in BTB-TAGE
+3. `f3327bde07` configs: Scale BTB-TAGE ways by 4x in align
+4. `5bc3d42aa1` configs: Scale BTB-TAGE table capacity by 4x
+5. `b44d5b169b` configs: Fix BTB-TAGE tableSizes assignment
+
+> 注：第 5 条是配置修复，避免 `tableSizes` 赋值方式导致配置阶段异常。
+
+## 8. 下一步建议
+
+1. 在 CI 上优先验证「`position-mix` + 原始容量（2k, 2-way）」是否能稳定收益。
+2. 把 low-table 去别名做成更 RTL 友好的版本（不依赖运行期 `position`）。
+3. 为低表引入轻量冲突感知替换/分配策略，继续压 `updateAllocFailure`。
+4. 最后再做长窗口（20M warmup + 20M run）确认快速窗结论是否稳定。
+
+## 9. 风险与边界
+
+1. 5M 快速窗口主要用于方向判断，最终需长窗口确认幅度。
+2. 某些参数组合（例如非 2 幂 `tableSizes`）可能触发运行期异常，需规避。
+3. sjeng 对索引扰动更敏感，参数应避免一刀切（`mix4` 比 `mix8` 更稳）。

--- a/docs/Gem5_Docs/frontend/tage_index_capacity_exploration_20260305.md
+++ b/docs/Gem5_Docs/frontend/tage_index_capacity_exploration_20260305.md
@@ -128,3 +128,419 @@ sjeng（off -> mix2/mix4/mix8）：
 1. 5M 快速窗口主要用于方向判断，最终需长窗口确认幅度。
 2. 某些参数组合（例如非 2 幂 `tableSizes`）可能触发运行期异常，需规避。
 3. sjeng 对索引扰动更敏感，参数应避免一刀切（`mix4` 比 `mix8` 更稳）。
+
+## 10. 2026-03-10 补充：CI 归档与本地 5M 复验
+
+### 10.1 先修正一个认识：branchPC-index 只是 upper bound
+
+RTL 在 query index 时只有 `startPC`，`branchPC` 需要下一拍才能拿到，因此：
+
+1. `branchPC-index` 适合作为“冲突是否主要来自同块多分支”的**上界验证**。
+2. 但它**不应**直接作为 RTL 主方案继续推进。
+3. 后续更值得讨论的是：在 `startPC-only` 约束下，怎样提升 2-way 的**有效容量**。
+
+### 10.2 CI 归档补充分析：f3327 的收益确实主要来自 gobmk
+
+比较：
+
+- `run381 / a068a5fb07`
+- `run382 / f3327bde07`
+
+结论：
+
+1. Int score 约 `+0.198`。
+2. `gobmk` 单项约 `+0.899`，是头号贡献者。
+3. gobmk 不是单个 slice 偶然变好，而是五个子 workload 都在改善。
+
+CI 归档中的热点 branch 进一步支持“局部 branch-dense block 竞争”判断：
+
+- `gobmk_nngs_18098`
+  - `0x4f37c` / `0x4f388` -> `compute_connection_distances.lto_priv.0`
+  - `0x3ec02` -> `popgo`
+  - `0x3ac86` -> `remove_liberty`
+  - `0x40d9e` -> `chainlinks2`
+- `gobmk_trevord_4165`
+  - `0x40d96` / `0x40d9e` -> `chainlinks2`
+  - `0x4d040` / `0x4d04c` -> `order_moves.lto_priv.0`
+
+这些热点集中在很少的 32B/64B block 内，例如：
+
+1. `compute_connection_distances` 的 `0x4f37c`、`0x4f388` 位于同一紧凑循环。
+2. `chainlinks2` 的 `0x40d96`、`0x40d9e` 是同一循环体里的“条件判断 + 回边”。
+3. `order_moves` 的 `0x4d040`、`0x4d04c` 也是同一小循环。
+
+中间结论：
+
+- 这更像**结构竞争**，不是纯语义难预测。
+
+### 10.3 本地 5M 复现：原始命令可以正常跑通
+
+按如下命令可稳定跑通并落盘 `bp.db`：
+
+```bash
+./build/RISCV/gem5.opt -d debug/gobmk_nngs_18098 \
+  ./configs/example/kmhv3.py \
+  --generic-rv-cpt /nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/gobmk_nngs/18098/_18098_0.115927_.zstd \
+  --enable-bp-db tage
+```
+
+为便于快速迭代，本地后续统一使用：
+
+```bash
+--maxinsts=5000000
+```
+
+### 10.4 本地 5M 对照：ways 的短窗效果是“先消压力，再慢慢转成精度”
+
+在 `gobmk_nngs_18098` 上做局部对照：
+
+| 配置 | IPC | branchMissPrediction | updateAllocFailure |
+|---|---:|---:|---:|
+| 当前默认（startPC + position-mix + 2way） | 2.583373 | 0.320990 | 6121 |
+| `branchPC + 2way` | 2.582294 | 0.321232 | 6825 |
+| `branchPC + 8way` | 2.592163 | 0.318747 | 0 |
+
+解释：
+
+1. `8way` 在前 5M 内，首先明显清掉了 allocation pressure（`updateAllocFailure -> 0`）。
+2. 但短窗里 IPC / mispredict 收益还比较温和，没有 CI 全程那么大。
+3. 这说明“ways 生效”的路径更像：
+   - 先让热点 branch 能共存；
+   - 再在更长窗口里逐渐转成更明显的精度收益。
+
+### 10.5 一个重要发现：`numTablesToAlloc` 原先基本没有真正生效
+
+本地尝试 `2way + branchPC + numTablesToAlloc=2` 时，发现：
+
+1. 旧代码下结果与 `numTablesToAlloc=1` 几乎完全一致。
+2. 说明该参数虽然存在，但主路径里基本没有真正发挥作用。
+
+为验证这个方向，临时补了一个本地原型，使 `handleNewEntryAllocation()` 真正支持一次 update 连续分配多个表项。
+
+补丁后的 5M 结果（`branchPC + 2way + numTablesToAlloc=2`）：
+
+| 配置 | IPC | branchMissPrediction | updateAllocSuccess |
+|---|---:|---:|---:|
+| `branchPC + 2way` | 2.582294 | 0.321232 | 29494 |
+| `branchPC + 2way + alloc2` | 2.650533 | 0.305852 | 53785 |
+
+热点 branch 中，多条出现了实质下降：
+
+1. `0x3ac86`: `1258 -> 1098`
+2. `0x4f57a`: `553 -> 501`
+3. `0x3ef4a`: `546 -> 483`
+4. `0x3b67e`: `628 -> 583`
+5. `0x4f37c`: `1180 -> 1127`
+
+中间结论：
+
+- 对这个 slice 来说，“**一次学得更多**”比“只堆 way”更像一条值得继续看的低容量方向。
+
+### 10.6 alloc-fail victim 原型：方向有信号，但收益很敏感
+
+为了逼近 RTL 可行性，又做了一个更保守的 update-path-only 原型：
+
+1. 默认关闭。
+2. 只在低表开启。
+3. 只在同一 set 连续 alloc-fail 达阈值后，触发一次 victim replacement。
+4. victim 选择偏向 `useful` 低、counter 弱的 way。
+
+在**当前默认配置**（`startPC + position-mix + 2way`）上，做了两档参数：
+
+| 配置 | IPC | branchMissPrediction | updateAllocVictim |
+|---|---:|---:|---:|
+| baseline | 2.583373 | 0.320990 | 0 |
+| victim, threshold=8 | 2.586999 | 0.320779 | 90 |
+| victim, threshold=4 | 2.572993 | 0.322612 | 555 |
+
+解释：
+
+1. `threshold=8` 只有很小的正收益，说明这条线**不是完全没用**。
+2. `threshold=4` 明显变差，说明过于激进会破坏已学到的 entry。
+3. 这条线目前更像“可选辅助手段”，不像主增益来源。
+
+### 10.7 当前阶段性判断（更新版）
+
+结合 CI 与本地 5M，当前更稳妥的中间结论是：
+
+1. **同块/近块多分支竞争**仍然是 gobmk 提升的核心背景。
+2. `branchPC-index` 证明了问题存在，但不应再作为 RTL 主方案。
+3. 如果目标是“**不明显增容量**”，更值得看的方向是：
+   - `startPC-only` 下的更快学习（如 limited multi-allocation）
+   - 热 set 压力感知策略（但 victim 需很保守）
+   - 低表去别名，而不是全表统一扰动
+4. 单纯扩大 ways 在模型里有效，但 RTL 上收益不一定等价；这进一步说明问题不只是“名义容量”，而是“**有效容量/entry 流动性**”。
+
+### 10.8 当前不建议直接下结论的点
+
+1. 不建议根据 `branchPC-index` 直接推 RTL 收益幅度。
+2. 不建议仅凭一个 aggressiveness 很高的 victim policy 判断“replacement 线无效”。
+3. 5M 窗口适合看压力释放与学习速度，不足以完全替代长窗口 score 判断。
+
+### 10.9 建议的下一步收敛方向
+
+如果后续继续做，建议只保留两条主线，不再扩散：
+
+1. `startPC-only + limited multi-allocation`
+2. `startPC-only + 更克制的 pressure policy`
+
+其中第 1 条目前信号更强，第 2 条应作为次优候选继续谨慎探索。
+
+### 10.10 再补：20M warmup + 20M measured 复现实验（本地）
+
+为回答“20M warmup 之后，2-way 是否其实已经学好了”这个问题，直接复现了更接近 CI 的 long-window 运行：
+
+```bash
+./build/RISCV/gem5.opt ./configs/example/kmhv3.py \
+  --generic-rv-cpt <path> \
+  --warmup-insts-no-switch=20000000 \
+  --maxinsts=40000000
+```
+
+注意：
+
+1. `stats.txt` 中会有两段 dump。
+2. 第一段是 warmup 结束时的 dump+reset。
+3. 第二段才是 measured window（后 20M）的结果。
+4. 之前若直接 grep 或用前缀匹配，容易把 `updateAllocFailure` 和 `updateAllocFailureNoValidTable` 混淆，导致误读。
+
+#### 10.10.1 `gobmk_nngs_18098`：2way 与 8way 的 long-window 对照
+
+配置：
+
+- `useBranchPcForIndex=True`
+- `usePositionForIndexMix=False`
+- `numWays=2 / 8`
+
+measured window（后 20M）：
+
+| 配置 | IPC | branchMissPrediction | predNoHitUseBim | updateNoHitUseBim | updateAllocFailure | predTableHits::mean |
+|---|---:|---:|---:|---:|---:|---:|
+| `2way` | 3.195621 | 0.241918 | 4443868 | 148953 | 73884 | 1.418889 |
+| `8way` | 3.480643 | 0.192274 | 3691136 | 109685 | 1828 | 1.643924 |
+
+关键结论：
+
+1. 即使经过 20M warmup，`2way` 在 measured window 中依然有非常高的 `updateAllocFailure`。
+2. `predNoHitUseBim` / `updateNoHitUseBim` 也显著更高，说明 measured window 里仍存在大量“没 provider / provider 太浅”的情况。
+3. 因此不能简单认为“20M warmup 之后，2way 其实已经把高表都学好了”。
+
+热点 branch 对照（measured window）：
+
+| PC | `2way` mispred | `8way` mispred | `noPredMiss` 变化 |
+|---|---:|---:|---:|
+| `3ec02` | 9432 | 7871 | `1 -> 1` |
+| `4f388` | 8879 | 8831 | `1 -> 1` |
+| `4f37c` | 9696 | 9434 | `1 -> 1` |
+| `3ac86` | 6587 | 5383 | `1 -> 1` |
+| `40d9e` | 2807 | 2291 | `1 -> 1` |
+| `4f57a` | 3766 | 3349 | `1 -> 1` |
+
+解释：
+
+1. 热点 branch 的收益几乎都是 `dirMiss` 下降。
+2. `noPredMiss` 基本不变。
+3. 所以 hottest branches 的主要收益，不像是“以前完全没有 entry，现在终于有了”，而更像“provider 更深、更稳、alias 更少”。
+
+#### 10.10.2 `gobmk_trevord_7886`：2way 与 8way 的 long-window 对照
+
+配置同上。
+
+measured window（后 20M）：
+
+| 配置 | IPC | branchMissPrediction | predNoHitUseBim | updateNoHitUseBim | updateAllocFailure | predTableHits::mean |
+|---|---:|---:|---:|---:|---:|---:|
+| `2way` | 1.916166 | 0.409479 | 8476178 | 293283 | 170141 | 0.950604 |
+| `8way` | 2.079487 | 0.367182 | 5733766 | 95896 | 67502 | 1.166095 |
+
+关键结论：
+
+1. `trevord_7886` 上同样不是“warmup 后已经学完了”。
+2. `2way` 在 measured window 里仍然表现出持续更高的 `no-hit-use-bim` 与 `alloc-fail`。
+3. `8way` 平均命中表更深，说明收益来自更稳定的 provider，而不是单纯更大的 BTB 存活率。
+
+热点 branch 对照（measured window）：
+
+| PC | `2way` mispred | `8way` mispred | `noPredMiss` 变化 |
+|---|---:|---:|---:|
+| `1d9ac` | 13757 | 12308 | `54 -> 57` |
+| `40d96` | 10638 | 10673 | `1 -> 1` |
+| `3ec02` | 9803 | 9309 | `1 -> 1` |
+| `40d9e` | 9518 | 9178 | `0 -> 0` |
+| `4d040` | 8305 | 7803 | `0 -> 0` |
+| `4d04c` | 5853 | 4223 | `0 -> 0` |
+
+解释：
+
+1. 和 `nngs` 一样，热点收益主要来自 `dirMiss` 下降。
+2. `noPredMiss` 基本没有贡献。
+
+#### 10.10.3 一个很关键的判断：2way -> 8way 的根因不是单一因素
+
+结合 long-window 与 CI，可把根因拆成两层：
+
+1. **全 slice 视角**：
+   - `2way` 的确存在明显容量/分配压力。
+   - measured window 里仍然有更多 `predNoHitUseBim`、`updateNoHitUseBim`、`updateAllocFailure`。
+   - 这说明有一部分收益确实来自“更多 branch/history 能共存下来”。
+2. **热点 branch 视角**：
+   - 最大的可见收益几乎都是 `dirMiss` 下降，而不是 `noPredMiss` 下降。
+   - 这说明 hottest branches 并不主要是“根本没有 entry”，而是“有 entry 但 provider 太浅、太不稳定、alias 太重”。
+
+因此更准确的表述是：
+
+- `8way` 的收益既有“共存能力提升”的成分，也有“provider 深度与稳定性提升”的成分。
+- 对 gobmk 这两个 slice 来说，**两者都有，但对最热分支的直接可见收益，更偏向后者**。
+
+#### 10.10.4 `numTablesToAlloc=2` 的长窗口验证：不能替代 8way
+
+为验证“是不是只是爬升太慢”，又跑了：
+
+- `useBranchPcForIndex=True`
+- `usePositionForIndexMix=False`
+- `numWays=2`
+- `numTablesToAlloc=2`
+
+在 `gobmk_nngs_18098` measured window 上结果为：
+
+| 配置 | IPC | branchMissPrediction | predNoHitUseBim | updateNoHitUseBim | updateAllocFailure | updateAllocSuccess | predTableHits::mean |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `2way` | 3.195621 | 0.241918 | 4443868 | 148953 | 73884 | 85428 | 1.418889 |
+| `2way + alloc2` | 3.215223 | 0.239555 | 4428262 | 138467 | 109911 | 155084 | 1.452967 |
+| `8way` | 3.480643 | 0.192274 | 3691136 | 109685 | 1828 | 57793 | 1.643924 |
+
+解释：
+
+1. `alloc2` 在短窗（5M）里曾表现出较强正收益，但在 long-window 中只带来很小改善。
+2. 它虽然略微提升了 `predTableHits::mean`，也让部分 branch 改善，但无法逼近 `8way`。
+3. 更重要的是，它显著增加了 `updateAllocSuccess` 与 `updateAllocFailure`，说明“更积极地分配”在 2way 下也会带来更强 churn。
+
+中间结论：
+
+- `numTablesToAlloc=2` 说明“爬升速度”确实是问题的一部分。
+- 但它**不能替代** ways 带来的“同时共存”能力。
+- 因此 `8way` 的根因不能被简化成“只是学得慢”；更像是“**容量/共存 + 爬升/稳定性**”共同作用。
+
+### 10.11 2way / 4way / 8way：SPEC06 CI 三点对照（2026-03-10）
+
+新增一条 CI：
+
+- `run402 / 68582d41be`
+- archive: `/nfs/home/share/gem5_ci/performance_data/spec06-0.3c/20260310_111017_68582d41be_run402`
+
+配置确认：
+
+1. `useBranchPcForIndex=True`
+2. `numWays=4`
+3. `tableSizes=[2048 x 8]`
+
+即：这是 `branchPC + 4way` 的整套 SPEC06 数据点。
+
+#### 10.11.1 总分位置
+
+| 配置 | Estimated Int score per GHz |
+|---|---:|
+| `2way` | 17.725340 |
+| `4way` | 17.834559 |
+| `8way` | 17.923055 |
+
+定义 `2way -> 8way` 的总收益为 100%，则：
+
+- `4way` 吃到了约 **55.24%** 的总收益
+
+这说明：
+
+1. `4way` 不是没用，而是明显有效。
+2. 但 `4way` 仍然只走到了 `8way` 的一半左右，不是“已经基本够了”。
+
+#### 10.11.2 benchmark 级位置
+
+关键 benchmark：
+
+| benchmark | `2way` | `4way` | `8way` | `4way` 吃到 `8way` 收益比例 |
+|---|---:|---:|---:|---:|
+| `gobmk` | 13.534 | 14.069 | 14.433 | 59.5% |
+| `sjeng` | 11.671 | 11.912 | 11.996 | 74.0% |
+| `astar` | 21.145 | 21.368 | 21.449 | 73.4% |
+
+解释：
+
+1. `sjeng` 上，`4way` 已经较接近 `8way`。
+2. `gobmk` 上，`4way` 明显还没有吃满收益。
+3. 这进一步说明 gobmk 对“更高共存能力”更敏感。
+
+#### 10.11.3 `gobmk_nngs_18098`：4way 已接近 8way 的大部分可见收益
+
+| 配置 | IPC | branchMissPrediction | predNoHitUseBim | updateAllocFailure | predTableHits::mean |
+|---|---:|---:|---:|---:|---:|
+| `2way` | 3.195290 | 0.243045 | 4497784 | 75773 | 1.423695 |
+| `4way` | 3.422341 | 0.202649 | 3847954 | 40322 | 1.572258 |
+| `8way` | 3.480643 | 0.192274 | 3691136 | 1828 | 1.643924 |
+
+这里最有信息量的点是：
+
+1. `4way` 已经拿到了约 **80%** 的 IPC / branchMissPrediction 改善。
+2. 但只拿到了约 **48%** 的 alloc-fail 改善。
+
+这说明：
+
+- `4way` 已经足以把一部分关键热点 branch 稳住；
+- 但更深层的共存压力还明显存在，因此 `updateAllocFailure` 还远高于 `8way`。
+
+热点 branch 也支持这个判断：
+
+| PC | `2way` | `4way` | `8way` |
+|---|---:|---:|---:|
+| `3ec02` | 9420 | 8137 | 7871 |
+| `3ac86` | 6629 | 5680 | 5383 |
+| `40d9e` | 2803 | 2314 | 2291 |
+| `3ef4a` | 3257 | 2736 | 2646 |
+| `3b67e` | 3555 | 3057 | 2932 |
+
+但 `compute_connection_distances` 中的最顽固两条：
+
+| PC | `2way` | `4way` | `8way` |
+|---|---:|---:|---:|
+| `4f388` | 8897 | 8867 | 8831 |
+| `4f37c` | 9662 | 9409 | 9434 |
+
+几乎没有明显改善，说明它们更可能带有较强语义难度，或仍然需要更强的共存/更少 alias 才能继续下降。
+
+#### 10.11.4 `gobmk_trevord_7886`：4way 更像只解决了一半问题
+
+| 配置 | IPC | branchMissPrediction | predNoHitUseBim | updateAllocFailure | predTableHits::mean |
+|---|---:|---:|---:|---:|---:|
+| `2way` | 1.905328 | 0.410177 | 8684844 | 171059 | 0.954579 |
+| `4way` | 1.990286 | 0.389931 | 6686210 | 127246 | 1.018934 |
+| `8way` | 2.079487 | 0.367182 | 5733766 | 67502 | 1.166095 |
+
+这里 `4way` 只拿到大约：
+
+1. **48.8%** 的 IPC 收益
+2. **47.1%** 的 branchMissPrediction 改善
+
+热点 branch 也体现出“只解决了一半”：
+
+| PC | `2way` | `4way` | `8way` |
+|---|---:|---:|---:|
+| `1d9ac` | 13784 | 13191 | 12308 |
+| `4d04c` | 5803 | 4850 | 4223 |
+| `1d99c` | 6402 | 5784 | 5096 |
+| `2a664` | 5863 | 5350 | 4967 |
+| `3fa08` | 5413 | 4983 | 4556 |
+
+而像 `40d96` / `40d9e` 这类 branch，`4way` 的改善就相对有限。
+
+因此：
+
+- `trevord_7886` 比 `nngs_18098` 更需要更高的共存能力；
+- `4way` 只能部分缓解，`8way` 才开始把一整簇 dense block 内的竞争真正摊开。
+
+#### 10.11.5 这一小节的阶段性理解
+
+`4way` 的位置可以总结为：
+
+1. 它足以证明问题确实和 ways / 共存能力高度相关。
+2. 它对 `sjeng` 已经比较接近饱和。
+3. 它对 `gobmk` 只是中间态，不足以说明“继续加 way 没意义”。
+4. 但由于 `4way` 到 `8way` 仍有较大剩余空间，单纯依赖轻微改替换或轻微改分配，大概率还不能完全替代更高共存能力。

--- a/docs/Gem5_Docs/frontend/tage_upper_bound_design_20260310.md
+++ b/docs/Gem5_Docs/frontend/tage_upper_bound_design_20260310.md
@@ -1,0 +1,296 @@
+# UB-S(outcome) TAGE v1 设计（2026-03-10）
+
+## 1. 目的
+
+这份文档只定义一个可实现的 `v1`：
+
+- 名称：`UB-S(outcome)`
+- 目标：给 `gobmk_nngs_18098` 和 `gobmk_trevord_7886` 提供一个 **无 set/tag/way/replacement 竞争** 的 TAGE 上界
+- 作用：回答 `8way` 到底离“当前 history-length 体系下的无竞争上界”还有多远
+
+它不是 RTL 方案，也不是 oracle predictor。
+
+## 2. v1 定义
+
+`UB-S(outcome)` 的查找键定义为：
+
+`(branchPC, exact outcome history prefix of length Li)`
+
+其中：
+
+- `branchPC`：该条件分支的 PC
+- `Li`：第 `i` 张 TAGE 表的 history length
+- `exact outcome history`：精确的 taken/not-taken 比特串，不做 folding
+
+因此，v1 去掉了这些因素：
+
+- set 冲突
+- tag alias
+- way 限制
+- replacement / victim
+- folded-history alias
+
+但仍然保留这些因素：
+
+- 固定的一组 history lengths
+- provider / alternate 选择
+- counter 更新
+- base predictor 兜底
+
+所以它是一个 **偏强但仍然像 TAGE 的上界**，而不是“纯结构上界”的严格最小定义。
+
+## 3. 实现形态
+
+第一版采用：
+
+- `class BTBTAGEUpperBound : public BTBTAGE`
+
+原因不是为了复用当前数组表项组织，而是为了复用：
+
+- predictor 接线方式
+- `FullBTBPrediction` / `FetchTarget` / `TageMeta` 生命周期
+- decoupled frontend 的预测、更新、恢复入口
+
+但要明确：
+
+- **继承 `BTBTAGE` 不等于自动继承了 UB-S(outcome) 需要的 history 生命周期**
+- 当前生产代码真正维护的是 path-history folding；`specUpdateHist/recoverHist` 这部分对 `UB-S(outcome)` 不能直接沿用
+
+## 4. 核心设计决策
+
+### 4.1 必做项
+
+`v1` 固定采用以下约束：
+
+- 名称明确为 `UB-S(outcome)`，不再泛称 “upper-bound TAGE”
+- `updateOnRead = false`
+- exact outcome history 由子类自己维护
+- `meta` 里不保存 `unordered_map` iterator
+- key 使用 fixed-width 表示，不用 `dynamic_bitset` 直接做哈希 key
+- 每张表预留 `reserve`
+- 输出 `contexts_per_table` 与 `contexts_per_hot_branch`
+
+### 4.2 v1 不做的事
+
+- 不做 exact path history 版本
+- 不做 oracle / infinite-context predictor
+- 不先追求全 SPEC 可跑
+- 不在 `BTBTAGE` 里打很多条件分支混跑
+
+## 5. 数据结构
+
+每张表维护一个哈希表：
+
+```text
+ubTable[i] : unordered_map<UBKey_i, UBEntry>
+```
+
+逻辑上：
+
+- 一张表对应一个 history length `Li`
+- 同一 `(branchPC, exact outcome history prefix Li)` 唯一映射到一个 `UBEntry`
+- 没有 set/way/replacement
+
+`UBEntry` 第一版只保留最小字段：
+
+- direction counter
+- useful bit / usefulness counter（若 provider/alt 逻辑仍依赖）
+
+如果实现时发现 `u` 在 v1 里没有解释价值，可以先保留字段但弱化其作用；不要为了完全复刻当前 array-TAGE 的替换语义而复杂化 v1。
+
+## 6. Key 设计
+
+推荐定义两个固定宽度 key：
+
+### 6.1 短历史表
+
+对 `Li <= 64`：
+
+- `pc`
+- `hist_lo`
+- `hist_len`
+
+### 6.2 长历史表
+
+对 `Li > 64`：
+
+- `pc`
+- `hist_words[N]`
+- `hist_len`
+
+这里的 `N` 不做动态长度，直接按当前配置支持的最大 history length 预留固定 word 数。
+
+要求：
+
+- 自定义 `hash`
+- 自定义 `operator==`
+- 避免把 STL 容器本身嵌进 key
+
+## 7. History 生命周期
+
+这是 reviewer 最后强调、也是 v1 最需要写清楚的点。
+
+### 7.1 不能直接依赖现有 BTBTAGE 的 outcome-history 生命周期
+
+当前 `BTBTAGE` 生产路径真正实现的是：
+
+- `specUpdatePHist`
+- `recoverPHist`
+
+它维护的是 path-history folding。
+
+而 `UB-S(outcome)` 需要的是：
+
+- prediction 时可取到 exact outcome history snapshot
+- squash 时可恢复并重放 exact outcome history
+
+所以子类必须自己实现：
+
+- `specUpdateHist`
+- `recoverHist`
+
+并在自己的 `meta` 中保存与 exact outcome history 对应的 snapshot。
+
+### 7.2 v1 的做法
+
+建议在 `BTBTAGEUpperBound` 中额外维护：
+
+- 一份精确的 speculative global outcome history
+- 一份 prediction-time snapshot，写入 `meta`
+
+规则：
+
+1. prediction 时按当前 exact history 构造各表 key
+2. `specUpdateHist` 用最终预测方向推测更新 exact history
+3. squash 时 `recoverHist` 先恢复 snapshot，再按真实结果重放
+
+是否继续调用基类的 `specUpdatePHist/recoverPHist`：
+
+- 可以保留，用于不破坏现有前端组件期望的 path-history 生命周期
+- 但 `UB-S(outcome)` 的查找正确性不能依赖它
+
+## 8. Meta 设计
+
+第一版 `meta` 至少保存：
+
+- prediction-time exact outcome history snapshot
+- provider table id
+- alternate table id
+- provider key
+- alternate key
+- provider / alt / base 的决策结果
+
+不要保存：
+
+- `unordered_map` iterator
+- 任何依赖容器不 rehash 的裸引用
+
+原因很直接：
+
+- 插入新 context 后 `unordered_map` 可能 rehash
+- iterator / reference 稳定性不足以作为 update 阶段句柄
+
+第一版更稳的方案是：
+
+- `meta` 存 table + key + decision
+- update 时按 key 二次查表
+
+这也是 `updateOnRead=false` 的直接配套设计。
+
+## 9. 预测与更新流程
+
+### 9.1 预测
+
+对每个表 `i`：
+
+1. 取 `branchPC`
+2. 从 exact outcome history 截取长度 `Li` 的前缀
+3. 构造 `UBKey_i`
+4. 从最长表到最短表寻找存在项
+
+规则保持 TAGE 风格：
+
+- 最长命中项作为 provider
+- 次长命中项作为 alternate
+- 都没有则落回 base predictor
+
+### 9.2 更新
+
+更新方向保持“像 TAGE”，但不再有分配失败：
+
+1. 若 provider 存在，更新 provider counter
+2. 若需要分配更长历史表项，直接在目标表 `emplace`
+3. 不做 set 内择路
+4. 不做 victim 选择
+5. 不统计 alloc-fail
+
+因此 `UB-S(outcome)` 的提升可直接理解为：
+
+- 去掉跨分支、跨上下文的组织竞争后，当前 history-length 体系还能学到什么程度
+
+## 10. 统计项
+
+除常规 `IPC`、`branchMissPrediction`、`topMispredictsByBranch.csv` 外，v1 必须新增：
+
+- `contexts_per_table`
+- `contexts_per_hot_branch`
+- `provider_table_distribution`
+
+推荐再加：
+
+- `base/provider/alt` 命中分布
+- 每张表的 live contexts 峰值
+
+这些统计是解释 `8way -> UB-S(outcome)` 差距的关键，不是可选项。
+
+## 11. 验证范围
+
+第一批只跑：
+
+- `gobmk_nngs_18098`
+- `gobmk_trevord_7886`
+
+推荐顺序：
+
+1. 先做短窗口功能验证
+2. 再做 `20M warmup + 20M measured`
+3. 只对热点分支输出 `2way / 4way / 8way / UB-S(outcome)` 对照
+
+## 12. 结果解释规则
+
+如果出现：
+
+- `8way ≈ UB-S(outcome)`
+  说明 ways/组织空间基本吃满，剩余误判更像 history 表达或分支语义上限
+
+- `2way << 8way << UB-S(outcome)`
+  说明仍有大量结构空间，继续做低表共存/去 alias 才有意义
+
+- `2way ≈ 8way << UB-S(outcome)`
+  说明问题不主要在 ways，本质更像当前 TAGE 组织方式没有抓到合适上下文
+
+## 13. 最小实现建议
+
+建议新增独立文件：
+
+- `src/cpu/pred/btb/btb_tage_ub.hh`
+- `src/cpu/pred/btb/btb_tage_ub.cc`
+
+以及 Python 接线：
+
+- `src/cpu/pred/BranchPredictor.py`
+
+推荐实现顺序：
+
+1. 定义 `UBKey` / `UBEntry` / custom hash
+2. 搭 `BTBTAGEUpperBound : public BTBTAGE`
+3. 实现 exact outcome history 的 `specUpdateHist/recoverHist`
+4. 实现 provider/alt 查找
+5. 实现 update + 统计
+6. 跑两个 gobmk slice
+
+## 14. 当前结论
+
+这份文档收敛后的结论只有一条：
+
+**下一步最值得做的不是继续猜 replacement 或 alloc policy，而是先做 `UB-S(outcome)`，把 `8way` 与“无竞争上界”的距离量出来。**

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1043,6 +1043,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     needMoreHistories = Param.Bool(True, "BTBTAGE needs more histories")
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
+    useBranchPcForIndex = Param.Bool(False, "Use branch PC (instead of stream startPC) to compute TAGE index")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([2048]*8, "the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13]*8, "the T0~Tn entry's tag bit size")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1044,6 +1044,8 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
     useBranchPcForIndex = Param.Bool(False, "Use branch PC (instead of stream startPC) to compute TAGE index")
+    usePositionForIndexMix = Param.Bool(False, "Mix branch position into index for low tables")
+    indexMixTables = Param.Unsigned(4, "Number of low tables using position-mixed index")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([2048]*8, "the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13]*8, "the T0~Tn entry's tag bit size")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1070,6 +1070,8 @@ class BTBTAGEUpperBound(BTBTAGE):
 
     needMoreHistories = False
     updateOnRead = False
+    usePathHashHistory = Param.Bool(
+        False, "Use exact path-hash history instead of exact outcome history")
 
 class MicroTAGE(BTBTAGE):
     """A smaller TAGE predictor configuration to assist uBTB"""

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1063,6 +1063,14 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableBankConflict = Param.Bool(False, "Enable bank conflict simulation")
     numDelay = 2
 
+class BTBTAGEUpperBound(BTBTAGE):
+    type = 'BTBTAGEUpperBound'
+    cxx_class = 'gem5::branch_prediction::btb_pred::BTBTAGEUpperBound'
+    cxx_header = "cpu/pred/btb/btb_tage_ub.hh"
+
+    needMoreHistories = False
+    updateOnRead = False
+
 class MicroTAGE(BTBTAGE):
     """A smaller TAGE predictor configuration to assist uBTB"""
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -49,7 +49,8 @@ SimObject('BranchPredictor.py', sim_objects=[
     'DecoupledStreamBPU', 'DefaultFTB', 'DecoupledBPUWithFTB',
     'TimedBaseFTBPredictor', 'FTBTAGE', 'FTBRAS', 'FTBuRAS', 'FTBITTAGE',
     'AheadBTB', 'MBTB', 'UBTB', 'DecoupledBPUWithBTB',
-    'TimedBaseBTBPredictor', 'BTBRAS', 'BTBTAGE', 'BTBITTAGE', 'BTBMGSC'], enums=["BpType"])
+    'TimedBaseBTBPredictor', 'BTBRAS', 'BTBTAGE', 'BTBTAGEUpperBound',
+    'BTBITTAGE', 'BTBMGSC'], enums=["BpType"])
 
 DebugFlag('Indirect')
 Source('bpred_unit.cc')
@@ -100,6 +101,7 @@ Source('btb/abtb.cc')
 Source('btb/mbtb.cc')
 Source('btb/timed_base_pred.cc')
 Source('btb/btb_tage.cc')
+Source('btb/btb_tage_ub.cc')
 Source('btb/btb_ittage.cc')
 Source('btb/btb_mgsc.cc')
 Source('btb/folded_hist.cc')

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -43,6 +43,8 @@ BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSize, u
       useAltOnNaWidth(7),
       updateOnRead(false),
       useBranchPcForIndex(false),
+      usePositionForIndexMix(false),
+      indexMixTables(4),
       numBanks(numBanks),
       bankIdWidth(ceilLog2(numBanks)),
       blockWidth(floorLog2(blockSize)),
@@ -83,6 +85,8 @@ numTablesToAlloc(p.numTablesToAlloc),
 enableSC(p.enableSC),
 updateOnRead(p.updateOnRead),
 useBranchPcForIndex(p.useBranchPcForIndex),
+usePositionForIndexMix(p.usePositionForIndexMix),
+indexMixTables(p.indexMixTables),
 numBanks(p.numBanks),
 bankIdWidth(ceilLog2(p.numBanks)),
 blockWidth(floorLog2(blockSize)),
@@ -210,9 +214,10 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     // Search from highest to lowest table for matches
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(btb_entry.pc, startPC);
-    Addr indexPc = useBranchPcForIndex ? btb_entry.pc : startPC;
+    Addr baseIndexPc = useBranchPcForIndex ? btb_entry.pc : startPC;
 
     for (int i = numPredictors - 1; i >= 0; --i) {
+        Addr indexPc = buildIndexPC(baseIndexPc, position, i);
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
         Addr index = predMeta ? getTageIndex(indexPc, i, predMeta->indexFoldedHist[i].get())
@@ -574,9 +579,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
-    Addr indexPc = useBranchPcForIndex ? entry.pc : startPC;
+    Addr baseIndexPc = useBranchPcForIndex ? entry.pc : startPC;
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
+        Addr indexPc = buildIndexPC(baseIndexPc, position, ti);
         Addr newIndex = getTageIndex(indexPc, ti, meta->indexFoldedHist[ti].get());
         Addr newTag = getTageTag(startPC, ti,
             meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
@@ -902,6 +908,20 @@ BTBTAGE::getBranchIndexInBlock(Addr branchPC, Addr startPC) {
     Addr offset = (branchPC - alignedPC) >> instShiftAmt;
     assert(offset < maxBranchPositions);
     return offset;
+}
+
+Addr
+BTBTAGE::buildIndexPC(Addr basePc, unsigned position, unsigned table) const
+{
+    if (!usePositionForIndexMix || table >= indexMixTables) {
+        return basePc;
+    }
+
+    // Mix branch slot position into PC to reduce low-table set aliasing within one block.
+    const Addr pos = static_cast<Addr>(position + 1);
+    const Addr salt = (pos * 0x9E3779B97F4A7C15ULL) ^
+        (static_cast<Addr>(table + 1) * 0xBF58476D1CE4E5B9ULL);
+    return basePc ^ salt;
 }
 
 unsigned

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -42,6 +42,7 @@ BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSize, u
       useAltOnNaSize(1024),
       useAltOnNaWidth(7),
       updateOnRead(false),
+      useBranchPcForIndex(false),
       numBanks(numBanks),
       bankIdWidth(ceilLog2(numBanks)),
       blockWidth(floorLog2(blockSize)),
@@ -81,6 +82,7 @@ useAltOnNaWidth(p.useAltOnNaWidth),
 numTablesToAlloc(p.numTablesToAlloc),
 enableSC(p.enableSC),
 updateOnRead(p.updateOnRead),
+useBranchPcForIndex(p.useBranchPcForIndex),
 numBanks(p.numBanks),
 bankIdWidth(ceilLog2(p.numBanks)),
 blockWidth(floorLog2(blockSize)),
@@ -208,12 +210,13 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     // Search from highest to lowest table for matches
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(btb_entry.pc, startPC);
+    Addr indexPc = useBranchPcForIndex ? btb_entry.pc : startPC;
 
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
-        Addr index = predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get())
-                          : getTageIndex(startPC, i);
+        Addr index = predMeta ? getTageIndex(indexPc, i, predMeta->indexFoldedHist[i].get())
+                          : getTageIndex(indexPc, i);
         Addr tag = predMeta ? getTageTag(startPC, i,
                             predMeta->tagFoldedHist[i].get(), predMeta->altTagFoldedHist[i].get(), position)
                         : getTageTag(startPC, i, position);
@@ -571,9 +574,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
+    Addr indexPc = useBranchPcForIndex ? entry.pc : startPC;
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
-        Addr newIndex = getTageIndex(startPC, ti, meta->indexFoldedHist[ti].get());
+        Addr newIndex = getTageIndex(indexPc, ti, meta->indexFoldedHist[ti].get());
         Addr newTag = getTageTag(startPC, ti,
             meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
 

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -896,7 +896,7 @@ BTBTAGE::satDecrement(int min, short &counter)
 }
 
 Addr
-BTBTAGE::getUseAltIdx(Addr pc) {
+BTBTAGE::getUseAltIdx(Addr pc) const {
     Addr shiftedPc = pc >> instShiftAmt;
     return shiftedPc & (useAltOnNaSize - 1);
 }

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -194,6 +194,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Get branch index within a prediction block
     unsigned getBranchIndexInBlock(Addr branchPC, Addr startPC);
 
+    // Build per-table index PC with optional position mixing for low tables.
+    Addr buildIndexPC(Addr basePc, unsigned position, unsigned table) const;
+
     // Get bank ID from PC (after removing instruction alignment bits)
     // Extract bits [bankBaseShift + bankIdWidth - 1 : bankBaseShift]
     unsigned getBankId(Addr pc) const;
@@ -298,6 +301,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // Whether to use branch PC (instead of stream startPC) for index computation
     bool useBranchPcForIndex;
+
+    // Whether to mix branch position into index for low tables.
+    bool usePositionForIndexMix;
+    unsigned indexMixTables;
 
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -296,6 +296,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Whether to update on read
     bool updateOnRead;
 
+    // Whether to use branch PC (instead of stream startPC) for index computation
+    bool useBranchPcForIndex;
+
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
     // When prediction and update access the same bank in one cycle, update is dropped

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -162,10 +162,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
     void setTrace() override;
 
     // check folded hists after speculative update and recover
-    void checkFoldedHist(const bitset &history, const char *when);
+    virtual void checkFoldedHist(const bitset &history, const char *when);
 
 #ifndef UNIT_TEST
-  private:
+  protected:
 #endif
 
     // Look up predictions in TAGE tables for a stream of instructions
@@ -285,7 +285,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     bool satDecrement(int min, short &counter);
 
     // Get index for useAlt table
-    Addr getUseAltIdx(Addr pc);
+    Addr getUseAltIdx(Addr pc) const;
 
     // Cache for TAGE indices
     std::vector<Addr> tageIndex;

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -1,0 +1,572 @@
+#include "cpu/pred/btb/btb_tage_ub.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#include <boost/dynamic_bitset.hpp>
+
+#ifndef UNIT_TEST
+#include "base/logging.hh"
+#include "base/trace.hh"
+#include "debug/TAGE.hh"
+
+#endif
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+#ifdef UNIT_TEST
+namespace test {
+#endif
+
+std::size_t
+BTBTAGEUpperBound::ExactHistoryKeyHash::operator()(
+    const ExactHistoryKey &key) const
+{
+    auto mix = [](uint64_t value) {
+        value ^= value >> 30;
+        value *= 0xbf58476d1ce4e5b9ULL;
+        value ^= value >> 27;
+        value *= 0x94d049bb133111ebULL;
+        value ^= value >> 31;
+        return value;
+    };
+
+    uint64_t seed = mix(key.branchPC ^ key.activeWords);
+    for (unsigned i = 0; i < key.activeWords; ++i) {
+        seed ^= mix(key.words[i] + 0x9e3779b97f4a7c15ULL +
+                    (seed << 6) + (seed >> 2));
+    }
+    return static_cast<std::size_t>(seed);
+}
+
+#ifdef UNIT_TEST
+BTBTAGEUpperBound::BTBTAGEUpperBound(unsigned numPredictors,
+                                     unsigned tableSize,
+                                     unsigned numBanks)
+    : BTBTAGE(numPredictors, 1, tableSize, numBanks),
+      ubStats(numPredictors)
+{
+    needMoreHistories = false;
+    updateOnRead = false;
+    initUpperBoundState();
+}
+#else
+BTBTAGEUpperBound::BTBTAGEUpperBound(const Params &p)
+    : BTBTAGE(p),
+      ubStats(this, p.numPredictors)
+{
+    needMoreHistories = false;
+    updateOnRead = false;
+    initUpperBoundState();
+}
+#endif
+
+#ifndef UNIT_TEST
+BTBTAGEUpperBound::UpperBoundStats::UpperBoundStats(
+    statistics::Group *parent, unsigned numPredictors)
+    : statistics::Group(parent),
+      ADD_STAT(liveContextsPerTable, statistics::units::Count::get(),
+               "Number of live exact-history contexts in each upper-bound table"),
+      ADD_STAT(totalContexts, statistics::units::Count::get(),
+               "Total number of live exact-history contexts"),
+      ADD_STAT(updateAllocInsert, statistics::units::Count::get(),
+               "Number of exact-history entry insertions on update"),
+      ADD_STAT(updateAllocAllTablesHit, statistics::units::Count::get(),
+               "Updates where all higher tables already had the exact context")
+{
+    liveContextsPerTable.init(numPredictors);
+}
+#endif
+
+void
+BTBTAGEUpperBound::initUpperBoundState()
+{
+    exactTables.clear();
+    exactTables.resize(numPredictors);
+    historyBlocksScratch.reserve(MaxHistoryWords);
+
+    for (unsigned i = 0; i < numPredictors; ++i) {
+#ifdef UNIT_TEST
+        assert(histLengths[i] <= MaxSupportedHistBits);
+#else
+        fatal_if(histLengths[i] > MaxSupportedHistBits,
+                 "BTBTAGEUpperBound only supports history lengths up to %u "
+                 "bits, got table %u length %u",
+                 MaxSupportedHistBits, i, histLengths[i]);
+#endif
+
+        unsigned reserveEntries = std::max<unsigned>(16,
+            tableSizes[i] * std::max<unsigned>(1, numWays));
+        exactTables[i].reserve(reserveEntries);
+    }
+}
+
+void
+BTBTAGEUpperBound::captureHistoryWords(
+    const bitset &history,
+    std::array<uint64_t, MaxHistoryWords> &words) const
+{
+    words.fill(0);
+
+    historyBlocksScratch.clear();
+    historyBlocksScratch.reserve((history.size() + 63) / 64);
+    boost::to_block_range(history, std::back_inserter(historyBlocksScratch));
+
+    const unsigned copyWords = std::min<unsigned>(
+        MaxHistoryWords, historyBlocksScratch.size());
+    for (unsigned i = 0; i < copyWords; ++i) {
+        words[i] = historyBlocksScratch[i];
+    }
+}
+
+BTBTAGEUpperBound::ExactHistoryKey
+BTBTAGEUpperBound::buildKey(
+    Addr branchPC,
+    const std::array<uint64_t, MaxHistoryWords> &words,
+    unsigned histLen) const
+{
+    ExactHistoryKey key;
+    key.branchPC = branchPC;
+    key.words.fill(0);
+    key.activeWords = (histLen + 63) / 64;
+
+    for (unsigned i = 0; i < key.activeWords; ++i) {
+        key.words[i] = words[i];
+    }
+
+    const unsigned rem = histLen % 64;
+    if (key.activeWords > 0 && rem != 0) {
+        key.words[key.activeWords - 1] &= ((1ULL << rem) - 1);
+    }
+
+    return key;
+}
+
+BTBTAGE::TageTableInfo
+BTBTAGEUpperBound::makeTableInfo(bool found, const TageEntry *entry,
+                                 unsigned table) const
+{
+    if (!found || entry == nullptr) {
+        return TageTableInfo();
+    }
+    return TageTableInfo(true, *entry, table, 0, 0, 0);
+}
+
+BTBTAGE::TagePrediction
+BTBTAGEUpperBound::lookupExactPrediction(
+    const BTBEntry &btbEntry,
+    const std::array<uint64_t, MaxHistoryWords> &historyWords,
+    BranchPredictionMeta *metaOut) const
+{
+    bool provided = false;
+    bool altProvided = false;
+    TageTableInfo mainInfo, altInfo;
+    BranchPredictionMeta localMeta;
+
+    for (int i = numPredictors - 1; i >= 0; --i) {
+        auto key = buildKey(btbEntry.pc, historyWords, histLengths[i]);
+        auto it = exactTables[i].find(key);
+        if (it == exactTables[i].end()) {
+            continue;
+        }
+
+        if (!provided) {
+            mainInfo = makeTableInfo(true, &it->second, i);
+            localMeta.main = {true, static_cast<unsigned>(i), key};
+            provided = true;
+        } else if (!altProvided) {
+            altInfo = makeTableInfo(true, &it->second, i);
+            localMeta.alt = {true, static_cast<unsigned>(i), key};
+            altProvided = true;
+            break;
+        }
+    }
+
+    if (metaOut != nullptr) {
+        *metaOut = localMeta;
+    }
+
+    const bool mainTaken = mainInfo.taken();
+    const bool altTaken = altInfo.taken();
+    const bool baseTaken = btbEntry.ctr >= 0;
+    const bool altPred = altProvided ? altTaken : baseTaken;
+
+    bool useAltPred = false;
+    if (!provided) {
+        useAltPred = true;
+    } else {
+        const bool mainWeak =
+            (mainInfo.entry.counter == 0 || mainInfo.entry.counter == -1);
+        if (mainWeak) {
+            Addr uidx = getUseAltIdx(btbEntry.pc);
+            useAltPred = (useAlt[uidx] >= 0);
+        }
+    }
+
+    const bool taken = useAltPred ? altPred : mainTaken;
+    return TagePrediction(btbEntry.pc, mainInfo, altInfo, useAltPred, taken,
+                          altPred);
+}
+
+void
+BTBTAGEUpperBound::notePredictionResult(
+    const BTBEntry &btbEntry,
+    const TagePrediction &pred,
+    std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs,
+    CondTakens &results) const
+{
+    results.push_back({btbEntry.pc, pred.taken || btbEntry.alwaysTaken});
+    tageInfoForMgscs[btbEntry.pc].tage_pred_taken = pred.taken;
+    tageInfoForMgscs[btbEntry.pc].tage_main_taken =
+        pred.mainInfo.found ? pred.mainInfo.taken() : false;
+    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_high =
+        pred.mainInfo.found && abs(pred.mainInfo.entry.counter * 2 + 1) == 7;
+    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_mid =
+        pred.mainInfo.found &&
+        (abs(pred.mainInfo.entry.counter * 2 + 1) < 7 &&
+         abs(pred.mainInfo.entry.counter * 2 + 1) > 1);
+    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_low =
+        !pred.mainInfo.found ||
+        (abs(pred.mainInfo.entry.counter * 2 + 1) <= 1);
+    tageInfoForMgscs[btbEntry.pc].tage_pred_alt_diff =
+        pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
+}
+
+void
+BTBTAGEUpperBound::putPCHistory(Addr startAddr, const bitset &history,
+                                std::vector<FullBTBPrediction> &stagePreds)
+{
+    lastPredBankId = getBankId(startAddr);
+    predBankValid = true;
+
+#ifndef UNIT_TEST
+    tageStats.predAccessPerBank[lastPredBankId]++;
+#endif
+
+    ubMeta = std::make_shared<UpperBoundMeta>();
+    ubMeta->history = history;
+    captureHistoryWords(history, ubMeta->historyWords);
+
+    for (int s = getDelay(); s < stagePreds.size(); ++s) {
+        auto &stagePred = stagePreds[s];
+        stagePred.condTakens.clear();
+        stagePred.tageInfoForMgscs.clear();
+
+        for (auto &btbEntry : stagePred.btbEntries) {
+            if (!(btbEntry.isCond && btbEntry.valid)) {
+                continue;
+            }
+
+            BranchPredictionMeta branchMeta;
+            auto pred = lookupExactPrediction(
+                btbEntry, ubMeta->historyWords, &branchMeta);
+            ubMeta->preds[btbEntry.pc] = pred;
+            ubMeta->branchMeta[btbEntry.pc] = branchMeta;
+            tageStats.updateStatsWithTagePrediction(pred, true);
+            notePredictionResult(btbEntry, pred, stagePred.tageInfoForMgscs,
+                                 stagePred.condTakens);
+        }
+    }
+}
+
+std::shared_ptr<void>
+BTBTAGEUpperBound::getPredictionMeta()
+{
+    return ubMeta;
+}
+
+void
+BTBTAGEUpperBound::specUpdateHist(const boost::dynamic_bitset<> &history,
+                                  FullBTBPrediction &pred)
+{
+    (void)history;
+    (void)pred;
+}
+
+void
+BTBTAGEUpperBound::recoverHist(const boost::dynamic_bitset<> &history,
+                               const FetchTarget &entry, int shamt,
+                               bool cond_taken)
+{
+    (void)history;
+    (void)entry;
+    (void)shamt;
+    (void)cond_taken;
+}
+
+bool
+BTBTAGEUpperBound::updatePredictorStateAndCheckAllocation(
+    const BTBEntry &entry, bool actualTaken, const TagePrediction &pred,
+    const BranchPredictionMeta &meta, const FetchTarget &stream)
+{
+    tageStats.updateStatsWithTagePrediction(pred, false);
+
+    const auto &mainInfo = pred.mainInfo;
+    const auto &altInfo = pred.altInfo;
+    const bool usedAlt = pred.useAlt;
+    const bool baseTaken = entry.ctr >= 0;
+    const bool altTaken = altInfo.found ? altInfo.taken() : baseTaken;
+
+    if (mainInfo.found) {
+        const bool mainWeak =
+            (mainInfo.entry.counter == 0 || mainInfo.entry.counter == -1);
+        if (mainWeak) {
+            tageStats.updateProviderNa++;
+            Addr uidx = getUseAltIdx(entry.pc);
+            bool altCorrect = (altTaken == actualTaken);
+            updateCounter(altCorrect, useAltOnNaWidth, useAlt[uidx]);
+            tageStats.updateUseAltOnNaUpdated++;
+            if (altCorrect) {
+                tageStats.updateUseAltOnNaCorrect++;
+            } else {
+                tageStats.updateUseAltOnNaWrong++;
+            }
+        }
+    }
+
+    if (meta.main.found) {
+        auto tableIt = exactTables[meta.main.table].find(meta.main.key);
+        assert(tableIt != exactTables[meta.main.table].end());
+        auto &way = tableIt->second;
+
+        updateCounter(actualTaken, 3, way.counter);
+
+        const bool mainIsCorrect = mainInfo.taken() == actualTaken;
+        const bool altIsCorrectAndStrong = altInfo.found &&
+            (altInfo.taken() == actualTaken) &&
+            (abs(2 * altInfo.entry.counter + 1) == 7);
+
+        if (altIsCorrectAndStrong && mainIsCorrect) {
+            way.useful = 0;
+        } else if (mainInfo.taken() != altTaken && mainIsCorrect) {
+            way.useful = 1;
+        }
+
+        if (way.counter == 0 || way.counter == -1) {
+            way.useful = 0;
+        }
+    }
+
+    if (usedAlt && meta.alt.found) {
+        auto tableIt = exactTables[meta.alt.table].find(meta.alt.key);
+        assert(tableIt != exactTables[meta.alt.table].end());
+        updateCounter(actualTaken, 3, tableIt->second.counter);
+    }
+
+    if (usedAlt) {
+        bool altCorrect = altTaken == actualTaken;
+        if (altCorrect) {
+            tageStats.updateUseAltCorrect++;
+        } else {
+            tageStats.updateUseAltWrong++;
+        }
+        if (mainInfo.found && mainInfo.taken() != altTaken) {
+            tageStats.updateAltDiffers++;
+        }
+    }
+
+    const bool thisFbMispred =
+        stream.squashType == SquashType::SQUASH_CTRL &&
+        stream.squashPC == entry.pc;
+    if (getDelay() == 2 && thisFbMispred) {
+        tageStats.updateMispred++;
+        if (!usedAlt && mainInfo.found) {
+#ifndef UNIT_TEST
+            tageStats.updateTableMispreds[mainInfo.table]++;
+#endif
+        }
+    }
+
+    if (!thisFbMispred) {
+        return false;
+    }
+
+    if (usedAlt && mainInfo.found && mainInfo.taken() == actualTaken) {
+        return false;
+    }
+
+    return true;
+}
+
+bool
+BTBTAGEUpperBound::allocateExactEntry(
+    const BTBEntry &entry, bool actualTaken, unsigned startTable,
+    const std::array<uint64_t, MaxHistoryWords> &historyWords,
+    uint64_t &allocatedTable)
+{
+    for (unsigned ti = startTable; ti < numPredictors; ++ti) {
+        auto key = buildKey(entry.pc, historyWords, histLengths[ti]);
+        auto [it, inserted] = exactTables[ti].emplace(
+            key, TageEntry(0, actualTaken ? 0 : -1, entry.pc));
+        if (!inserted) {
+            continue;
+        }
+
+        refreshContextStats(ti);
+        ubStats.totalContexts++;
+        ubStats.updateAllocInsert++;
+        tageStats.updateAllocSuccess++;
+        allocatedTable = ti;
+        return true;
+    }
+
+    ubStats.updateAllocAllTablesHit++;
+    return false;
+}
+
+std::vector<BTBEntry>
+BTBTAGEUpperBound::prepareUpperBoundUpdateEntries(const FetchTarget &stream)
+{
+    auto allEntries = stream.updateBTBEntries;
+
+    if (!stream.updateIsOldEntry) {
+        BTBEntry potentialNewEntry = stream.updateNewBTBEntry;
+        bool newEntryTaken =
+            stream.exeTaken && stream.getControlPC() == potentialNewEntry.pc;
+        if (!newEntryTaken) {
+            potentialNewEntry.alwaysTaken = false;
+        }
+        allEntries.push_back(potentialNewEntry);
+    }
+
+    if (getResolvedUpdate()) {
+        auto removeIt = std::remove_if(
+            allEntries.begin(), allEntries.end(),
+            [](const BTBEntry &e) {
+                return !(e.isCond && !e.alwaysTaken && e.resolved);
+            });
+        allEntries.erase(removeIt, allEntries.end());
+    } else {
+        auto removeIt = std::remove_if(
+            allEntries.begin(), allEntries.end(),
+            [](const BTBEntry &e) {
+                return !(e.isCond && !e.alwaysTaken);
+            });
+        allEntries.erase(removeIt, allEntries.end());
+    }
+
+    return allEntries;
+}
+
+void
+BTBTAGEUpperBound::refreshContextStats(unsigned table)
+{
+    ubStats.liveContextsPerTable[table] = exactTables[table].size();
+}
+
+void
+BTBTAGEUpperBound::update(const FetchTarget &stream)
+{
+    auto entriesToUpdate = prepareUpperBoundUpdateEntries(stream);
+    auto predMeta = std::static_pointer_cast<UpperBoundMeta>(
+        stream.predMetas[getComponentIdx()]);
+    if (!predMeta) {
+        return;
+    }
+
+    bool hasStoredVsActualDiff = false;
+    for (auto &btbEntry : entriesToUpdate) {
+        auto predIt = predMeta->preds.find(btbEntry.pc);
+        auto metaIt = predMeta->branchMeta.find(btbEntry.pc);
+        const bool actualTaken =
+            stream.exeTaken && stream.exeBranchInfo == btbEntry;
+        TagePrediction storedPred;
+        BranchPredictionMeta storedMeta;
+        if (predIt != predMeta->preds.end() &&
+            metaIt != predMeta->branchMeta.end()) {
+            storedPred = predIt->second;
+            storedMeta = metaIt->second;
+        } else {
+            // BTB miss / new conditional branches are absent from prediction-time
+            // maps, but they still must be trained using the prediction-time
+            // history snapshot carried in predMeta.
+            storedPred = lookupExactPrediction(
+                btbEntry, predMeta->historyWords, &storedMeta);
+        }
+
+        if (storedPred.taken != actualTaken) {
+            hasStoredVsActualDiff = true;
+        }
+
+        bool needAllocate = updatePredictorStateAndCheckAllocation(
+            btbEntry, actualTaken, storedPred, storedMeta, stream);
+
+        if (needAllocate) {
+            uint64_t allocatedTable = 0;
+            unsigned startTable = 0;
+            if (storedMeta.main.found) {
+                startTable = storedMeta.main.table + 1;
+            }
+            allocateExactEntry(btbEntry, actualTaken, startTable,
+                               predMeta->historyWords, allocatedTable);
+        }
+    }
+
+    if (hasStoredVsActualDiff) {
+        tageStats.recomputedVsActualDiff++;
+    }
+    if (getDelay() < 2) {
+        checkUtageUpdateMisspred(stream);
+    }
+}
+
+void
+BTBTAGEUpperBound::checkFoldedHist(const bitset &history, const char *when)
+{
+    (void)history;
+    (void)when;
+}
+
+#ifdef UNIT_TEST
+BTBTAGEUpperBound::ExactHistoryKey
+BTBTAGEUpperBound::makeExactKey(Addr branchPC, const bitset &history,
+                                unsigned table) const
+{
+    std::array<uint64_t, MaxHistoryWords> historyWords{};
+    captureHistoryWords(history, historyWords);
+    return buildKey(branchPC, historyWords, histLengths[table]);
+}
+
+bool
+BTBTAGEUpperBound::insertExactEntry(unsigned table, Addr branchPC,
+                                    const bitset &history, short counter,
+                                    bool useful)
+{
+    auto key = makeExactKey(branchPC, history, table);
+    auto [it, inserted] = exactTables[table].emplace(
+        key, TageEntry(0, counter, branchPC));
+    it->second.useful = useful;
+    if (inserted) {
+        refreshContextStats(table);
+        ubStats.totalContexts++;
+        ubStats.updateAllocInsert++;
+    }
+    return inserted;
+}
+
+bool
+BTBTAGEUpperBound::hasExactEntry(unsigned table, Addr branchPC,
+                                 const bitset &history) const
+{
+    auto key = makeExactKey(branchPC, history, table);
+    return exactTables[table].find(key) != exactTables[table].end();
+}
+#endif
+
+#ifdef UNIT_TEST
+} // namespace test
+#endif
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -50,20 +50,24 @@ BTBTAGEUpperBound::ExactHistoryKeyHash::operator()(
 #ifdef UNIT_TEST
 BTBTAGEUpperBound::BTBTAGEUpperBound(unsigned numPredictors,
                                      unsigned tableSize,
-                                     unsigned numBanks)
+                                     unsigned numBanks,
+                                     HistorySource source)
     : BTBTAGE(numPredictors, 1, tableSize, numBanks),
-      ubStats(numPredictors)
+      ubStats(numPredictors),
+      historySource(source)
 {
-    needMoreHistories = false;
+    needMoreHistories = (historySource == HistorySource::PathHash);
     updateOnRead = false;
     initUpperBoundState();
 }
 #else
 BTBTAGEUpperBound::BTBTAGEUpperBound(const Params &p)
     : BTBTAGE(p),
-      ubStats(this, p.numPredictors)
+      ubStats(this, p.numPredictors),
+      historySource(p.usePathHashHistory ? HistorySource::PathHash
+                                         : HistorySource::Outcome)
 {
-    needMoreHistories = false;
+    needMoreHistories = (historySource == HistorySource::PathHash);
     updateOnRead = false;
     initUpperBoundState();
 }
@@ -92,6 +96,7 @@ BTBTAGEUpperBound::initUpperBoundState()
     exactTables.clear();
     exactTables.resize(numPredictors);
     historyBlocksScratch.reserve(MaxHistoryWords);
+    exactPathHistory.resize(maxHistLen, false);
 
     for (unsigned i = 0; i < numPredictors; ++i) {
 #ifdef UNIT_TEST
@@ -107,6 +112,31 @@ BTBTAGEUpperBound::initUpperBoundState()
             tableSizes[i] * std::max<unsigned>(1, numWays));
         exactTables[i].reserve(reserveEntries);
     }
+}
+
+void
+BTBTAGEUpperBound::updatePathHistory(bitset &history, bool taken, Addr pc,
+                                     Addr target) const
+{
+    if (!taken || history.empty()) {
+        return;
+    }
+
+    uint64_t hash = pathHash(pc, target);
+    history <<= PathHistoryShift;
+    for (unsigned i = 0; i < pathHashLength && i < history.size(); ++i) {
+        history[i] = (hash & 1) ^ history[i];
+        hash >>= 1;
+    }
+}
+
+const BTBTAGEUpperBound::bitset &
+BTBTAGEUpperBound::selectHistory(const bitset &outcomeHistory) const
+{
+    if (historySource == HistorySource::PathHash) {
+        return exactPathHistory;
+    }
+    return outcomeHistory;
 }
 
 void
@@ -252,8 +282,9 @@ BTBTAGEUpperBound::putPCHistory(Addr startAddr, const bitset &history,
 #endif
 
     ubMeta = std::make_shared<UpperBoundMeta>();
-    ubMeta->history = history;
-    captureHistoryWords(history, ubMeta->historyWords);
+    const bitset &selectedHistory = selectHistory(history);
+    ubMeta->history = selectedHistory;
+    captureHistoryWords(selectedHistory, ubMeta->historyWords);
 
     for (int s = getDelay(); s < stagePreds.size(); ++s) {
         auto &stagePred = stagePreds[s];
@@ -292,6 +323,19 @@ BTBTAGEUpperBound::specUpdateHist(const boost::dynamic_bitset<> &history,
 }
 
 void
+BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                                   FullBTBPrediction &pred)
+{
+    if (historySource != HistorySource::PathHash) {
+        return;
+    }
+
+    exactPathHistory = history;
+    auto [pc, target, taken] = pred.getPHistInfo();
+    updatePathHistory(exactPathHistory, taken, pc, target);
+}
+
+void
 BTBTAGEUpperBound::recoverHist(const boost::dynamic_bitset<> &history,
                                const FetchTarget &entry, int shamt,
                                bool cond_taken)
@@ -300,6 +344,22 @@ BTBTAGEUpperBound::recoverHist(const boost::dynamic_bitset<> &history,
     (void)entry;
     (void)shamt;
     (void)cond_taken;
+}
+
+void
+BTBTAGEUpperBound::recoverPHist(const boost::dynamic_bitset<> &history,
+                                const FetchTarget &entry, int shamt,
+                                bool cond_taken)
+{
+    (void)shamt;
+
+    if (historySource != HistorySource::PathHash) {
+        return;
+    }
+
+    exactPathHistory = history;
+    updatePathHistory(exactPathHistory, cond_taken,
+                      entry.getControlPC(), entry.getTakenTarget());
 }
 
 bool
@@ -521,8 +581,10 @@ BTBTAGEUpperBound::update(const FetchTarget &stream)
 void
 BTBTAGEUpperBound::checkFoldedHist(const bitset &history, const char *when)
 {
-    (void)history;
     (void)when;
+    if (historySource == HistorySource::PathHash) {
+        assert(exactPathHistory == history);
+    }
 }
 
 #ifdef UNIT_TEST

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -33,6 +33,13 @@ class BTBTAGEUpperBound : public BTBTAGE
   public:
     static constexpr unsigned MaxSupportedHistBits = 512;
     static constexpr unsigned MaxHistoryWords = MaxSupportedHistBits / 64;
+    static constexpr unsigned PathHistoryShift = 2;
+
+    enum class HistorySource
+    {
+        Outcome,
+        PathHash,
+    };
 
     struct ExactHistoryKey
     {
@@ -77,7 +84,8 @@ class BTBTAGEUpperBound : public BTBTAGE
 #ifdef UNIT_TEST
     BTBTAGEUpperBound(unsigned numPredictors = 4,
                       unsigned tableSize = 1024,
-                      unsigned numBanks = 4);
+                      unsigned numBanks = 4,
+                      HistorySource source = HistorySource::Outcome);
 #else
     typedef BTBTAGEUpperBoundParams Params;
     BTBTAGEUpperBound(const Params &p);
@@ -91,10 +99,16 @@ class BTBTAGEUpperBound : public BTBTAGE
 
     void specUpdateHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred) override;
     void recoverHist(const boost::dynamic_bitset<> &history,
                      const FetchTarget &entry,
                      int shamt,
                      bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history,
+                      const FetchTarget &entry,
+                      int shamt,
+                      bool cond_taken) override;
     void update(const FetchTarget &entry) override;
     void checkFoldedHist(const bitset &history, const char *when) override;
 
@@ -136,6 +150,9 @@ class BTBTAGEUpperBound : public BTBTAGE
 #endif
 
     void initUpperBoundState();
+    void updatePathHistory(bitset &history, bool taken, Addr pc,
+                           Addr target) const;
+    const bitset &selectHistory(const bitset &outcomeHistory) const;
     void captureHistoryWords(const bitset &history,
                              std::array<uint64_t, MaxHistoryWords> &words) const;
     ExactHistoryKey buildKey(Addr branchPC,
@@ -168,6 +185,8 @@ class BTBTAGEUpperBound : public BTBTAGE
     mutable std::vector<uint64_t> historyBlocksScratch;
     std::shared_ptr<UpperBoundMeta> ubMeta;
     UpperBoundStats ubStats;
+    HistorySource historySource;
+    bitset exactPathHistory;
 };
 
 #ifdef UNIT_TEST

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -1,0 +1,183 @@
+#ifndef __CPU_PRED_BTB_TAGE_UB_HH__
+#define __CPU_PRED_BTB_TAGE_UB_HH__
+
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "cpu/pred/btb/btb_tage.hh"
+
+#ifndef UNIT_TEST
+#include "params/BTBTAGEUpperBound.hh"
+
+#endif
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+#ifdef UNIT_TEST
+namespace test {
+#endif
+
+class BTBTAGEUpperBound : public BTBTAGE
+{
+    using bitset = boost::dynamic_bitset<>;
+
+  public:
+    static constexpr unsigned MaxSupportedHistBits = 512;
+    static constexpr unsigned MaxHistoryWords = MaxSupportedHistBits / 64;
+
+    struct ExactHistoryKey
+    {
+        Addr branchPC = 0;
+        std::array<uint64_t, MaxHistoryWords> words{};
+        uint8_t activeWords = 0;
+
+        bool
+        operator==(const ExactHistoryKey &other) const
+        {
+            return branchPC == other.branchPC &&
+                activeWords == other.activeWords &&
+                words == other.words;
+        }
+    };
+
+    struct ExactHistoryKeyHash
+    {
+        std::size_t
+        operator()(const ExactHistoryKey &key) const;
+    };
+
+    struct ExactProviderHandle
+    {
+        bool found = false;
+        unsigned table = 0;
+        ExactHistoryKey key;
+    };
+
+    struct BranchPredictionMeta
+    {
+        ExactProviderHandle main;
+        ExactProviderHandle alt;
+    };
+
+    struct UpperBoundMeta : public BTBTAGE::TageMeta
+    {
+        std::unordered_map<Addr, BranchPredictionMeta> branchMeta;
+        std::array<uint64_t, MaxHistoryWords> historyWords{};
+    };
+
+#ifdef UNIT_TEST
+    BTBTAGEUpperBound(unsigned numPredictors = 4,
+                      unsigned tableSize = 1024,
+                      unsigned numBanks = 4);
+#else
+    typedef BTBTAGEUpperBoundParams Params;
+    BTBTAGEUpperBound(const Params &p);
+#endif
+
+    void putPCHistory(Addr startAddr,
+                      const boost::dynamic_bitset<> &history,
+                      std::vector<FullBTBPrediction> &stagePreds) override;
+
+    std::shared_ptr<void> getPredictionMeta() override;
+
+    void specUpdateHist(const boost::dynamic_bitset<> &history,
+                        FullBTBPrediction &pred) override;
+    void recoverHist(const boost::dynamic_bitset<> &history,
+                     const FetchTarget &entry,
+                     int shamt,
+                     bool cond_taken) override;
+    void update(const FetchTarget &entry) override;
+    void checkFoldedHist(const bitset &history, const char *when) override;
+
+#ifdef UNIT_TEST
+    ExactHistoryKey makeExactKey(Addr branchPC, const bitset &history,
+                                 unsigned table) const;
+    bool insertExactEntry(unsigned table, Addr branchPC, const bitset &history,
+                          short counter, bool useful = false);
+    bool hasExactEntry(unsigned table, Addr branchPC,
+                       const bitset &history) const;
+#endif
+
+  private:
+    using ExactTable = std::unordered_map<ExactHistoryKey, TageEntry,
+                                          ExactHistoryKeyHash>;
+
+#ifdef UNIT_TEST
+    struct UpperBoundStats
+    {
+        explicit UpperBoundStats(unsigned numPredictors)
+          : liveContextsPerTable(numPredictors, 0)
+        {}
+
+        std::vector<uint64_t> liveContextsPerTable;
+        uint64_t totalContexts = 0;
+        uint64_t updateAllocInsert = 0;
+        uint64_t updateAllocAllTablesHit = 0;
+    };
+#else
+    struct UpperBoundStats : public statistics::Group
+    {
+        statistics::Vector liveContextsPerTable;
+        statistics::Scalar totalContexts;
+        statistics::Scalar updateAllocInsert;
+        statistics::Scalar updateAllocAllTablesHit;
+
+        UpperBoundStats(statistics::Group *parent, unsigned numPredictors);
+    };
+#endif
+
+    void initUpperBoundState();
+    void captureHistoryWords(const bitset &history,
+                             std::array<uint64_t, MaxHistoryWords> &words) const;
+    ExactHistoryKey buildKey(Addr branchPC,
+                             const std::array<uint64_t, MaxHistoryWords> &words,
+                             unsigned histLen) const;
+    TageTableInfo makeTableInfo(bool found, const TageEntry *entry,
+                                unsigned table) const;
+    TagePrediction lookupExactPrediction(const BTBEntry &btbEntry,
+                                         const std::array<uint64_t,
+                                             MaxHistoryWords> &historyWords,
+                                         BranchPredictionMeta *metaOut) const;
+    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
+                                                bool actualTaken,
+                                                const TagePrediction &pred,
+                                                const BranchPredictionMeta &meta,
+                                                const FetchTarget &stream);
+    bool allocateExactEntry(const BTBEntry &entry, bool actualTaken,
+                            unsigned startTable,
+                            const std::array<uint64_t, MaxHistoryWords> &historyWords,
+                            uint64_t &allocatedTable);
+    std::vector<BTBEntry> prepareUpperBoundUpdateEntries(
+        const FetchTarget &stream);
+    void refreshContextStats(unsigned table);
+    void notePredictionResult(const BTBEntry &btbEntry,
+                              const TagePrediction &pred,
+                              std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs,
+                              CondTakens &results) const;
+
+    std::vector<ExactTable> exactTables;
+    mutable std::vector<uint64_t> historyBlocksScratch;
+    std::shared_ptr<UpperBoundMeta> ubMeta;
+    UpperBoundStats ubStats;
+};
+
+#ifdef UNIT_TEST
+} // namespace test
+#endif
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5
+
+#endif // __CPU_PRED_BTB_TAGE_UB_HH__

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -23,6 +23,7 @@ GTest('abtb.test',
 # Add TAGE test with necessary dependencies
 GTest('tage.test', 
     '../btb_tage.cc',
+    '../btb_tage_ub.cc',
     'btb_tage.test.cc',
     '../folded_hist.cc',
     '../timed_base_pred.cc',

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -964,6 +964,24 @@ class BTBTAGEUpperBoundTest : public ::testing::Test
     std::vector<FullBTBPrediction> stagePreds;
 };
 
+class BTBTAGEUpperBoundPathHashTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override {
+        tage = new BTBTAGEUpperBound(4, 1024, 4,
+            BTBTAGEUpperBound::HistorySource::PathHash);
+        memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
+        outcomeHistory.resize(128, false);
+        pathHistory.resize(128, false);
+        stagePreds.resize(2);
+    }
+
+    BTBTAGEUpperBound *tage;
+    boost::dynamic_bitset<> outcomeHistory;
+    boost::dynamic_bitset<> pathHistory;
+    std::vector<FullBTBPrediction> stagePreds;
+};
+
 TEST_F(BTBTAGEUpperBoundTest, ExactContextLookup) {
     BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1);
     boost::dynamic_bitset<> historyA(128, 0);
@@ -1038,6 +1056,24 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
     tage->update(stream);
 
     EXPECT_TRUE(tage->hasExactEntry(0, newEntry.pc, historyA));
+}
+
+TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesPathHashHistorySnapshot) {
+    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1, 0x2000);
+    boost::dynamic_bitset<> pathHistoryA(128, 0);
+    boost::dynamic_bitset<> pathHistoryB(128, 0);
+    applyPathHistoryTaken(pathHistoryB, entry.pc, entry.target);
+
+    ASSERT_TRUE(tage->insertExactEntry(2, entry.pc, pathHistoryB, 2));
+
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(entry);
+    pred.condTakens.push_back({entry.pc, true});
+    tage->specUpdatePHist(pathHistoryA, pred);
+
+    bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
+
+    EXPECT_TRUE(predicted);
 }
 
 

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -5,6 +5,7 @@
 
 #include "base/types.hh"
 #include "cpu/pred/btb/btb_tage.hh"
+#include "cpu/pred/btb/btb_tage_ub.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/folded_hist.hh"
 
@@ -946,6 +947,97 @@ TEST_F(BTBTAGETest, BankConflict) {
         // No conflict even with same bank
         EXPECT_EQ(bankTage->tageStats.updateBankConflict, conflicts_before);
     }
+}
+
+class BTBTAGEUpperBoundTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override {
+        tage = new BTBTAGEUpperBound();
+        memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
+        history.resize(128, false);
+        stagePreds.resize(2);
+    }
+
+    BTBTAGEUpperBound *tage;
+    boost::dynamic_bitset<> history;
+    std::vector<FullBTBPrediction> stagePreds;
+};
+
+TEST_F(BTBTAGEUpperBoundTest, ExactContextLookup) {
+    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1);
+    boost::dynamic_bitset<> historyA(128, 0);
+    boost::dynamic_bitset<> historyB(128, 0);
+    historyB[0] = true;
+
+    ASSERT_TRUE(tage->insertExactEntry(3, entry.pc, historyA, 2));
+    EXPECT_TRUE(tage->hasExactEntry(3, entry.pc, historyA));
+    EXPECT_FALSE(tage->hasExactEntry(3, entry.pc, historyB));
+
+    bool predA = predictTAGE(tage, 0x1000, {entry}, historyA, stagePreds);
+    bool predB = predictTAGE(tage, 0x1000, {entry}, historyB, stagePreds);
+
+    EXPECT_TRUE(predA);
+    EXPECT_FALSE(predB);
+}
+
+TEST_F(BTBTAGEUpperBoundTest, ProviderAltSelection) {
+    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1);
+
+    ASSERT_TRUE(tage->insertExactEntry(3, entry.pc, history, 0));
+    ASSERT_TRUE(tage->insertExactEntry(1, entry.pc, history, -2));
+
+    predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
+    auto meta = std::static_pointer_cast<BTBTAGE::TageMeta>(tage->getPredictionMeta());
+    auto pred = meta->preds[entry.pc];
+
+    EXPECT_EQ(pred.mainInfo.table, 3u);
+    EXPECT_EQ(pred.altInfo.table, 1u);
+    EXPECT_TRUE(pred.useAlt);
+    EXPECT_FALSE(pred.taken);
+}
+
+TEST_F(BTBTAGEUpperBoundTest, AllocationUsesPredictionTimeHistory) {
+    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1);
+    boost::dynamic_bitset<> historyA(128, 0);
+    boost::dynamic_bitset<> historyB(128, 0);
+    historyB[0] = true;
+
+    predictTAGE(tage, 0x1000, {entry}, historyA, stagePreds);
+    auto meta = tage->getPredictionMeta();
+
+    FetchTarget stream = createStream(0x1000, entry, true, meta);
+    stream = setMispredStream(stream);
+
+    tage->recoverHist(historyB, stream, 1, true);
+    tage->update(stream);
+
+    EXPECT_TRUE(tage->hasExactEntry(0, entry.pc, historyA));
+    EXPECT_FALSE(tage->hasExactEntry(0, entry.pc, historyB));
+}
+
+TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
+    boost::dynamic_bitset<> historyA(128, 0);
+    stagePreds[1].btbEntries.clear();
+    tage->putPCHistory(0x1000, historyA, stagePreds);
+    auto meta = tage->getPredictionMeta();
+
+    BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
+    FetchTarget stream;
+    stream.startPC = 0x1000;
+    stream.exeBranchInfo = newEntry;
+    stream.exeTaken = true;
+    stream.resolved = true;
+    stream.predBranchInfo = newEntry;
+    stream.updateBTBEntries.clear();
+    stream.updateIsOldEntry = false;
+    stream.updateNewBTBEntry = newEntry;
+    stream.predMetas[0] = meta;
+    stream = setMispredStream(stream);
+
+    tage->update(stream);
+
+    EXPECT_TRUE(tage->hasExactEntry(0, newEntry.pc, historyA));
 }
 
 


### PR DESCRIPTION
## Summary
- add `BTBTAGEUpperBound` as an optional `kmhv3` predictor mode
- keep `kmhv3` default predictor settings aligned with current `xs-dev`
- reduce the configuration surface to a single `--btb-tage-upper-bound` switch
- keep the upper-bound implementation using path-hash history when enabled

## What changed
- add the `BTBTAGEUpperBound` SimObject and implementation
- wire it into `kmhv3` so it replaces the default `BTBTAGE` only when the new flag is passed
- merge with current `xs-dev` predictor changes, including the standalone `MicroTAGE` integration
- add unit tests for exact-context lookup, allocation behavior, and path-hash history snapshots

## Notes
- default `kmhv3` behavior remains unchanged unless `--btb-tage-upper-bound` is specified
- this PR still keeps the supporting design docs and CI-analysis helper that were used during evaluation

## Validation
- `python3 -m py_compile configs/common/xiangshan.py configs/example/kmhv3.py src/cpu/pred/BranchPredictor.py`
- `scons build/RISCV/cpu/pred/btb/test/tage.test.debug --unit-test -j32`
- `./build/RISCV/cpu/pred/btb/test/tage.test.debug --gtest_filter=BTBTAGEUpperBoundTest.ExactContextLookup:BTBTAGEUpperBoundPathHashTest.PredictionUsesPathHashHistorySnapshot`