### PR TITLE
2 Taken & 2 Fetch Exploration Framework

### DIFF
--- a/src/cpu/difftest.cc
+++ b/src/cpu/difftest.cc
@@ -215,4 +215,3 @@ SpikeProxy::SpikeProxy(int coreid, const char *ref_so, bool enable_sdcard_diff)
 
     nemu_init();
 }
-

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -970,6 +970,8 @@ class TimedBaseBTBPredictor(SimObject):
     numDelay = Param.Unsigned(1000, "Number of bubbles to put on a prediction")
     resolvedUpdate = Param.Bool(False, "Enable resolved update, no need to wait until commit")
     enabled = Param.Bool(True, "Enable this predictor component")
+    block1Participate = Param.Bool(False,
+        "Whether this predictor actively participates in block1 prediction")
 
 class MBTB(TimedBaseBTBPredictor):
     type = 'MBTB'
@@ -1193,6 +1195,19 @@ class DecoupledBPUWithBTB(BranchPredictor):
     ittage = Param.BTBITTAGE(BTBITTAGE(), "ITTAGE predictor")
     mgsc = Param.BTBMGSC(BTBMGSC(), "MGSC predictor")
     ras = Param.BTBRAS(BTBRAS(), "RAS")
+
+    enableTwoTaken = Param.Bool(False,
+        "Enable generating an optional second fetch block from one prediction")
+    dropBlock1OnBlock0Override = Param.Bool(True,
+        "Drop block1 when block0 is overridden by later stages")
+    dropBlock1WhenFTQHasOnlyOneSlot = Param.Bool(True,
+        "Drop block1 when the FTQ has only one free slot left")
+    dropBlock1OnCondWithoutTage = Param.Bool(True,
+        "Drop block1 when it contains a conditional branch without direction support")
+    dropBlock1OnIndirectWithoutIttage = Param.Bool(True,
+        "Drop block1 when it contains an indirect branch without ITTAGE support")
+    dropBlock1OnReturnWithoutRas = Param.Bool(True,
+        "Drop block1 when it contains a return without RAS support")
 
     bpDBSwitches = VectorParam.String([], "Enable which traces in the form of database")
     resolveBlockThreshold = Param.Unsigned(8, "Consecutive resolve dequeue failures before blocking prediction once")

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -30,75 +30,75 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 {
     using defer = std::shared_ptr<void>;
     using bitset = boost::dynamic_bitset<>;
-
   public:
     typedef BTBITTAGEParams Params;
 
     struct TageEntry
     {
-      public:
-        bool valid;
-        Addr tag;
-        Addr target;
-        short counter;
-        bool useful;
-        Addr pc;  // TODO: should use lowest bits only
+        public:
+            bool valid;
+            Addr tag;
+            Addr target;
+            short counter;
+            bool useful;
+            Addr pc; // TODO: should use lowest bits only
 
-        TageEntry() : valid(false), tag(0), target(0), counter(0), useful(false), pc(0) {}
+            TageEntry() : valid(false), tag(0), target(0), counter(0), useful(false), pc(0) {}
 
-        TageEntry(Addr tag, Addr target, short counter, Addr pc)
-            : valid(true), tag(tag), target(target), counter(counter), useful(false), pc(pc)
-        {
-        }
-        bool taken() { return counter >= 2; }
+            TageEntry(Addr tag, Addr target, short counter, Addr pc) :
+                        valid(true), tag(tag), target(target), counter(counter), useful(false), pc(pc) {}
+            bool taken() {
+                return counter >= 2;
+            }
     };
 
     struct TageTableInfo
     {
-      public:
-        bool found;
-        TageEntry entry;
-        unsigned table;
-        Addr index;
-        Addr tag;
-        TageTableInfo() : found(false), table(0), index(0), tag(0) {}
-        TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag)
-            : found(found), entry(entry), table(table), index(index), tag(tag)
-        {
-        }
-        bool taken() { return entry.taken(); }
+        public:
+            bool found;
+            TageEntry entry;
+            unsigned table;
+            Addr index;
+            Addr tag;
+            TageTableInfo() : found(false), table(0), index(0), tag(0) {}
+            TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag) :
+                        found(found), entry(entry), table(table), index(index), tag(tag) {}
+            bool taken() { return entry.taken(); }
     };
 
     struct TagePrediction
     {
-      public:
-        Addr btb_pc;
-        TageTableInfo mainInfo;
-        TageTableInfo altInfo;
+        public:
+            Addr btb_pc;
+            TageTableInfo mainInfo;
+            TageTableInfo altInfo;
 
-        bool useAlt;
-        // bitset usefulMask;
-        // bool taken;
-        Addr target;
+            bool useAlt;
+            // bitset usefulMask;
+            // bool taken;
+            Addr target;
 
-        TagePrediction() : btb_pc(0), useAlt(false), target(0) {}
+            TagePrediction() : btb_pc(0), useAlt(false), target(0) {}
 
-        TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo, bool useAlt, Addr target)
-            : btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo), useAlt(useAlt), target(target)
-        {
-        }
+            TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo,
+                            bool useAlt, Addr target) :
+                            btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo),
+                            useAlt(useAlt), target(target) {}
+
     };
 
   public:
-    BTBITTAGE(const Params &p);
+    BTBITTAGE(const Params& p);
 
     void tickStart() override;
 
     void tick() override;
     void dryRunCycle(Addr startAddr) override;
     // make predictions, record in stage preds
-    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+    void putPCHistory(Addr startAddr,
+                      const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
+
     void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
                                const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
                                const std::vector<boost::dynamic_bitset<>> &lhistory,
@@ -124,8 +124,8 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
-    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                      bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history,
+                        const FetchTarget &entry,int shamt, bool cond_taken) override;
 
     void update(const FetchTarget &entry) override;
 
@@ -135,8 +135,9 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     void checkFoldedHist(const bitset &history, const char *when);
 
   private:
+
     // return provided
-    void lookupHelper(Addr stream_start, const std::vector<BTBEntry> &btbEntries, IndirectTargets &results);
+    void lookupHelper(Addr stream_start, const std::vector<BTBEntry> &btbEntries, IndirectTargets& results);
 
     // use blockPC
     Addr getTageIndex(Addr pc, int table);
@@ -150,7 +151,9 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // use blockPC (uint64_t version for performance)
     Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist);
 
-    Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }
+    Addr getOffset(Addr pc) {
+        return (pc & (blockSize - 1)) >> 1;
+    }
 
     // Update branch history
     void doUpdateHist(const bitset &history, bool taken, Addr pc, Addr target);
@@ -188,7 +191,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     unsigned numBr;
 
-    unsigned instShiftAmt{1};
+    unsigned instShiftAmt {1};
 
     void updateCounter(bool taken, unsigned width, short &counter);
 
@@ -229,7 +232,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
         statistics::Distribution updateTableHits;
 
         int numPredictors;
-        IttageStats(statistics::Group *parent, int numPredictors);
+        IttageStats(statistics::Group* parent, int numPredictors);
 #endif
         Scalar commitHits;
         Scalar callHits;
@@ -277,12 +280,13 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     std::shared_ptr<TageMeta> meta;
 
-  public:
+public:
+
     Addr debugPC = 0;
     Addr debugPC2 = 0;
     bool debugFlag = false;
 
-    void recoverFoldedHist(const bitset &history);
+    void recoverFoldedHist(const bitset& history);
     bool tageHit();
 
     // void checkFoldedHist(const bitset& history);

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -107,8 +107,10 @@ class BTBITTAGE : public TimedBaseBTBPredictor
         (void)phistory;
         (void)bwhistory;
         (void)lhistory;
-        (void)lowerPred;
         if (!participatesInBlock1()) {
+            for (int s = getDelay(); s < stagePreds.size(); s++) {
+                stagePreds[s].indirectTargets = lowerPred.indirectTargets;
+            }
             return;
         }
         putPCHistory(startAddr, history, stagePreds);

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -30,74 +30,89 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 {
     using defer = std::shared_ptr<void>;
     using bitset = boost::dynamic_bitset<>;
+
   public:
     typedef BTBITTAGEParams Params;
 
     struct TageEntry
     {
-        public:
-            bool valid;
-            Addr tag;
-            Addr target;
-            short counter;
-            bool useful;
-            Addr pc; // TODO: should use lowest bits only
+      public:
+        bool valid;
+        Addr tag;
+        Addr target;
+        short counter;
+        bool useful;
+        Addr pc;  // TODO: should use lowest bits only
 
-            TageEntry() : valid(false), tag(0), target(0), counter(0), useful(false), pc(0) {}
+        TageEntry() : valid(false), tag(0), target(0), counter(0), useful(false), pc(0) {}
 
-            TageEntry(Addr tag, Addr target, short counter, Addr pc) :
-                        valid(true), tag(tag), target(target), counter(counter), useful(false), pc(pc) {}
-            bool taken() {
-                return counter >= 2;
-            }
+        TageEntry(Addr tag, Addr target, short counter, Addr pc)
+            : valid(true), tag(tag), target(target), counter(counter), useful(false), pc(pc)
+        {
+        }
+        bool taken() { return counter >= 2; }
     };
 
     struct TageTableInfo
     {
-        public:
-            bool found;
-            TageEntry entry;
-            unsigned table;
-            Addr index;
-            Addr tag;
-            TageTableInfo() : found(false), table(0), index(0), tag(0) {}
-            TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag) :
-                        found(found), entry(entry), table(table), index(index), tag(tag) {}
-            bool taken() { return entry.taken(); }
+      public:
+        bool found;
+        TageEntry entry;
+        unsigned table;
+        Addr index;
+        Addr tag;
+        TageTableInfo() : found(false), table(0), index(0), tag(0) {}
+        TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag)
+            : found(found), entry(entry), table(table), index(index), tag(tag)
+        {
+        }
+        bool taken() { return entry.taken(); }
     };
 
     struct TagePrediction
     {
-        public:
-            Addr btb_pc;
-            TageTableInfo mainInfo;
-            TageTableInfo altInfo;
+      public:
+        Addr btb_pc;
+        TageTableInfo mainInfo;
+        TageTableInfo altInfo;
 
-            bool useAlt;
-            // bitset usefulMask;
-            // bool taken;
-            Addr target;
+        bool useAlt;
+        // bitset usefulMask;
+        // bool taken;
+        Addr target;
 
-            TagePrediction() : btb_pc(0), useAlt(false), target(0) {}
+        TagePrediction() : btb_pc(0), useAlt(false), target(0) {}
 
-            TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo,
-                            bool useAlt, Addr target) :
-                            btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo),
-                            useAlt(useAlt), target(target) {}
-
+        TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo, bool useAlt, Addr target)
+            : btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo), useAlt(useAlt), target(target)
+        {
+        }
     };
 
   public:
-    BTBITTAGE(const Params& p);
+    BTBITTAGE(const Params &p);
 
     void tickStart() override;
 
     void tick() override;
     void dryRunCycle(Addr startAddr) override;
     // make predictions, record in stage preds
-    void putPCHistory(Addr startAddr,
-                      const boost::dynamic_bitset<> &history,
+    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
+    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                               const std::vector<boost::dynamic_bitset<>> &lhistory,
+                               std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
+    {
+        (void)phistory;
+        (void)bwhistory;
+        (void)lhistory;
+        (void)lowerPred;
+        if (!participatesInBlock1()) {
+            return;
+        }
+        putPCHistory(startAddr, history, stagePreds);
+    }
 
     std::shared_ptr<void> getPredictionMeta() override;
 
@@ -107,8 +122,8 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
-    void recoverPHist(const boost::dynamic_bitset<> &history,
-                        const FetchTarget &entry,int shamt, bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                      bool cond_taken) override;
 
     void update(const FetchTarget &entry) override;
 
@@ -118,9 +133,8 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     void checkFoldedHist(const bitset &history, const char *when);
 
   private:
-
     // return provided
-    void lookupHelper(Addr stream_start, const std::vector<BTBEntry> &btbEntries, IndirectTargets& results);
+    void lookupHelper(Addr stream_start, const std::vector<BTBEntry> &btbEntries, IndirectTargets &results);
 
     // use blockPC
     Addr getTageIndex(Addr pc, int table);
@@ -134,9 +148,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // use blockPC (uint64_t version for performance)
     Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist);
 
-    Addr getOffset(Addr pc) {
-        return (pc & (blockSize - 1)) >> 1;
-    }
+    Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }
 
     // Update branch history
     void doUpdateHist(const bitset &history, bool taken, Addr pc, Addr target);
@@ -174,7 +186,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     unsigned numBr;
 
-    unsigned instShiftAmt {1};
+    unsigned instShiftAmt{1};
 
     void updateCounter(bool taken, unsigned width, short &counter);
 
@@ -215,7 +227,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
         statistics::Distribution updateTableHits;
 
         int numPredictors;
-        IttageStats(statistics::Group* parent, int numPredictors);
+        IttageStats(statistics::Group *parent, int numPredictors);
 #endif
         Scalar commitHits;
         Scalar callHits;
@@ -263,13 +275,12 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     std::shared_ptr<TageMeta> meta;
 
-public:
-
+  public:
     Addr debugPC = 0;
     Addr debugPC2 = 0;
     bool debugFlag = false;
 
-    void recoverFoldedHist(const bitset& history);
+    void recoverFoldedHist(const bitset &history);
     bool tageHit();
 
     // void checkFoldedHist(const bitset& history);

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -6,10 +6,12 @@
 
 #ifdef UNIT_TEST
 // Define debug flags for unit testing
-namespace gem5 {
-namespace debug {
-    bool TAGEUseful = true;
-    bool TAGEHistory = true;
+namespace gem5
+{
+namespace debug
+{
+bool TAGEUseful = true;
+bool TAGEHistory = true;
 }
 }
 #endif
@@ -22,14 +24,18 @@ namespace debug {
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/TAGE.hh"
 #endif
-namespace gem5 {
+namespace gem5
+{
 
-namespace branch_prediction {
+namespace branch_prediction
+{
 
-namespace btb_pred{
+namespace btb_pred
+{
 
 #ifdef UNIT_TEST
-namespace test {
+namespace test
+{
 #endif
 
 #ifdef UNIT_TEST
@@ -61,35 +67,35 @@ BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSize, u
     for (unsigned i = 0; i < numPredictors; ++i) {
         histLengths[i] = (i + 1) * 4;
     }
-    maxHistLen = histLengths[numPredictors-1];
+    maxHistLen = histLengths[numPredictors - 1];
     numTablesToAlloc = 1;
     enableSC = false;
 #else
 // Constructor: Initialize TAGE predictor with given parameters
-BTBTAGE::BTBTAGE(const Params& p):
-TimedBaseBTBPredictor(p),
-numPredictors(p.numPredictors),
-tableSizes(p.tableSizes),
-tableTagBits(p.TTagBitSizes),
-tablePcShifts(p.TTagPcShifts),
-histLengths(p.histLengths),
-maxHistLen(p.maxHistLen),
-numWays(p.numWays),
-maxBranchPositions(p.maxBranchPositions),
-useAltOnNaSize(p.useAltOnNaSize),
-useAltOnNaWidth(p.useAltOnNaWidth),
-numTablesToAlloc(p.numTablesToAlloc),
-enableSC(p.enableSC),
-updateOnRead(p.updateOnRead),
-numBanks(p.numBanks),
-bankIdWidth(ceilLog2(p.numBanks)),
-blockWidth(floorLog2(blockSize)),
-bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
-indexShift(bankBaseShift + ceilLog2(p.numBanks)),
-enableBankConflict(p.enableBankConflict),
-lastPredBankId(0),
-predBankValid(false),
-tageStats(this, p.numPredictors, p.numBanks)
+BTBTAGE::BTBTAGE(const Params &p)
+    : TimedBaseBTBPredictor(p),
+      numPredictors(p.numPredictors),
+      tableSizes(p.tableSizes),
+      tableTagBits(p.TTagBitSizes),
+      tablePcShifts(p.TTagPcShifts),
+      histLengths(p.histLengths),
+      maxHistLen(p.maxHistLen),
+      numWays(p.numWays),
+      maxBranchPositions(p.maxBranchPositions),
+      useAltOnNaSize(p.useAltOnNaSize),
+      useAltOnNaWidth(p.useAltOnNaWidth),
+      numTablesToAlloc(p.numTablesToAlloc),
+      enableSC(p.enableSC),
+      updateOnRead(p.updateOnRead),
+      numBanks(p.numBanks),
+      bankIdWidth(ceilLog2(p.numBanks)),
+      blockWidth(floorLog2(blockSize)),
+      bankBaseShift(instShiftAmt),  // strip instruction alignment bits before indexing
+      indexShift(bankBaseShift + ceilLog2(p.numBanks)),
+      enableBankConflict(p.enableBankConflict),
+      lastPredBankId(0),
+      predBankValid(false),
+      tageStats(this, p.numPredictors, p.numBanks)
 {
     this->needMoreHistories = p.needMoreHistories;
 
@@ -105,7 +111,7 @@ tageStats(this, p.numPredictors, p.numBanks)
     tableTagMasks.resize(numPredictors);
 
     for (unsigned int i = 0; i < numPredictors; ++i) {
-        //initialize ittage predictor
+        // initialize ittage predictor
         assert(tableSizes.size() >= numPredictors);
         tageTable[i].resize(tableSizes[i]);
         for (unsigned int j = 0; j < tableSizes[i]; ++j) {
@@ -123,7 +129,7 @@ tageStats(this, p.numPredictors, p.numBanks)
         assert(tablePcShifts.size() >= numPredictors);
 
         tagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i], 16));
-        altTagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i]-1, 16));
+        altTagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i] - 1, 16));
         indexFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableIndexBits[i], 16));
     }
     usefulResetCnt = 0;
@@ -133,15 +139,17 @@ tageStats(this, p.numPredictors, p.numBanks)
 #ifndef UNIT_TEST
     hasDB = true;
     switch (getDelay()) {
-        case 0: dbName = std::string("microtage"); break;
-        default: dbName = std::string("tage"); break;
+        case 0:
+            dbName = std::string("microtage");
+            break;
+        default:
+            dbName = std::string("tage");
+            break;
     }
 #endif
 }
 
-BTBTAGE::~BTBTAGE()
-{
-}
+BTBTAGE::~BTBTAGE() {}
 
 // Set up tracing for debugging
 void
@@ -150,28 +158,17 @@ BTBTAGE::setTrace()
 #ifndef UNIT_TEST
     if (enableDB) {
         std::vector<std::pair<std::string, DataType>> fields_vec = {
-            std::make_pair("startPC", UINT64),
-            std::make_pair("branchPC", UINT64),
-            std::make_pair("wayIdx", UINT64),
-            std::make_pair("mainFound", UINT64),
-            std::make_pair("mainCounter", UINT64),
-            std::make_pair("mainUseful", UINT64),
-            std::make_pair("mainTable", UINT64),
-            std::make_pair("mainIndex", UINT64),
-            std::make_pair("altFound", UINT64),
-            std::make_pair("altCounter", UINT64),
-            std::make_pair("altUseful", UINT64),
-            std::make_pair("altTable", UINT64),
-            std::make_pair("altIndex", UINT64),
-            std::make_pair("useAlt", UINT64),
-            std::make_pair("predTaken", UINT64),
-            std::make_pair("actualTaken", UINT64),
-            std::make_pair("allocSuccess", UINT64),
-            std::make_pair("allocTable", UINT64),
-            std::make_pair("allocIndex", UINT64),
-            std::make_pair("allocWay", UINT64),
-            std::make_pair("history", TEXT),
-            std::make_pair("indexFoldedHist", UINT64),
+            std::make_pair("startPC", UINT64),      std::make_pair("branchPC", UINT64),
+            std::make_pair("wayIdx", UINT64),       std::make_pair("mainFound", UINT64),
+            std::make_pair("mainCounter", UINT64),  std::make_pair("mainUseful", UINT64),
+            std::make_pair("mainTable", UINT64),    std::make_pair("mainIndex", UINT64),
+            std::make_pair("altFound", UINT64),     std::make_pair("altCounter", UINT64),
+            std::make_pair("altUseful", UINT64),    std::make_pair("altTable", UINT64),
+            std::make_pair("altIndex", UINT64),     std::make_pair("useAlt", UINT64),
+            std::make_pair("predTaken", UINT64),    std::make_pair("actualTaken", UINT64),
+            std::make_pair("allocSuccess", UINT64), std::make_pair("allocTable", UINT64),
+            std::make_pair("allocIndex", UINT64),   std::make_pair("allocWay", UINT64),
+            std::make_pair("history", TEXT),        std::make_pair("indexFoldedHist", UINT64),
         };
         tageMissTrace = _db->addAndGetTrace("TAGEMISSTRACE", fields_vec);
         tageMissTrace->init_table();
@@ -180,10 +177,14 @@ BTBTAGE::setTrace()
 }
 
 void
-BTBTAGE::tick() {}
+BTBTAGE::tick()
+{
+}
 
 void
-BTBTAGE::tickStart() {}
+BTBTAGE::tickStart()
+{
+}
 
 /**
  * @brief Generate prediction for a single BTB entry by searching TAGE tables
@@ -195,9 +196,8 @@ BTBTAGE::tickStart() {}
  * @return TagePrediction containing main and alternative predictions
  */
 BTBTAGE::TagePrediction
-BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
-                                 const Addr &startPC,
-                                 std::shared_ptr<TageMeta> predMeta) {
+BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC, std::shared_ptr<TageMeta> predMeta)
+{
     DPRINTF(TAGE, "generateSinglePrediction for btbEntry: %#lx\n", btb_entry.pc);
 
     // Find main and alternative predictions
@@ -212,13 +212,13 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
-        Addr index = predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get())
-                          : getTageIndex(startPC, i);
-        Addr tag = predMeta ? getTageTag(startPC, i,
-                            predMeta->tagFoldedHist[i].get(), predMeta->altTagFoldedHist[i].get(), position)
-                        : getTageTag(startPC, i, position);
+        Addr index =
+            predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get()) : getTageIndex(startPC, i);
+        Addr tag = predMeta ? getTageTag(startPC, i, predMeta->tagFoldedHist[i].get(),
+                                         predMeta->altTagFoldedHist[i].get(), position)
+                            : getTageTag(startPC, i, position);
 
-        bool match = false; // for each table, only one way can be matched
+        bool match = false;  // for each table, only one way can be matched
         TageEntry matching_entry;
         unsigned matching_way = 0;
 
@@ -233,8 +233,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
 
                 // Do not use LRU; keep logic simple and align with CBP-style replacement
 
-                DPRINTF(TAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n",
-                    i, index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
+                DPRINTF(TAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n", i,
+                        index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
                 break;  // only one way can be matched, aviod multi hit, TODO: RTL how to do this?
             }
         }
@@ -251,8 +251,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
                 break;
             }
         } else {
-            DPRINTF(TAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n",
-                i, index, tag, position, btb_entry.pc);
+            DPRINTF(TAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n", i, index, tag, position,
+                    btb_entry.pc);
         }
     }
 
@@ -261,8 +261,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     bool alt_taken = alt_info.taken();
     // Use base table instead of btb_entry.ctr
     bool base_taken = btb_entry.ctr >= 0;
-    //bool base_taken = btb_entry.ctr >= 0;
-    bool alt_pred = alt_provided ? alt_taken : base_taken; // if alt provided, use alt prediction, otherwise use base
+    // bool base_taken = btb_entry.ctr >= 0;
+    bool alt_pred = alt_provided ? alt_taken : base_taken;  // if alt provided, use alt prediction, otherwise use base
 
     // use_alt_on_na gating: when provider weak, consult per-PC counter
     bool use_alt = false;
@@ -280,22 +280,22 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     bool taken = use_alt ? alt_pred : main_taken;
 
     DPRINTF(TAGE, "tage predict %#lx taken %d\n", btb_entry.pc, taken);
-    DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n",
-        use_alt, alt_provided, alt_taken, base_taken, main_taken);
+    DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n", use_alt,
+            alt_provided, alt_taken, base_taken, main_taken);
 
     return TagePrediction(btb_entry.pc, main_info, alt_info, use_alt, taken, alt_pred);
 }
 
 /**
  * @brief Look up predictions in TAGE tables for a stream of instructions
- * 
+ *
  * @param startPC The starting PC address for the instruction stream
  * @param btbEntries Vector of BTB entries to make predictions for
  * @return Map of branch PC addresses to their predicted outcomes
  */
 void
 BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntries,
-                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results)
+                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results)
 {
     DPRINTF(TAGE, "lookupHelper startAddr: %#lx\n", startPC);
 
@@ -309,21 +309,25 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
             results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
             tageInfoForMgscs[btb_entry.pc].tage_pred_taken = pred.taken;
             tageInfoForMgscs[btb_entry.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high = pred.mainInfo.found &&
-                                         abs(pred.mainInfo.entry.counter*2 + 1) == 7; // counter saturated, -4 or 3
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid = pred.mainInfo.found &&
-                                         (abs(pred.mainInfo.entry.counter*2 + 1) < 7 &&
-                                         abs(pred.mainInfo.entry.counter*2 + 1) > 1); // counter not saturated, -3, -2, 1, 2
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_low = !pred.mainInfo.found ||
-                                         (abs(pred.mainInfo.entry.counter*2 + 1) <= 1); // counter initialized, -1 or 0
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high =
+                pred.mainInfo.found && abs(pred.mainInfo.entry.counter * 2 + 1) == 7;  // counter saturated, -4 or 3
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid =
+                pred.mainInfo.found &&
+                (abs(pred.mainInfo.entry.counter * 2 + 1) < 7 &&
+                 abs(pred.mainInfo.entry.counter * 2 + 1) > 1);  // counter not saturated, -3, -2, 1, 2
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_low =
+                !pred.mainInfo.found ||
+                (abs(pred.mainInfo.entry.counter * 2 + 1) <= 1);  // counter initialized, -1 or 0
             // main predict is different from alt predict/base predict
-            tageInfoForMgscs[btb_entry.pc].tage_pred_alt_diff = pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
+            tageInfoForMgscs[btb_entry.pc].tage_pred_alt_diff =
+                pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
         }
     }
 }
 
 void
-BTBTAGE::dryRunCycle(Addr startPC) {
+BTBTAGE::dryRunCycle(Addr startPC)
+{
     // No operation in dry run cycle for BTBTAGE
     // Record prediction bank for next tick's conflict detection
     lastPredBankId = getBankId(startPC);
@@ -334,18 +338,19 @@ BTBTAGE::dryRunCycle(Addr startPC) {
 
 /**
  * @brief Makes predictions for a stream of instructions using TAGE predictor
- * 
+ *
  * This function is called during the prediction stage and:
  * 1. Uses lookupHelper to get predictions for all BTB entries
  * 2. Stores predictions in the stage prediction structure
  * 3. Handles multiple prediction stages with different delays
- * 
+ *
  * @param startPC Starting PC of the instruction stream
  * @param history Current branch history
  * @param stagePreds Vector of predictions for different pipeline stages
  */
 void
-BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPrediction> &stagePreds) {
+BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPrediction> &stagePreds)
+{
     // Record prediction bank for next tick's conflict detection
     lastPredBankId = getBankId(startPC);
     predBankValid = true;
@@ -355,8 +360,7 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
     tageStats.predAccessPerBank[lastPredBankId]++;
 #endif
 
-    DPRINTF(TAGE, "putPCHistory startAddr: %#lx, bank: %u\n",
-            startPC, lastPredBankId);
+    DPRINTF(TAGE, "putPCHistory startAddr: %#lx, bank: %u\n", startPC, lastPredBankId);
 
     // IMPORTANT: when this function is called,
     // btb entries should already be in stagePreds
@@ -375,22 +379,23 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
         stage_pred.condTakens.clear();
         lookupHelper(startPC, stage_pred.btbEntries, stage_pred.tageInfoForMgscs, stage_pred.condTakens);
     }
-
 }
 
 std::shared_ptr<void>
-BTBTAGE::getPredictionMeta() {
+BTBTAGE::getPredictionMeta()
+{
     return meta;
 }
 
 /**
  * @brief Prepare BTB entries for update by filtering and processing
- * 
+ *
  * @param stream The fetch stream containing update information
  * @return Vector of BTB entries that need to be updated
  */
 std::vector<BTBEntry>
-BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
+BTBTAGE::prepareUpdateEntries(const FetchTarget &stream)
+{
     auto all_entries = stream.updateBTBEntries;
 
     // Add potential new BTB entry if it's a btb miss during prediction
@@ -406,11 +411,11 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
+                                        [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
+                                        [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -419,7 +424,7 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
 
 /**
  * @brief Update predictor state for a single entry
- * 
+ *
  * @param entry The BTB entry being updated
  * @param actual_taken The actual outcome of the branch
  * @param pred The prediction made for this entry
@@ -427,10 +432,9 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
  * @return true if need to allocate new entry
  */
 bool
-BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
-                             bool actual_taken,
-                             const TagePrediction &pred,
-                             const FetchTarget &stream) {
+BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actual_taken, const TagePrediction &pred,
+                                                const FetchTarget &stream)
+{
     tageStats.updateStatsWithTagePrediction(pred, false);
 
     auto &main_info = pred.mainInfo;
@@ -461,7 +465,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     // Update main prediction provider
     if (main_info.found) {
         DPRINTF(TAGE, "prediction provided by table %d, idx %lu, way %u, updating corresponding entry\n",
-            main_info.table, main_info.index, main_info.way);
+                main_info.table, main_info.index, main_info.way);
 
         auto &way = tageTable[main_info.table][main_info.index][main_info.way];
 
@@ -470,9 +474,8 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
 
         // Update useful bit based on several conditions
         bool main_is_correct = main_info.taken() == actual_taken;
-        bool alt_is_correct_and_strong = alt_info.found &&
-                                     (alt_info.taken() == actual_taken) &&
-                                     (abs(2 * alt_info.entry.counter + 1) == 7);
+        bool alt_is_correct_and_strong =
+            alt_info.found && (alt_info.taken() == actual_taken) && (abs(2 * alt_info.entry.counter + 1) == 7);
 
         // a. Special reset (humility mechanism)
         if (alt_is_correct_and_strong && main_is_correct) {
@@ -516,9 +519,8 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     }
 
     // Check if misprediction occurred
-    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
-                               stream.squashPC == entry.pc;
-    if (getDelay() == 2){
+    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL && stream.squashPC == entry.pc;
+    if (getDelay() == 2) {
         if (this_fb_mispred) {
             tageStats.updateMispred++;
             if (!used_alt && main_info.found) {
@@ -547,7 +549,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
 
 /**
  * @brief Handle allocation of new entries
- * 
+ *
  * @param startPC The starting PC address
  * @param entry The BTB entry being updated
  * @param actual_taken The actual outcome of the branch
@@ -556,14 +558,10 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
  * @return true if allocation is successful
  */
 bool
-BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
-                                 const BTBEntry &entry,
-                                 bool actual_taken,
-                                 unsigned start_table,
-                                 std::shared_ptr<TageMeta> meta,
-                                 uint64_t &allocated_table,
-                                 uint64_t &allocated_index,
-                                 uint64_t &allocated_way) {
+BTBTAGE::handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bool actual_taken, unsigned start_table,
+                                  std::shared_ptr<TageMeta> meta, uint64_t &allocated_table, uint64_t &allocated_index,
+                                  uint64_t &allocated_way)
+{
     // Simple set-associative allocation (no LFSR, no per-way table gating):
     // - For each table from start_table upward, check the set at computed index.
     // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
@@ -574,20 +572,20 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
         Addr newIndex = getTageIndex(startPC, ti, meta->indexFoldedHist[ti].get());
-        Addr newTag = getTageTag(startPC, ti,
-            meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
+        Addr newTag =
+            getTageTag(startPC, ti, meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
 
         auto &set = tageTable[ti][newIndex];
 
         // Allocate into invalid way or not-useful and weak way
         for (unsigned way = 0; way < numWays; ++way) {
             auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
+            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;  // -3,-2,-1,0,1,2
             if (!cand.valid || (!cand.useful && weakish)) {
                 short newCounter = actual_taken ? 0 : -1;
                 DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
                         ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+                cand = TageEntry(newTag, newCounter, entry.pc);  // u = 0 default
                 tageStats.updateAllocSuccess++;
                 allocated_table = ti;
                 allocated_index = newIndex;
@@ -602,10 +600,13 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
             auto &cand = set[way];
             const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
             if (!cand.useful && !weakish) {
-                if (cand.counter > 0) cand.counter--; else cand.counter++;
-                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n",
-                        ti, newIndex, way, cand.counter);
-                break; // one penalty per table per update
+                if (cand.counter > 0)
+                    cand.counter--;
+                else
+                    cand.counter++;
+                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n", ti, newIndex, way,
+                        cand.counter);
+                break;  // one penalty per table per update
             }
         }
 
@@ -636,7 +637,8 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
  * Returns false if the update cannot proceed due to a bank conflict.
  */
 bool
-BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
+BTBTAGE::canResolveUpdate(const FetchTarget &stream)
+{
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -651,9 +653,10 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
 #ifndef UNIT_TEST
         tageStats.updateBankConflictPerBank[updateBank]++;
 #endif
-        DPRINTF(TAGE, "Bank conflict detected: update bank %u conflicts with prediction bank %u, "
-                      "deferring this update (will retry after blocking prediction)\n",
-                      updateBank, lastPredBankId);
+        DPRINTF(TAGE,
+                "Bank conflict detected: update bank %u conflicts with prediction bank %u, "
+                "deferring this update (will retry after blocking prediction)\n",
+                updateBank, lastPredBankId);
         predBankValid = false;
         return false;
     }
@@ -665,7 +668,8 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
  * @brief Perform resolved update after probe success.
  */
 void
-BTBTAGE::doResolveUpdate(const FetchTarget &stream) {
+BTBTAGE::doResolveUpdate(const FetchTarget &stream)
+{
     if (enableBankConflict && predBankValid) {
         // Prediction consumed; clear bank tag for next cycle
         predBankValid = false;
@@ -675,11 +679,12 @@ BTBTAGE::doResolveUpdate(const FetchTarget &stream) {
 
 /**
  * @brief Updates the TAGE predictor state based on actual branch execution results
- * 
+ *
  * @param stream The fetch stream containing branch execution information
  */
 void
-BTBTAGE::update(const FetchTarget &stream) {
+BTBTAGE::update(const FetchTarget &stream)
+{
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -688,7 +693,7 @@ BTBTAGE::update(const FetchTarget &stream) {
     // ========== Normal Update Logic ==========
     // Prepare BTB entries to update
     auto entries_to_update = prepareUpdateEntries(stream);
-    
+
     // Get prediction metadata snapshot and bind to member for helpers
     auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
     if (!predMeta) {
@@ -702,7 +707,7 @@ BTBTAGE::update(const FetchTarget &stream) {
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
         TagePrediction recomputed;
-        if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
+        if (updateOnRead) {  // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
             // Track differences for statistics
@@ -710,7 +715,7 @@ BTBTAGE::update(const FetchTarget &stream) {
             if (it != predMeta->preds.end() && recomputed.taken != it->second.taken) {
                 hasRecomputedVsOriginalDiff = true;
             }
-        } else { // otherwise, use the prediction from the prediction-time main/alt
+        } else {  // otherwise, use the prediction from the prediction-time main/alt
             recomputed = predMeta->preds[btb_entry.pc];
         }
         if (recomputed.taken != actual_taken) {
@@ -731,10 +736,10 @@ BTBTAGE::update(const FetchTarget &stream) {
             uint start_table = 0;
             auto &main_info = recomputed.mainInfo;
             if (main_info.found) {
-                start_table = main_info.table + 1; // start from the table after the main prediction table
+                start_table = main_info.table + 1;  // start from the table after the main prediction table
             }
-            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
-                                   start_table, predMeta, allocated_table, allocated_index, allocated_way);
+            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken, start_table, predMeta,
+                                                     allocated_table, allocated_index, allocated_way);
         }
 
 #ifndef UNIT_TEST
@@ -748,14 +753,11 @@ BTBTAGE::update(const FetchTarget &stream) {
             boost::to_string(history_low50, history_str);
             auto main_info = recomputed.mainInfo;
             auto alt_info = recomputed.altInfo;
-            t.set(startAddr, btb_entry.pc, main_info.way,
-                main_info.found, main_info.entry.counter, main_info.entry.useful,
-                main_info.table, main_info.index,
-                alt_info.found, alt_info.entry.counter, alt_info.entry.useful,
-                alt_info.table, alt_info.index,
-                recomputed.useAlt, recomputed.taken, actual_taken, alloc_success,
-                allocated_table, allocated_index, allocated_way,
-                history_str, predMeta->indexFoldedHist[main_info.table].get());
+            t.set(startAddr, btb_entry.pc, main_info.way, main_info.found, main_info.entry.counter,
+                  main_info.entry.useful, main_info.table, main_info.index, alt_info.found, alt_info.entry.counter,
+                  alt_info.entry.useful, alt_info.table, alt_info.index, recomputed.useAlt, recomputed.taken,
+                  actual_taken, alloc_success, allocated_table, allocated_index, allocated_way, history_str,
+                  predMeta->indexFoldedHist[main_info.table].get());
             tageMissTrace->write_record(t);
         }
 #endif
@@ -767,14 +769,15 @@ BTBTAGE::update(const FetchTarget &stream) {
     if (hasRecomputedVsOriginalDiff) {
         tageStats.recomputedVsOriginalDiff++;
     }
-    if (getDelay() <2){
+    if (getDelay() < 2) {
         checkUtageUpdateMisspred(stream);
     }
     DPRINTF(TAGE, "end update\n");
 }
 
 void
-BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
+BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream)
+{
     auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
     // use for microtage updatemispred counting
     // sort microtage predictions by pc to find the first taken branch
@@ -784,10 +787,9 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
         lastPreds.emplace_back(kv.first, kv.second);
     }
     std::sort(lastPreds.begin(), lastPreds.end(),
-            [](const std::pair<Addr, TagePrediction> &a,
-                const std::pair<Addr, TagePrediction> &b) {
-                return a.first < b.first;
-            });
+              [](const std::pair<Addr, TagePrediction> &a, const std::pair<Addr, TagePrediction> &b) {
+                  return a.first < b.first;
+              });
     Addr first_taken_pc = 0;
     for (auto &entry_info : lastPreds) {
         if (entry_info.second.taken) {
@@ -795,8 +797,7 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
             break;
         }
     }
-    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) ||
-                                (first_taken_pc != 0 && !stream.exeTaken);
+    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) || (first_taken_pc != 0 && !stream.exeTaken);
     bool branch_mispred = stream.exeTaken && first_taken_pc != stream.exeBranchInfo.pc;
     if (fallthrough_mispred || branch_mispred) {
         tageStats.updateMispred++;
@@ -805,9 +806,10 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
 
 // Update prediction counter with saturation
 void
-BTBTAGE::updateCounter(bool taken, unsigned width, short &counter) {
-    int max = (1 << (width-1)) - 1;
-    int min = -(1 << (width-1));
+BTBTAGE::updateCounter(bool taken, unsigned width, short &counter)
+{
+    int max = (1 << (width - 1)) - 1;
+    int min = -(1 << (width - 1));
     if (taken) {
         satIncrement(max, counter);
     } else {
@@ -823,7 +825,7 @@ BTBTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHist,
     Addr mask = (1ULL << tableTagBits[t]) - 1;
 
     unsigned pcShift = enableBankConflict ? indexShift : bankBaseShift;
-    pcShift += tableIndexBits[t] - 1;   // since tableIndexBits = log(2048) = 11, RTL is 10
+    pcShift += tableIndexBits[t] - 1;  // since tableIndexBits = log(2048) = 11, RTL is 10
     Addr pcBits = (pc >> pcShift) & mask;
 
     // Extract and prepare folded history bits
@@ -886,13 +888,15 @@ BTBTAGE::satDecrement(int min, short &counter)
 }
 
 Addr
-BTBTAGE::getUseAltIdx(Addr pc) {
+BTBTAGE::getUseAltIdx(Addr pc)
+{
     Addr shiftedPc = pc >> instShiftAmt;
     return shiftedPc & (useAltOnNaSize - 1);
 }
 
 unsigned
-BTBTAGE::getBranchIndexInBlock(Addr branchPC, Addr startPC) {
+BTBTAGE::getBranchIndexInBlock(Addr branchPC, Addr startPC)
+{
     // Calculate branch position within the fetch block (0 .. maxBranchPositions-1)
     Addr alignedPC = startPC & ~(blockSize - 1);
     Addr offset = (branchPC - alignedPC) >> instShiftAmt;
@@ -909,12 +913,12 @@ BTBTAGE::getBankId(Addr pc) const
 
 /**
  * @brief Updates branch history for speculative execution
- * 
+ *
  * This function updates three types of folded histories:
  * - Tag folded history: Used for tag computation
  * - Alternative tag folded history: Used for alternative tag computation
  * - Index folded history: Used for table index computation
- * 
+ *
  * @param history The current branch history
  * @param shamt The number of bits to shift
  * @param taken Whether the branch was taken
@@ -922,7 +926,7 @@ BTBTAGE::getBankId(Addr pc) const
 void
 BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr pc, Addr target)
 {
-    if (debug::TAGEHistory) {   // if debug flag is off, do not use to_string since it's too slow
+    if (debug::TAGEHistory) {  // if debug flag is off, do not use to_string since it's too slow
         std::string buf;
         boost::to_string(history, buf);
         DPRINTF(TAGEHistory, "in doUpdateHist, taken %d, pc %#lx, history %s\n", taken, pc, buf.c_str());
@@ -944,13 +948,13 @@ BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr p
 
 /**
  * @brief Updates branch history for speculative execution
- * 
+ *
  * This function updates the branch history for speculative execution
  * based on the provided history and prediction information.
- * 
+ *
  * It first retrieves the history information from the prediction metadata
  * and then calls the doUpdateHist function to update the folded histories.
- * 
+ *
  * @param history The current branch history
  * @param pred The prediction metadata containing history information
  */
@@ -963,20 +967,19 @@ BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredicti
 
 /**
  * @brief Recovers branch history state after a misprediction
- * 
+ *
  * This function:
  * 1. Restores the folded histories from the saved metadata
  * 2. Updates the histories with the correct branch outcome
  * 3. Ensures predictor state is consistent after recovery
- * 
+ *
  * @param history The branch history to recover to
  * @param entry The fetch stream entry containing recovery information
  * @param shamt Number of bits to shift in history update
  * @param cond_taken The actual branch outcome
  */
 void
-BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchTarget &entry, int shamt, bool cond_taken)
+BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < numPredictors; i++) {
@@ -989,7 +992,7 @@ BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
 
 // Check folded history after speculative update and recovery
 void
-BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char * when)
+BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char *when)
 {
     DPRINTF(TAGE, "checking folded history when %s\n", when);
     if (debug::TAGEHistory) {
@@ -1008,46 +1011,54 @@ BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char * when)
 
 #ifndef UNIT_TEST
 // Constructor for TAGE statistics
-BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int numBanks):
-    statistics::Group(parent),
-    ADD_STAT(predNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on prediction"),
-    ADD_STAT(predUseAlt, statistics::units::Count::get(), "use alt on prediction"),
-    ADD_STAT(updateNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on update"),
-    ADD_STAT(updateUseAlt, statistics::units::Count::get(), "use alt on update"),
-    ADD_STAT(updateUseAltCorrect, statistics::units::Count::get(), "use alt on update and correct"),
-    ADD_STAT(updateUseAltWrong, statistics::units::Count::get(), "use alt on update and wrong"),
-    ADD_STAT(updateAltDiffers, statistics::units::Count::get(), "alt differs on update"),
-    ADD_STAT(updateUseAltOnNaUpdated, statistics::units::Count::get(), "use alt on na ctr updated when update"),
-    ADD_STAT(updateProviderNa, statistics::units::Count::get(), "provider weak when update"),
-    ADD_STAT(updateUseNaCorrect, statistics::units::Count::get(), "use na on update and correct"),
-    ADD_STAT(updateUseNaWrong, statistics::units::Count::get(), "use na on update and wrong"),
-    ADD_STAT(updateUseAltOnNaCorrect, statistics::units::Count::get(), "use alt on na correct when update"),
-    ADD_STAT(updateUseAltOnNaWrong, statistics::units::Count::get(), "use alt on na wrong when update"),
-    ADD_STAT(updateAllocFailure, statistics::units::Count::get(), "alloc failure when update"),
-    ADD_STAT(updateAllocFailureNoValidTable, statistics::units::Count::get(), "alloc failure no valid table when update"),
-    ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
-    ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
-    ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
-    ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != actual_taken"),
-    ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != original pred.taken"),
-    ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
-    ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(), "number of updates deferred due to bank conflict (retried later)"),
-    ADD_STAT(updateBankConflictPerBank, statistics::units::Count::get(), "bank conflicts per bank"),
-    ADD_STAT(updateAccessPerBank, statistics::units::Count::get(), "update accesses per bank"),
-    ADD_STAT(predAccessPerBank, statistics::units::Count::get(), "prediction accesses per bank"),
-    ADD_STAT(predTableHits, statistics::units::Count::get(), "hit of each tage table on prediction"),
-    ADD_STAT(updateTableHits, statistics::units::Count::get(), "hit of each tage table on update"),
-    ADD_STAT(updateTableMispreds, statistics::units::Count::get(), "mispreds of each table when update"),
+BTBTAGE::TageStats::TageStats(statistics::Group *parent, int numPredictors, int numBanks)
+    : statistics::Group(parent),
+      ADD_STAT(predNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on prediction"),
+      ADD_STAT(predUseAlt, statistics::units::Count::get(), "use alt on prediction"),
+      ADD_STAT(updateNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on update"),
+      ADD_STAT(updateUseAlt, statistics::units::Count::get(), "use alt on update"),
+      ADD_STAT(updateUseAltCorrect, statistics::units::Count::get(), "use alt on update and correct"),
+      ADD_STAT(updateUseAltWrong, statistics::units::Count::get(), "use alt on update and wrong"),
+      ADD_STAT(updateAltDiffers, statistics::units::Count::get(), "alt differs on update"),
+      ADD_STAT(updateUseAltOnNaUpdated, statistics::units::Count::get(), "use alt on na ctr updated when update"),
+      ADD_STAT(updateProviderNa, statistics::units::Count::get(), "provider weak when update"),
+      ADD_STAT(updateUseNaCorrect, statistics::units::Count::get(), "use na on update and correct"),
+      ADD_STAT(updateUseNaWrong, statistics::units::Count::get(), "use na on update and wrong"),
+      ADD_STAT(updateUseAltOnNaCorrect, statistics::units::Count::get(), "use alt on na correct when update"),
+      ADD_STAT(updateUseAltOnNaWrong, statistics::units::Count::get(), "use alt on na wrong when update"),
+      ADD_STAT(updateAllocFailure, statistics::units::Count::get(), "alloc failure when update"),
+      ADD_STAT(updateAllocFailureNoValidTable, statistics::units::Count::get(),
+               "alloc failure no valid table when update"),
+      ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
+      ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
+      ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
+      ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(),
+               "fetchBlocks where recomputed.taken != actual_taken"),
+      ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(),
+               "fetchBlocks where recomputed.taken != original pred.taken"),
+      ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
+      ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(),
+               "number of updates deferred due to bank conflict (retried later)"),
+      ADD_STAT(updateBankConflictPerBank, statistics::units::Count::get(), "bank conflicts per bank"),
+      ADD_STAT(updateAccessPerBank, statistics::units::Count::get(), "update accesses per bank"),
+      ADD_STAT(predAccessPerBank, statistics::units::Count::get(), "prediction accesses per bank"),
+      ADD_STAT(predTableHits, statistics::units::Count::get(), "hit of each tage table on prediction"),
+      ADD_STAT(updateTableHits, statistics::units::Count::get(), "hit of each tage table on update"),
+      ADD_STAT(updateTableMispreds, statistics::units::Count::get(), "mispreds of each table when update"),
 
-    ADD_STAT(condPredwrong, statistics::units::Count::get(), "number of conditional branch mispredictions committed"),
-    ADD_STAT(condMissTakens, statistics::units::Count::get(), "number of conditional branch mispredictions committed with no prediction"),
-    ADD_STAT(condCorrect, statistics::units::Count::get(), "number of conditional branch correct predictions committed"),
-    ADD_STAT(condMissNoTakens, statistics::units::Count::get(), "number of conditional branch correct predictions committed with no prediction"),
-    ADD_STAT(predHit, statistics::units::Count::get(), "number of conditional branch predictions that hit"),
-    ADD_STAT(predMiss, statistics::units::Count::get(), "number of conditional branch predictions that miss")
+      ADD_STAT(condPredwrong, statistics::units::Count::get(),
+               "number of conditional branch mispredictions committed"),
+      ADD_STAT(condMissTakens, statistics::units::Count::get(),
+               "number of conditional branch mispredictions committed with no prediction"),
+      ADD_STAT(condCorrect, statistics::units::Count::get(),
+               "number of conditional branch correct predictions committed"),
+      ADD_STAT(condMissNoTakens, statistics::units::Count::get(),
+               "number of conditional branch correct predictions committed with no prediction"),
+      ADD_STAT(predHit, statistics::units::Count::get(), "number of conditional branch predictions that hit"),
+      ADD_STAT(predMiss, statistics::units::Count::get(), "number of conditional branch predictions that miss")
 {
-    predTableHits.init(0, numPredictors-1, 1);
-    updateTableHits.init(0, numPredictors-1, 1);
+    predTableHits.init(0, numPredictors - 1, 1);
+    updateTableHits.init(0, numPredictors - 1, 1);
     updateTableMispreds.init(numPredictors);
 
     // Initialize per-bank statistics vectors
@@ -1113,7 +1124,7 @@ BTBTAGE::getLRUVictim(int table, Addr index)
     // Find the entry with the highest LRU counter
     for (unsigned i = 0; i < numWays; i++) {
         if (!tageTable[table][index][i].valid) {
-            return i; // Use invalid entry if available
+            return i;  // Use invalid entry if available
         }
         if (tageTable[table][index][i].lruCounter > maxLRU) {
             maxLRU = tageTable[table][index][i].lruCounter;
@@ -1148,7 +1159,7 @@ BTBTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         if (!pred_hit) {
             tageStats.condMissTakens++;
         }
-    }else{
+    } else {
         tageStats.condCorrect++;
         if (!pred_hit) {
             tageStats.condMissNoTakens++;
@@ -1164,10 +1175,10 @@ BTBTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
 #endif
 
 #ifdef UNIT_TEST
-} // namespace test
+}  // namespace test
 #endif
 
-} // namespace btb_pred
+}  // namespace btb_pred
 
 }  // namespace branch_prediction
 

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -6,12 +6,10 @@
 
 #ifdef UNIT_TEST
 // Define debug flags for unit testing
-namespace gem5
-{
-namespace debug
-{
-bool TAGEUseful = true;
-bool TAGEHistory = true;
+namespace gem5 {
+namespace debug {
+    bool TAGEUseful = true;
+    bool TAGEHistory = true;
 }
 }
 #endif
@@ -24,18 +22,14 @@ bool TAGEHistory = true;
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/TAGE.hh"
 #endif
-namespace gem5
-{
+namespace gem5 {
 
-namespace branch_prediction
-{
+namespace branch_prediction {
 
-namespace btb_pred
-{
+namespace btb_pred{
 
 #ifdef UNIT_TEST
-namespace test
-{
+namespace test {
 #endif
 
 #ifdef UNIT_TEST
@@ -67,35 +61,35 @@ BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSize, u
     for (unsigned i = 0; i < numPredictors; ++i) {
         histLengths[i] = (i + 1) * 4;
     }
-    maxHistLen = histLengths[numPredictors - 1];
+    maxHistLen = histLengths[numPredictors-1];
     numTablesToAlloc = 1;
     enableSC = false;
 #else
 // Constructor: Initialize TAGE predictor with given parameters
-BTBTAGE::BTBTAGE(const Params &p)
-    : TimedBaseBTBPredictor(p),
-      numPredictors(p.numPredictors),
-      tableSizes(p.tableSizes),
-      tableTagBits(p.TTagBitSizes),
-      tablePcShifts(p.TTagPcShifts),
-      histLengths(p.histLengths),
-      maxHistLen(p.maxHistLen),
-      numWays(p.numWays),
-      maxBranchPositions(p.maxBranchPositions),
-      useAltOnNaSize(p.useAltOnNaSize),
-      useAltOnNaWidth(p.useAltOnNaWidth),
-      numTablesToAlloc(p.numTablesToAlloc),
-      enableSC(p.enableSC),
-      updateOnRead(p.updateOnRead),
-      numBanks(p.numBanks),
-      bankIdWidth(ceilLog2(p.numBanks)),
-      blockWidth(floorLog2(blockSize)),
-      bankBaseShift(instShiftAmt),  // strip instruction alignment bits before indexing
-      indexShift(bankBaseShift + ceilLog2(p.numBanks)),
-      enableBankConflict(p.enableBankConflict),
-      lastPredBankId(0),
-      predBankValid(false),
-      tageStats(this, p.numPredictors, p.numBanks)
+BTBTAGE::BTBTAGE(const Params& p):
+TimedBaseBTBPredictor(p),
+numPredictors(p.numPredictors),
+tableSizes(p.tableSizes),
+tableTagBits(p.TTagBitSizes),
+tablePcShifts(p.TTagPcShifts),
+histLengths(p.histLengths),
+maxHistLen(p.maxHistLen),
+numWays(p.numWays),
+maxBranchPositions(p.maxBranchPositions),
+useAltOnNaSize(p.useAltOnNaSize),
+useAltOnNaWidth(p.useAltOnNaWidth),
+numTablesToAlloc(p.numTablesToAlloc),
+enableSC(p.enableSC),
+updateOnRead(p.updateOnRead),
+numBanks(p.numBanks),
+bankIdWidth(ceilLog2(p.numBanks)),
+blockWidth(floorLog2(blockSize)),
+bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
+indexShift(bankBaseShift + ceilLog2(p.numBanks)),
+enableBankConflict(p.enableBankConflict),
+lastPredBankId(0),
+predBankValid(false),
+tageStats(this, p.numPredictors, p.numBanks)
 {
     this->needMoreHistories = p.needMoreHistories;
 
@@ -111,7 +105,7 @@ BTBTAGE::BTBTAGE(const Params &p)
     tableTagMasks.resize(numPredictors);
 
     for (unsigned int i = 0; i < numPredictors; ++i) {
-        // initialize ittage predictor
+        //initialize ittage predictor
         assert(tableSizes.size() >= numPredictors);
         tageTable[i].resize(tableSizes[i]);
         for (unsigned int j = 0; j < tableSizes[i]; ++j) {
@@ -129,7 +123,7 @@ BTBTAGE::BTBTAGE(const Params &p)
         assert(tablePcShifts.size() >= numPredictors);
 
         tagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i], 16));
-        altTagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i] - 1, 16));
+        altTagFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableTagBits[i]-1, 16));
         indexFoldedHist.push_back(PathFoldedHist((int)histLengths[i], (int)tableIndexBits[i], 16));
     }
     usefulResetCnt = 0;
@@ -139,17 +133,15 @@ BTBTAGE::BTBTAGE(const Params &p)
 #ifndef UNIT_TEST
     hasDB = true;
     switch (getDelay()) {
-        case 0:
-            dbName = std::string("microtage");
-            break;
-        default:
-            dbName = std::string("tage");
-            break;
+        case 0: dbName = std::string("microtage"); break;
+        default: dbName = std::string("tage"); break;
     }
 #endif
 }
 
-BTBTAGE::~BTBTAGE() {}
+BTBTAGE::~BTBTAGE()
+{
+}
 
 // Set up tracing for debugging
 void
@@ -158,17 +150,28 @@ BTBTAGE::setTrace()
 #ifndef UNIT_TEST
     if (enableDB) {
         std::vector<std::pair<std::string, DataType>> fields_vec = {
-            std::make_pair("startPC", UINT64),      std::make_pair("branchPC", UINT64),
-            std::make_pair("wayIdx", UINT64),       std::make_pair("mainFound", UINT64),
-            std::make_pair("mainCounter", UINT64),  std::make_pair("mainUseful", UINT64),
-            std::make_pair("mainTable", UINT64),    std::make_pair("mainIndex", UINT64),
-            std::make_pair("altFound", UINT64),     std::make_pair("altCounter", UINT64),
-            std::make_pair("altUseful", UINT64),    std::make_pair("altTable", UINT64),
-            std::make_pair("altIndex", UINT64),     std::make_pair("useAlt", UINT64),
-            std::make_pair("predTaken", UINT64),    std::make_pair("actualTaken", UINT64),
-            std::make_pair("allocSuccess", UINT64), std::make_pair("allocTable", UINT64),
-            std::make_pair("allocIndex", UINT64),   std::make_pair("allocWay", UINT64),
-            std::make_pair("history", TEXT),        std::make_pair("indexFoldedHist", UINT64),
+            std::make_pair("startPC", UINT64),
+            std::make_pair("branchPC", UINT64),
+            std::make_pair("wayIdx", UINT64),
+            std::make_pair("mainFound", UINT64),
+            std::make_pair("mainCounter", UINT64),
+            std::make_pair("mainUseful", UINT64),
+            std::make_pair("mainTable", UINT64),
+            std::make_pair("mainIndex", UINT64),
+            std::make_pair("altFound", UINT64),
+            std::make_pair("altCounter", UINT64),
+            std::make_pair("altUseful", UINT64),
+            std::make_pair("altTable", UINT64),
+            std::make_pair("altIndex", UINT64),
+            std::make_pair("useAlt", UINT64),
+            std::make_pair("predTaken", UINT64),
+            std::make_pair("actualTaken", UINT64),
+            std::make_pair("allocSuccess", UINT64),
+            std::make_pair("allocTable", UINT64),
+            std::make_pair("allocIndex", UINT64),
+            std::make_pair("allocWay", UINT64),
+            std::make_pair("history", TEXT),
+            std::make_pair("indexFoldedHist", UINT64),
         };
         tageMissTrace = _db->addAndGetTrace("TAGEMISSTRACE", fields_vec);
         tageMissTrace->init_table();
@@ -177,14 +180,10 @@ BTBTAGE::setTrace()
 }
 
 void
-BTBTAGE::tick()
-{
-}
+BTBTAGE::tick() {}
 
 void
-BTBTAGE::tickStart()
-{
-}
+BTBTAGE::tickStart() {}
 
 /**
  * @brief Generate prediction for a single BTB entry by searching TAGE tables
@@ -196,8 +195,9 @@ BTBTAGE::tickStart()
  * @return TagePrediction containing main and alternative predictions
  */
 BTBTAGE::TagePrediction
-BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC, std::shared_ptr<TageMeta> predMeta)
-{
+BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
+                                 const Addr &startPC,
+                                 std::shared_ptr<TageMeta> predMeta) {
     DPRINTF(TAGE, "generateSinglePrediction for btbEntry: %#lx\n", btb_entry.pc);
 
     // Find main and alternative predictions
@@ -212,13 +212,13 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
-        Addr index =
-            predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get()) : getTageIndex(startPC, i);
-        Addr tag = predMeta ? getTageTag(startPC, i, predMeta->tagFoldedHist[i].get(),
-                                         predMeta->altTagFoldedHist[i].get(), position)
-                            : getTageTag(startPC, i, position);
+        Addr index = predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get())
+                          : getTageIndex(startPC, i);
+        Addr tag = predMeta ? getTageTag(startPC, i,
+                            predMeta->tagFoldedHist[i].get(), predMeta->altTagFoldedHist[i].get(), position)
+                        : getTageTag(startPC, i, position);
 
-        bool match = false;  // for each table, only one way can be matched
+        bool match = false; // for each table, only one way can be matched
         TageEntry matching_entry;
         unsigned matching_way = 0;
 
@@ -233,8 +233,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
                 // Do not use LRU; keep logic simple and align with CBP-style replacement
 
-                DPRINTF(TAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n", i,
-                        index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
+                DPRINTF(TAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n",
+                    i, index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
                 break;  // only one way can be matched, aviod multi hit, TODO: RTL how to do this?
             }
         }
@@ -251,8 +251,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
                 break;
             }
         } else {
-            DPRINTF(TAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n", i, index, tag, position,
-                    btb_entry.pc);
+            DPRINTF(TAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n",
+                i, index, tag, position, btb_entry.pc);
         }
     }
 
@@ -261,8 +261,8 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     bool alt_taken = alt_info.taken();
     // Use base table instead of btb_entry.ctr
     bool base_taken = btb_entry.ctr >= 0;
-    // bool base_taken = btb_entry.ctr >= 0;
-    bool alt_pred = alt_provided ? alt_taken : base_taken;  // if alt provided, use alt prediction, otherwise use base
+    //bool base_taken = btb_entry.ctr >= 0;
+    bool alt_pred = alt_provided ? alt_taken : base_taken; // if alt provided, use alt prediction, otherwise use base
 
     // use_alt_on_na gating: when provider weak, consult per-PC counter
     bool use_alt = false;
@@ -280,22 +280,22 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     bool taken = use_alt ? alt_pred : main_taken;
 
     DPRINTF(TAGE, "tage predict %#lx taken %d\n", btb_entry.pc, taken);
-    DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n", use_alt,
-            alt_provided, alt_taken, base_taken, main_taken);
+    DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n",
+        use_alt, alt_provided, alt_taken, base_taken, main_taken);
 
     return TagePrediction(btb_entry.pc, main_info, alt_info, use_alt, taken, alt_pred);
 }
 
 /**
  * @brief Look up predictions in TAGE tables for a stream of instructions
- *
+ * 
  * @param startPC The starting PC address for the instruction stream
  * @param btbEntries Vector of BTB entries to make predictions for
  * @return Map of branch PC addresses to their predicted outcomes
  */
 void
 BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntries,
-                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results)
+                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results)
 {
     DPRINTF(TAGE, "lookupHelper startAddr: %#lx\n", startPC);
 
@@ -309,25 +309,21 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
             results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
             tageInfoForMgscs[btb_entry.pc].tage_pred_taken = pred.taken;
             tageInfoForMgscs[btb_entry.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high =
-                pred.mainInfo.found && abs(pred.mainInfo.entry.counter * 2 + 1) == 7;  // counter saturated, -4 or 3
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid =
-                pred.mainInfo.found &&
-                (abs(pred.mainInfo.entry.counter * 2 + 1) < 7 &&
-                 abs(pred.mainInfo.entry.counter * 2 + 1) > 1);  // counter not saturated, -3, -2, 1, 2
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_low =
-                !pred.mainInfo.found ||
-                (abs(pred.mainInfo.entry.counter * 2 + 1) <= 1);  // counter initialized, -1 or 0
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high = pred.mainInfo.found &&
+                                         abs(pred.mainInfo.entry.counter*2 + 1) == 7; // counter saturated, -4 or 3
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid = pred.mainInfo.found &&
+                                         (abs(pred.mainInfo.entry.counter*2 + 1) < 7 &&
+                                         abs(pred.mainInfo.entry.counter*2 + 1) > 1); // counter not saturated, -3, -2, 1, 2
+            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_low = !pred.mainInfo.found ||
+                                         (abs(pred.mainInfo.entry.counter*2 + 1) <= 1); // counter initialized, -1 or 0
             // main predict is different from alt predict/base predict
-            tageInfoForMgscs[btb_entry.pc].tage_pred_alt_diff =
-                pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
+            tageInfoForMgscs[btb_entry.pc].tage_pred_alt_diff = pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
         }
     }
 }
 
 void
-BTBTAGE::dryRunCycle(Addr startPC)
-{
+BTBTAGE::dryRunCycle(Addr startPC) {
     // No operation in dry run cycle for BTBTAGE
     // Record prediction bank for next tick's conflict detection
     lastPredBankId = getBankId(startPC);
@@ -338,19 +334,18 @@ BTBTAGE::dryRunCycle(Addr startPC)
 
 /**
  * @brief Makes predictions for a stream of instructions using TAGE predictor
- *
+ * 
  * This function is called during the prediction stage and:
  * 1. Uses lookupHelper to get predictions for all BTB entries
  * 2. Stores predictions in the stage prediction structure
  * 3. Handles multiple prediction stages with different delays
- *
+ * 
  * @param startPC Starting PC of the instruction stream
  * @param history Current branch history
  * @param stagePreds Vector of predictions for different pipeline stages
  */
 void
-BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPrediction> &stagePreds)
-{
+BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPrediction> &stagePreds) {
     // Record prediction bank for next tick's conflict detection
     lastPredBankId = getBankId(startPC);
     predBankValid = true;
@@ -360,7 +355,8 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
     tageStats.predAccessPerBank[lastPredBankId]++;
 #endif
 
-    DPRINTF(TAGE, "putPCHistory startAddr: %#lx, bank: %u\n", startPC, lastPredBankId);
+    DPRINTF(TAGE, "putPCHistory startAddr: %#lx, bank: %u\n",
+            startPC, lastPredBankId);
 
     // IMPORTANT: when this function is called,
     // btb entries should already be in stagePreds
@@ -378,24 +374,23 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
         auto &stage_pred = stagePreds[s];
         stage_pred.condTakens.clear();
         lookupHelper(startPC, stage_pred.btbEntries, stage_pred.tageInfoForMgscs, stage_pred.condTakens);
+
     }
 }
 
 std::shared_ptr<void>
-BTBTAGE::getPredictionMeta()
-{
+BTBTAGE::getPredictionMeta() {
     return meta;
 }
 
 /**
  * @brief Prepare BTB entries for update by filtering and processing
- *
+ * 
  * @param stream The fetch stream containing update information
  * @return Vector of BTB entries that need to be updated
  */
 std::vector<BTBEntry>
-BTBTAGE::prepareUpdateEntries(const FetchTarget &stream)
-{
+BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     auto all_entries = stream.updateBTBEntries;
 
     // Add potential new BTB entry if it's a btb miss during prediction
@@ -411,11 +406,11 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream)
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-                                        [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
+            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-                                        [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
+            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -424,7 +419,7 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream)
 
 /**
  * @brief Update predictor state for a single entry
- *
+ * 
  * @param entry The BTB entry being updated
  * @param actual_taken The actual outcome of the branch
  * @param pred The prediction made for this entry
@@ -432,9 +427,10 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream)
  * @return true if need to allocate new entry
  */
 bool
-BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actual_taken, const TagePrediction &pred,
-                                                const FetchTarget &stream)
-{
+BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
+                             bool actual_taken,
+                             const TagePrediction &pred,
+                             const FetchTarget &stream) {
     tageStats.updateStatsWithTagePrediction(pred, false);
 
     auto &main_info = pred.mainInfo;
@@ -465,7 +461,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actu
     // Update main prediction provider
     if (main_info.found) {
         DPRINTF(TAGE, "prediction provided by table %d, idx %lu, way %u, updating corresponding entry\n",
-                main_info.table, main_info.index, main_info.way);
+            main_info.table, main_info.index, main_info.way);
 
         auto &way = tageTable[main_info.table][main_info.index][main_info.way];
 
@@ -474,8 +470,9 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actu
 
         // Update useful bit based on several conditions
         bool main_is_correct = main_info.taken() == actual_taken;
-        bool alt_is_correct_and_strong =
-            alt_info.found && (alt_info.taken() == actual_taken) && (abs(2 * alt_info.entry.counter + 1) == 7);
+        bool alt_is_correct_and_strong = alt_info.found &&
+                                     (alt_info.taken() == actual_taken) &&
+                                     (abs(2 * alt_info.entry.counter + 1) == 7);
 
         // a. Special reset (humility mechanism)
         if (alt_is_correct_and_strong && main_is_correct) {
@@ -519,8 +516,9 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actu
     }
 
     // Check if misprediction occurred
-    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL && stream.squashPC == entry.pc;
-    if (getDelay() == 2) {
+    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
+                               stream.squashPC == entry.pc;
+    if (getDelay() == 2){
         if (this_fb_mispred) {
             tageStats.updateMispred++;
             if (!used_alt && main_info.found) {
@@ -549,7 +547,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actu
 
 /**
  * @brief Handle allocation of new entries
- *
+ * 
  * @param startPC The starting PC address
  * @param entry The BTB entry being updated
  * @param actual_taken The actual outcome of the branch
@@ -558,10 +556,14 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actu
  * @return true if allocation is successful
  */
 bool
-BTBTAGE::handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bool actual_taken, unsigned start_table,
-                                  std::shared_ptr<TageMeta> meta, uint64_t &allocated_table, uint64_t &allocated_index,
-                                  uint64_t &allocated_way)
-{
+BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
+                                 const BTBEntry &entry,
+                                 bool actual_taken,
+                                 unsigned start_table,
+                                 std::shared_ptr<TageMeta> meta,
+                                 uint64_t &allocated_table,
+                                 uint64_t &allocated_index,
+                                 uint64_t &allocated_way) {
     // Simple set-associative allocation (no LFSR, no per-way table gating):
     // - For each table from start_table upward, check the set at computed index.
     // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
@@ -572,20 +574,20 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bo
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
         Addr newIndex = getTageIndex(startPC, ti, meta->indexFoldedHist[ti].get());
-        Addr newTag =
-            getTageTag(startPC, ti, meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
+        Addr newTag = getTageTag(startPC, ti,
+            meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position);
 
         auto &set = tageTable[ti][newIndex];
 
         // Allocate into invalid way or not-useful and weak way
         for (unsigned way = 0; way < numWays; ++way) {
             auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;  // -3,-2,-1,0,1,2
+            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
             if (!cand.valid || (!cand.useful && weakish)) {
                 short newCounter = actual_taken ? 0 : -1;
                 DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
                         ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc);  // u = 0 default
+                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
                 tageStats.updateAllocSuccess++;
                 allocated_table = ti;
                 allocated_index = newIndex;
@@ -600,13 +602,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bo
             auto &cand = set[way];
             const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
             if (!cand.useful && !weakish) {
-                if (cand.counter > 0)
-                    cand.counter--;
-                else
-                    cand.counter++;
-                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n", ti, newIndex, way,
-                        cand.counter);
-                break;  // one penalty per table per update
+                if (cand.counter > 0) cand.counter--; else cand.counter++;
+                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n",
+                        ti, newIndex, way, cand.counter);
+                break; // one penalty per table per update
             }
         }
 
@@ -637,8 +636,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bo
  * Returns false if the update cannot proceed due to a bank conflict.
  */
 bool
-BTBTAGE::canResolveUpdate(const FetchTarget &stream)
-{
+BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -653,10 +651,9 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream)
 #ifndef UNIT_TEST
         tageStats.updateBankConflictPerBank[updateBank]++;
 #endif
-        DPRINTF(TAGE,
-                "Bank conflict detected: update bank %u conflicts with prediction bank %u, "
-                "deferring this update (will retry after blocking prediction)\n",
-                updateBank, lastPredBankId);
+        DPRINTF(TAGE, "Bank conflict detected: update bank %u conflicts with prediction bank %u, "
+                      "deferring this update (will retry after blocking prediction)\n",
+                      updateBank, lastPredBankId);
         predBankValid = false;
         return false;
     }
@@ -668,8 +665,7 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream)
  * @brief Perform resolved update after probe success.
  */
 void
-BTBTAGE::doResolveUpdate(const FetchTarget &stream)
-{
+BTBTAGE::doResolveUpdate(const FetchTarget &stream) {
     if (enableBankConflict && predBankValid) {
         // Prediction consumed; clear bank tag for next cycle
         predBankValid = false;
@@ -679,12 +675,11 @@ BTBTAGE::doResolveUpdate(const FetchTarget &stream)
 
 /**
  * @brief Updates the TAGE predictor state based on actual branch execution results
- *
+ * 
  * @param stream The fetch stream containing branch execution information
  */
 void
-BTBTAGE::update(const FetchTarget &stream)
-{
+BTBTAGE::update(const FetchTarget &stream) {
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -693,7 +688,7 @@ BTBTAGE::update(const FetchTarget &stream)
     // ========== Normal Update Logic ==========
     // Prepare BTB entries to update
     auto entries_to_update = prepareUpdateEntries(stream);
-
+    
     // Get prediction metadata snapshot and bind to member for helpers
     auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
     if (!predMeta) {
@@ -707,7 +702,7 @@ BTBTAGE::update(const FetchTarget &stream)
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
         TagePrediction recomputed;
-        if (updateOnRead) {  // if update on read is enabled, re-read providers using snapshot
+        if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
             // Track differences for statistics
@@ -715,7 +710,7 @@ BTBTAGE::update(const FetchTarget &stream)
             if (it != predMeta->preds.end() && recomputed.taken != it->second.taken) {
                 hasRecomputedVsOriginalDiff = true;
             }
-        } else {  // otherwise, use the prediction from the prediction-time main/alt
+        } else { // otherwise, use the prediction from the prediction-time main/alt
             recomputed = predMeta->preds[btb_entry.pc];
         }
         if (recomputed.taken != actual_taken) {
@@ -736,10 +731,10 @@ BTBTAGE::update(const FetchTarget &stream)
             uint start_table = 0;
             auto &main_info = recomputed.mainInfo;
             if (main_info.found) {
-                start_table = main_info.table + 1;  // start from the table after the main prediction table
+                start_table = main_info.table + 1; // start from the table after the main prediction table
             }
-            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken, start_table, predMeta,
-                                                     allocated_table, allocated_index, allocated_way);
+            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
+                                   start_table, predMeta, allocated_table, allocated_index, allocated_way);
         }
 
 #ifndef UNIT_TEST
@@ -753,11 +748,14 @@ BTBTAGE::update(const FetchTarget &stream)
             boost::to_string(history_low50, history_str);
             auto main_info = recomputed.mainInfo;
             auto alt_info = recomputed.altInfo;
-            t.set(startAddr, btb_entry.pc, main_info.way, main_info.found, main_info.entry.counter,
-                  main_info.entry.useful, main_info.table, main_info.index, alt_info.found, alt_info.entry.counter,
-                  alt_info.entry.useful, alt_info.table, alt_info.index, recomputed.useAlt, recomputed.taken,
-                  actual_taken, alloc_success, allocated_table, allocated_index, allocated_way, history_str,
-                  predMeta->indexFoldedHist[main_info.table].get());
+            t.set(startAddr, btb_entry.pc, main_info.way,
+                main_info.found, main_info.entry.counter, main_info.entry.useful,
+                main_info.table, main_info.index,
+                alt_info.found, alt_info.entry.counter, alt_info.entry.useful,
+                alt_info.table, alt_info.index,
+                recomputed.useAlt, recomputed.taken, actual_taken, alloc_success,
+                allocated_table, allocated_index, allocated_way,
+                history_str, predMeta->indexFoldedHist[main_info.table].get());
             tageMissTrace->write_record(t);
         }
 #endif
@@ -769,15 +767,14 @@ BTBTAGE::update(const FetchTarget &stream)
     if (hasRecomputedVsOriginalDiff) {
         tageStats.recomputedVsOriginalDiff++;
     }
-    if (getDelay() < 2) {
+    if (getDelay() <2){
         checkUtageUpdateMisspred(stream);
     }
     DPRINTF(TAGE, "end update\n");
 }
 
 void
-BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream)
-{
+BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
     auto predMeta = std::static_pointer_cast<TageMeta>(stream.predMetas[getComponentIdx()]);
     // use for microtage updatemispred counting
     // sort microtage predictions by pc to find the first taken branch
@@ -787,9 +784,10 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream)
         lastPreds.emplace_back(kv.first, kv.second);
     }
     std::sort(lastPreds.begin(), lastPreds.end(),
-              [](const std::pair<Addr, TagePrediction> &a, const std::pair<Addr, TagePrediction> &b) {
-                  return a.first < b.first;
-              });
+            [](const std::pair<Addr, TagePrediction> &a,
+                const std::pair<Addr, TagePrediction> &b) {
+                return a.first < b.first;
+            });
     Addr first_taken_pc = 0;
     for (auto &entry_info : lastPreds) {
         if (entry_info.second.taken) {
@@ -797,7 +795,8 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream)
             break;
         }
     }
-    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) || (first_taken_pc != 0 && !stream.exeTaken);
+    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) ||
+                                (first_taken_pc != 0 && !stream.exeTaken);
     bool branch_mispred = stream.exeTaken && first_taken_pc != stream.exeBranchInfo.pc;
     if (fallthrough_mispred || branch_mispred) {
         tageStats.updateMispred++;
@@ -806,10 +805,9 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream)
 
 // Update prediction counter with saturation
 void
-BTBTAGE::updateCounter(bool taken, unsigned width, short &counter)
-{
-    int max = (1 << (width - 1)) - 1;
-    int min = -(1 << (width - 1));
+BTBTAGE::updateCounter(bool taken, unsigned width, short &counter) {
+    int max = (1 << (width-1)) - 1;
+    int min = -(1 << (width-1));
     if (taken) {
         satIncrement(max, counter);
     } else {
@@ -825,7 +823,7 @@ BTBTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHist,
     Addr mask = (1ULL << tableTagBits[t]) - 1;
 
     unsigned pcShift = enableBankConflict ? indexShift : bankBaseShift;
-    pcShift += tableIndexBits[t] - 1;  // since tableIndexBits = log(2048) = 11, RTL is 10
+    pcShift += tableIndexBits[t] - 1;   // since tableIndexBits = log(2048) = 11, RTL is 10
     Addr pcBits = (pc >> pcShift) & mask;
 
     // Extract and prepare folded history bits
@@ -888,15 +886,13 @@ BTBTAGE::satDecrement(int min, short &counter)
 }
 
 Addr
-BTBTAGE::getUseAltIdx(Addr pc)
-{
+BTBTAGE::getUseAltIdx(Addr pc) {
     Addr shiftedPc = pc >> instShiftAmt;
     return shiftedPc & (useAltOnNaSize - 1);
 }
 
 unsigned
-BTBTAGE::getBranchIndexInBlock(Addr branchPC, Addr startPC)
-{
+BTBTAGE::getBranchIndexInBlock(Addr branchPC, Addr startPC) {
     // Calculate branch position within the fetch block (0 .. maxBranchPositions-1)
     Addr alignedPC = startPC & ~(blockSize - 1);
     Addr offset = (branchPC - alignedPC) >> instShiftAmt;
@@ -913,12 +909,12 @@ BTBTAGE::getBankId(Addr pc) const
 
 /**
  * @brief Updates branch history for speculative execution
- *
+ * 
  * This function updates three types of folded histories:
  * - Tag folded history: Used for tag computation
  * - Alternative tag folded history: Used for alternative tag computation
  * - Index folded history: Used for table index computation
- *
+ * 
  * @param history The current branch history
  * @param shamt The number of bits to shift
  * @param taken Whether the branch was taken
@@ -926,7 +922,7 @@ BTBTAGE::getBankId(Addr pc) const
 void
 BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr pc, Addr target)
 {
-    if (debug::TAGEHistory) {  // if debug flag is off, do not use to_string since it's too slow
+    if (debug::TAGEHistory) {   // if debug flag is off, do not use to_string since it's too slow
         std::string buf;
         boost::to_string(history, buf);
         DPRINTF(TAGEHistory, "in doUpdateHist, taken %d, pc %#lx, history %s\n", taken, pc, buf.c_str());
@@ -948,13 +944,13 @@ BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken, Addr p
 
 /**
  * @brief Updates branch history for speculative execution
- *
+ * 
  * This function updates the branch history for speculative execution
  * based on the provided history and prediction information.
- *
+ * 
  * It first retrieves the history information from the prediction metadata
  * and then calls the doUpdateHist function to update the folded histories.
- *
+ * 
  * @param history The current branch history
  * @param pred The prediction metadata containing history information
  */
@@ -967,19 +963,20 @@ BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredicti
 
 /**
  * @brief Recovers branch history state after a misprediction
- *
+ * 
  * This function:
  * 1. Restores the folded histories from the saved metadata
  * 2. Updates the histories with the correct branch outcome
  * 3. Ensures predictor state is consistent after recovery
- *
+ * 
  * @param history The branch history to recover to
  * @param entry The fetch stream entry containing recovery information
  * @param shamt Number of bits to shift in history update
  * @param cond_taken The actual branch outcome
  */
 void
-BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
+    const FetchTarget &entry, int shamt, bool cond_taken)
 {
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < numPredictors; i++) {
@@ -992,7 +989,7 @@ BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget 
 
 // Check folded history after speculative update and recovery
 void
-BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char *when)
+BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char * when)
 {
     DPRINTF(TAGE, "checking folded history when %s\n", when);
     if (debug::TAGEHistory) {
@@ -1011,54 +1008,46 @@ BTBTAGE::checkFoldedHist(const boost::dynamic_bitset<> &hist, const char *when)
 
 #ifndef UNIT_TEST
 // Constructor for TAGE statistics
-BTBTAGE::TageStats::TageStats(statistics::Group *parent, int numPredictors, int numBanks)
-    : statistics::Group(parent),
-      ADD_STAT(predNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on prediction"),
-      ADD_STAT(predUseAlt, statistics::units::Count::get(), "use alt on prediction"),
-      ADD_STAT(updateNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on update"),
-      ADD_STAT(updateUseAlt, statistics::units::Count::get(), "use alt on update"),
-      ADD_STAT(updateUseAltCorrect, statistics::units::Count::get(), "use alt on update and correct"),
-      ADD_STAT(updateUseAltWrong, statistics::units::Count::get(), "use alt on update and wrong"),
-      ADD_STAT(updateAltDiffers, statistics::units::Count::get(), "alt differs on update"),
-      ADD_STAT(updateUseAltOnNaUpdated, statistics::units::Count::get(), "use alt on na ctr updated when update"),
-      ADD_STAT(updateProviderNa, statistics::units::Count::get(), "provider weak when update"),
-      ADD_STAT(updateUseNaCorrect, statistics::units::Count::get(), "use na on update and correct"),
-      ADD_STAT(updateUseNaWrong, statistics::units::Count::get(), "use na on update and wrong"),
-      ADD_STAT(updateUseAltOnNaCorrect, statistics::units::Count::get(), "use alt on na correct when update"),
-      ADD_STAT(updateUseAltOnNaWrong, statistics::units::Count::get(), "use alt on na wrong when update"),
-      ADD_STAT(updateAllocFailure, statistics::units::Count::get(), "alloc failure when update"),
-      ADD_STAT(updateAllocFailureNoValidTable, statistics::units::Count::get(),
-               "alloc failure no valid table when update"),
-      ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
-      ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
-      ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
-      ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(),
-               "fetchBlocks where recomputed.taken != actual_taken"),
-      ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(),
-               "fetchBlocks where recomputed.taken != original pred.taken"),
-      ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
-      ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(),
-               "number of updates deferred due to bank conflict (retried later)"),
-      ADD_STAT(updateBankConflictPerBank, statistics::units::Count::get(), "bank conflicts per bank"),
-      ADD_STAT(updateAccessPerBank, statistics::units::Count::get(), "update accesses per bank"),
-      ADD_STAT(predAccessPerBank, statistics::units::Count::get(), "prediction accesses per bank"),
-      ADD_STAT(predTableHits, statistics::units::Count::get(), "hit of each tage table on prediction"),
-      ADD_STAT(updateTableHits, statistics::units::Count::get(), "hit of each tage table on update"),
-      ADD_STAT(updateTableMispreds, statistics::units::Count::get(), "mispreds of each table when update"),
+BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int numBanks):
+    statistics::Group(parent),
+    ADD_STAT(predNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on prediction"),
+    ADD_STAT(predUseAlt, statistics::units::Count::get(), "use alt on prediction"),
+    ADD_STAT(updateNoHitUseBim, statistics::units::Count::get(), "use bimodal when no hit on update"),
+    ADD_STAT(updateUseAlt, statistics::units::Count::get(), "use alt on update"),
+    ADD_STAT(updateUseAltCorrect, statistics::units::Count::get(), "use alt on update and correct"),
+    ADD_STAT(updateUseAltWrong, statistics::units::Count::get(), "use alt on update and wrong"),
+    ADD_STAT(updateAltDiffers, statistics::units::Count::get(), "alt differs on update"),
+    ADD_STAT(updateUseAltOnNaUpdated, statistics::units::Count::get(), "use alt on na ctr updated when update"),
+    ADD_STAT(updateProviderNa, statistics::units::Count::get(), "provider weak when update"),
+    ADD_STAT(updateUseNaCorrect, statistics::units::Count::get(), "use na on update and correct"),
+    ADD_STAT(updateUseNaWrong, statistics::units::Count::get(), "use na on update and wrong"),
+    ADD_STAT(updateUseAltOnNaCorrect, statistics::units::Count::get(), "use alt on na correct when update"),
+    ADD_STAT(updateUseAltOnNaWrong, statistics::units::Count::get(), "use alt on na wrong when update"),
+    ADD_STAT(updateAllocFailure, statistics::units::Count::get(), "alloc failure when update"),
+    ADD_STAT(updateAllocFailureNoValidTable, statistics::units::Count::get(), "alloc failure no valid table when update"),
+    ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
+    ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
+    ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
+    ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != actual_taken"),
+    ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != original pred.taken"),
+    ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
+    ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(), "number of updates deferred due to bank conflict (retried later)"),
+    ADD_STAT(updateBankConflictPerBank, statistics::units::Count::get(), "bank conflicts per bank"),
+    ADD_STAT(updateAccessPerBank, statistics::units::Count::get(), "update accesses per bank"),
+    ADD_STAT(predAccessPerBank, statistics::units::Count::get(), "prediction accesses per bank"),
+    ADD_STAT(predTableHits, statistics::units::Count::get(), "hit of each tage table on prediction"),
+    ADD_STAT(updateTableHits, statistics::units::Count::get(), "hit of each tage table on update"),
+    ADD_STAT(updateTableMispreds, statistics::units::Count::get(), "mispreds of each table when update"),
 
-      ADD_STAT(condPredwrong, statistics::units::Count::get(),
-               "number of conditional branch mispredictions committed"),
-      ADD_STAT(condMissTakens, statistics::units::Count::get(),
-               "number of conditional branch mispredictions committed with no prediction"),
-      ADD_STAT(condCorrect, statistics::units::Count::get(),
-               "number of conditional branch correct predictions committed"),
-      ADD_STAT(condMissNoTakens, statistics::units::Count::get(),
-               "number of conditional branch correct predictions committed with no prediction"),
-      ADD_STAT(predHit, statistics::units::Count::get(), "number of conditional branch predictions that hit"),
-      ADD_STAT(predMiss, statistics::units::Count::get(), "number of conditional branch predictions that miss")
+    ADD_STAT(condPredwrong, statistics::units::Count::get(), "number of conditional branch mispredictions committed"),
+    ADD_STAT(condMissTakens, statistics::units::Count::get(), "number of conditional branch mispredictions committed with no prediction"),
+    ADD_STAT(condCorrect, statistics::units::Count::get(), "number of conditional branch correct predictions committed"),
+    ADD_STAT(condMissNoTakens, statistics::units::Count::get(), "number of conditional branch correct predictions committed with no prediction"),
+    ADD_STAT(predHit, statistics::units::Count::get(), "number of conditional branch predictions that hit"),
+    ADD_STAT(predMiss, statistics::units::Count::get(), "number of conditional branch predictions that miss")
 {
-    predTableHits.init(0, numPredictors - 1, 1);
-    updateTableHits.init(0, numPredictors - 1, 1);
+    predTableHits.init(0, numPredictors-1, 1);
+    updateTableHits.init(0, numPredictors-1, 1);
     updateTableMispreds.init(numPredictors);
 
     // Initialize per-bank statistics vectors
@@ -1124,7 +1113,7 @@ BTBTAGE::getLRUVictim(int table, Addr index)
     // Find the entry with the highest LRU counter
     for (unsigned i = 0; i < numWays; i++) {
         if (!tageTable[table][index][i].valid) {
-            return i;  // Use invalid entry if available
+            return i; // Use invalid entry if available
         }
         if (tageTable[table][index][i].lruCounter > maxLRU) {
             maxLRU = tageTable[table][index][i].lruCounter;
@@ -1159,7 +1148,7 @@ BTBTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         if (!pred_hit) {
             tageStats.condMissTakens++;
         }
-    } else {
+    }else{
         tageStats.condCorrect++;
         if (!pred_hit) {
             tageStats.condMissNoTakens++;
@@ -1175,10 +1164,10 @@ BTBTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
 #endif
 
 #ifdef UNIT_TEST
-}  // namespace test
+} // namespace test
 #endif
 
-}  // namespace btb_pred
+} // namespace btb_pred
 
 }  // namespace branch_prediction
 

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -14,15 +14,16 @@
 #include "cpu/pred/btb/folded_hist.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
 
-// Conditional includes based on build mode
 #ifdef UNIT_TEST
-    #include "cpu/pred/btb/test/test_dprintf.hh"
+#include "cpu/pred/btb/test/test_dprintf.hh"
+
 #else
-    #include "debug/DecoupleBP.hh"
-    #include "debug/TAGEUseful.hh"
-    #include "debug/TAGEHistory.hh"
-    #include "params/BTBTAGE.hh"
-    #include "sim/sim_object.hh"
+#include "debug/DecoupleBP.hh"
+#include "debug/TAGEHistory.hh"
+#include "debug/TAGEUseful.hh"
+#include "params/BTBTAGE.hh"
+#include "sim/sim_object.hh"
+
 #endif
 
 namespace gem5
@@ -36,13 +37,15 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test {
+namespace test
+{
 #endif
 
 class BTBTAGE : public TimedBaseBTBPredictor
 {
     using defer = std::shared_ptr<void>;
     using bitset = boost::dynamic_bitset<>;
+
   public:
 #ifdef UNIT_TEST
     // Test constructor
@@ -55,64 +58,66 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Represents a single entry in the TAGE prediction table
     struct TageEntry
     {
-        public:
-            bool valid;      // Whether this entry is valid
-            Addr tag;       // Tag for matching
-            short counter;  // Prediction counter (-4 to 3), 3bits， 0 and -1 are weak
-            bool useful;    // 1-bit usefulness counter; true means useful
-            Addr pc;        // branch pc, like branch position, for btb entry pc check
-            unsigned lruCounter; // Counter for LRU replacement policy
+      public:
+        bool valid;           // Whether this entry is valid
+        Addr tag;             // Tag for matching
+        short counter;        // Prediction counter (-4 to 3), 3bits， 0 and -1 are weak
+        bool useful;          // 1-bit usefulness counter; true means useful
+        Addr pc;              // branch pc, like branch position, for btb entry pc check
+        unsigned lruCounter;  // Counter for LRU replacement policy
 
-            TageEntry() : valid(false), tag(0), counter(0), useful(false), pc(0), lruCounter(0) {}
+        TageEntry() : valid(false), tag(0), counter(0), useful(false), pc(0), lruCounter(0) {}
 
-            TageEntry(Addr tag, short counter, Addr pc) :
-                      valid(true), tag(tag), counter(counter), useful(false), pc(pc), lruCounter(0) {}
-            bool taken() const {
-                return counter >= 0;
-            }
+        TageEntry(Addr tag, short counter, Addr pc)
+            : valid(true), tag(tag), counter(counter), useful(false), pc(pc), lruCounter(0)
+        {
+        }
+        bool taken() const { return counter >= 0; }
     };
 
     // Contains information about a TAGE table lookup
     struct TageTableInfo
     {
-        public:
-            bool found;     // Whether a matching entry was found
-            TageEntry entry; // The matching entry
-            unsigned table; // Which table this entry was found in
-            Addr index;     // Index in the table
-            Addr tag;       // Tag that was matched
-            unsigned way;    // Which way this entry was found in
-            TageTableInfo() : found(false), table(0), index(0), tag(0), way(0) {}
-            TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag, unsigned way) :
-                        found(found), entry(entry), table(table), index(index), tag(tag), way(way) {}
-            bool taken() const {
-                return entry.taken();
-            }
+      public:
+        bool found;       // Whether a matching entry was found
+        TageEntry entry;  // The matching entry
+        unsigned table;   // Which table this entry was found in
+        Addr index;       // Index in the table
+        Addr tag;         // Tag that was matched
+        unsigned way;     // Which way this entry was found in
+        TageTableInfo() : found(false), table(0), index(0), tag(0), way(0) {}
+        TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag, unsigned way)
+            : found(found), entry(entry), table(table), index(index), tag(tag), way(way)
+        {
+        }
+        bool taken() const { return entry.taken(); }
     };
 
     // Contains the complete prediction result
     struct TagePrediction
     {
-        public:
-            Addr btb_pc;           // btb entry pc, same as tage entry pc
-            TageTableInfo mainInfo; // Main prediction info
-            TageTableInfo altInfo;  // Alternative prediction info
-            bool useAlt;           // Whether to use alternative prediction, true if main is weak or no main prediction
-            bool taken;            // Final prediction (taken/not taken) = use_alt ? alt_provided ? alt_taken : base_taken : main_taken
-            bool altPred;          // Alternative prediction = alt_provided ? alt_taken : base_taken;
+      public:
+        Addr btb_pc;             // btb entry pc, same as tage entry pc
+        TageTableInfo mainInfo;  // Main prediction info
+        TageTableInfo altInfo;   // Alternative prediction info
+        bool useAlt;             // Whether to use alternative prediction, true if main is weak or no main prediction
+        bool taken;    // Final prediction (taken/not taken) = use_alt ? alt_provided ? alt_taken : base_taken :
+                       // main_taken
+        bool altPred;  // Alternative prediction = alt_provided ? alt_taken : base_taken;
 
 
-            TagePrediction() : btb_pc(0), useAlt(false), taken(false), altPred(false) {}
+        TagePrediction() : btb_pc(0), useAlt(false), taken(false), altPred(false) {}
 
-            TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo,
-                            bool useAlt, bool taken, bool altPred) :
-                            btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo),
-                            useAlt(useAlt), taken(taken), altPred(altPred){}
+        TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo, bool useAlt, bool taken,
+                       bool altPred)
+            : btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo), useAlt(useAlt), taken(taken), altPred(altPred)
+        {
+        }
     };
 
 
 #ifndef UNIT_TEST
-    BTBTAGE(const Params& p);
+    BTBTAGE(const Params &p);
 #endif
     ~BTBTAGE();
 
@@ -121,9 +126,22 @@ class BTBTAGE : public TimedBaseBTBPredictor
     void tick() override;
     void dryRunCycle(Addr startAddr) override;
     // Make predictions for a stream of instructions and record in stage preds
-    void putPCHistory(Addr startAddr,
-                      const boost::dynamic_bitset<> &history,
+    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
+    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                               const std::vector<boost::dynamic_bitset<>> &lhistory,
+                               std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
+    {
+        (void)phistory;
+        (void)bwhistory;
+        (void)lhistory;
+        (void)lowerPred;
+        if (!participatesInBlock1()) {
+            return;
+        }
+        putPCHistory(startAddr, history, stagePreds);
+    }
 
     std::shared_ptr<void> getPredictionMeta() override;
 
@@ -133,8 +151,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
-    void recoverPHist(const boost::dynamic_bitset<> &history,
-                        const FetchTarget &entry,int shamt, bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                      bool cond_taken) override;
 
 #ifdef UNIT_TEST
     // API compatibility wrappers for testing
@@ -170,7 +188,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // Look up predictions in TAGE tables for a stream of instructions
     void lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntries,
-                    std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results);
+                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results);
 
     // Calculate TAGE index for a given PC and table
     Addr getTageIndex(Addr pc, int table);
@@ -187,9 +205,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist, Addr position = 0);
 
     // Get offset within a block for a given PC
-    Addr getOffset(Addr pc) {
-        return (pc & (blockSize - 1)) >> 1;
-    }
+    Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }
 
     // Get branch index within a prediction block
     unsigned getBranchIndexInBlock(Addr branchPC, Addr startPC);
@@ -267,7 +283,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     unsigned numTablesToAlloc;
 
     // Instruction shift amount
-    unsigned instShiftAmt {1};
+    unsigned instShiftAmt{1};
 
     // use for microtage updatemispred counting
     void checkUtageUpdateMisspred(const FetchTarget &stream);
@@ -299,16 +315,16 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
     // When prediction and update access the same bank in one cycle, update is dropped
-    const unsigned numBanks;         // Number of banks (e.g., 4)
-    const unsigned bankIdWidth;      // log2(numBanks), computed in constructor
-    const unsigned blockWidth;       // floorLog2(blockSize), e.g., 5 for 32B blocks
-    const unsigned bankBaseShift;    // Bits removed before bank selection (default: instShiftAmt)
-    const unsigned indexShift;       // bankBaseShift + bankIdWidth when banking enabled
-    bool enableBankConflict;         // Enable/disable bank conflict simulation
+    const unsigned numBanks;       // Number of banks (e.g., 4)
+    const unsigned bankIdWidth;    // log2(numBanks), computed in constructor
+    const unsigned blockWidth;     // floorLog2(blockSize), e.g., 5 for 32B blocks
+    const unsigned bankBaseShift;  // Bits removed before bank selection (default: instShiftAmt)
+    const unsigned indexShift;     // bankBaseShift + bankIdWidth when banking enabled
+    bool enableBankConflict;       // Enable/disable bank conflict simulation
 
     // Track last prediction bank for conflict detection
-    unsigned lastPredBankId;         // Bank ID of last prediction
-    bool predBankValid;              // Whether lastPredBankId is valid
+    unsigned lastPredBankId;  // Bank ID of last prediction
+    bool predBankValid;       // Whether lastPredBankId is valid
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -344,8 +360,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
         Scalar updateResetU;
 
         // Recomputed prediction difference statistics (per fetchBlock)
-        Scalar recomputedVsActualDiff;   // recomputed.taken != actual_taken
-        Scalar recomputedVsOriginalDiff; // recomputed.taken != original pred.taken
+        Scalar recomputedVsActualDiff;    // recomputed.taken != actual_taken
+        Scalar recomputedVsOriginalDiff;  // recomputed.taken != original pred.taken
 
         // Bank conflict statistics
         Scalar updateBankConflict;           // Number of bank conflicts detected
@@ -377,10 +393,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
         int numBanks;
 
 #ifndef UNIT_TEST
-        TageStats(statistics::Group* parent, int numPredictors, int numBanks);
+        TageStats(statistics::Group *parent, int numPredictors, int numBanks);
 #endif
         void updateStatsWithTagePrediction(const TagePrediction &pred, bool when_pred);
-    } ;
+    };
 
     TageStats tageStats;
 
@@ -388,14 +404,11 @@ class BTBTAGE : public TimedBaseBTBPredictor
     TraceManager *tageMissTrace;
 #endif
 
-public:
-
+  public:
     // Recover folded history after misprediction
-    void recoverFoldedHist(const bitset& history);
+    void recoverFoldedHist(const bitset &history);
 
-public:
-
-
+  public:
     // Metadata for TAGE prediction
     typedef struct TageMeta
     {
@@ -403,37 +416,28 @@ public:
         std::vector<PathFoldedHist> tagFoldedHist;
         std::vector<PathFoldedHist> altTagFoldedHist;
         std::vector<PathFoldedHist> indexFoldedHist;
-        bitset history;     // for viewing
+        bitset history;  // for viewing
         TageMeta() {}
     } TageMeta;
 
-private:
-
+  private:
     // Helper method to generate prediction for a single BTB entry
     // If predMeta is provided, use snapshot folded history for index/tag calculation (update path)
     // If predMeta is nullptr, use current folded history (prediction path)
-    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry,
-                                           const Addr &startPC,
-                                           const std::shared_ptr<TageMeta> predMeta = nullptr);
+    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC,
+                                            const std::shared_ptr<TageMeta> predMeta = nullptr);
 
     // Helper method to prepare BTB entries for update
     std::vector<BTBEntry> prepareUpdateEntries(const FetchTarget &stream);
 
     // Helper method to update predictor state for a single entry
-    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
-                                 bool actual_taken,
-                                 const TagePrediction &pred,
-                                 const FetchTarget &stream);
+    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actual_taken, const TagePrediction &pred,
+                                                const FetchTarget &stream);
 
     // Helper method to handle new entry allocation
-    bool handleNewEntryAllocation(const Addr &startPC,
-                                 const BTBEntry &entry,
-                                 bool actual_taken,
-                                 unsigned main_table,
-                                 std::shared_ptr<TageMeta> meta,
-                                 uint64_t &allocated_table,
-                                 uint64_t &allocated_index,
-                                 uint64_t &allocated_way);
+    bool handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bool actual_taken, unsigned main_table,
+                                  std::shared_ptr<TageMeta> meta, uint64_t &allocated_table, uint64_t &allocated_index,
+                                  uint64_t &allocated_way);
 
 
     // Helper methods for LRU management
@@ -445,13 +449,13 @@ private:
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-} // namespace test
+}  // namespace test
 #endif
 
-} // namespace btb_pred
+}  // namespace btb_pred
 
-} // namespace branch_prediction
+}  // namespace branch_prediction
 
-} // namespace gem5
+}  // namespace gem5
 
 #endif  // __CPU_PRED_BTB_TAGE_HH__

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -136,8 +136,11 @@ class BTBTAGE : public TimedBaseBTBPredictor
         (void)phistory;
         (void)bwhistory;
         (void)lhistory;
-        (void)lowerPred;
         if (!participatesInBlock1()) {
+            for (int s = getDelay(); s < stagePreds.size(); s++) {
+                stagePreds[s].condTakens = lowerPred.condTakens;
+                stagePreds[s].tageInfoForMgscs = lowerPred.tageInfoForMgscs;
+            }
             return;
         }
         putPCHistory(startAddr, history, stagePreds);

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -15,8 +15,7 @@
 #include "cpu/pred/btb/timed_base_pred.hh"
 
 #ifdef UNIT_TEST
-#include "cpu/pred/btb/test/test_dprintf.hh"
-
+    #include "cpu/pred/btb/test/test_dprintf.hh"
 #else
 #include "debug/DecoupleBP.hh"
 #include "debug/TAGEHistory.hh"
@@ -37,15 +36,13 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test
-{
+namespace test {
 #endif
 
 class BTBTAGE : public TimedBaseBTBPredictor
 {
     using defer = std::shared_ptr<void>;
     using bitset = boost::dynamic_bitset<>;
-
   public:
 #ifdef UNIT_TEST
     // Test constructor
@@ -58,39 +55,39 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Represents a single entry in the TAGE prediction table
     struct TageEntry
     {
-      public:
-        bool valid;           // Whether this entry is valid
-        Addr tag;             // Tag for matching
-        short counter;        // Prediction counter (-4 to 3), 3bits， 0 and -1 are weak
-        bool useful;          // 1-bit usefulness counter; true means useful
-        Addr pc;              // branch pc, like branch position, for btb entry pc check
-        unsigned lruCounter;  // Counter for LRU replacement policy
+        public:
+            bool valid;      // Whether this entry is valid
+            Addr tag;       // Tag for matching
+            short counter;  // Prediction counter (-4 to 3), 3bits， 0 and -1 are weak
+            bool useful;    // 1-bit usefulness counter; true means useful
+            Addr pc;        // branch pc, like branch position, for btb entry pc check
+            unsigned lruCounter; // Counter for LRU replacement policy
 
-        TageEntry() : valid(false), tag(0), counter(0), useful(false), pc(0), lruCounter(0) {}
+            TageEntry() : valid(false), tag(0), counter(0), useful(false), pc(0), lruCounter(0) {}
 
-        TageEntry(Addr tag, short counter, Addr pc)
-            : valid(true), tag(tag), counter(counter), useful(false), pc(pc), lruCounter(0)
-        {
-        }
-        bool taken() const { return counter >= 0; }
+            TageEntry(Addr tag, short counter, Addr pc) :
+                      valid(true), tag(tag), counter(counter), useful(false), pc(pc), lruCounter(0) {}
+            bool taken() const {
+                return counter >= 0;
+            }
     };
 
     // Contains information about a TAGE table lookup
     struct TageTableInfo
     {
-      public:
-        bool found;       // Whether a matching entry was found
-        TageEntry entry;  // The matching entry
-        unsigned table;   // Which table this entry was found in
-        Addr index;       // Index in the table
-        Addr tag;         // Tag that was matched
-        unsigned way;     // Which way this entry was found in
-        TageTableInfo() : found(false), table(0), index(0), tag(0), way(0) {}
-        TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag, unsigned way)
-            : found(found), entry(entry), table(table), index(index), tag(tag), way(way)
-        {
-        }
-        bool taken() const { return entry.taken(); }
+        public:
+            bool found;     // Whether a matching entry was found
+            TageEntry entry; // The matching entry
+            unsigned table; // Which table this entry was found in
+            Addr index;     // Index in the table
+            Addr tag;       // Tag that was matched
+            unsigned way;    // Which way this entry was found in
+            TageTableInfo() : found(false), table(0), index(0), tag(0), way(0) {}
+            TageTableInfo(bool found, TageEntry entry, unsigned table, Addr index, Addr tag, unsigned way) :
+                        found(found), entry(entry), table(table), index(index), tag(tag), way(way) {}
+            bool taken() const {
+                return entry.taken();
+            }
     };
 
     // Contains the complete prediction result
@@ -117,7 +114,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
 
 #ifndef UNIT_TEST
-    BTBTAGE(const Params &p);
+    BTBTAGE(const Params& p);
 #endif
     ~BTBTAGE();
 
@@ -126,7 +123,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
     void tick() override;
     void dryRunCycle(Addr startAddr) override;
     // Make predictions for a stream of instructions and record in stage preds
-    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+    void putPCHistory(Addr startAddr,
+                      const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
     void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
                                const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
@@ -154,8 +152,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
-    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                      bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history,
+                        const FetchTarget &entry,int shamt, bool cond_taken) override;
 
 #ifdef UNIT_TEST
     // API compatibility wrappers for testing
@@ -191,7 +189,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // Look up predictions in TAGE tables for a stream of instructions
     void lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntries,
-                      std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results);
+                    std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens& results);
 
     // Calculate TAGE index for a given PC and table
     Addr getTageIndex(Addr pc, int table);
@@ -208,7 +206,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     Addr getTageTag(Addr pc, int table, uint64_t foldedHist, uint64_t altFoldedHist, Addr position = 0);
 
     // Get offset within a block for a given PC
-    Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }
+    Addr getOffset(Addr pc) {
+        return (pc & (blockSize - 1)) >> 1;
+    }
 
     // Get branch index within a prediction block
     unsigned getBranchIndexInBlock(Addr branchPC, Addr startPC);
@@ -286,7 +286,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
     unsigned numTablesToAlloc;
 
     // Instruction shift amount
-    unsigned instShiftAmt{1};
+    unsigned instShiftAmt {1};
 
     // use for microtage updatemispred counting
     void checkUtageUpdateMisspred(const FetchTarget &stream);
@@ -318,16 +318,16 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
     // When prediction and update access the same bank in one cycle, update is dropped
-    const unsigned numBanks;       // Number of banks (e.g., 4)
-    const unsigned bankIdWidth;    // log2(numBanks), computed in constructor
-    const unsigned blockWidth;     // floorLog2(blockSize), e.g., 5 for 32B blocks
-    const unsigned bankBaseShift;  // Bits removed before bank selection (default: instShiftAmt)
-    const unsigned indexShift;     // bankBaseShift + bankIdWidth when banking enabled
-    bool enableBankConflict;       // Enable/disable bank conflict simulation
+    const unsigned numBanks;         // Number of banks (e.g., 4)
+    const unsigned bankIdWidth;      // log2(numBanks), computed in constructor
+    const unsigned blockWidth;       // floorLog2(blockSize), e.g., 5 for 32B blocks
+    const unsigned bankBaseShift;    // Bits removed before bank selection (default: instShiftAmt)
+    const unsigned indexShift;       // bankBaseShift + bankIdWidth when banking enabled
+    bool enableBankConflict;         // Enable/disable bank conflict simulation
 
     // Track last prediction bank for conflict detection
-    unsigned lastPredBankId;  // Bank ID of last prediction
-    bool predBankValid;       // Whether lastPredBankId is valid
+    unsigned lastPredBankId;         // Bank ID of last prediction
+    bool predBankValid;              // Whether lastPredBankId is valid
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -363,8 +363,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
         Scalar updateResetU;
 
         // Recomputed prediction difference statistics (per fetchBlock)
-        Scalar recomputedVsActualDiff;    // recomputed.taken != actual_taken
-        Scalar recomputedVsOriginalDiff;  // recomputed.taken != original pred.taken
+        Scalar recomputedVsActualDiff;   // recomputed.taken != actual_taken
+        Scalar recomputedVsOriginalDiff; // recomputed.taken != original pred.taken
 
         // Bank conflict statistics
         Scalar updateBankConflict;           // Number of bank conflicts detected
@@ -396,10 +396,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
         int numBanks;
 
 #ifndef UNIT_TEST
-        TageStats(statistics::Group *parent, int numPredictors, int numBanks);
+        TageStats(statistics::Group* parent, int numPredictors, int numBanks);
 #endif
         void updateStatsWithTagePrediction(const TagePrediction &pred, bool when_pred);
-    };
+    } ;
 
     TageStats tageStats;
 
@@ -407,7 +407,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
     TraceManager *tageMissTrace;
 #endif
 
-  public:
+public:
+
     // Recover folded history after misprediction
     void recoverFoldedHist(const bitset &history);
 
@@ -419,28 +420,37 @@ class BTBTAGE : public TimedBaseBTBPredictor
         std::vector<PathFoldedHist> tagFoldedHist;
         std::vector<PathFoldedHist> altTagFoldedHist;
         std::vector<PathFoldedHist> indexFoldedHist;
-        bitset history;  // for viewing
+        bitset history;     // for viewing
         TageMeta() {}
     } TageMeta;
 
-  private:
+private:
+
     // Helper method to generate prediction for a single BTB entry
     // If predMeta is provided, use snapshot folded history for index/tag calculation (update path)
     // If predMeta is nullptr, use current folded history (prediction path)
-    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC,
-                                            const std::shared_ptr<TageMeta> predMeta = nullptr);
+    TagePrediction generateSinglePrediction(const BTBEntry &btb_entry,
+                                           const Addr &startPC,
+                                           const std::shared_ptr<TageMeta> predMeta = nullptr);
 
     // Helper method to prepare BTB entries for update
     std::vector<BTBEntry> prepareUpdateEntries(const FetchTarget &stream);
 
     // Helper method to update predictor state for a single entry
-    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry, bool actual_taken, const TagePrediction &pred,
-                                                const FetchTarget &stream);
+    bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
+                                 bool actual_taken,
+                                 const TagePrediction &pred,
+                                 const FetchTarget &stream);
 
     // Helper method to handle new entry allocation
-    bool handleNewEntryAllocation(const Addr &startPC, const BTBEntry &entry, bool actual_taken, unsigned main_table,
-                                  std::shared_ptr<TageMeta> meta, uint64_t &allocated_table, uint64_t &allocated_index,
-                                  uint64_t &allocated_way);
+    bool handleNewEntryAllocation(const Addr &startPC,
+                                 const BTBEntry &entry,
+                                 bool actual_taken,
+                                 unsigned main_table,
+                                 std::shared_ptr<TageMeta> meta,
+                                 uint64_t &allocated_table,
+                                 uint64_t &allocated_index,
+                                 uint64_t &allocated_way);
 
 
     // Helper methods for LRU management
@@ -452,13 +462,13 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-}  // namespace test
+} // namespace test
 #endif
 
-}  // namespace btb_pred
+} // namespace btb_pred
 
-}  // namespace branch_prediction
+} // namespace branch_prediction
 
-}  // namespace gem5
+} // namespace gem5
 
 #endif  // __CPU_PRED_BTB_TAGE_HH__

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -152,8 +152,7 @@ UBTB::PredStatistics(const TickedUBTBEntry entry, Addr startAddr)
 void
 UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPrediction> &stagePreds)
 {
-    FillStageLoop(s)
-    {
+    FillStageLoop(s) {
         DPRINTF(UBTB, "UBTB: assigning prediction for stage %d\n", s);
 
         // Copy uBTB entries to stage prediction
@@ -187,7 +186,7 @@ UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::
     (void)history;
     meta = std::make_shared<UBTBMeta>();
     auto it = lookup(startAddr);
-    auto &entry = meta->hit_entry;
+    auto& entry = meta->hit_entry;
     entry = (it != ubtb.end()) ? *it : TickedUBTBEntry();
 
     PredStatistics(entry, startAddr);
@@ -252,7 +251,7 @@ UBTB::replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry, Addr
     TickedUBTBEntry newEntry = TickedUBTBEntry(newTakenEntry, curTick());
     // important! this is so that target set by RAS or ITTAGE is used
     newEntry.target = newTakenEntry.target;
-    newEntry.ctr = 0;  // have a bug here:ubtb will accept ctr from mbtb, reset it to 0 at here
+    newEntry.ctr = 0; // have a bug here:ubtb will accept ctr from mbtb, reset it to 0 at here
     // important: update tag (mbtb and ubtb have different tags, even diffferent tag length)
     newEntry.tag = getTag(startAddr);
     *oldEntryIter = newEntry;
@@ -269,23 +268,23 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
     auto takenEntry = s3Pred.getTakenEntry();
     if (takenEntry.valid) {
         ubtbStats.s3UpdateHits++;
-    } else {
+    }else {
         ubtbStats.s3UpdateMisses++;
     }
     auto startAddr = s3Pred.bbStart;
     UBTBIter oldEntryIter = lastPred.hit_entry;
     takenEntry.source = getComponentIdx();
+
     updateNewEntry(oldEntryIter, takenEntry, startAddr);
 }
 
 
 
-void
-UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr)
+void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr)
 {
-    // using the FB final taken branch to update uBTB
+    //using the FB final taken branch to update uBTB
     if (oldEntryIter != ubtb.end()) {
-        assert(oldEntryIter->valid);  // lookup() should only return valid entry
+        assert(oldEntryIter->valid); //lookup() should only return valid entry
     }
     if (oldEntryIter != ubtb.end() && !takenEntry.valid) {
         // S0 has a hit entry, but S3 predicts fall through
@@ -312,13 +311,13 @@ UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Ad
             }
         }
 
-        // If no invalid entry found, use LRU policy
-        // TODO: consider using LRU only among the entries with the least confidence(smallest uctr)
-        if (!foundInvalidEntry) {
-            // Find the least recently used entry
-            std::make_heap(mruList.begin(), mruList.end(), older());
-            toBeReplacedIter = mruList.front();
-        }
+            // If no invalid entry found, use LRU policy
+            // TODO: consider using LRU only among the entries with the least confidence(smallest uctr)
+            if (!foundInvalidEntry) {
+                // Find the least recently used entry
+                std::make_heap(mruList.begin(), mruList.end(), older());
+                toBeReplacedIter = mruList.front();
+            }
 
         // Replace the entry with the new prediction
         replaceOldEntry(toBeReplacedIter, takenEntry, startAddr);
@@ -353,23 +352,23 @@ UBTB::update(const FetchTarget &stream)
 
     auto pred_hit_entry = meta->hit_entry;
     // Find the iterator in ubtb that matches pred_hit_entry (by tag and pc)
-    // Use BTBEntry instead of BranchInfo; make it invalid when not taken
+     // Use BTBEntry instead of BranchInfo; make it invalid when not taken
     BTBEntry takenEntry = stream.exeTaken ? BTBEntry(stream.exeBranchInfo) : BTBEntry();
     auto startAddr = stream.getRealStartPC();
     Addr oldtag = getTag(startAddr);
 
     UBTBIter oldEntryIter = ubtb.end();
 
-    oldEntryIter = meta->hit_entry.valid
-                       ? std::find_if(ubtb.begin(), ubtb.end(),
-                                      [oldtag](const TickedUBTBEntry &e) { return e.valid && e.tag == oldtag; })
-                       : ubtb.end();
+    oldEntryIter = meta->hit_entry.valid ?
+                    std::find_if(ubtb.begin(), ubtb.end(), [oldtag](const TickedUBTBEntry &e) {
+                        return e.valid && e.tag == oldtag;
+                    }) : ubtb.end();
 
     if (stream.exeTaken) {
         if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
             DPRINTF(UBTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
             ubtbStats.updateMiss++;
-        } else {
+        }else {
             ubtbStats.updateHit++;
         }
     }

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -32,11 +32,21 @@
 #include "base/intmath.hh"
 #include "base/trace.hh"
 #include "common.hh"
+#ifndef UNIT_TEST
 #include "cpu/o3/dyn_inst.hh"
 #include "debug/Fetch.hh"
+#endif
 
 namespace gem5
 {
+
+#ifdef UNIT_TEST
+namespace Gem5Internal
+{
+Tick testCurTick = 1;
+__thread Tick *_curTickPtr = &testCurTick;
+}
+#endif
 
 namespace branch_prediction
 {
@@ -44,6 +54,40 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+#ifdef UNIT_TEST
+namespace test
+{
+#endif
+
+#ifdef UNIT_TEST
+UBTB::UBTB(unsigned numEntries_, unsigned tagBits_)
+    : TimedBaseBTBPredictor(),
+      lastPred(),
+      meta(),
+      ubtb(),
+      mruList(),
+      numEntries(numEntries_),
+      tagBits(tagBits_),
+      tagMask((1UL << tagBits_) - 1),
+      usingS3Pred(true),
+      ubtbStats()
+{
+    setNumDelay(0);
+    predictWidth = 64;
+
+    if (!isPowerOf2(numEntries)) {
+        panic("uBTB entries is not a power of 2!");
+    }
+
+    ubtb.resize(numEntries);
+    mruList.clear();
+    for (auto it = ubtb.begin(); it != ubtb.end(); it++) {
+        it->valid = false;
+        mruList.push_back(it);
+    }
+    std::make_heap(mruList.begin(), mruList.end(), older());
+}
+#else
 UBTB::UBTB(const Params &p)
     : TimedBaseBTBPredictor(p),
       lastPred(),
@@ -72,11 +116,13 @@ UBTB::UBTB(const Params &p)
     hasDB = true;
     dbName = "ubtb";
 }
+#endif
 
 
 void
 UBTB::setTrace()
 {
+#ifndef UNIT_TEST
     if (enableDB) {
         std::vector<std::pair<std::string, DataType>> fields_vec = {
             std::make_pair("pc", UINT64),  std::make_pair("brType", UINT64), std::make_pair("target", UINT64),
@@ -84,6 +130,7 @@ UBTB::setTrace()
         ubtbTrace = _db->addAndGetTrace("uBTBTrace", fields_vec);
         ubtbTrace->init_table();
     }
+#endif
 }
 
 void
@@ -105,7 +152,8 @@ UBTB::PredStatistics(const TickedUBTBEntry entry, Addr startAddr)
 void
 UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPrediction> &stagePreds)
 {
-    FillStageLoop(s) {
+    FillStageLoop(s)
+    {
         DPRINTF(UBTB, "UBTB: assigning prediction for stage %d\n", s);
 
         // Copy uBTB entries to stage prediction
@@ -136,9 +184,10 @@ UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPred
 void
 UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::vector<FullBTBPrediction> &stagePreds)
 {
+    (void)history;
     meta = std::make_shared<UBTBMeta>();
     auto it = lookup(startAddr);
-    auto& entry = meta->hit_entry;
+    auto &entry = meta->hit_entry;
     entry = (it != ubtb.end()) ? *it : TickedUBTBEntry();
 
     PredStatistics(entry, startAddr);
@@ -148,6 +197,19 @@ UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::
 
     // Update metadata for later stages
     lastPred.hit_entry = it;
+}
+
+void
+UBTB::putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                            const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                            const std::vector<boost::dynamic_bitset<>> &lhistory,
+                            std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred)
+{
+    (void)phistory;
+    (void)bwhistory;
+    (void)lhistory;
+    (void)lowerPred;
+    putPCHistory(startAddr, history, stagePreds);
 }
 
 UBTB::UBTBIter
@@ -190,7 +252,7 @@ UBTB::replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry, Addr
     TickedUBTBEntry newEntry = TickedUBTBEntry(newTakenEntry, curTick());
     // important! this is so that target set by RAS or ITTAGE is used
     newEntry.target = newTakenEntry.target;
-    newEntry.ctr = 0; // have a bug here:ubtb will accept ctr from mbtb, reset it to 0 at here
+    newEntry.ctr = 0;  // have a bug here:ubtb will accept ctr from mbtb, reset it to 0 at here
     // important: update tag (mbtb and ubtb have different tags, even diffferent tag length)
     newEntry.tag = getTag(startAddr);
     *oldEntryIter = newEntry;
@@ -207,78 +269,78 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
     auto takenEntry = s3Pred.getTakenEntry();
     if (takenEntry.valid) {
         ubtbStats.s3UpdateHits++;
-    }else {
+    } else {
         ubtbStats.s3UpdateMisses++;
     }
     auto startAddr = s3Pred.bbStart;
     UBTBIter oldEntryIter = lastPred.hit_entry;
     takenEntry.source = getComponentIdx();
     updateNewEntry(oldEntryIter, takenEntry, startAddr);
-
 }
 
 
 
-void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr)
+void
+UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr)
 {
-    //using the FB final taken branch to update uBTB
+    // using the FB final taken branch to update uBTB
     if (oldEntryIter != ubtb.end()) {
-        assert(oldEntryIter->valid); //lookup() should only return valid entry
+        assert(oldEntryIter->valid);  // lookup() should only return valid entry
     }
     if (oldEntryIter != ubtb.end() && !takenEntry.valid) {
-            // S0 has a hit entry, but S3 predicts fall through
-            ubtbStats.s1Hits3FallThrough++;
+        // S0 has a hit entry, but S3 predicts fall through
+        ubtbStats.s1Hits3FallThrough++;
+        updateUCtr(oldEntryIter->uctr, false);
+        if (oldEntryIter->uctr == 0) {
+            ubtbStats.s1InvalidatedEntries++;
+            oldEntryIter->valid = false;
+        }
+    } else if (oldEntryIter == ubtb.end() && takenEntry.valid) {
+        ubtbStats.s1Misses3Taken++;
+        /* S0 misses, but S3 predicts taken,
+         * generate new entry and replace another using LRU
+         */
+        UBTBIter toBeReplacedIter;
+        // First try to find an invalid entry in the set
+        bool foundInvalidEntry = false;
+
+        for (auto it = ubtb.begin(); it != ubtb.end(); ++it) {
+            if (!it->valid) {
+                toBeReplacedIter = it;
+                foundInvalidEntry = true;
+                break;
+            }
+        }
+
+        // If no invalid entry found, use LRU policy
+        // TODO: consider using LRU only among the entries with the least confidence(smallest uctr)
+        if (!foundInvalidEntry) {
+            // Find the least recently used entry
+            std::make_heap(mruList.begin(), mruList.end(), older());
+            toBeReplacedIter = mruList.front();
+        }
+
+        // Replace the entry with the new prediction
+        replaceOldEntry(toBeReplacedIter, takenEntry, startAddr);
+
+    } else if (oldEntryIter != ubtb.end() && takenEntry.valid) {
+        ubtbStats.s1Hits3Taken++;
+        // both S0 and S3 predict taken
+        if (oldEntryIter->pc != takenEntry.pc || oldEntryIter->target != takenEntry.target) {
+            // S0 and S3 predict different branch instruction
             updateUCtr(oldEntryIter->uctr, false);
             if (oldEntryIter->uctr == 0) {
-                ubtbStats.s1InvalidatedEntries++;
-                oldEntryIter->valid = false;
-            }
-        } else if (oldEntryIter == ubtb.end() && takenEntry.valid) {
-            ubtbStats.s1Misses3Taken++;
-            /* S0 misses, but S3 predicts taken,
-            * generate new entry and replace another using LRU
-            */
-            UBTBIter toBeReplacedIter;
-            // First try to find an invalid entry in the set
-            bool foundInvalidEntry = false;
-
-            for (auto it = ubtb.begin(); it != ubtb.end(); ++it) {
-                if (!it->valid) {
-                    toBeReplacedIter = it;
-                    foundInvalidEntry = true;
-                    break;
-                }
-            }
-
-            // If no invalid entry found, use LRU policy
-            // TODO: consider using LRU only among the entries with the least confidence(smallest uctr)
-            if (!foundInvalidEntry) {
-                // Find the least recently used entry
-                std::make_heap(mruList.begin(), mruList.end(), older());
-                toBeReplacedIter = mruList.front();
-            }
-
-            // Replace the entry with the new prediction
-            replaceOldEntry(toBeReplacedIter, takenEntry, startAddr);
-
-        } else if (oldEntryIter != ubtb.end() && takenEntry.valid) {
-            ubtbStats.s1Hits3Taken++;
-            // both S0 and S3 predict taken
-            if (oldEntryIter->pc != takenEntry.pc || oldEntryIter->target != takenEntry.target) {
-                // S0 and S3 predict different branch instruction
-                updateUCtr(oldEntryIter->uctr, false);
-                if (oldEntryIter->uctr == 0) {
-                    // replace the old entry with the new one
-                    replaceOldEntry(oldEntryIter, takenEntry, startAddr);
-                }
-            } else {
-                // S0 and S3 predict the same (brpc and target)
-                updateUCtr(oldEntryIter->uctr, true);
+                // replace the old entry with the new one
+                replaceOldEntry(oldEntryIter, takenEntry, startAddr);
             }
         } else {
-            ubtbStats.s1Misses3FallThrough++;
-            // both S0 and S3 predict fall through, do nothing
+            // S0 and S3 predict the same (brpc and target)
+            updateUCtr(oldEntryIter->uctr, true);
         }
+    } else {
+        ubtbStats.s1Misses3FallThrough++;
+        // both S0 and S3 predict fall through, do nothing
+    }
 }
 
 
@@ -291,23 +353,23 @@ UBTB::update(const FetchTarget &stream)
 
     auto pred_hit_entry = meta->hit_entry;
     // Find the iterator in ubtb that matches pred_hit_entry (by tag and pc)
-     // Use BTBEntry instead of BranchInfo; make it invalid when not taken
+    // Use BTBEntry instead of BranchInfo; make it invalid when not taken
     BTBEntry takenEntry = stream.exeTaken ? BTBEntry(stream.exeBranchInfo) : BTBEntry();
     auto startAddr = stream.getRealStartPC();
     Addr oldtag = getTag(startAddr);
 
     UBTBIter oldEntryIter = ubtb.end();
 
-    oldEntryIter = meta->hit_entry.valid ?
-                    std::find_if(ubtb.begin(), ubtb.end(), [oldtag](const TickedUBTBEntry &e) {
-                        return e.valid && e.tag == oldtag;
-                    }) : ubtb.end();
+    oldEntryIter = meta->hit_entry.valid
+                       ? std::find_if(ubtb.begin(), ubtb.end(),
+                                      [oldtag](const TickedUBTBEntry &e) { return e.valid && e.tag == oldtag; })
+                       : ubtb.end();
 
     if (stream.exeTaken) {
         if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
             DPRINTF(UBTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
             ubtbStats.updateMiss++;
-        }else {
+        } else {
             ubtbStats.updateHit++;
         }
     }
@@ -319,6 +381,7 @@ UBTB::update(const FetchTarget &stream)
     }
 }
 
+#ifndef UNIT_TEST
 void
 UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
 {
@@ -409,8 +472,10 @@ UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         }
     }
 }
+#endif
 
 // Initialize uBTB statistics
+#ifndef UNIT_TEST
 UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
     : statistics::Group(parent),
       ADD_STAT(predMiss, statistics::units::Count::get(), "misses encountered on prediction"),
@@ -466,6 +531,11 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(s1InvalidatedEntries, statistics::units::Count::get(), "s1 invalidated entries")
 {
 }
+#endif
+
+#ifdef UNIT_TEST
+}  // namespace test
+#endif
 
 }  // namespace btb_pred
 }  // namespace branch_prediction

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -82,6 +82,7 @@ namespace test
 
 class UBTB : public TimedBaseBTBPredictor
 {
+
   private:
   public:
 #ifdef UNIT_TEST
@@ -108,17 +109,17 @@ class UBTB : public TimedBaseBTBPredictor
      */
     typedef struct TickedUBTBEntry : public BTBEntry
     {
-        unsigned uctr;  // 2-bit saturation counter used in replacement policy
+        unsigned uctr; //2-bit saturation counter used in replacement policy
         uint64_t tick;  // timestamp for MRU replacement
         TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0) {}
         TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick) {}
-    } TickedUBTBEntry;
+    }TickedUBTBEntry;
 
     using UBTBIter = typename std::vector<TickedUBTBEntry>::iterator;
-    using UBTBHeap = std::vector<UBTBIter>;  // for MRU tracking
+    using UBTBHeap = std::vector<UBTBIter>; // for MRU tracking
 
-    void tickStart() override {};
-    void tick() override {};
+    void tickStart() override{};
+    void tick() override{};
 
     /*
      * Entry point for uBTB Prediction, called at S1
@@ -165,32 +166,33 @@ class UBTB : public TimedBaseBTBPredictor
     /** Get prediction BTBMeta
      *  @return Returns the prediction meta
      */
-    std::shared_ptr<void> getPredictionMeta() override { return meta; }
+    std::shared_ptr<void> getPredictionMeta() override
+    {
+        return meta;
+    }
 
     // the following methods are not used
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override {}
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                     bool cond_taken) override {};
+    void recoverHist(const boost::dynamic_bitset<> &history,
+        const FetchTarget &entry, int shamt, bool cond_taken) override{};
     void reset();
     void setTrace() override;
     TraceManager *ubtbTrace;
 
     // for debuggin purpose
-    void printTickedUBTBEntry(const TickedUBTBEntry &e)
-    {
-        DPRINTF(UBTB,
-                "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
+    void printTickedUBTBEntry(const TickedUBTBEntry &e) {
+        DPRINTF(UBTB, "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, tick:%lu\n",
-                e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
+            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
     }
 
-    void dumpMruList()
-    {
+    void dumpMruList() {
         DPRINTF(UBTB, "MRU list:\n");
-        for (const auto &it : mruList) {
+        for (const auto &it: mruList) {
             printTickedUBTBEntry(*it);
         }
     }
+
 
 
 
@@ -200,10 +202,9 @@ class UBTB : public TimedBaseBTBPredictor
      */
     struct LastPred
     {
-        UBTBIter hit_entry;  // this might point to ubtb.end()
+        UBTBIter hit_entry; // this might point to ubtb.end()
 
-        LastPred()
-        {
+        LastPred() {
             // Default constructor - will be assigned proper value later
         }
     };
@@ -217,7 +218,9 @@ class UBTB : public TimedBaseBTBPredictor
     struct UBTBMeta
     {
         TickedUBTBEntry hit_entry;
-        UBTBMeta() { hit_entry = TickedUBTBEntry(); }
+        UBTBMeta() {
+            hit_entry = TickedUBTBEntry();
+        }
     };
     std::shared_ptr<UBTBMeta> meta;
 
@@ -229,7 +232,10 @@ class UBTB : public TimedBaseBTBPredictor
      */
     struct older
     {
-        bool operator()(const UBTBIter &a, const UBTBIter &b) const { return a->tick > b->tick; }
+        bool operator()(const UBTBIter &a, const UBTBIter &b) const
+        {
+            return a->tick > b->tick;
+        }
     };
 
     /** Returns the tag bits of a given address.
@@ -237,16 +243,13 @@ class UBTB : public TimedBaseBTBPredictor
      *  @param startPC The start address of the fetch block
      *  @return Returns the tag bits.
      */
-    inline Addr getTag(Addr startPC) { return (startPC >> 1) & tagMask; }
+    inline Addr getTag(Addr startPC) {
+        return (startPC >> 1) & tagMask;
+    }
 
-    void updateUCtr(unsigned &ctr, bool inc)
-    {
-        if (inc && ctr < 3) {
-            ctr++;
-        }
-        if (!inc && ctr > 0) {
-            ctr--;
-        }
+    void updateUCtr(unsigned &ctr, bool inc) {
+        if (inc && ctr < 3) {ctr++;}
+        if (!inc && ctr > 0) {ctr--;}
     }
 
     /** helper method called by putPCHistory: Searches for a entry in the uBTB.
@@ -265,7 +268,8 @@ class UBTB : public TimedBaseBTBPredictor
      *  @param entry The BTB entry containing branch info
      *  @param stagePreds Predictions for each pipeline stage
      */
-    void fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPrediction> &stagePreds);
+    void fillStagePredictions(const TickedUBTBEntry& entry,
+                              std::vector<FullBTBPrediction>& stagePreds);
 
     /** helper method called in updateUsingS3Pred: This function replaces an existing uBTB entry with new prediction
      *
@@ -274,7 +278,7 @@ class UBTB : public TimedBaseBTBPredictor
      */
     void replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry, Addr startAddr);
 
-    // using the FB final taken branch to update uBTB
+    //using the FB final taken branch to update uBTB
     void updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr);
 
 
@@ -293,12 +297,12 @@ class UBTB : public TimedBaseBTBPredictor
     UBTBHeap mruList;
 
     /** uBTB configuration parameters */
-    unsigned numEntries;  // Total number of entries
+    unsigned numEntries;    // Total number of entries
 
     /** Address calculation masks and shifts */
-    unsigned tagBits;  // Number of tag bits
-    Addr tagMask;      // Mask for extracting tag bits
-    bool usingS3Pred;  // using S3 prediction to update uBTB
+    unsigned tagBits;      // Number of tag bits
+    Addr tagMask;          // Mask for extracting tag bits
+    bool usingS3Pred;    // using S3 prediction to update uBTB
 
 
 #ifdef UNIT_TEST
@@ -393,6 +397,8 @@ class UBTB : public TimedBaseBTBPredictor
 
         UBTBStats() = default;
 #endif
+
+
     } ubtbStats;
 };
 
@@ -403,4 +409,4 @@ class UBTB : public TimedBaseBTBPredictor
 }  // namespace branch_prediction
 }  // namespace gem5
 
-#endif  // __CPU_PRED_BTB_UBTB_HH__
+#endif // __CPU_PRED_BTB_UBTB_HH__

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -47,14 +47,24 @@
 
 #include <queue>
 
-#include "arch/generic/pcstate.hh"
-#include "base/logging.hh"
 #include "base/types.hh"
-#include "config/the_isa.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
+
+#ifdef UNIT_TEST
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/test/test_dprintf.hh"
+
+#else
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "config/the_isa.hh"
 #include "debug/UBTB.hh"
 #include "params/UBTB.hh"
+
+#endif
 
 namespace gem5
 {
@@ -65,12 +75,18 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+#ifdef UNIT_TEST
+namespace test
+{
+#endif
+
 class UBTB : public TimedBaseBTBPredictor
 {
   private:
-
   public:
-
+#ifdef UNIT_TEST
+    UBTB(unsigned numEntries, unsigned tagBits);
+#else
     typedef UBTBParams Params;
 
     /** Creates a uBTB with the given number of entries, number of bits per
@@ -78,7 +94,8 @@ class UBTB : public TimedBaseBTBPredictor
      *  @param numEntries Number of entries for the uBTB.
      *  @param tagBits Number of bits for each tag in the uBTB.
      */
-    UBTB(const Params& p);
+    UBTB(const Params &p);
+#endif
 
     /*
      * Micro-BTB Entry with timestamp for MRU replacement
@@ -91,17 +108,17 @@ class UBTB : public TimedBaseBTBPredictor
      */
     typedef struct TickedUBTBEntry : public BTBEntry
     {
-        unsigned uctr; //2-bit saturation counter used in replacement policy
+        unsigned uctr;  // 2-bit saturation counter used in replacement policy
         uint64_t tick;  // timestamp for MRU replacement
         TickedUBTBEntry() : BTBEntry(), uctr(0), tick(0) {}
         TickedUBTBEntry(const BTBEntry &be, uint64_t tick) : BTBEntry(be), uctr(0), tick(tick) {}
-    }TickedUBTBEntry;
+    } TickedUBTBEntry;
 
     using UBTBIter = typename std::vector<TickedUBTBEntry>::iterator;
-    using UBTBHeap = std::vector<UBTBIter>; // for MRU tracking
+    using UBTBHeap = std::vector<UBTBIter>;  // for MRU tracking
 
-    void tickStart() override{};
-    void tick() override{};
+    void tickStart() override {};
+    void tick() override {};
 
     /*
      * Entry point for uBTB Prediction, called at S1
@@ -116,6 +133,11 @@ class UBTB : public TimedBaseBTBPredictor
      */
     void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
+    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                               const std::vector<boost::dynamic_bitset<>> &lhistory,
+                               std::vector<FullBTBPrediction> &stagePreds,
+                               const FullBTBPrediction &lowerPred) override;
 
     /** Updates the uBTB predictions based on S3 prediction results.
      * This function is called from decoupled_bpred during S3 prediction
@@ -136,34 +158,36 @@ class UBTB : public TimedBaseBTBPredictor
      * @param stream The fetch stream containing execution results
      * @param inst The dynamic instruction being committed
      */
+#ifndef UNIT_TEST
     void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
+#endif
 
     /** Get prediction BTBMeta
      *  @return Returns the prediction meta
      */
-    std::shared_ptr<void> getPredictionMeta() override
-    {
-        return meta;
-    }
+    std::shared_ptr<void> getPredictionMeta() override { return meta; }
 
     // the following methods are not used
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override {}
-    void recoverHist(const boost::dynamic_bitset<> &history,
-        const FetchTarget &entry, int shamt, bool cond_taken) override{};
+    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                     bool cond_taken) override {};
     void reset();
     void setTrace() override;
     TraceManager *ubtbTrace;
 
     // for debuggin purpose
-    void printTickedUBTBEntry(const TickedUBTBEntry &e) {
-        DPRINTF(UBTB, "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
+    void printTickedUBTBEntry(const TickedUBTBEntry &e)
+    {
+        DPRINTF(UBTB,
+                "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, tick:%lu\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
+                e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
     }
 
-    void dumpMruList() {
+    void dumpMruList()
+    {
         DPRINTF(UBTB, "MRU list:\n");
-        for (const auto &it: mruList) {
+        for (const auto &it : mruList) {
             printTickedUBTBEntry(*it);
         }
     }
@@ -171,15 +195,15 @@ class UBTB : public TimedBaseBTBPredictor
 
 
   private:
-
     /** this struct holds the lastest prediction made by uBTB,
      * it's set in putPCHistory, and used in updateUsingS3Pred
      */
     struct LastPred
     {
-        UBTBIter hit_entry; // this might point to ubtb.end()
+        UBTBIter hit_entry;  // this might point to ubtb.end()
 
-        LastPred() {
+        LastPred()
+        {
             // Default constructor - will be assigned proper value later
         }
     };
@@ -193,9 +217,7 @@ class UBTB : public TimedBaseBTBPredictor
     struct UBTBMeta
     {
         TickedUBTBEntry hit_entry;
-        UBTBMeta() {
-            hit_entry = TickedUBTBEntry();
-        }
+        UBTBMeta() { hit_entry = TickedUBTBEntry(); }
     };
     std::shared_ptr<UBTBMeta> meta;
 
@@ -207,10 +229,7 @@ class UBTB : public TimedBaseBTBPredictor
      */
     struct older
     {
-        bool operator()(const UBTBIter &a, const UBTBIter &b) const
-        {
-            return a->tick > b->tick;
-        }
+        bool operator()(const UBTBIter &a, const UBTBIter &b) const { return a->tick > b->tick; }
     };
 
     /** Returns the tag bits of a given address.
@@ -218,13 +237,16 @@ class UBTB : public TimedBaseBTBPredictor
      *  @param startPC The start address of the fetch block
      *  @return Returns the tag bits.
      */
-    inline Addr getTag(Addr startPC) {
-        return (startPC >> 1) & tagMask;
-    }
+    inline Addr getTag(Addr startPC) { return (startPC >> 1) & tagMask; }
 
-    void updateUCtr(unsigned &ctr, bool inc) {
-        if (inc && ctr < 3) {ctr++;}
-        if (!inc && ctr > 0) {ctr--;}
+    void updateUCtr(unsigned &ctr, bool inc)
+    {
+        if (inc && ctr < 3) {
+            ctr++;
+        }
+        if (!inc && ctr > 0) {
+            ctr--;
+        }
     }
 
     /** helper method called by putPCHistory: Searches for a entry in the uBTB.
@@ -243,8 +265,7 @@ class UBTB : public TimedBaseBTBPredictor
      *  @param entry The BTB entry containing branch info
      *  @param stagePreds Predictions for each pipeline stage
      */
-    void fillStagePredictions(const TickedUBTBEntry& entry,
-                              std::vector<FullBTBPrediction>& stagePreds);
+    void fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPrediction> &stagePreds);
 
     /** helper method called in updateUsingS3Pred: This function replaces an existing uBTB entry with new prediction
      *
@@ -253,7 +274,7 @@ class UBTB : public TimedBaseBTBPredictor
      */
     void replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry, Addr startAddr);
 
-    //using the FB final taken branch to update uBTB
+    // using the FB final taken branch to update uBTB
     void updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry, const Addr startAddr);
 
 
@@ -272,17 +293,22 @@ class UBTB : public TimedBaseBTBPredictor
     UBTBHeap mruList;
 
     /** uBTB configuration parameters */
-    unsigned numEntries;    // Total number of entries
+    unsigned numEntries;  // Total number of entries
 
     /** Address calculation masks and shifts */
-    unsigned tagBits;      // Number of tag bits
-    Addr tagMask;          // Mask for extracting tag bits
-    bool usingS3Pred;    // using S3 prediction to update uBTB
+    unsigned tagBits;  // Number of tag bits
+    Addr tagMask;      // Mask for extracting tag bits
+    bool usingS3Pred;  // using S3 prediction to update uBTB
 
 
+#ifdef UNIT_TEST
+    struct UBTBStats
+#else
     struct UBTBStats : public statistics::Group
+#endif
     {
 
+#ifndef UNIT_TEST
         statistics::Scalar predMiss;
         statistics::Scalar predHit;
         statistics::Scalar updateMiss;
@@ -327,14 +353,54 @@ class UBTB : public TimedBaseBTBPredictor
         statistics::Scalar s1Misses3FallThrough;
         statistics::Scalar s1InvalidatedEntries;
 
-        UBTBStats(statistics::Group* parent);
+        UBTBStats(statistics::Group *parent);
+#else
+        uint64_t predMiss = 0;
+        uint64_t predHit = 0;
+        uint64_t updateMiss = 0;
+        uint64_t updateHit = 0;
+        uint64_t s3UpdateHits = 0;
+        uint64_t s3UpdateMisses = 0;
+        uint64_t allBranchHits = 0;
+        uint64_t allBranchHitTakens = 0;
+        uint64_t allBranchHitNotTakens = 0;
+        uint64_t allBranchMisses = 0;
+        uint64_t allBranchMissTakens = 0;
+        uint64_t allBranchMissNotTakens = 0;
+        uint64_t condHits = 0;
+        uint64_t condHitTakens = 0;
+        uint64_t condHitNotTakens = 0;
+        uint64_t condMisses = 0;
+        uint64_t condMissTakens = 0;
+        uint64_t condMissNotTakens = 0;
+        uint64_t condPredCorrect = 0;
+        uint64_t condPredWrong = 0;
+        uint64_t uncondHits = 0;
+        uint64_t uncondMisses = 0;
+        uint64_t indirectHits = 0;
+        uint64_t indirectMisses = 0;
+        uint64_t indirectPredCorrect = 0;
+        uint64_t indirectPredWrong = 0;
+        uint64_t callHits = 0;
+        uint64_t callMisses = 0;
+        uint64_t returnHits = 0;
+        uint64_t returnMisses = 0;
+        uint64_t s1Hits3FallThrough = 0;
+        uint64_t s1Misses3Taken = 0;
+        uint64_t s1Hits3Taken = 0;
+        uint64_t s1Misses3FallThrough = 0;
+        uint64_t s1InvalidatedEntries = 0;
+
+        UBTBStats() = default;
+#endif
     } ubtbStats;
-
-
 };
 
-} // namespace btb_pred
-} // namespace branch_prediction
-} // namespace gem5
+}  // namespace btb_pred
+#ifdef UNIT_TEST
+}  // namespace test
+#endif
+}  // namespace branch_prediction
+}  // namespace gem5
 
-#endif // __CPU_PRED_BTB_UBTB_HH__
+#endif  // __CPU_PRED_BTB_UBTB_HH__

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -12,15 +12,18 @@
 #include "cpu/pred/general_arch_db.hh"
 #include "cpu/static_inst.hh"
 
-namespace gem5 {
+namespace gem5
+{
 
-namespace branch_prediction {
+namespace branch_prediction
+{
 
-namespace btb_pred {
+namespace btb_pred
+{
 
 enum EndType
 {
-    END_CALL=0,
+    END_CALL = 0,
     END_RET,
     END_OTHER_TAKEN,
     END_NOT_TAKEN,
@@ -28,44 +31,37 @@ enum EndType
     END_NONE
 };
 
-enum SquashType
-{
-    SQUASH_NONE=0,
-    SQUASH_TRAP,
-    SQUASH_CTRL,
-    SQUASH_OTHER
-};
+enum SquashType { SQUASH_NONE = 0, SQUASH_TRAP, SQUASH_CTRL, SQUASH_OTHER };
 
 enum BranchType
 {
-    BR_COND=0,
-    BR_DIRECT_NORMAL=1,
-    BR_DIRECT_CALL=2,
-    BR_INDIRECT_NORMAL=3,
-    BR_INDIRECT_RET=4,
-    BR_INDIRECT_CALL=5,
-    BR_INDIRECT_CALL_RET=6,
-    BR_DIRECT_RET=7
+    BR_COND = 0,
+    BR_DIRECT_NORMAL = 1,
+    BR_DIRECT_CALL = 2,
+    BR_INDIRECT_NORMAL = 3,
+    BR_INDIRECT_RET = 4,
+    BR_INDIRECT_CALL = 5,
+    BR_INDIRECT_CALL_RET = 6,
+    BR_DIRECT_RET = 7
 };
 
-enum class OverrideReason
+enum class OverrideReason { NO_OVERRIDE, FALL_THRU, CONTROL_ADDR, TARGET, END, HIST_INFO };
+
+enum class Block1DropReason
 {
-    NO_OVERRIDE,
-    FALL_THRU,
-    CONTROL_ADDR,
-    TARGET,
-    END,
-    HIST_INFO
+    None,
+    Disabled,
+    NoUBTBHit,
+    FTQNoSpace,
+    Block0Override,
+    InvalidNextPC,
+    CondNoSupport,
+    IndirectNoSupport,
+    ReturnNoSupport,
+    PredictorRejected
 };
 
-enum class HistoryType
-{
-    GLOBAL,
-    GLOBALBW,
-    LOCAL,
-    IMLI,
-    PATH
-};
+enum class HistoryType { GLOBAL, GLOBALBW, LOCAL, IMLI, PATH };
 
 
 /**
@@ -112,10 +108,11 @@ struct BranchInfo
           size(size)
     {
     }
-    int getType() const {
+    int getType() const
+    {
         if (isCond) {
             return BR_COND;
-        } else if (!isIndirect) { // uncond direct
+        } else if (!isIndirect) {  // uncond direct
             if (isReturn) {
                 fatal("jal return detected!\n");
                 return BR_DIRECT_RET;
@@ -128,39 +125,27 @@ struct BranchInfo
         } else {  // uncond indirect
             if (!isCall) {
                 if (!isReturn) {
-                    return BR_INDIRECT_NORMAL; // normal indirect
+                    return BR_INDIRECT_NORMAL;  // normal indirect
                 } else {
-                    return BR_INDIRECT_RET; // indirect return
+                    return BR_INDIRECT_RET;  // indirect return
                 }
             } else {
-                if (!isReturn) { // indirect call
+                if (!isReturn) {  // indirect call
                     return BR_INDIRECT_CALL;
-                } else { // call & return
+                } else {  // call & return
                     return BR_INDIRECT_CALL_RET;
                 }
             }
         }
     }
 
-    bool operator < (const BranchInfo &other) const
-    {
-        return this->pc < other.pc;
-    }
+    bool operator<(const BranchInfo &other) const { return this->pc < other.pc; }
 
-    bool operator == (const BranchInfo &other) const
-    {
-        return this->pc == other.pc;
-    }
+    bool operator==(const BranchInfo &other) const { return this->pc == other.pc; }
 
-    bool operator > (const BranchInfo &other) const
-    {
-        return this->pc > other.pc;
-    }
+    bool operator>(const BranchInfo &other) const { return this->pc > other.pc; }
 
-    bool operator != (const BranchInfo &other) const
-    {
-        return this->pc != other.pc;
-    }
+    bool operator!=(const BranchInfo &other) const { return this->pc != other.pc; }
 };
 
 
@@ -179,19 +164,15 @@ struct BTBEntry : BranchInfo
     bool alwaysTaken;
     int ctr;
     Addr tag;
-    int source;//only use for countering the source of the entry
+    int source;  // only use for countering the source of the entry
     // Addr offset; // retrived from lowest bits of pc
-    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0) ,source(-1){}
-    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0),source(-1){}
+    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0), source(-1) {}
+    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0), source(-1) {}
     BranchInfo getBranchInfo() { return BranchInfo(*this); }
 
-    int getsource() const {
-        return source;
-    }
+    int getsource() const { return source; }
 
-    void setsource(int src) {
-        source = src;
-    }
+    void setsource(int src) { source = src; }
 };
 
 /**
@@ -210,21 +191,21 @@ struct TageInfoForMGSC
     // Addr offset; // retrived from lowest bits of pc
     TageInfoForMGSC()
         : tage_pred_taken(false),
-            tage_main_taken(false),
-            tage_pred_conf_high(false),
-            tage_pred_conf_mid(false),
-            tage_pred_conf_low(false),
-            tage_pred_alt_diff(false)
+          tage_main_taken(false),
+          tage_pred_conf_high(false),
+          tage_pred_conf_mid(false),
+          tage_pred_conf_low(false),
+          tage_pred_alt_diff(false)
     {
     }
     TageInfoForMGSC(bool tage_pred_taken, bool tage_main_taken, bool tage_pred_conf_high, bool tage_pred_conf_mid,
                     bool tage_pred_conf_low, bool tage_pred_alt_diff)
         : tage_pred_taken(tage_pred_taken),
-            tage_main_taken(tage_main_taken),
-            tage_pred_conf_high(tage_pred_conf_high),
-            tage_pred_conf_mid(tage_pred_conf_mid),
-            tage_pred_conf_low(tage_pred_conf_low),
-            tage_pred_alt_diff(tage_pred_alt_diff)
+          tage_main_taken(tage_main_taken),
+          tage_pred_conf_high(tage_pred_conf_high),
+          tage_pred_conf_mid(tage_pred_conf_mid),
+          tage_pred_conf_low(tage_pred_conf_low),
+          tage_pred_alt_diff(tage_pred_alt_diff)
     {
     }
 };
@@ -233,11 +214,13 @@ struct LFSR64
 {
     uint64_t lfsr;
     LFSR64() : lfsr(0x1234567887654321UL) {}
-    uint64_t get() {
+    uint64_t get()
+    {
         next();
         return lfsr;
     }
-    void next() {
+    void next()
+    {
         if (lfsr == 0) {
             lfsr = 1;
         } else {
@@ -255,9 +238,8 @@ using CondTakens = std::vector<std::pair<Addr, bool>>;
 using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
 #define CondTakens_find(condTakens, branch_pc) \
-    std::find_if(condTakens.begin(), condTakens.end(), \
-                 [&branch_pc](const auto &p) { return p.first == branch_pc; })
-#define IndirectTakens_find(indirectTargets, branch_pc) \
+    std::find_if(condTakens.begin(), condTakens.end(), [&branch_pc](const auto &p) { return p.first == branch_pc; })
+#define IndirectTakens_find(indirectTargets, branch_pc)          \
     std::find_if(indirectTargets.begin(), indirectTargets.end(), \
                  [&branch_pc](const auto &p) { return p.first == branch_pc; })
 
@@ -276,85 +258,87 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 struct FetchTarget
 {
     ThreadID tid;
-    Addr startPC;       // start pc of the stream
-    bool predTaken;     // whether the FetchTarget has taken branch
-    Addr predEndPC;     // predicted stream end pc (fall through pc)
-    BranchInfo predBranchInfo; // predicted branch info
+    Addr startPC;               // start pc of the stream
+    bool predTaken;             // whether the FetchTarget has taken branch
+    Addr predEndPC;             // predicted stream end pc (fall through pc)
+    BranchInfo predBranchInfo;  // predicted branch info
 
-    bool isHit;          // whether the predicted btb entry is hit
-    bool falseHit;       // not used
-    std::vector<BTBEntry> predBTBEntries;   // record predicted BTB entries
+    bool isHit;                            // whether the predicted btb entry is hit
+    bool falseHit;                         // not used
+    std::vector<BTBEntry> predBTBEntries;  // record predicted BTB entries
 
     // for commit, write at redirect or fetch
-    bool exeTaken;         // whether the branch is taken(resolved)
-    BranchInfo exeBranchInfo; // executed branch info
+    bool exeTaken;             // whether the branch is taken(resolved)
+    BranchInfo exeBranchInfo;  // executed branch info
 
-    BTBEntry updateNewBTBEntry; // the possible new entry, set by L1BTB.getAndSetNewBTBEntry, used by L1BTB/L0BTB.update
-    bool updateIsOldEntry; // whether the BTB entry is old, true: update the old entry, false: use updateNewBTBEntry
-    bool resolved;  // whether the branch is resolved/executed
+    BTBEntry updateNewBTBEntry;  // the possible new entry, set by L1BTB.getAndSetNewBTBEntry, used by
+                                 // L1BTB/L0BTB.update
+    bool updateIsOldEntry;  // whether the BTB entry is old, true: update the old entry, false: use updateNewBTBEntry
+    bool resolved;          // whether the branch is resolved/executed
 
     // below two should be set before components update
     // used to decide which branches to update (don't update if not actually executed)
-    Addr updateEndInstPC;   // end pc of the squash inst/taken inst
+    Addr updateEndInstPC;  // end pc of the squash inst/taken inst
     // for components to decide which entries to update
-    std::vector<BTBEntry> updateBTBEntries; // mostly like predBTBEntries
+    std::vector<BTBEntry> updateBTBEntries;  // mostly like predBTBEntries
 
-    int squashType;         // squash type
-    Addr squashPC;         // pc of the squash inst
-    unsigned predSource;   // source of the prediction(numStage)
-    OverrideReason overrideReason; // reason of the override(for profiling)
+    int squashType;                 // squash type
+    Addr squashPC;                  // pc of the squash inst
+    unsigned predSource;            // source of the prediction(numStage)
+    OverrideReason overrideReason;  // reason of the override(for profiling)
 
     // prediction metas
     // FIXME: use vec
-    std::array<std::shared_ptr<void>, 8> predMetas; // each component has a meta, TODO
+    std::array<std::shared_ptr<void>, 8> predMetas;  // each component has a meta, TODO
 
-    Tick predTick;         // tick of the prediction
-    boost::dynamic_bitset<> history; // record GHR/s0History
-    boost::dynamic_bitset<> phistory; // record PATH/s0History
-    boost::dynamic_bitset<> bwhistory; // record BWHR/s0History
-    std::vector<boost::dynamic_bitset<>> lhistory; // record LHR/s0History
-    std::queue<Addr> previousPCs; // previous PCs, used by ahead BTB
+    Tick predTick;                                  // tick of the prediction
+    boost::dynamic_bitset<> history;                // record GHR/s0History
+    boost::dynamic_bitset<> phistory;               // record PATH/s0History
+    boost::dynamic_bitset<> bwhistory;              // record BWHR/s0History
+    std::vector<boost::dynamic_bitset<>> lhistory;  // record LHR/s0History
+    std::queue<Addr> previousPCs;                   // previous PCs, used by ahead BTB
 
     // for profiling
     int fetchInstNum;
     int commitInstNum;
 
-    int s1Source; // which stage the prediction comes from
-    int s3Source; // which stage the prediction comes from
+    int s1Source;  // which stage the prediction comes from
+    int s3Source;  // which stage the prediction comes from
 
-   FetchTarget()
-       : startPC(0),
-         predTaken(false),
-         predEndPC(0),
-         predBranchInfo(BranchInfo()),
-         isHit(false),
-         falseHit(false),
-         exeTaken(false),
-         exeBranchInfo(BranchInfo()),
-         updateNewBTBEntry(BTBEntry()),
-         updateIsOldEntry(false),
-         resolved(false),
-         updateEndInstPC(0),
-         squashType(SquashType::SQUASH_NONE),
-         squashPC(0),
-         predSource(0),
-         predTick(0),
-         history(),
-         phistory(),
-         bwhistory(),
-         lhistory(),
-         fetchInstNum(0),
-         commitInstNum(0),
-         s1Source(-1),
-         s3Source(-1)
-   {
-       predMetas.fill(nullptr);
-       predBTBEntries.clear();
-       updateBTBEntries.clear();
-   }
+    FetchTarget()
+        : startPC(0),
+          predTaken(false),
+          predEndPC(0),
+          predBranchInfo(BranchInfo()),
+          isHit(false),
+          falseHit(false),
+          exeTaken(false),
+          exeBranchInfo(BranchInfo()),
+          updateNewBTBEntry(BTBEntry()),
+          updateIsOldEntry(false),
+          resolved(false),
+          updateEndInstPC(0),
+          squashType(SquashType::SQUASH_NONE),
+          squashPC(0),
+          predSource(0),
+          predTick(0),
+          history(),
+          phistory(),
+          bwhistory(),
+          lhistory(),
+          fetchInstNum(0),
+          commitInstNum(0),
+          s1Source(-1),
+          s3Source(-1)
+    {
+        predMetas.fill(nullptr);
+        predBTBEntries.clear();
+        updateBTBEntries.clear();
+    }
 
     // the default exe result should be consistent with prediction
-    void setDefaultResolve() {
+    void setDefaultResolve()
+    {
         resolved = false;
         exeBranchInfo = predBranchInfo;
         exeTaken = predTaken;
@@ -363,13 +347,14 @@ struct FetchTarget
     // bool getEnded() const { return resolved ? exeEnded : predEnded; }
     BranchInfo getBranchInfo() const { return resolved ? exeBranchInfo : predBranchInfo; }
     Addr getControlPC() const { return getBranchInfo().pc; }
-    Addr getEndPC() const { return getBranchInfo().getEnd(); } // FIXME: should be end of squash inst when non-control squash of trap squash
+    Addr getEndPC() const
+    {
+        return getBranchInfo().getEnd();
+    }  // FIXME: should be end of squash inst when non-control squash of trap squash
     Addr getTaken() const { return resolved ? exeTaken : predTaken; }
     Addr getTakenTarget() const { return getBranchInfo().target; }
 
-    Addr getRealStartPC() const {
-        return startPC;
-    }
+    Addr getRealStartPC() const { return startPC; }
 
     std::pair<int, bool> getHistInfoDuringSquash(Addr squash_pc, bool is_cond, bool actually_taken)
     {
@@ -407,9 +392,9 @@ struct FetchTarget
     void setUpdateInstEndPC(unsigned predictWidth)
     {
         if (squashType == SQUASH_NONE) {
-            if (exeTaken) { // taken inst pc
+            if (exeTaken) {  // taken inst pc
                 updateEndInstPC = getControlPC();
-            } else { // natural fall through, align to the next block
+            } else {  // natural fall through, align to the next block
                 // assert(halfAligned);
                 updateEndInstPC = (startPC + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
             }
@@ -453,13 +438,13 @@ struct FullBTBPrediction
 {
     ThreadID tid;
     Addr bbStart;
-    std::vector<BTBEntry> btbEntries; // for BTB, only assigned when hit, sorted by inst order
+    std::vector<BTBEntry> btbEntries;  // for BTB, only assigned when hit, sorted by inst order
     // for conditional branch predictors, mapped with lowest bits of branches
     CondTakens condTakens;
 
     // for indirect predictor, mapped with lowest bits of branches
     IndirectTargets indirectTargets;
-    Addr returnTarget; // for RAS
+    Addr returnTarget;  // for RAS
 
     std::unordered_map<Addr, TageInfoForMGSC> tageInfoForMgscs;
 
@@ -467,23 +452,27 @@ struct FullBTBPrediction
     OverrideReason overrideReason;
     Tick predTick;
 
-    //only use for countering the source of the prediction
+    // only use for countering the source of the prediction
     int s1Source;
     int s3Source;
 
-    FullBTBPrediction() :
-        bbStart(0),
-        btbEntries(),
-        condTakens(),
-        indirectTargets(),
-        returnTarget(0),
-        tageInfoForMgscs(),
-        predSource(0),
-        predTick(0),
-        s1Source(-1),
-        s3Source(-1) {}
+    FullBTBPrediction()
+        : tid(0),
+          bbStart(0),
+          btbEntries(),
+          condTakens(),
+          indirectTargets(),
+          returnTarget(0),
+          tageInfoForMgscs(),
+          predSource(0),
+          predTick(0),
+          s1Source(-1),
+          s3Source(-1)
+    {
+    }
 
-    BTBEntry getTakenEntry() {
+    BTBEntry getTakenEntry()
+    {
         // IMPORTANT: assume entries are sorted
         for (auto &entry : this->btbEntries) {
             // hit
@@ -491,56 +480,60 @@ struct FullBTBPrediction
                 if (entry.isCond) {
                     // find corresponding direction pred in condTakens
                     // TODO: use lower-bit offset of branch instruction
-                    auto& pc = entry.pc;
+                    auto &pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
-                        if (it->second) {   // find and taken, return the entry
+                        if (it->second) {  // find and taken, return the entry
                             return entry;
                         }
                     }
                 }
-                if (entry.isUncond()) { // find the first uncond entry
+                if (entry.isUncond()) {  // find the first uncond entry
                     return entry;
                 }
             }
         }
-        return BTBEntry(); // not found, return empty entry
+        return BTBEntry();  // not found, return empty entry
     }
 
-    bool isTaken() {
-        return getTakenEntry().valid;   // if find a taken entry, return true
+    bool isTaken()
+    {
+        return getTakenEntry().valid;  // if find a taken entry, return true
     }
 
-    Addr getFallThrough(Addr predictWidth) {
+    Addr getFallThrough(Addr predictWidth)
+    {
         // max 64 byte block, 32 byte aligned
         return (bbStart + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
     }
 
-    Addr getTarget(Addr predictWidth) {
+    Addr getTarget(Addr predictWidth)
+    {
         Addr target;
         const auto &entry = getTakenEntry();
-        if (entry.valid) { // found a taken entry
+        if (entry.valid) {  // found a taken entry
             target = entry.target;
             // indirect target should come from ipred or ras,
             // or btb itself when ipred miss
             if (entry.isIndirect) {
-                if (!entry.isReturn) { // normal indirect, see ittage
-                    auto& pc = entry.pc;
+                if (!entry.isReturn) {  // normal indirect, see ittage
+                    auto &pc = entry.pc;
                     auto it = IndirectTakens_find(indirectTargets, pc);
-                    if (it != indirectTargets.end()) { // found in ittage, use it
+                    if (it != indirectTargets.end()) {  // found in ittage, use it
                         target = it->second;
                     }
-                } else { // indirect return, use RAS target
+                } else {  // indirect return, use RAS target
                     target = returnTarget;
                 }
-            } // else: normal taken, use btb target
+            }  // else: normal taken, use btb target
         } else {
             target = getFallThrough(predictWidth);
         }
         return target;
     }
 
-    Addr getEnd(Addr predictWidth) {
+    Addr getEnd(Addr predictWidth)
+    {
         if (isTaken()) {
             return getTakenEntry().getEnd();
         } else {
@@ -549,9 +542,7 @@ struct FullBTBPrediction
     }
 
 
-    Addr controlAddr() {
-        return getTakenEntry().pc;
-    }
+    Addr controlAddr() { return getTakenEntry().pc; }
 
     std::pair<bool, OverrideReason> match(FullBTBPrediction &other, Addr predictWidth)
     {
@@ -564,11 +555,9 @@ struct FullBTBPrediction
             if (this_taken_entry.valid && other_taken_entry.valid) {
                 if (this->controlAddr() != other.controlAddr()) {
                     return std::make_pair(false, OverrideReason::CONTROL_ADDR);
-                }
-                else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
+                } else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
                     return std::make_pair(false, OverrideReason::TARGET);
-                }
-                else {
+                } else {
                     return std::make_pair(true, btb_pred::OverrideReason::NO_OVERRIDE);
                 }
             } else {
@@ -577,18 +566,18 @@ struct FullBTBPrediction
         }
     }
 
-    std::pair<int, bool> getHistInfo()  //global or local
+    std::pair<int, bool> getHistInfo()  // global or local
     {
-        int shamt = 0; // shamt is the number of bits to shift in history update
+        int shamt = 0;  // shamt is the number of bits to shift in history update
         bool taken = false;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond) { // if found a cond branch, shamt++
+                if (entry.isCond) {  // if found a cond branch, shamt++
                     shamt++;
-                    auto& pc = entry.pc;
+                    auto &pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
-                        if (it->second) { // if the cond branch is taken, taken = true
+                        if (it->second) {  // if the cond branch is taken, taken = true
                             taken = true;
                             break;
                         }
@@ -604,7 +593,7 @@ struct FullBTBPrediction
         return std::make_pair(shamt, taken);
     }
 
-    std::pair<int, bool> getBwHistInfo() //global backward or imli
+    std::pair<int, bool> getBwHistInfo()  // global backward or imli
     {
         int shamt = 0;
         bool taken = false;
@@ -612,11 +601,11 @@ struct FullBTBPrediction
             if (entry.valid) {
                 if (entry.isCond) {
                     shamt++;
-                    auto& pc = entry.pc;
+                    auto &pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
-                            taken = (entry.target < entry.pc); // branch is backward if target < pc
+                            taken = (entry.target < entry.pc);  // branch is backward if target < pc
                             break;
                         }
                     }
@@ -629,7 +618,7 @@ struct FullBTBPrediction
         return std::make_pair(shamt, taken);
     }
 
-    std::tuple<Addr, Addr, bool> getPHistInfo() //path
+    std::tuple<Addr, Addr, bool> getPHistInfo()  // path
     {
         bool taken = false;
         Addr pc = 0;
@@ -637,12 +626,12 @@ struct FullBTBPrediction
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) {
-                    auto& _pc = entry.pc;
+                    auto &_pc = entry.pc;
                     auto it = CondTakens_find(condTakens, _pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
                             taken = true;
-                            pc = entry.pc; // get the pc of the cond branch
+                            pc = entry.pc;  // get the pc of the cond branch
                             target = entry.target;
                             break;
                         }
@@ -650,7 +639,7 @@ struct FullBTBPrediction
                 } else {
                     // uncond
                     taken = true;
-                    pc = entry.pc; // get the pc of the cond branch
+                    pc = entry.pc;  // get the pc of the cond branch
                     target = entry.target;
                     break;
                 }
@@ -658,17 +647,69 @@ struct FullBTBPrediction
         }
         return std::make_tuple(pc, target, taken);
     }
-
 };
+
+inline Block1DropReason
+getBlock1DropReason(const FullBTBPrediction &pred, bool dropOnCondWithoutTage, bool hasCondDirectionSupport,
+                    bool dropOnIndirectWithoutIttage, bool hasIndirectTargetSupport, bool dropOnReturnWithoutRas,
+                    bool hasReturnTargetSupport)
+{
+    for (const auto &entry : pred.btbEntries) {
+        if (!entry.valid) {
+            continue;
+        }
+
+        if (entry.isReturn && dropOnReturnWithoutRas && !hasReturnTargetSupport) {
+            return Block1DropReason::ReturnNoSupport;
+        }
+
+        if (entry.isIndirect && !entry.isReturn && dropOnIndirectWithoutIttage && !hasIndirectTargetSupport) {
+            return Block1DropReason::IndirectNoSupport;
+        }
+
+        if (entry.isCond && dropOnCondWithoutTage && !hasCondDirectionSupport) {
+            return Block1DropReason::CondNoSupport;
+        }
+    }
+
+    return Block1DropReason::None;
+}
+
+inline Block1DropReason
+getInitialBlock1DropReason(bool enableTwoTaken, bool dropBlock1OnBlock0Override, bool block0Overridden,
+                           bool dropBlock1WhenFTQHasOnlyOneSlot, unsigned freeFTQSlots, Addr nextPC,
+                           bool block0HasUBTBHit, Addr invalidPC = MaxAddr)
+{
+    if (!enableTwoTaken) {
+        return Block1DropReason::Disabled;
+    }
+
+    if (dropBlock1OnBlock0Override && block0Overridden) {
+        return Block1DropReason::Block0Override;
+    }
+
+    if (dropBlock1WhenFTQHasOnlyOneSlot && freeFTQSlots < 2) {
+        return Block1DropReason::FTQNoSpace;
+    }
+
+    if (nextPC == invalidPC) {
+        return Block1DropReason::InvalidNextPC;
+    }
+
+    if (!block0HasUBTBHit) {
+        return Block1DropReason::NoUBTBHit;
+    }
+
+    return Block1DropReason::None;
+}
 
 struct TageMissTrace : public Record
 {
-    void set(uint64_t startPC, uint64_t branchPC, uint64_t wayIdx,
-        uint64_t mainFound, uint64_t mainCounter, uint64_t mainUseful, uint64_t mainTable, uint64_t mainIndex,
-        uint64_t altFound, uint64_t altCounter, uint64_t altUseful, uint64_t altTable, uint64_t altIndex,
-        uint64_t useAlt, uint64_t predTaken, uint64_t actualTaken, uint64_t allocSuccess,
-        uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay,
-        std::string history, uint64_t indexFoldedHist)
+    void set(uint64_t startPC, uint64_t branchPC, uint64_t wayIdx, uint64_t mainFound, uint64_t mainCounter,
+             uint64_t mainUseful, uint64_t mainTable, uint64_t mainIndex, uint64_t altFound, uint64_t altCounter,
+             uint64_t altUseful, uint64_t altTable, uint64_t altIndex, uint64_t useAlt, uint64_t predTaken,
+             uint64_t actualTaken, uint64_t allocSuccess, uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay,
+             std::string history, uint64_t indexFoldedHist)
     {
         _tick = curTick();
         _uint64_data["startPC"] = startPC;
@@ -696,9 +737,11 @@ struct TageMissTrace : public Record
     }
 };
 
-struct BTBTrace : public Record {
+struct BTBTrace : public Record
+{
     // mode: read, write, evict
-    void set(uint64_t pc, uint64_t brType, uint64_t target, uint64_t idx, uint64_t mode, uint64_t hit) {
+    void set(uint64_t pc, uint64_t brType, uint64_t target, uint64_t idx, uint64_t mode, uint64_t hit)
+    {
         _tick = curTick();
         _uint64_data["pc"] = pc;
         _uint64_data["brType"] = brType;
@@ -712,15 +755,15 @@ struct BTBTrace : public Record {
 struct MgscTrace : public Record
 {
     void set(uint64_t branchPC,
-        // TAGE prediction info
-        uint64_t tagePred, uint64_t tageConfHigh, uint64_t tageConfMid, uint64_t tageConfLow,
-        // Percsum for each table (signed values stored as int64)
-        int64_t bwPercsum, int64_t lPercsum, int64_t iPercsum,
-        int64_t gPercsum, int64_t pPercsum, int64_t biasPercsum,
-        // SC decision
-        int64_t totalSum, int64_t totalThres, uint64_t useSc, uint64_t scPred,
-        // Result
-        uint64_t actualTaken)
+             // TAGE prediction info
+             uint64_t tagePred, uint64_t tageConfHigh, uint64_t tageConfMid, uint64_t tageConfLow,
+             // Percsum for each table (signed values stored as int64)
+             int64_t bwPercsum, int64_t lPercsum, int64_t iPercsum, int64_t gPercsum, int64_t pPercsum,
+             int64_t biasPercsum,
+             // SC decision
+             int64_t totalSum, int64_t totalThres, uint64_t useSc, uint64_t scPred,
+             // Result
+             uint64_t actualTaken)
     {
         _tick = curTick();
         _uint64_data["branchPC"] = branchPC;

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -12,18 +12,15 @@
 #include "cpu/pred/general_arch_db.hh"
 #include "cpu/static_inst.hh"
 
-namespace gem5
-{
+namespace gem5 {
 
-namespace branch_prediction
-{
+namespace branch_prediction {
 
-namespace btb_pred
-{
+namespace btb_pred {
 
 enum EndType
 {
-    END_CALL = 0,
+    END_CALL=0,
     END_RET,
     END_OTHER_TAKEN,
     END_NOT_TAKEN,
@@ -31,21 +28,35 @@ enum EndType
     END_NONE
 };
 
-enum SquashType { SQUASH_NONE = 0, SQUASH_TRAP, SQUASH_CTRL, SQUASH_OTHER };
+enum SquashType
+{
+    SQUASH_NONE=0,
+    SQUASH_TRAP,
+    SQUASH_CTRL,
+    SQUASH_OTHER
+};
 
 enum BranchType
 {
-    BR_COND = 0,
-    BR_DIRECT_NORMAL = 1,
-    BR_DIRECT_CALL = 2,
-    BR_INDIRECT_NORMAL = 3,
-    BR_INDIRECT_RET = 4,
-    BR_INDIRECT_CALL = 5,
-    BR_INDIRECT_CALL_RET = 6,
-    BR_DIRECT_RET = 7
+    BR_COND=0,
+    BR_DIRECT_NORMAL=1,
+    BR_DIRECT_CALL=2,
+    BR_INDIRECT_NORMAL=3,
+    BR_INDIRECT_RET=4,
+    BR_INDIRECT_CALL=5,
+    BR_INDIRECT_CALL_RET=6,
+    BR_DIRECT_RET=7
 };
 
-enum class OverrideReason { NO_OVERRIDE, FALL_THRU, CONTROL_ADDR, TARGET, END, HIST_INFO };
+enum class OverrideReason
+{
+    NO_OVERRIDE,
+    FALL_THRU,
+    CONTROL_ADDR,
+    TARGET,
+    END,
+    HIST_INFO
+};
 
 enum class Block1DropReason
 {
@@ -108,11 +119,10 @@ struct BranchInfo
           size(size)
     {
     }
-    int getType() const
-    {
+    int getType() const {
         if (isCond) {
             return BR_COND;
-        } else if (!isIndirect) {  // uncond direct
+        } else if (!isIndirect) { // uncond direct
             if (isReturn) {
                 fatal("jal return detected!\n");
                 return BR_DIRECT_RET;
@@ -125,27 +135,39 @@ struct BranchInfo
         } else {  // uncond indirect
             if (!isCall) {
                 if (!isReturn) {
-                    return BR_INDIRECT_NORMAL;  // normal indirect
+                    return BR_INDIRECT_NORMAL; // normal indirect
                 } else {
-                    return BR_INDIRECT_RET;  // indirect return
+                    return BR_INDIRECT_RET; // indirect return
                 }
             } else {
-                if (!isReturn) {  // indirect call
+                if (!isReturn) { // indirect call
                     return BR_INDIRECT_CALL;
-                } else {  // call & return
+                } else { // call & return
                     return BR_INDIRECT_CALL_RET;
                 }
             }
         }
     }
 
-    bool operator<(const BranchInfo &other) const { return this->pc < other.pc; }
+    bool operator < (const BranchInfo &other) const
+    {
+        return this->pc < other.pc;
+    }
 
-    bool operator==(const BranchInfo &other) const { return this->pc == other.pc; }
+    bool operator == (const BranchInfo &other) const
+    {
+        return this->pc == other.pc;
+    }
 
-    bool operator>(const BranchInfo &other) const { return this->pc > other.pc; }
+    bool operator > (const BranchInfo &other) const
+    {
+        return this->pc > other.pc;
+    }
 
-    bool operator!=(const BranchInfo &other) const { return this->pc != other.pc; }
+    bool operator != (const BranchInfo &other) const
+    {
+        return this->pc != other.pc;
+    }
 };
 
 
@@ -164,15 +186,19 @@ struct BTBEntry : BranchInfo
     bool alwaysTaken;
     int ctr;
     Addr tag;
-    int source;  // only use for countering the source of the entry
+    int source;//only use for countering the source of the entry
     // Addr offset; // retrived from lowest bits of pc
-    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0), source(-1) {}
-    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0), source(-1) {}
+    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0) ,source(-1){}
+    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0),source(-1){}
     BranchInfo getBranchInfo() { return BranchInfo(*this); }
 
-    int getsource() const { return source; }
+    int getsource() const {
+        return source;
+    }
 
-    void setsource(int src) { source = src; }
+    void setsource(int src) {
+        source = src;
+    }
 };
 
 /**
@@ -191,21 +217,21 @@ struct TageInfoForMGSC
     // Addr offset; // retrived from lowest bits of pc
     TageInfoForMGSC()
         : tage_pred_taken(false),
-          tage_main_taken(false),
-          tage_pred_conf_high(false),
-          tage_pred_conf_mid(false),
-          tage_pred_conf_low(false),
-          tage_pred_alt_diff(false)
+            tage_main_taken(false),
+            tage_pred_conf_high(false),
+            tage_pred_conf_mid(false),
+            tage_pred_conf_low(false),
+            tage_pred_alt_diff(false)
     {
     }
     TageInfoForMGSC(bool tage_pred_taken, bool tage_main_taken, bool tage_pred_conf_high, bool tage_pred_conf_mid,
                     bool tage_pred_conf_low, bool tage_pred_alt_diff)
         : tage_pred_taken(tage_pred_taken),
-          tage_main_taken(tage_main_taken),
-          tage_pred_conf_high(tage_pred_conf_high),
-          tage_pred_conf_mid(tage_pred_conf_mid),
-          tage_pred_conf_low(tage_pred_conf_low),
-          tage_pred_alt_diff(tage_pred_alt_diff)
+            tage_main_taken(tage_main_taken),
+            tage_pred_conf_high(tage_pred_conf_high),
+            tage_pred_conf_mid(tage_pred_conf_mid),
+            tage_pred_conf_low(tage_pred_conf_low),
+            tage_pred_alt_diff(tage_pred_alt_diff)
     {
     }
 };
@@ -214,13 +240,11 @@ struct LFSR64
 {
     uint64_t lfsr;
     LFSR64() : lfsr(0x1234567887654321UL) {}
-    uint64_t get()
-    {
+    uint64_t get() {
         next();
         return lfsr;
     }
-    void next()
-    {
+    void next() {
         if (lfsr == 0) {
             lfsr = 1;
         } else {
@@ -258,18 +282,18 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 struct FetchTarget
 {
     ThreadID tid;
-    Addr startPC;               // start pc of the stream
-    bool predTaken;             // whether the FetchTarget has taken branch
-    Addr predEndPC;             // predicted stream end pc (fall through pc)
-    BranchInfo predBranchInfo;  // predicted branch info
+    Addr startPC;       // start pc of the stream
+    bool predTaken;     // whether the FetchTarget has taken branch
+    Addr predEndPC;     // predicted stream end pc (fall through pc)
+    BranchInfo predBranchInfo; // predicted branch info
 
-    bool isHit;                            // whether the predicted btb entry is hit
-    bool falseHit;                         // not used
-    std::vector<BTBEntry> predBTBEntries;  // record predicted BTB entries
+    bool isHit;          // whether the predicted btb entry is hit
+    bool falseHit;       // not used
+    std::vector<BTBEntry> predBTBEntries;   // record predicted BTB entries
 
     // for commit, write at redirect or fetch
-    bool exeTaken;             // whether the branch is taken(resolved)
-    BranchInfo exeBranchInfo;  // executed branch info
+    bool exeTaken;         // whether the branch is taken(resolved)
+    BranchInfo exeBranchInfo; // executed branch info
 
     BTBEntry updateNewBTBEntry;  // the possible new entry, set by L1BTB.getAndSetNewBTBEntry, used by
                                  // L1BTB/L0BTB.update
@@ -278,67 +302,66 @@ struct FetchTarget
 
     // below two should be set before components update
     // used to decide which branches to update (don't update if not actually executed)
-    Addr updateEndInstPC;  // end pc of the squash inst/taken inst
+    Addr updateEndInstPC;   // end pc of the squash inst/taken inst
     // for components to decide which entries to update
-    std::vector<BTBEntry> updateBTBEntries;  // mostly like predBTBEntries
+    std::vector<BTBEntry> updateBTBEntries; // mostly like predBTBEntries
 
-    int squashType;                 // squash type
-    Addr squashPC;                  // pc of the squash inst
-    unsigned predSource;            // source of the prediction(numStage)
-    OverrideReason overrideReason;  // reason of the override(for profiling)
+    int squashType;         // squash type
+    Addr squashPC;         // pc of the squash inst
+    unsigned predSource;   // source of the prediction(numStage)
+    OverrideReason overrideReason; // reason of the override(for profiling)
 
     // prediction metas
     // FIXME: use vec
-    std::array<std::shared_ptr<void>, 8> predMetas;  // each component has a meta, TODO
+    std::array<std::shared_ptr<void>, 8> predMetas; // each component has a meta, TODO
 
-    Tick predTick;                                  // tick of the prediction
-    boost::dynamic_bitset<> history;                // record GHR/s0History
-    boost::dynamic_bitset<> phistory;               // record PATH/s0History
-    boost::dynamic_bitset<> bwhistory;              // record BWHR/s0History
-    std::vector<boost::dynamic_bitset<>> lhistory;  // record LHR/s0History
-    std::queue<Addr> previousPCs;                   // previous PCs, used by ahead BTB
+    Tick predTick;         // tick of the prediction
+    boost::dynamic_bitset<> history; // record GHR/s0History
+    boost::dynamic_bitset<> phistory; // record PATH/s0History
+    boost::dynamic_bitset<> bwhistory; // record BWHR/s0History
+    std::vector<boost::dynamic_bitset<>> lhistory; // record LHR/s0History
+    std::queue<Addr> previousPCs; // previous PCs, used by ahead BTB
 
     // for profiling
     int fetchInstNum;
     int commitInstNum;
 
-    int s1Source;  // which stage the prediction comes from
-    int s3Source;  // which stage the prediction comes from
+    int s1Source; // which stage the prediction comes from
+    int s3Source; // which stage the prediction comes from
 
-    FetchTarget()
-        : startPC(0),
-          predTaken(false),
-          predEndPC(0),
-          predBranchInfo(BranchInfo()),
-          isHit(false),
-          falseHit(false),
-          exeTaken(false),
-          exeBranchInfo(BranchInfo()),
-          updateNewBTBEntry(BTBEntry()),
-          updateIsOldEntry(false),
-          resolved(false),
-          updateEndInstPC(0),
-          squashType(SquashType::SQUASH_NONE),
-          squashPC(0),
-          predSource(0),
-          predTick(0),
-          history(),
-          phistory(),
-          bwhistory(),
-          lhistory(),
-          fetchInstNum(0),
-          commitInstNum(0),
-          s1Source(-1),
-          s3Source(-1)
-    {
-        predMetas.fill(nullptr);
-        predBTBEntries.clear();
-        updateBTBEntries.clear();
-    }
+   FetchTarget()
+       : startPC(0),
+         predTaken(false),
+         predEndPC(0),
+         predBranchInfo(BranchInfo()),
+         isHit(false),
+         falseHit(false),
+         exeTaken(false),
+         exeBranchInfo(BranchInfo()),
+         updateNewBTBEntry(BTBEntry()),
+         updateIsOldEntry(false),
+         resolved(false),
+         updateEndInstPC(0),
+         squashType(SquashType::SQUASH_NONE),
+         squashPC(0),
+         predSource(0),
+         predTick(0),
+         history(),
+         phistory(),
+         bwhistory(),
+         lhistory(),
+         fetchInstNum(0),
+         commitInstNum(0),
+         s1Source(-1),
+         s3Source(-1)
+   {
+       predMetas.fill(nullptr);
+       predBTBEntries.clear();
+       updateBTBEntries.clear();
+   }
 
     // the default exe result should be consistent with prediction
-    void setDefaultResolve()
-    {
+    void setDefaultResolve() {
         resolved = false;
         exeBranchInfo = predBranchInfo;
         exeTaken = predTaken;
@@ -347,14 +370,13 @@ struct FetchTarget
     // bool getEnded() const { return resolved ? exeEnded : predEnded; }
     BranchInfo getBranchInfo() const { return resolved ? exeBranchInfo : predBranchInfo; }
     Addr getControlPC() const { return getBranchInfo().pc; }
-    Addr getEndPC() const
-    {
-        return getBranchInfo().getEnd();
-    }  // FIXME: should be end of squash inst when non-control squash of trap squash
+    Addr getEndPC() const { return getBranchInfo().getEnd(); } // FIXME: should be end of squash inst when non-control squash of trap squash
     Addr getTaken() const { return resolved ? exeTaken : predTaken; }
     Addr getTakenTarget() const { return getBranchInfo().target; }
 
-    Addr getRealStartPC() const { return startPC; }
+    Addr getRealStartPC() const {
+        return startPC;
+    }
 
     std::pair<int, bool> getHistInfoDuringSquash(Addr squash_pc, bool is_cond, bool actually_taken)
     {
@@ -392,9 +414,9 @@ struct FetchTarget
     void setUpdateInstEndPC(unsigned predictWidth)
     {
         if (squashType == SQUASH_NONE) {
-            if (exeTaken) {  // taken inst pc
+            if (exeTaken) { // taken inst pc
                 updateEndInstPC = getControlPC();
-            } else {  // natural fall through, align to the next block
+            } else { // natural fall through, align to the next block
                 // assert(halfAligned);
                 updateEndInstPC = (startPC + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
             }
@@ -438,13 +460,13 @@ struct FullBTBPrediction
 {
     ThreadID tid;
     Addr bbStart;
-    std::vector<BTBEntry> btbEntries;  // for BTB, only assigned when hit, sorted by inst order
+    std::vector<BTBEntry> btbEntries; // for BTB, only assigned when hit, sorted by inst order
     // for conditional branch predictors, mapped with lowest bits of branches
     CondTakens condTakens;
 
     // for indirect predictor, mapped with lowest bits of branches
     IndirectTargets indirectTargets;
-    Addr returnTarget;  // for RAS
+    Addr returnTarget; // for RAS
 
     std::unordered_map<Addr, TageInfoForMGSC> tageInfoForMgscs;
 
@@ -452,7 +474,7 @@ struct FullBTBPrediction
     OverrideReason overrideReason;
     Tick predTick;
 
-    // only use for countering the source of the prediction
+    //only use for countering the source of the prediction
     int s1Source;
     int s3Source;
 
@@ -480,60 +502,56 @@ struct FullBTBPrediction
                 if (entry.isCond) {
                     // find corresponding direction pred in condTakens
                     // TODO: use lower-bit offset of branch instruction
-                    auto &pc = entry.pc;
+                    auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
-                        if (it->second) {  // find and taken, return the entry
+                        if (it->second) {   // find and taken, return the entry
                             return entry;
                         }
                     }
                 }
-                if (entry.isUncond()) {  // find the first uncond entry
+                if (entry.isUncond()) { // find the first uncond entry
                     return entry;
                 }
             }
         }
-        return BTBEntry();  // not found, return empty entry
+        return BTBEntry(); // not found, return empty entry
     }
 
-    bool isTaken()
-    {
-        return getTakenEntry().valid;  // if find a taken entry, return true
+    bool isTaken() {
+        return getTakenEntry().valid;   // if find a taken entry, return true
     }
 
-    Addr getFallThrough(Addr predictWidth)
-    {
+    Addr getFallThrough(Addr predictWidth) {
         // max 64 byte block, 32 byte aligned
         return (bbStart + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
     }
 
-    Addr getTarget(Addr predictWidth)
-    {
+    Addr getTarget(Addr predictWidth) {
         Addr target;
         const auto &entry = getTakenEntry();
-        if (entry.valid) {  // found a taken entry
+        if (entry.valid) { // found a taken entry
             target = entry.target;
             // indirect target should come from ipred or ras,
             // or btb itself when ipred miss
             if (entry.isIndirect) {
-                if (!entry.isReturn) {  // normal indirect, see ittage
-                    auto &pc = entry.pc;
+                if (!entry.isReturn) { // normal indirect, see ittage
+                    auto& pc = entry.pc;
                     auto it = IndirectTakens_find(indirectTargets, pc);
-                    if (it != indirectTargets.end()) {  // found in ittage, use it
+                    if (it != indirectTargets.end()) { // found in ittage, use it
                         target = it->second;
                     }
-                } else {  // indirect return, use RAS target
+                } else { // indirect return, use RAS target
                     target = returnTarget;
                 }
-            }  // else: normal taken, use btb target
+            } // else: normal taken, use btb target
         } else {
             target = getFallThrough(predictWidth);
         }
         return target;
     }
 
-    Addr getEnd(Addr predictWidth)
-    {
+    Addr getEnd(Addr predictWidth) {
         if (isTaken()) {
             return getTakenEntry().getEnd();
         } else {
@@ -542,7 +560,9 @@ struct FullBTBPrediction
     }
 
 
-    Addr controlAddr() { return getTakenEntry().pc; }
+    Addr controlAddr() {
+        return getTakenEntry().pc;
+    }
 
     std::pair<bool, OverrideReason> match(FullBTBPrediction &other, Addr predictWidth)
     {
@@ -555,9 +575,11 @@ struct FullBTBPrediction
             if (this_taken_entry.valid && other_taken_entry.valid) {
                 if (this->controlAddr() != other.controlAddr()) {
                     return std::make_pair(false, OverrideReason::CONTROL_ADDR);
-                } else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
+                }
+                else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
                     return std::make_pair(false, OverrideReason::TARGET);
-                } else {
+                }
+                else {
                     return std::make_pair(true, btb_pred::OverrideReason::NO_OVERRIDE);
                 }
             } else {
@@ -566,18 +588,18 @@ struct FullBTBPrediction
         }
     }
 
-    std::pair<int, bool> getHistInfo()  // global or local
+    std::pair<int, bool> getHistInfo()  //global or local
     {
-        int shamt = 0;  // shamt is the number of bits to shift in history update
+        int shamt = 0; // shamt is the number of bits to shift in history update
         bool taken = false;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond) {  // if found a cond branch, shamt++
+                if (entry.isCond) { // if found a cond branch, shamt++
                     shamt++;
-                    auto &pc = entry.pc;
+                    auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
-                        if (it->second) {  // if the cond branch is taken, taken = true
+                        if (it->second) { // if the cond branch is taken, taken = true
                             taken = true;
                             break;
                         }
@@ -593,7 +615,7 @@ struct FullBTBPrediction
         return std::make_pair(shamt, taken);
     }
 
-    std::pair<int, bool> getBwHistInfo()  // global backward or imli
+    std::pair<int, bool> getBwHistInfo() //global backward or imli
     {
         int shamt = 0;
         bool taken = false;
@@ -601,11 +623,11 @@ struct FullBTBPrediction
             if (entry.valid) {
                 if (entry.isCond) {
                     shamt++;
-                    auto &pc = entry.pc;
+                    auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
-                            taken = (entry.target < entry.pc);  // branch is backward if target < pc
+                            taken = (entry.target < entry.pc); // branch is backward if target < pc
                             break;
                         }
                     }
@@ -618,7 +640,7 @@ struct FullBTBPrediction
         return std::make_pair(shamt, taken);
     }
 
-    std::tuple<Addr, Addr, bool> getPHistInfo()  // path
+    std::tuple<Addr, Addr, bool> getPHistInfo() //path
     {
         bool taken = false;
         Addr pc = 0;
@@ -626,12 +648,12 @@ struct FullBTBPrediction
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) {
-                    auto &_pc = entry.pc;
+                    auto& _pc = entry.pc;
                     auto it = CondTakens_find(condTakens, _pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
                             taken = true;
-                            pc = entry.pc;  // get the pc of the cond branch
+                            pc = entry.pc; // get the pc of the cond branch
                             target = entry.target;
                             break;
                         }
@@ -639,13 +661,14 @@ struct FullBTBPrediction
                 } else {
                     // uncond
                     taken = true;
-                    pc = entry.pc;  // get the pc of the cond branch
+                    pc = entry.pc; // get the pc of the cond branch
                     target = entry.target;
                     break;
                 }
             }
         }
         return std::make_tuple(pc, target, taken);
+
     }
 };
 
@@ -705,11 +728,12 @@ getInitialBlock1DropReason(bool enableTwoTaken, bool dropBlock1OnBlock0Override,
 
 struct TageMissTrace : public Record
 {
-    void set(uint64_t startPC, uint64_t branchPC, uint64_t wayIdx, uint64_t mainFound, uint64_t mainCounter,
-             uint64_t mainUseful, uint64_t mainTable, uint64_t mainIndex, uint64_t altFound, uint64_t altCounter,
-             uint64_t altUseful, uint64_t altTable, uint64_t altIndex, uint64_t useAlt, uint64_t predTaken,
-             uint64_t actualTaken, uint64_t allocSuccess, uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay,
-             std::string history, uint64_t indexFoldedHist)
+    void set(uint64_t startPC, uint64_t branchPC, uint64_t wayIdx,
+        uint64_t mainFound, uint64_t mainCounter, uint64_t mainUseful, uint64_t mainTable, uint64_t mainIndex,
+        uint64_t altFound, uint64_t altCounter, uint64_t altUseful, uint64_t altTable, uint64_t altIndex,
+        uint64_t useAlt, uint64_t predTaken, uint64_t actualTaken, uint64_t allocSuccess,
+        uint64_t allocTable, uint64_t allocIndex, uint64_t allocWay,
+        std::string history, uint64_t indexFoldedHist)
     {
         _tick = curTick();
         _uint64_data["startPC"] = startPC;
@@ -737,11 +761,9 @@ struct TageMissTrace : public Record
     }
 };
 
-struct BTBTrace : public Record
-{
+struct BTBTrace : public Record {
     // mode: read, write, evict
-    void set(uint64_t pc, uint64_t brType, uint64_t target, uint64_t idx, uint64_t mode, uint64_t hit)
-    {
+    void set(uint64_t pc, uint64_t brType, uint64_t target, uint64_t idx, uint64_t mode, uint64_t hit) {
         _tick = curTick();
         _uint64_data["pc"] = pc;
         _uint64_data["brType"] = brType;
@@ -755,15 +777,15 @@ struct BTBTrace : public Record
 struct MgscTrace : public Record
 {
     void set(uint64_t branchPC,
-             // TAGE prediction info
-             uint64_t tagePred, uint64_t tageConfHigh, uint64_t tageConfMid, uint64_t tageConfLow,
-             // Percsum for each table (signed values stored as int64)
-             int64_t bwPercsum, int64_t lPercsum, int64_t iPercsum, int64_t gPercsum, int64_t pPercsum,
-             int64_t biasPercsum,
-             // SC decision
-             int64_t totalSum, int64_t totalThres, uint64_t useSc, uint64_t scPred,
-             // Result
-             uint64_t actualTaken)
+        // TAGE prediction info
+        uint64_t tagePred, uint64_t tageConfHigh, uint64_t tageConfMid, uint64_t tageConfLow,
+        // Percsum for each table (signed values stored as int64)
+        int64_t bwPercsum, int64_t lPercsum, int64_t iPercsum,
+        int64_t gPercsum, int64_t pPercsum, int64_t biasPercsum,
+        // SC decision
+        int64_t totalSum, int64_t totalThres, uint64_t useSc, uint64_t scPred,
+        // Result
+        uint64_t actualTaken)
     {
         _tick = curTick();
         _uint64_data["branchPC"] = branchPC;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -21,6 +21,23 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+namespace
+{
+
+const FullBTBPrediction &
+latestStagePrediction(const std::vector<FullBTBPrediction> &stagePreds)
+{
+    for (int i = (int)stagePreds.size() - 1; i >= 0; --i) {
+        if (!stagePreds[i].btbEntries.empty() || !stagePreds[i].condTakens.empty() ||
+            !stagePreds[i].indirectTargets.empty() || stagePreds[i].returnTarget != 0) {
+            return stagePreds[i];
+        }
+    }
+    return stagePreds[0];
+}
+
+}  // namespace
+
 void
 DecoupledBPUWithBTB::consumeFetchTarget(unsigned fetched_inst_num, ThreadID tid)
 {
@@ -33,6 +50,12 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
 
       predictWidth(p.predictWidth),
       maxInstsNum(p.predictWidth / 2),
+      enableTwoTaken(p.enableTwoTaken),
+      dropBlock1OnBlock0Override(p.dropBlock1OnBlock0Override),
+      dropBlock1WhenFTQHasOnlyOneSlot(p.dropBlock1WhenFTQHasOnlyOneSlot),
+      dropBlock1OnCondWithoutTage(p.dropBlock1OnCondWithoutTage),
+      dropBlock1OnIndirectWithoutIttage(p.dropBlock1OnIndirectWithoutIttage),
+      dropBlock1OnReturnWithoutRas(p.dropBlock1OnReturnWithoutRas),
       historyBits(p.maxHistLen),
       ubtb(p.ubtb),
       abtb(p.abtb),
@@ -46,7 +69,7 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       bpDBSwitches(p.bpDBSwitches),
       numStages(p.numStages),
       ftq(2, p.ftq_size),
-      historyManager(16), // TODO: fix this
+      historyManager(16),  // TODO: fix this
       resolveBlockThreshold(p.resolveBlockThreshold),
       dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
 {
@@ -55,14 +78,22 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
     }
     bpType = DecoupledBTBType;
     // Only add enabled components to the list
-    if (ubtb->isEnabled()) components.push_back(ubtb);
-    if (abtb->isEnabled()) components.push_back(abtb);
-    if (microtage->isEnabled()) components.push_back(microtage);
-    if (mbtb->isEnabled()) components.push_back(mbtb);
-    if (tage->isEnabled()) components.push_back(tage);
-    if (ras->isEnabled()) components.push_back(ras);
-    if (ittage->isEnabled()) components.push_back(ittage);
-    if (mgsc->isEnabled()) components.push_back(mgsc);
+    if (ubtb->isEnabled())
+        components.push_back(ubtb);
+    if (abtb->isEnabled())
+        components.push_back(abtb);
+    if (microtage->isEnabled())
+        components.push_back(microtage);
+    if (mbtb->isEnabled())
+        components.push_back(mbtb);
+    if (tage->isEnabled())
+        components.push_back(tage);
+    if (ras->isEnabled())
+        components.push_back(ras);
+    if (ittage->isEnabled())
+        components.push_back(ittage);
+    if (mgsc->isEnabled())
+        components.push_back(mgsc);
     numComponents = components.size();
     for (int i = 0; i < numComponents; i++) {
         components[i]->setComponentIdx(i);
@@ -86,8 +117,8 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
         printf("\n");
     }
 
-    for (int tid=0;tid<numThreads; tid++) {
-        auto& thread = threads[tid];
+    for (int tid = 0; tid < numThreads; tid++) {
+        auto &thread = threads[tid];
 
         thread.s0PC = 0x80000000;
         thread.predsOfEachStage.resize(numStages);
@@ -105,14 +136,12 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
         thread.squashing = true;
     }
 
-    commitFsqEntryHasInstsVector.resize(maxInstsNum+1, 0);
-    lastPhaseFsqEntryNumCommittedInstDist.resize(maxInstsNum+1, 0);
-    commitFsqEntryFetchedInstsVector.resize(maxInstsNum+1, 0);
-    lastPhaseFsqEntryNumFetchedInstDist.resize(maxInstsNum+1, 0);
+    commitFsqEntryHasInstsVector.resize(maxInstsNum + 1, 0);
+    lastPhaseFsqEntryNumCommittedInstDist.resize(maxInstsNum + 1, 0);
+    commitFsqEntryFetchedInstsVector.resize(maxInstsNum + 1, 0);
+    lastPhaseFsqEntryNumFetchedInstDist.resize(maxInstsNum + 1, 0);
 
-    registerExitCallback([this]() {
-        this->dumpStats();
-    });
+    registerExitCallback([this]() { this->dumpStats(); });
 }
 
 
@@ -158,7 +187,7 @@ DecoupledBPUWithBTB::tick()
         processNewPrediction(tid);
 
         // Decrement override bubbles counter
-        auto& numOverrideBubbles = threads[tid].numOverrideBubbles;
+        auto &numOverrideBubbles = threads[tid].numOverrideBubbles;
         if (numOverrideBubbles > 0) {
             numOverrideBubbles--;
             dbpBtbStats.overrideBubbleNum++;
@@ -178,8 +207,8 @@ DecoupledBPUWithBTB::tick()
 void
 DecoupledBPUWithBTB::requestNewPrediction(ThreadID tid)
 {
-    auto& thread = threads[tid];
-    auto& predsOfEachStage = threads[tid].predsOfEachStage;
+    auto &thread = threads[tid];
+    auto &predsOfEachStage = threads[tid].predsOfEachStage;
 
     DPRINTF(Override, "Requesting new prediction for PC %#lx\n", thread.s0PC);
 
@@ -192,10 +221,12 @@ DecoupledBPUWithBTB::requestNewPrediction(ThreadID tid)
 
     // Query each predictor component with current PC and history
     for (int i = 0; i < numComponents; i++) {
-        components[i]->putPCHistory(thread.s0PC, thread.s0History, predsOfEachStage);  //s0History not used
+        components[i]->putPCHistory(thread.s0PC, thread.s0History, predsOfEachStage);  // s0History not used
     }
 
     generateFinalPredAndCreateBubbles(tid);
+
+    buildPredictionBundle(tid);
 
     DPRINTF(Override, "Generating final prediction for PC %#lx\n", thread.s0PC);
 
@@ -209,8 +240,8 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 {
     DPRINTF(Override, "In generateFinalPredAndCreateBubbles().\n");
 
-    auto& predsOfEachStage = threads[tid].predsOfEachStage;
-    auto& finalPred = threads[tid].finalPred;
+    auto &predsOfEachStage = threads[tid].predsOfEachStage;
+    auto &finalPred = threads[tid].finalPred;
 
     // 1. Debug output: dump predictions from all stages
     for (int i = 0; i < numStages; i++) {
@@ -233,12 +264,12 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     // Store the chosen prediction as our final prediction
     finalPred = *chosenPrediction;
 
-    finalPred.s1Source = -1;//meaning fallthrough
+    finalPred.s1Source = -1;  // meaning fallthrough
     finalPred.s3Source = -1;
 
     if (predsOfEachStage[0].btbEntries.size() != 0) {
-        for (auto entry : predsOfEachStage[0].btbEntries){
-            if (entry.isIndirect || entry.isDirect || entry.ctr >= 0 ||entry.alwaysTaken){
+        for (auto entry : predsOfEachStage[0].btbEntries) {
+            if (entry.isIndirect || entry.isDirect || entry.ctr >= 0 || entry.alwaysTaken) {
                 finalPred.s1Source = entry.source;
                 break;
             }
@@ -251,8 +282,8 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     for (BTBEntry entry : predsOfEachStage[2].btbEntries) {
         if (entry.isDirect || entry.isIndirect || entry.ctr >= 0 || entry.alwaysTaken) {
             found_s3_taken = true;
-        }else if (entry.isCond){
-            //only use when there's no taken prediction in s3
+        } else if (entry.isCond) {
+            // only use when there's no taken prediction in s3
             na_s3_taken_but_have_cond = true;
         }
     }
@@ -264,15 +295,15 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
                 finalPred.s3Source = ras->getComponentIdx();
             } else if (pred_taken_entry.isIndirect && ittage->tageHit()) {
                 finalPred.s3Source = ittage->getComponentIdx();
-            }else if (pred_taken_entry.isCond) {
+            } else if (pred_taken_entry.isCond) {
                 finalPred.s3Source = tage->getComponentIdx();
             } else {
                 finalPred.s3Source = mbtb->getComponentIdx();
             }
-        }else {
+        } else {
             if (na_s3_taken_but_have_cond) {
                 finalPred.s3Source = tage->getComponentIdx();
-            }else {
+            } else {
                 finalPred.s3Source = -1;
             }
         }
@@ -354,24 +385,19 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
         return;
     }
 
-    auto& s0PC = threads[tid].s0PC;
+    auto &bundle = threads[tid].bundle;
+    auto initialState = makeSpecState(tid);
 
     // Validate PC value
-    if (s0PC == MaxAddr) {
-        DPRINTF(DecoupleBP, "Invalid PC value %#lx, cannot make prediction\n", s0PC);
+    if (initialState.pc == MaxAddr) {
+        DPRINTF(DecoupleBP, "Invalid PC value %#lx, cannot make prediction\n", initialState.pc);
         return;
     }
 
-    DPRINTF(DecoupleBP, "Creating new prediction for PC %#lx\n", s0PC);
+    DPRINTF(DecoupleBP, "Creating new prediction for PC %#lx\n", initialState.pc);
 
     // 1. Create a new fetch target entry with prediction information
-    FetchTarget entry = createFetchTargetEntry(tid);
-
-    // 2. Update global PC state to target or fall-through
-    s0PC = threads[tid].finalPred.getTarget(predictWidth);;
-
-    // 3. Update history information
-    updateHistoryForPrediction(entry);
+    FetchTarget entry = createFetchTargetEntry(tid, initialState, bundle.pred0, bundle.pred0Metas);
 
     // 4. Fill ahead pipeline
     fillAheadPipeline(entry);
@@ -382,16 +408,169 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
 
     // 5. Add entry to fetch target queue
     ftq.insert(entry);
+    dbpBtbStats.fsqEntryEnqueued++;
+
+    if (bundle.hasPred1) {
+        FetchTarget entry1 = createFetchTargetEntry(tid, bundle.stateAfter0, bundle.pred1, bundle.pred1Metas);
+        fillAheadPipeline(entry1);
+        if (enablePredFSQTrace) {
+            predTraceManager->write_record(PredictionTrace(ftq.backId(tid), entry1));
+        }
+        ftq.insert(entry1);
+        printTarget(entry1);
+        dbpBtbStats.fsqEntryEnqueued++;
+    }
+
+    commitSpecState(tid, bundle.stateAfterFinal);
     threads[tid].validprediction = false;
 
     // 6. Debug output and update statistics
     dumpFsq("after insert new target");
-    DPRINTF(DecoupleBP, "Inserted fetch target %lu starting at PC %#lx\n",
-            ftq.backId(tid), entry.startPC);
+    DPRINTF(DecoupleBP, "Inserted fetch target %lu starting at PC %#lx\n", ftq.backId(tid), entry.startPC);
 
     // 7. Increment statistics
     printTarget(entry);
-    dbpBtbStats.fsqEntryEnqueued++;
+}
+
+DecoupledBPUWithBTB::SpecState
+DecoupledBPUWithBTB::makeSpecState(ThreadID tid) const
+{
+    SpecState state;
+    state.pc = threads[tid].s0PC;
+    state.history = threads[tid].s0History;
+    state.phistory = threads[tid].s0PHistory;
+    state.bwhistory = threads[tid].s0BwHistory;
+    state.lhistory = threads[tid].s0LHistory;
+    return state;
+}
+
+void
+DecoupledBPUWithBTB::commitSpecState(ThreadID tid, const SpecState &state)
+{
+    threads[tid].s0PC = state.pc;
+    threads[tid].s0History = state.history;
+    threads[tid].s0PHistory = state.phistory;
+    threads[tid].s0BwHistory = state.bwhistory;
+    threads[tid].s0LHistory = state.lhistory;
+}
+
+std::array<std::shared_ptr<void>, 8>
+DecoupledBPUWithBTB::capturePredictionMetas() const
+{
+    std::array<std::shared_ptr<void>, 8> predMetas{};
+    predMetas.fill(nullptr);
+    for (int i = 0; i < numComponents; i++) {
+        predMetas[i] = components[i]->getPredictionMeta();
+    }
+    return predMetas;
+}
+
+void
+DecoupledBPUWithBTB::buildPredictionBundle(ThreadID tid)
+{
+    auto &thread = threads[tid];
+    auto &bundle = thread.bundle;
+    auto initialState = makeSpecState(tid);
+
+    bundle.pred0 = thread.finalPred;
+    bundle.pred0Metas = capturePredictionMetas();
+    bundle.hasPred1 = false;
+    bundle.pred1 = FullBTBPrediction();
+    bundle.pred1Metas.fill(nullptr);
+    bundle.pred1DropReason = getInitialBlock1DropReason(
+        enableTwoTaken, dropBlock1OnBlock0Override, thread.finalPred.overrideReason != OverrideReason::NO_OVERRIDE,
+        dropBlock1WhenFTQHasOnlyOneSlot, ftq.freeSlots(tid), thread.finalPred.getTarget(predictWidth),
+        !thread.predsOfEachStage.empty() && !thread.predsOfEachStage[0].btbEntries.empty(), MaxAddr);
+    bundle.stateAfter0 = computeNextSpecState(tid, initialState, bundle.pred0, ftq.backId(tid) + 1);
+    bundle.stateAfterFinal = bundle.stateAfter0;
+
+    if (enableTwoTaken) {
+        dbpBtbStats.block1Attempted++;
+    }
+
+    if (bundle.pred1DropReason != Block1DropReason::None) {
+        switch (bundle.pred1DropReason) {
+            case Block1DropReason::Block0Override:
+                dbpBtbStats.block1DroppedByBlock0Override++;
+                break;
+            case Block1DropReason::FTQNoSpace:
+                dbpBtbStats.block1DroppedByFTQFull++;
+                break;
+            default:
+                dbpBtbStats.block1DroppedOther++;
+                break;
+        }
+        return;
+    }
+
+    std::vector<FullBTBPrediction> block1StagePreds(numStages);
+    for (int i = 0; i < numStages; i++) {
+        block1StagePreds[i].tid = tid;
+        block1StagePreds[i].bbStart = bundle.stateAfter0.pc;
+    }
+
+    FullBTBPrediction lowerPred;
+    lowerPred.tid = tid;
+    lowerPred.bbStart = bundle.stateAfter0.pc;
+    for (int i = 0; i < numComponents; i++) {
+        components[i]->putPCHistoryForBlock1(bundle.stateAfter0.pc, bundle.stateAfter0.history,
+                                             bundle.stateAfter0.phistory, bundle.stateAfter0.bwhistory,
+                                             bundle.stateAfter0.lhistory, block1StagePreds, lowerPred);
+        lowerPred = latestStagePrediction(block1StagePreds);
+    }
+
+    FullBTBPrediction *chosenPrediction = &block1StagePreds[0];
+    for (int i = (int)numStages - 1; i >= 0; i--) {
+        if (!block1StagePreds[i].btbEntries.empty()) {
+            chosenPrediction = &block1StagePreds[i];
+            break;
+        }
+    }
+
+    bundle.pred1 = *chosenPrediction;
+    unsigned first_hit_stage = 0;
+    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
+    while (first_hit_stage < numStages - 1) {
+        auto [matches, reason] = block1StagePreds[first_hit_stage].match(*chosenPrediction, predictWidth);
+        if (matches) {
+            break;
+        }
+        first_hit_stage++;
+        overrideReason = reason;
+    }
+    bundle.pred1.predSource = first_hit_stage;
+    bundle.pred1.overrideReason = overrideReason;
+
+    bundle.pred1DropReason = getBlock1DropReason(
+        bundle.pred1, dropBlock1OnCondWithoutTage, tage->participatesInBlock1(), dropBlock1OnIndirectWithoutIttage,
+        ittage->participatesInBlock1(), dropBlock1OnReturnWithoutRas, ras->participatesInBlock1());
+    if (bundle.pred1DropReason != Block1DropReason::None || bundle.pred1.btbEntries.empty()) {
+        if (bundle.pred1DropReason == Block1DropReason::None) {
+            bundle.pred1DropReason = Block1DropReason::PredictorRejected;
+        }
+        switch (bundle.pred1DropReason) {
+            case Block1DropReason::CondNoSupport:
+                dbpBtbStats.block1DroppedByCond++;
+                break;
+            case Block1DropReason::IndirectNoSupport:
+                dbpBtbStats.block1DroppedByIndirect++;
+                break;
+            case Block1DropReason::ReturnNoSupport:
+                dbpBtbStats.block1DroppedByReturn++;
+                break;
+            default:
+                dbpBtbStats.block1DroppedOther++;
+                break;
+        }
+        bundle.pred1 = FullBTBPrediction();
+        bundle.stateAfterFinal = bundle.stateAfter0;
+        return;
+    }
+
+    bundle.pred1Metas = capturePredictionMetas();
+    bundle.hasPred1 = true;
+    dbpBtbStats.block1Accepted++;
+    bundle.stateAfterFinal = computeNextSpecState(tid, bundle.stateAfter0, bundle.pred1, ftq.backId(tid) + 2);
 }
 
 /**
@@ -414,14 +593,9 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
  * @param control_inst_size Size of the control instruction (for control squash)
  */
 void
-DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id,
-                                 SquashType squash_type,
-                                 const PCStateBase &squash_pc,
-                                 Addr redirect_pc,
-                                 bool is_conditional,
-                                 bool actually_taken,
-                                 const StaticInstPtr &static_inst,
-                                 unsigned control_inst_size)
+DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id, SquashType squash_type,
+                                  const PCStateBase &squash_pc, Addr redirect_pc, bool is_conditional,
+                                  bool actually_taken, const StaticInstPtr &static_inst, unsigned control_inst_size)
 {
     // Set squashing state
     threads[tid].squashing = true;
@@ -461,19 +635,15 @@ DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id,
     // Update PC and target ID
     threads[tid].s0PC = redirect_pc;
 
-    DPRINTF(DecoupleBP,
-            "After squash, fsqId(next alloc)=%lu, fetchHeadFsqId=%lu, s0pc=%#lx\n",
-            ftq.backId(tid) + 1, ftq.frontId(tid), redirect_pc);
+    DPRINTF(DecoupleBP, "After squash, fsqId(next alloc)=%lu, fetchHeadFsqId=%lu, s0pc=%#lx\n", ftq.backId(tid) + 1,
+            ftq.frontId(tid), redirect_pc);
 }
 
 void
-DecoupledBPUWithBTB::controlSquash(unsigned target_id,
-                            const PCStateBase &control_pc,
-                            const PCStateBase &corr_target,
-                            const StaticInstPtr &static_inst,
-                            unsigned control_inst_size, bool actually_taken,
-                            const InstSeqNum &seq, ThreadID tid,
-                            const unsigned &currentLoopIter, const bool fromCommit)
+DecoupledBPUWithBTB::controlSquash(unsigned target_id, const PCStateBase &control_pc, const PCStateBase &corr_target,
+                                   const StaticInstPtr &static_inst, unsigned control_inst_size, bool actually_taken,
+                                   const InstSeqNum &seq, ThreadID tid, const unsigned &currentLoopIter,
+                                   const bool fromCommit)
 {
     if (fromCommit) {
         dbpBtbStats.controlSquashFromCommit++;
@@ -505,19 +675,16 @@ DecoupledBPUWithBTB::controlSquash(unsigned target_id,
             "Control squash: ftq_id=%d,"
             " control_pc=%#lx, real_target=%#lx, is_conditional=%u, "
             "is_indirect=%u, actually_taken=%u, branch seq: %lu\n",
-            target_id, control_pc.instAddr(),
-            real_target, is_conditional, is_indirect,
-            actually_taken, seq);
+            target_id, control_pc.instAddr(), real_target, is_conditional, is_indirect, actually_taken, seq);
 
     // Call shared squash handling logic
-    handleSquash(tid, target_id, SQUASH_CTRL, control_pc,
-                real_target, is_conditional, actually_taken, static_inst, control_inst_size);
+    handleSquash(tid, target_id, SQUASH_CTRL, control_pc, real_target, is_conditional, actually_taken, static_inst,
+                 control_inst_size);
 }
 
 void
-DecoupledBPUWithBTB::nonControlSquash(unsigned target_id,
-                               const PCStateBase &inst_pc,
-                               const InstSeqNum seq, ThreadID tid, const unsigned &currentLoopIter)
+DecoupledBPUWithBTB::nonControlSquash(unsigned target_id, const PCStateBase &inst_pc, const InstSeqNum seq,
+                                      ThreadID tid, const unsigned &currentLoopIter)
 {
     dbpBtbStats.nonControlSquash++;
     DPRINTF(DecoupleBP,
@@ -530,14 +697,11 @@ DecoupledBPUWithBTB::nonControlSquash(unsigned target_id,
 }
 
 void
-DecoupledBPUWithBTB::trapSquash(unsigned target_id,
-                         Addr last_committed_pc, const PCStateBase &inst_pc,
-                         ThreadID tid, const unsigned &currentLoopIter)
+DecoupledBPUWithBTB::trapSquash(unsigned target_id, Addr last_committed_pc, const PCStateBase &inst_pc, ThreadID tid,
+                                const unsigned &currentLoopIter)
 {
     dbpBtbStats.trapSquash++;
-    DPRINTF(DecoupleBP,
-            "Trap squash: target id: %d, inst_pc: %#lx\n",
-            target_id, inst_pc.instAddr());
+    DPRINTF(DecoupleBP, "Trap squash: target id: %d, inst_pc: %#lx\n", target_id, inst_pc.instAddr());
 
     // Call shared squash handling logic
     handleSquash(tid, target_id, SQUASH_TRAP, inst_pc, inst_pc.instAddr());
@@ -715,7 +879,7 @@ DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<>
     if (shamt == 0) {
         return;
     }
-    if(taken){
+    if (taken) {
         // Calculate path hash
         uint64_t hash = pathHash(pc, target);
 
@@ -732,55 +896,84 @@ DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<>
  *
  * @return FetchTarget The created fetch target
  */
-FetchTarget
-DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
+DecoupledBPUWithBTB::SpecState
+DecoupledBPUWithBTB::computeNextSpecState(ThreadID tid, const SpecState &state, const FullBTBPrediction &pred,
+                                          FetchTargetId targetId)
 {
-    auto& s0PC = threads[tid].s0PC;
-    auto& s0History = threads[tid].s0History;
-    auto& s0PHistory = threads[tid].s0PHistory;
-    auto& s0BwHistory = threads[tid].s0BwHistory;
-    auto& s0LHistory = threads[tid].s0LHistory;
-    auto& finalPred = threads[tid].finalPred;
+    SpecState next = state;
+    auto predCopy = pred;
 
+    for (int i = 0; i < numComponents; i++) {
+        components[i]->specUpdateHist(next.history, predCopy);
+        if (components[i]->needMoreHistories) {
+            components[i]->specUpdatePHist(next.phistory, predCopy);
+            components[i]->specUpdateBwHist(next.bwhistory, predCopy);
+            components[i]->specUpdateIHist(predCopy);
+            components[i]->specUpdateLHist(next.lhistory, predCopy);
+        }
+    }
+
+    auto [shamt, taken] = predCopy.getHistInfo();
+    histShiftIn(shamt, taken, next.history);
+    BranchInfo histBranchInfo;
+    if (predCopy.isTaken()) {
+        histBranchInfo = predCopy.getTakenEntry().getBranchInfo();
+    }
+    historyManager.addSpeculativeHist(state.pc, shamt, taken, histBranchInfo, targetId);
+
+    auto [bw_shamt, bw_taken] = predCopy.getBwHistInfo();
+    auto [p_pc, p_target, p_taken] = predCopy.getPHistInfo();
+    histShiftIn(bw_shamt, bw_taken, next.bwhistory);
+    pHistShiftIn(2, p_taken, next.phistory, p_pc, p_target);
+    histShiftIn(shamt, taken,
+                next.lhistory[mgsc->getPcIndex(predCopy.bbStart, log2(mgsc->getNumEntriesFirstLocalHistories()))]);
+
+    next.pc = predCopy.getTarget(predictWidth);
+    return next;
+}
+
+FetchTarget
+DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid, const SpecState &state, const FullBTBPrediction &pred,
+                                            const std::array<std::shared_ptr<void>, 8> &predMetas)
+{
+    auto predCopy = pred;
     // Create a new fetch target entry
     FetchTarget entry;
     entry.tid = tid;
-    entry.startPC = s0PC;
+    entry.startPC = state.pc;
 
     // Extract branch prediction information
-    bool taken = finalPred.isTaken();
-    Addr fallThroughAddr = finalPred.getFallThrough(predictWidth);
-    Addr nextPC = finalPred.getTarget(predictWidth);
+    bool taken = predCopy.isTaken();
+    Addr fallThroughAddr = predCopy.getFallThrough(predictWidth);
+    Addr nextPC = predCopy.getTarget(predictWidth);
 
     // Configure target entry with prediction details
-    entry.isHit = !finalPred.btbEntries.empty();
+    entry.isHit = !predCopy.btbEntries.empty();
     entry.falseHit = false;
-    entry.predBTBEntries = finalPred.btbEntries;
+    entry.predBTBEntries = predCopy.btbEntries;
     entry.predTaken = taken;
     entry.predEndPC = fallThroughAddr;
 
     // Set branch info for taken predictions
     if (taken) {
-        entry.predBranchInfo = finalPred.getTakenEntry().getBranchInfo();
-        entry.predBranchInfo.target = nextPC; // Use final target (may not be from BTB)
+        entry.predBranchInfo = predCopy.getTakenEntry().getBranchInfo();
+        entry.predBranchInfo.target = nextPC;  // Use final target (may not be from BTB)
     }
 
     // Record current history and prediction metadata
-    entry.history = s0History;
-    entry.phistory = s0PHistory;
-    entry.bwhistory = s0BwHistory;
-    entry.lhistory = s0LHistory;
-    entry.predTick = finalPred.predTick;
-    entry.predSource = finalPred.predSource;
-    entry.overrideReason = finalPred.overrideReason;
+    entry.history = state.history;
+    entry.phistory = state.phistory;
+    entry.bwhistory = state.bwhistory;
+    entry.lhistory = state.lhistory;
+    entry.predTick = predCopy.predTick;
+    entry.predSource = predCopy.predSource;
+    entry.overrideReason = predCopy.overrideReason;
 
-    entry.s1Source = finalPred.s1Source;
-    entry.s3Source = finalPred.s3Source;
+    entry.s1Source = predCopy.s1Source;
+    entry.s3Source = predCopy.s3Source;
 
     // Save predictors' metadata
-    for (int i = 0; i < numComponents; i++) {
-        entry.predMetas[i] = components[i]->getPredictionMeta();
-    }
+    entry.predMetas = predMetas;
 
     // Initialize default resolution state
     entry.setDefaultResolve();
@@ -825,13 +1018,13 @@ DecoupledBPUWithBTB::checkHistory(const boost::dynamic_bitset<> &history)
     boost::dynamic_bitset<> ideal_hash_hist(historyBits, 0);
 
     // Iterate through all speculative history entries stored in HistoryManager
-    for (const auto entry: historyManager.getSpeculativeHist()) {
+    for (const auto entry : historyManager.getSpeculativeHist()) {
         // Only process entries that have non-zero shift amount (actual branches)
         if (entry.shamt != 0) {
             // Accumulate total history bits
             ideal_size += entry.shamt;
-            DPRINTF(DecoupleBPVerbose, "pc: %#lx, shamt: %lu, cond_taken: %d\n", entry.pc,
-                    entry.shamt, entry.cond_taken);
+            DPRINTF(DecoupleBPVerbose, "pc: %#lx, shamt: %lu, cond_taken: %d\n", entry.pc, entry.shamt,
+                    entry.cond_taken);
 
             // Rebuild history by shifting and setting bits based on recorded outcomes
             // This emulates how history would be built if all branches were predicted perfectly
@@ -852,9 +1045,8 @@ DecoupledBPUWithBTB::checkHistory(const boost::dynamic_bitset<> &history)
 
     // boost::to_string(ideal_hash_hist, buf1);
     // boost::to_string(sized_real_hist, buf2);
-    DPRINTF(DecoupleBP,
-            "Ideal size:\t%u, real history size:\t%u, comparable size:\t%u\n",
-            ideal_size, historyBits, comparable_size);
+    DPRINTF(DecoupleBP, "Ideal size:\t%u, real history size:\t%u, comparable size:\t%u\n", ideal_size, historyBits,
+            comparable_size);
     // DPRINTF(DecoupleBP, "Ideal history:\t%s\nreal history:\t%s\n",
     //         buf1.c_str(), buf2.c_str());
 
@@ -883,75 +1075,6 @@ DecoupledBPUWithBTB::getPreservedReturnAddr(const DynInstPtr &dynInst)
  *
  * @param entry The fetch target entry to update history for
  */
-void
-DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
-{
-    ThreadID tid = entry.tid;
-    auto& s0History = threads[tid].s0History;
-    auto& s0PHistory = threads[tid].s0PHistory;
-    auto& s0BwHistory = threads[tid].s0BwHistory;
-    auto& s0LHistory = threads[tid].s0LHistory;
-    auto& finalPred = threads[tid].finalPred;
-
-
-    // Update component-specific history, for TAGE/ITTAGE/MGSC
-    for (int i = 0; i < numComponents; i++) {
-        // use old s0History to update folded history, then use finalPred to update folded history
-        components[i]->specUpdateHist(s0History, finalPred);
-        if(components[i]->needMoreHistories){
-            components[i]->specUpdatePHist(s0PHistory, finalPred);
-            components[i]->specUpdateBwHist(s0BwHistory, finalPred);
-            components[i]->specUpdateIHist(finalPred);
-            components[i]->specUpdateLHist(s0LHistory, finalPred);
-        }
-    }
-
-    // Get prediction information for history updates
-    int shamt;
-    bool taken;
-    std::tie(shamt, taken) = finalPred.getHistInfo();
-
-    // Update global history
-    histShiftIn(shamt, taken, s0History);
-
-    // Update history manager and verify TAGE folded history
-    historyManager.addSpeculativeHist(
-        entry.startPC, shamt, taken, entry.predBranchInfo, ftq.backId(tid) + 1);
-
-    // Get prediction information for global backward history updates
-    int bw_shamt;
-    bool bw_taken;
-    std::tie(bw_shamt, bw_taken) = finalPred.getBwHistInfo();
-
-    // Get prediction information for path history updates
-    auto [p_pc, p_target, p_taken]= finalPred.getPHistInfo(); // p_taken = taken
-
-    // Update global backward history
-    histShiftIn(bw_shamt, bw_taken, s0BwHistory);
-
-    // Update path history
-    pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);
-
-    // Update local history
-    histShiftIn(shamt, taken,
-        s0LHistory[mgsc->getPcIndex(finalPred.bbStart, log2(mgsc->getNumEntriesFirstLocalHistories()))]);
-
-#ifndef NDEBUG
-    if (tage->isEnabled()) {
-        tage->checkFoldedHist(s0PHistory, "speculative update");
-    }
-    if (ittage->isEnabled()) {
-        ittage->checkFoldedHist(s0PHistory, "speculative update");
-    }
-    if (microtage->isEnabled()) {
-        microtage->checkFoldedHist(s0PHistory, "speculative update");
-    }
-    if (mgsc->isEnabled()) {
-        mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, "speculative update");
-    }
-#endif
-}
-
 /**
  * @brief Recovers branch history during a squash event
  *
@@ -963,23 +1086,18 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
  * @param squash_type Type of squash (CTRL/OTHER/TRAP)
  */
 void
-DecoupledBPUWithBTB::recoverHistoryForSquash(
-    FetchTarget &target,
-    unsigned target_id,
-    const PCStateBase &squash_pc,
-    bool is_conditional,
-    bool actually_taken,
-    SquashType squash_type,
-    Addr redirect_pc)
+DecoupledBPUWithBTB::recoverHistoryForSquash(FetchTarget &target, unsigned target_id, const PCStateBase &squash_pc,
+                                             bool is_conditional, bool actually_taken, SquashType squash_type,
+                                             Addr redirect_pc)
 {
     ThreadID tid = target.tid;
-    auto& s0History = threads[tid].s0History;
-    auto& s0PHistory = threads[tid].s0PHistory;
-    auto& s0BwHistory = threads[tid].s0BwHistory;
-    auto& s0LHistory = threads[tid].s0LHistory;
+    auto &s0History = threads[tid].s0History;
+    auto &s0PHistory = threads[tid].s0PHistory;
+    auto &s0BwHistory = threads[tid].s0BwHistory;
+    auto &s0LHistory = threads[tid].s0LHistory;
 
-    //printf("recover target_id: %u\n", target_id);
-    // Restore history from the target
+    // printf("recover target_id: %u\n", target_id);
+    //  Restore history from the target
     s0History = target.history;
     s0PHistory = target.phistory;
     s0BwHistory = target.bwhistory;
@@ -988,19 +1106,19 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     // Get actual history shift information
     int real_shamt;
     bool real_taken;
-    std::tie(real_shamt, real_taken) = target.getHistInfoDuringSquash(
-        squash_pc.instAddr(), is_conditional, actually_taken);
+    std::tie(real_shamt, real_taken) =
+        target.getHistInfoDuringSquash(squash_pc.instAddr(), is_conditional, actually_taken);
 
     // Get actual history shift information
     int real_bw_shamt;
     bool real_bw_taken;
-    std::tie(real_bw_shamt, real_bw_taken) = target.getBwHistInfoDuringSquash(
-    squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
+    std::tie(real_bw_shamt, real_bw_taken) =
+        target.getBwHistInfoDuringSquash(squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {
         components[i]->recoverHist(s0History, target, real_shamt, real_taken);
-        if (components[i]->needMoreHistories){
+        if (components[i]->needMoreHistories) {
             components[i]->recoverPHist(s0PHistory, target, real_shamt, real_taken);
             components[i]->recoverBwHist(s0BwHistory, target, real_bw_shamt, real_bw_taken);
             components[i]->recoverIHist(target, real_bw_shamt, real_bw_taken);
@@ -1032,24 +1150,25 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
 #ifndef NDEBUG
     checkHistory(s0History);
     if (tage->isEnabled()) {
-        tage->checkFoldedHist(s0PHistory,
-            squash_type == SQUASH_CTRL ? "control squash" :
-            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+        tage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
+                                          : squash_type == SQUASH_OTHER ? "non control squash"
+                                                                        : "trap squash");
     }
     if (ittage->isEnabled()) {
-        ittage->checkFoldedHist(s0PHistory,
-            squash_type == SQUASH_CTRL ? "control squash" :
-            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+        ittage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
+                                            : squash_type == SQUASH_OTHER ? "non control squash"
+                                                                          : "trap squash");
     }
     if (microtage->isEnabled()) {
-        microtage->checkFoldedHist(s0PHistory,
-            squash_type == SQUASH_CTRL ? "control squash" :
-            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+        microtage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
+                                               : squash_type == SQUASH_OTHER ? "non control squash"
+                                                                             : "trap squash");
     }
     if (mgsc->isEnabled()) {
         mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory,
-            squash_type == SQUASH_CTRL ? "control squash" :
-            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
+                              squash_type == SQUASH_CTRL    ? "control squash"
+                              : squash_type == SQUASH_OTHER ? "non control squash"
+                                                            : "trap squash");
     }
 #endif
 }

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -541,9 +541,12 @@ DecoupledBPUWithBTB::buildPredictionBundle(ThreadID tid)
     bundle.pred1.predSource = first_hit_stage;
     bundle.pred1.overrideReason = overrideReason;
 
-    bundle.pred1DropReason = getBlock1DropReason(
-        bundle.pred1, dropBlock1OnCondWithoutTage, tage->participatesInBlock1(), dropBlock1OnIndirectWithoutIttage,
-        ittage->participatesInBlock1(), dropBlock1OnReturnWithoutRas, ras->participatesInBlock1());
+    bool hasCondDirectionSupport = tage->participatesInBlock1() || !bundle.pred1.condTakens.empty();
+    bool hasIndirectTargetSupport = ittage->participatesInBlock1() || !bundle.pred1.indirectTargets.empty();
+    bool hasReturnTargetSupport = ras->participatesInBlock1() || bundle.pred1.returnTarget != 0;
+    bundle.pred1DropReason = getBlock1DropReason(bundle.pred1, dropBlock1OnCondWithoutTage, hasCondDirectionSupport,
+                                                 dropBlock1OnIndirectWithoutIttage, hasIndirectTargetSupport,
+                                                 dropBlock1OnReturnWithoutRas, hasReturnTargetSupport);
     if (bundle.pred1DropReason != Block1DropReason::None || bundle.pred1.btbEntries.empty()) {
         if (bundle.pred1DropReason == Block1DropReason::None) {
             bundle.pred1DropReason = Block1DropReason::PredictorRejected;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -69,7 +69,7 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       bpDBSwitches(p.bpDBSwitches),
       numStages(p.numStages),
       ftq(2, p.ftq_size),
-      historyManager(16),  // TODO: fix this
+      historyManager(16), // TODO: fix this
       resolveBlockThreshold(p.resolveBlockThreshold),
       dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
 {
@@ -78,22 +78,14 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
     }
     bpType = DecoupledBTBType;
     // Only add enabled components to the list
-    if (ubtb->isEnabled())
-        components.push_back(ubtb);
-    if (abtb->isEnabled())
-        components.push_back(abtb);
-    if (microtage->isEnabled())
-        components.push_back(microtage);
-    if (mbtb->isEnabled())
-        components.push_back(mbtb);
-    if (tage->isEnabled())
-        components.push_back(tage);
-    if (ras->isEnabled())
-        components.push_back(ras);
-    if (ittage->isEnabled())
-        components.push_back(ittage);
-    if (mgsc->isEnabled())
-        components.push_back(mgsc);
+    if (ubtb->isEnabled()) components.push_back(ubtb);
+    if (abtb->isEnabled()) components.push_back(abtb);
+    if (microtage->isEnabled()) components.push_back(microtage);
+    if (mbtb->isEnabled()) components.push_back(mbtb);
+    if (tage->isEnabled()) components.push_back(tage);
+    if (ras->isEnabled()) components.push_back(ras);
+    if (ittage->isEnabled()) components.push_back(ittage);
+    if (mgsc->isEnabled()) components.push_back(mgsc);
     numComponents = components.size();
     for (int i = 0; i < numComponents; i++) {
         components[i]->setComponentIdx(i);
@@ -117,8 +109,8 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
         printf("\n");
     }
 
-    for (int tid = 0; tid < numThreads; tid++) {
-        auto &thread = threads[tid];
+    for (int tid=0;tid<numThreads; tid++) {
+        auto& thread = threads[tid];
 
         thread.s0PC = 0x80000000;
         thread.predsOfEachStage.resize(numStages);
@@ -136,12 +128,14 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
         thread.squashing = true;
     }
 
-    commitFsqEntryHasInstsVector.resize(maxInstsNum + 1, 0);
-    lastPhaseFsqEntryNumCommittedInstDist.resize(maxInstsNum + 1, 0);
-    commitFsqEntryFetchedInstsVector.resize(maxInstsNum + 1, 0);
-    lastPhaseFsqEntryNumFetchedInstDist.resize(maxInstsNum + 1, 0);
+    commitFsqEntryHasInstsVector.resize(maxInstsNum+1, 0);
+    lastPhaseFsqEntryNumCommittedInstDist.resize(maxInstsNum+1, 0);
+    commitFsqEntryFetchedInstsVector.resize(maxInstsNum+1, 0);
+    lastPhaseFsqEntryNumFetchedInstDist.resize(maxInstsNum+1, 0);
 
-    registerExitCallback([this]() { this->dumpStats(); });
+    registerExitCallback([this]() {
+        this->dumpStats();
+    });
 }
 
 
@@ -187,7 +181,7 @@ DecoupledBPUWithBTB::tick()
         processNewPrediction(tid);
 
         // Decrement override bubbles counter
-        auto &numOverrideBubbles = threads[tid].numOverrideBubbles;
+        auto& numOverrideBubbles = threads[tid].numOverrideBubbles;
         if (numOverrideBubbles > 0) {
             numOverrideBubbles--;
             dbpBtbStats.overrideBubbleNum++;
@@ -207,8 +201,8 @@ DecoupledBPUWithBTB::tick()
 void
 DecoupledBPUWithBTB::requestNewPrediction(ThreadID tid)
 {
-    auto &thread = threads[tid];
-    auto &predsOfEachStage = threads[tid].predsOfEachStage;
+    auto& thread = threads[tid];
+    auto& predsOfEachStage = threads[tid].predsOfEachStage;
 
     DPRINTF(Override, "Requesting new prediction for PC %#lx\n", thread.s0PC);
 
@@ -221,7 +215,7 @@ DecoupledBPUWithBTB::requestNewPrediction(ThreadID tid)
 
     // Query each predictor component with current PC and history
     for (int i = 0; i < numComponents; i++) {
-        components[i]->putPCHistory(thread.s0PC, thread.s0History, predsOfEachStage);  // s0History not used
+        components[i]->putPCHistory(thread.s0PC, thread.s0History, predsOfEachStage);  //s0History not used
     }
 
     generateFinalPredAndCreateBubbles(tid);
@@ -240,8 +234,8 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 {
     DPRINTF(Override, "In generateFinalPredAndCreateBubbles().\n");
 
-    auto &predsOfEachStage = threads[tid].predsOfEachStage;
-    auto &finalPred = threads[tid].finalPred;
+    auto& predsOfEachStage = threads[tid].predsOfEachStage;
+    auto& finalPred = threads[tid].finalPred;
 
     // 1. Debug output: dump predictions from all stages
     for (int i = 0; i < numStages; i++) {
@@ -264,12 +258,12 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     // Store the chosen prediction as our final prediction
     finalPred = *chosenPrediction;
 
-    finalPred.s1Source = -1;  // meaning fallthrough
+    finalPred.s1Source = -1;//meaning fallthrough
     finalPred.s3Source = -1;
 
     if (predsOfEachStage[0].btbEntries.size() != 0) {
-        for (auto entry : predsOfEachStage[0].btbEntries) {
-            if (entry.isIndirect || entry.isDirect || entry.ctr >= 0 || entry.alwaysTaken) {
+        for (auto entry : predsOfEachStage[0].btbEntries){
+            if (entry.isIndirect || entry.isDirect || entry.ctr >= 0 ||entry.alwaysTaken){
                 finalPred.s1Source = entry.source;
                 break;
             }
@@ -282,8 +276,8 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     for (BTBEntry entry : predsOfEachStage[2].btbEntries) {
         if (entry.isDirect || entry.isIndirect || entry.ctr >= 0 || entry.alwaysTaken) {
             found_s3_taken = true;
-        } else if (entry.isCond) {
-            // only use when there's no taken prediction in s3
+        }else if (entry.isCond){
+            //only use when there's no taken prediction in s3
             na_s3_taken_but_have_cond = true;
         }
     }
@@ -295,15 +289,15 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
                 finalPred.s3Source = ras->getComponentIdx();
             } else if (pred_taken_entry.isIndirect && ittage->tageHit()) {
                 finalPred.s3Source = ittage->getComponentIdx();
-            } else if (pred_taken_entry.isCond) {
+            }else if (pred_taken_entry.isCond) {
                 finalPred.s3Source = tage->getComponentIdx();
             } else {
                 finalPred.s3Source = mbtb->getComponentIdx();
             }
-        } else {
+        }else {
             if (na_s3_taken_but_have_cond) {
                 finalPred.s3Source = tage->getComponentIdx();
-            } else {
+            }else {
                 finalPred.s3Source = -1;
             }
         }
@@ -426,7 +420,8 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
 
     // 6. Debug output and update statistics
     dumpFsq("after insert new target");
-    DPRINTF(DecoupleBP, "Inserted fetch target %lu starting at PC %#lx\n", ftq.backId(tid), entry.startPC);
+    DPRINTF(DecoupleBP, "Inserted fetch target %lu starting at PC %#lx\n",
+            ftq.backId(tid), entry.startPC);
 
     // 7. Increment statistics
     printTarget(entry);
@@ -596,9 +591,14 @@ DecoupledBPUWithBTB::buildPredictionBundle(ThreadID tid)
  * @param control_inst_size Size of the control instruction (for control squash)
  */
 void
-DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id, SquashType squash_type,
-                                  const PCStateBase &squash_pc, Addr redirect_pc, bool is_conditional,
-                                  bool actually_taken, const StaticInstPtr &static_inst, unsigned control_inst_size)
+DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id,
+                                 SquashType squash_type,
+                                 const PCStateBase &squash_pc,
+                                 Addr redirect_pc,
+                                 bool is_conditional,
+                                 bool actually_taken,
+                                 const StaticInstPtr &static_inst,
+                                 unsigned control_inst_size)
 {
     // Set squashing state
     threads[tid].squashing = true;
@@ -638,15 +638,19 @@ DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id, SquashType s
     // Update PC and target ID
     threads[tid].s0PC = redirect_pc;
 
-    DPRINTF(DecoupleBP, "After squash, fsqId(next alloc)=%lu, fetchHeadFsqId=%lu, s0pc=%#lx\n", ftq.backId(tid) + 1,
-            ftq.frontId(tid), redirect_pc);
+    DPRINTF(DecoupleBP,
+            "After squash, fsqId(next alloc)=%lu, fetchHeadFsqId=%lu, s0pc=%#lx\n",
+            ftq.backId(tid) + 1, ftq.frontId(tid), redirect_pc);
 }
 
 void
-DecoupledBPUWithBTB::controlSquash(unsigned target_id, const PCStateBase &control_pc, const PCStateBase &corr_target,
-                                   const StaticInstPtr &static_inst, unsigned control_inst_size, bool actually_taken,
-                                   const InstSeqNum &seq, ThreadID tid, const unsigned &currentLoopIter,
-                                   const bool fromCommit)
+DecoupledBPUWithBTB::controlSquash(unsigned target_id,
+                            const PCStateBase &control_pc,
+                            const PCStateBase &corr_target,
+                            const StaticInstPtr &static_inst,
+                            unsigned control_inst_size, bool actually_taken,
+                            const InstSeqNum &seq, ThreadID tid,
+                            const unsigned &currentLoopIter, const bool fromCommit)
 {
     if (fromCommit) {
         dbpBtbStats.controlSquashFromCommit++;
@@ -678,16 +682,19 @@ DecoupledBPUWithBTB::controlSquash(unsigned target_id, const PCStateBase &contro
             "Control squash: ftq_id=%d,"
             " control_pc=%#lx, real_target=%#lx, is_conditional=%u, "
             "is_indirect=%u, actually_taken=%u, branch seq: %lu\n",
-            target_id, control_pc.instAddr(), real_target, is_conditional, is_indirect, actually_taken, seq);
+            target_id, control_pc.instAddr(),
+            real_target, is_conditional, is_indirect,
+            actually_taken, seq);
 
     // Call shared squash handling logic
-    handleSquash(tid, target_id, SQUASH_CTRL, control_pc, real_target, is_conditional, actually_taken, static_inst,
-                 control_inst_size);
+    handleSquash(tid, target_id, SQUASH_CTRL, control_pc,
+                real_target, is_conditional, actually_taken, static_inst, control_inst_size);
 }
 
 void
-DecoupledBPUWithBTB::nonControlSquash(unsigned target_id, const PCStateBase &inst_pc, const InstSeqNum seq,
-                                      ThreadID tid, const unsigned &currentLoopIter)
+DecoupledBPUWithBTB::nonControlSquash(unsigned target_id,
+                               const PCStateBase &inst_pc,
+                               const InstSeqNum seq, ThreadID tid, const unsigned &currentLoopIter)
 {
     dbpBtbStats.nonControlSquash++;
     DPRINTF(DecoupleBP,
@@ -700,11 +707,14 @@ DecoupledBPUWithBTB::nonControlSquash(unsigned target_id, const PCStateBase &ins
 }
 
 void
-DecoupledBPUWithBTB::trapSquash(unsigned target_id, Addr last_committed_pc, const PCStateBase &inst_pc, ThreadID tid,
-                                const unsigned &currentLoopIter)
+DecoupledBPUWithBTB::trapSquash(unsigned target_id,
+                         Addr last_committed_pc, const PCStateBase &inst_pc,
+                         ThreadID tid, const unsigned &currentLoopIter)
 {
     dbpBtbStats.trapSquash++;
-    DPRINTF(DecoupleBP, "Trap squash: target id: %d, inst_pc: %#lx\n", target_id, inst_pc.instAddr());
+    DPRINTF(DecoupleBP,
+            "Trap squash: target id: %d, inst_pc: %#lx\n",
+            target_id, inst_pc.instAddr());
 
     // Call shared squash handling logic
     handleSquash(tid, target_id, SQUASH_TRAP, inst_pc, inst_pc.instAddr());
@@ -882,7 +892,7 @@ DecoupledBPUWithBTB::pHistShiftIn(int shamt, bool taken, boost::dynamic_bitset<>
     if (shamt == 0) {
         return;
     }
-    if (taken) {
+    if(taken){
         // Calculate path hash
         uint64_t hash = pathHash(pc, target);
 
@@ -1021,13 +1031,13 @@ DecoupledBPUWithBTB::checkHistory(const boost::dynamic_bitset<> &history)
     boost::dynamic_bitset<> ideal_hash_hist(historyBits, 0);
 
     // Iterate through all speculative history entries stored in HistoryManager
-    for (const auto entry : historyManager.getSpeculativeHist()) {
+    for (const auto entry: historyManager.getSpeculativeHist()) {
         // Only process entries that have non-zero shift amount (actual branches)
         if (entry.shamt != 0) {
             // Accumulate total history bits
             ideal_size += entry.shamt;
-            DPRINTF(DecoupleBPVerbose, "pc: %#lx, shamt: %lu, cond_taken: %d\n", entry.pc, entry.shamt,
-                    entry.cond_taken);
+            DPRINTF(DecoupleBPVerbose, "pc: %#lx, shamt: %lu, cond_taken: %d\n", entry.pc,
+                    entry.shamt, entry.cond_taken);
 
             // Rebuild history by shifting and setting bits based on recorded outcomes
             // This emulates how history would be built if all branches were predicted perfectly
@@ -1048,8 +1058,9 @@ DecoupledBPUWithBTB::checkHistory(const boost::dynamic_bitset<> &history)
 
     // boost::to_string(ideal_hash_hist, buf1);
     // boost::to_string(sized_real_hist, buf2);
-    DPRINTF(DecoupleBP, "Ideal size:\t%u, real history size:\t%u, comparable size:\t%u\n", ideal_size, historyBits,
-            comparable_size);
+    DPRINTF(DecoupleBP,
+            "Ideal size:\t%u, real history size:\t%u, comparable size:\t%u\n",
+            ideal_size, historyBits, comparable_size);
     // DPRINTF(DecoupleBP, "Ideal history:\t%s\nreal history:\t%s\n",
     //         buf1.c_str(), buf2.c_str());
 
@@ -1089,18 +1100,23 @@ DecoupledBPUWithBTB::getPreservedReturnAddr(const DynInstPtr &dynInst)
  * @param squash_type Type of squash (CTRL/OTHER/TRAP)
  */
 void
-DecoupledBPUWithBTB::recoverHistoryForSquash(FetchTarget &target, unsigned target_id, const PCStateBase &squash_pc,
-                                             bool is_conditional, bool actually_taken, SquashType squash_type,
-                                             Addr redirect_pc)
+DecoupledBPUWithBTB::recoverHistoryForSquash(
+    FetchTarget &target,
+    unsigned target_id,
+    const PCStateBase &squash_pc,
+    bool is_conditional,
+    bool actually_taken,
+    SquashType squash_type,
+    Addr redirect_pc)
 {
     ThreadID tid = target.tid;
-    auto &s0History = threads[tid].s0History;
-    auto &s0PHistory = threads[tid].s0PHistory;
-    auto &s0BwHistory = threads[tid].s0BwHistory;
-    auto &s0LHistory = threads[tid].s0LHistory;
+    auto& s0History = threads[tid].s0History;
+    auto& s0PHistory = threads[tid].s0PHistory;
+    auto& s0BwHistory = threads[tid].s0BwHistory;
+    auto& s0LHistory = threads[tid].s0LHistory;
 
-    // printf("recover target_id: %u\n", target_id);
-    //  Restore history from the target
+    //printf("recover target_id: %u\n", target_id);
+    // Restore history from the target
     s0History = target.history;
     s0PHistory = target.phistory;
     s0BwHistory = target.bwhistory;
@@ -1109,19 +1125,19 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(FetchTarget &target, unsigned targe
     // Get actual history shift information
     int real_shamt;
     bool real_taken;
-    std::tie(real_shamt, real_taken) =
-        target.getHistInfoDuringSquash(squash_pc.instAddr(), is_conditional, actually_taken);
+    std::tie(real_shamt, real_taken) = target.getHistInfoDuringSquash(
+        squash_pc.instAddr(), is_conditional, actually_taken);
 
     // Get actual history shift information
     int real_bw_shamt;
     bool real_bw_taken;
-    std::tie(real_bw_shamt, real_bw_taken) =
-        target.getBwHistInfoDuringSquash(squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
+    std::tie(real_bw_shamt, real_bw_taken) = target.getBwHistInfoDuringSquash(
+    squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {
         components[i]->recoverHist(s0History, target, real_shamt, real_taken);
-        if (components[i]->needMoreHistories) {
+        if (components[i]->needMoreHistories){
             components[i]->recoverPHist(s0PHistory, target, real_shamt, real_taken);
             components[i]->recoverBwHist(s0BwHistory, target, real_bw_shamt, real_bw_taken);
             components[i]->recoverIHist(target, real_bw_shamt, real_bw_taken);
@@ -1153,25 +1169,24 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(FetchTarget &target, unsigned targe
 #ifndef NDEBUG
     checkHistory(s0History);
     if (tage->isEnabled()) {
-        tage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
-                                          : squash_type == SQUASH_OTHER ? "non control squash"
-                                                                        : "trap squash");
+        tage->checkFoldedHist(s0PHistory,
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
     if (ittage->isEnabled()) {
-        ittage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
-                                            : squash_type == SQUASH_OTHER ? "non control squash"
-                                                                          : "trap squash");
+        ittage->checkFoldedHist(s0PHistory,
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
     if (microtage->isEnabled()) {
-        microtage->checkFoldedHist(s0PHistory, squash_type == SQUASH_CTRL    ? "control squash"
-                                               : squash_type == SQUASH_OTHER ? "non control squash"
-                                                                             : "trap squash");
+        microtage->checkFoldedHist(s0PHistory,
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
     if (mgsc->isEnabled()) {
         mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory,
-                              squash_type == SQUASH_CTRL    ? "control squash"
-                              : squash_type == SQUASH_OTHER ? "non control squash"
-                                                            : "trap squash");
+            squash_type == SQUASH_CTRL ? "control squash" :
+            squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
 #endif
 }

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -79,8 +79,14 @@ class DecoupledBPUWithBTB : public BPredUnit
     const int numThreads = 2;
     unsigned predictWidth;  // max predict width, default 64
     unsigned maxInstsNum;
+    const bool enableTwoTaken;
+    const bool dropBlock1OnBlock0Override;
+    const bool dropBlock1WhenFTQHasOnlyOneSlot;
+    const bool dropBlock1OnCondWithoutTage;
+    const bool dropBlock1OnIndirectWithoutIttage;
+    const bool dropBlock1OnReturnWithoutRas;
 
-    const unsigned historyBits{488}; // will be overridden later by the constructor
+    const unsigned historyBits{488};  // will be overridden later by the constructor
 
     const Addr MaxAddr{~(0ULL)};
 
@@ -100,7 +106,8 @@ class DecoupledBPUWithBTB : public BPredUnit
     bool enableBranchTrace{false};
     bool enablePredFSQTrace{false};
 
-    bool checkGivenSwitch(std::vector<std::string> switches, std::string switchName) {
+    bool checkGivenSwitch(std::vector<std::string> switches, std::string switchName)
+    {
         for (auto &sw : switches) {
             if (sw == switchName) {
                 return true;
@@ -108,7 +115,8 @@ class DecoupledBPUWithBTB : public BPredUnit
         }
         return false;
     }
-    void removeGivenSwitch(std::vector<std::string> &switches, std::string switchName) {
+    void removeGivenSwitch(std::vector<std::string> &switches, std::string switchName)
+    {
         auto it = std::remove(switches.begin(), switches.end(), switchName);
         switches.erase(it, switches.end());
     }
@@ -118,23 +126,45 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void initDB();
 
-    std::vector<TimedBaseBTBPredictor*> components{};
+    std::vector<TimedBaseBTBPredictor *> components{};
     // std::vector<FullBTBPrediction> predsOfEachStage{};
     unsigned numComponents{};
     unsigned numStages{};
 
     FetchTargetQueue ftq;
 
+    struct SpecState
+    {
+        Addr pc{0};
+        boost::dynamic_bitset<> history;
+        boost::dynamic_bitset<> phistory;
+        boost::dynamic_bitset<> bwhistory;
+        std::vector<boost::dynamic_bitset<>> lhistory;
+    };
+
+    struct PredictionBundle
+    {
+        FullBTBPrediction pred0;
+        std::array<std::shared_ptr<void>, 8> pred0Metas{};
+        bool hasPred1{false};
+        FullBTBPrediction pred1;
+        std::array<std::shared_ptr<void>, 8> pred1Metas{};
+        SpecState stateAfter0;
+        SpecState stateAfterFinal;
+        Block1DropReason pred1DropReason{Block1DropReason::None};
+    };
+
     struct
     {
         Addr s0PC;
         std::vector<FullBTBPrediction> predsOfEachStage{};
-        boost::dynamic_bitset<> s0History;  ///< global History bits
-        boost::dynamic_bitset<> s0PHistory;  ///< path History bits
-        boost::dynamic_bitset<> s0BwHistory;  ///< global backward History bits
+        boost::dynamic_bitset<> s0History;                ///< global History bits
+        boost::dynamic_bitset<> s0PHistory;               ///< path History bits
+        boost::dynamic_bitset<> s0BwHistory;              ///< global backward History bits
         std::vector<boost::dynamic_bitset<>> s0LHistory;  ///< local History bits
         boost::dynamic_bitset<> commitHistory;
-        FullBTBPrediction finalPred;      ///< Final prediction
+        FullBTBPrediction finalPred;  ///< Final prediction
+        PredictionBundle bundle;
         unsigned numOverrideBubbles{0};
         bool validprediction{false};
         bool squashing{false};
@@ -149,9 +179,19 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void processNewPrediction(ThreadID tid);
 
-    FetchTarget createFetchTargetEntry(ThreadID tid);
+    SpecState makeSpecState(ThreadID tid) const;
 
-    void updateHistoryForPrediction(FetchTarget &entry);
+    void commitSpecState(ThreadID tid, const SpecState &state);
+
+    std::array<std::shared_ptr<void>, 8> capturePredictionMetas() const;
+
+    SpecState computeNextSpecState(ThreadID tid, const SpecState &state, const FullBTBPrediction &pred,
+                                   FetchTargetId targetId);
+
+    FetchTarget createFetchTargetEntry(ThreadID tid, const SpecState &state, const FullBTBPrediction &pred,
+                                       const std::array<std::shared_ptr<void>, 8> &predMetas);
+
+    void buildPredictionBundle(ThreadID tid);
 
     void fillAheadPipeline(FetchTarget &entry);
 
@@ -171,10 +211,8 @@ class DecoupledBPUWithBTB : public BPredUnit
             DPRINTFR(DecoupleBPProbe, "FSQ Resolved target: ");
         }
         // TODO:fix this
-        DPRINTFR(DecoupleBPProbe,
-                 "%#lx-[%#lx, %#lx) --> %#lx, taken: %lu\n",
-                 e.startPC, e.getBranchInfo().pc, e.getEndPC(),
-                 e.getTakenTarget(), e.getTaken());
+        DPRINTFR(DecoupleBPProbe, "%#lx-[%#lx, %#lx) --> %#lx, taken: %lu\n", e.startPC, e.getBranchInfo().pc,
+                 e.getEndPC(), e.getTakenTarget(), e.getTaken());
     }
 
     /**
@@ -187,7 +225,8 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     void generateFinalPredAndCreateBubbles(ThreadID tid);
 
-    void clearPreds(ThreadID tid) {
+    void clearPreds(ThreadID tid)
+    {
         for (auto &stagePred : threads[tid].predsOfEachStage) {
             stagePred.condTakens.clear();
             stagePred.indirectTargets.clear();
@@ -197,15 +236,19 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     // const bool dumpLoopPred;
 
-    void printBTBEntry(const BTBEntry &e) {
-        DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken);
+    void printBTBEntry(const BTBEntry &e)
+    {
+        DPRINTF(BTB,
+                "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, "
+                "return:%d, always_taken:%d\n",
+                e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken);
     }
 
-    void printFullBTBPrediction(const FullBTBPrediction &pred) {
+    void printFullBTBPrediction(const FullBTBPrediction &pred)
+    {
         DPRINTF(DecoupleBP, "dumping FullBTBPrediction\n");
         DPRINTF(DecoupleBP, "bbStart: %#lx, btbEntry:\n", pred.bbStart);
-        for (auto &e: pred.btbEntries) {
+        for (auto &e : pred.btbEntries) {
             printBTBEntry(e);
         }
         DPRINTF(DecoupleBP, "condTakens: ");
@@ -214,8 +257,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         }
         DPRINTFR(DecoupleBP, "\n");
         for (auto pair : pred.indirectTargets) {
-            DPRINTF(DecoupleBP, "indirectTarget of %#lx: %#lx\n",
-            pair.first, pair.second);
+            DPRINTF(DecoupleBP, "indirectTarget of %#lx: %#lx\n", pair.first, pair.second);
         }
         DPRINTF(DecoupleBP, "returnTarget %#lx\n", pred.returnTarget);
     }
@@ -229,24 +271,25 @@ class DecoupledBPUWithBTB : public BPredUnit
      * - Queue utilization
      * - Loop and jump-ahead prediction performance
      */
-    struct DBPBTBStats : public statistics::Group {
+    struct DBPBTBStats : public statistics::Group
+    {
         // Branch type statistics
-        statistics::Scalar condNum;      ///< Number of conditional branches
-        statistics::Scalar uncondNum;    ///< Number of unconditional branches
-        statistics::Scalar returnNum;    ///< Number of return instructions
-        statistics::Scalar otherNum;     ///< Number of other control instructions
+        statistics::Scalar condNum;    ///< Number of conditional branches
+        statistics::Scalar uncondNum;  ///< Number of unconditional branches
+        statistics::Scalar returnNum;  ///< Number of return instructions
+        statistics::Scalar otherNum;   ///< Number of other control instructions
 
         // Misprediction statistics
-        statistics::Scalar condMiss;     ///< Conditional branch mispredictions
-        statistics::Scalar uncondMiss;   ///< Unconditional branch mispredictions
-        statistics::Scalar returnMiss;   ///< Return mispredictions
-        statistics::Scalar otherMiss;    ///< Other control mispredictions
+        statistics::Scalar condMiss;    ///< Conditional branch mispredictions
+        statistics::Scalar uncondMiss;  ///< Unconditional branch mispredictions
+        statistics::Scalar returnMiss;  ///< Return mispredictions
+        statistics::Scalar otherMiss;   ///< Other control mispredictions
 
         // Fine-grained branch classification statistics
-        statistics::Vector branchClassCounts; ///< Classified branch occurrences
-        statistics::Vector branchClassMisses; ///< Mispredictions per class
-        statistics::Scalar branchClassCountsTotal; ///< Total classified branches
-        statistics::Vector controlSquashByClass; ///< Commit/Resolve-path squashes per class
+        statistics::Vector branchClassCounts;       ///< Classified branch occurrences
+        statistics::Vector branchClassMisses;       ///< Mispredictions per class
+        statistics::Scalar branchClassCountsTotal;  ///< Total classified branches
+        statistics::Vector controlSquashByClass;    ///< Commit/Resolve-path squashes per class
 
         // Branch coverage statistics
         statistics::Scalar staticBranchNum;           ///< Total static branches seen
@@ -281,6 +324,14 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar ftqFullCannotEnq;
         statistics::Scalar fsqFullFetchHungry;
         statistics::Scalar fsqEmpty;
+        statistics::Scalar block1Attempted;
+        statistics::Scalar block1Accepted;
+        statistics::Scalar block1DroppedByBlock0Override;
+        statistics::Scalar block1DroppedByCond;
+        statistics::Scalar block1DroppedByIndirect;
+        statistics::Scalar block1DroppedByReturn;
+        statistics::Scalar block1DroppedByFTQFull;
+        statistics::Scalar block1DroppedOther;
         //
         statistics::Distribution commitFsqEntryHasInsts;
         // write back once an fsq entry finishes fetch
@@ -306,7 +357,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar s3PredWrongIttage;
         statistics::Scalar s3PredWrongRas;
 
-        DBPBTBStats(statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
+        DBPBTBStats(statistics::Group *parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
     } dbpBtbStats;
 
   public:
@@ -325,8 +376,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     {
         panic("Squashing decoupled BP with tightly coupled API\n");
     }
-    void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target,
-                bool actually_taken, ThreadID tid)
+    void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target, bool actually_taken, ThreadID tid)
     {
         panic("Squashing decoupled BP with tightly coupled API\n");
     }
@@ -339,9 +389,9 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     struct BpTrace : public Record
     {
-        void set(uint64_t fsqId, uint64_t startPC, uint64_t controlPC, uint64_t controlType,
-            uint64_t taken, uint64_t mispred, uint64_t fallThruPC,
-            uint64_t source, uint64_t target) {
+        void set(uint64_t fsqId, uint64_t startPC, uint64_t controlPC, uint64_t controlType, uint64_t taken,
+                 uint64_t mispred, uint64_t fallThruPC, uint64_t source, uint64_t target)
+        {
             _uint64_data["fsqId"] = fsqId;
             _uint64_data["startPC"] = startPC;
             _uint64_data["controlPC"] = controlPC;
@@ -358,9 +408,9 @@ class DecoupledBPUWithBTB : public BPredUnit
     // Prediction trace record for tracking prediction-time information
     struct PredictionTrace : public Record
     {
-        void set(uint64_t fsqId, uint64_t startPC, uint64_t predTaken, uint64_t predEndPC,
-                 uint64_t controlPC, uint64_t target,
-                 uint64_t predSource, uint64_t btbHit) {
+        void set(uint64_t fsqId, uint64_t startPC, uint64_t predTaken, uint64_t predEndPC, uint64_t controlPC,
+                 uint64_t target, uint64_t predSource, uint64_t btbHit)
+        {
             _uint64_data["fsqId"] = fsqId;
             _uint64_data["startPC"] = startPC;
             _uint64_data["predTaken"] = predTaken;
@@ -371,39 +421,43 @@ class DecoupledBPUWithBTB : public BPredUnit
             _uint64_data["btbHit"] = btbHit;
         }
 
-        PredictionTrace(uint64_t id, const FetchTarget &entry) {
+        PredictionTrace(uint64_t id, const FetchTarget &entry)
+        {
             _tick = curTick();
-            set(id, entry.startPC, entry.predTaken, entry.predEndPC,
-                entry.getControlPC(), entry.getTakenTarget(),
+            set(id, entry.startPC, entry.predTaken, entry.predEndPC, entry.getControlPC(), entry.getTakenTarget(),
                 entry.predSource, entry.isHit ? 1 : 0);
         }
     };
 
     // redirect the target
-    void controlSquash(unsigned fsq_id,
-                       const PCStateBase &control_pc,
-                       const PCStateBase &target_pc,
-                       const StaticInstPtr &static_inst, unsigned inst_bytes,
-                       bool actually_taken, const InstSeqNum &squashed_sn,
-                       ThreadID tid, const unsigned &currentLoopIter,
+    void controlSquash(unsigned fsq_id, const PCStateBase &control_pc, const PCStateBase &target_pc,
+                       const StaticInstPtr &static_inst, unsigned inst_bytes, bool actually_taken,
+                       const InstSeqNum &squashed_sn, ThreadID tid, const unsigned &currentLoopIter,
                        const bool fromCommit);
 
     // keep the target: original prediction might be right
     // For memory violation, target continues after squashing
-    void nonControlSquash(unsigned fsq_id,
-                          const PCStateBase &inst_pc, const InstSeqNum seq,
-                          ThreadID tid, const unsigned &currentLoopIter);
+    void nonControlSquash(unsigned fsq_id, const PCStateBase &inst_pc, const InstSeqNum seq, ThreadID tid,
+                          const unsigned &currentLoopIter);
 
     // Not a control. But target is actually disturbed
-    void trapSquash(unsigned fsq_id, Addr last_committed_pc,
-                    const PCStateBase &inst_pc, ThreadID tid, const unsigned &currentLoopIter);
+    void trapSquash(unsigned fsq_id, Addr last_committed_pc, const PCStateBase &inst_pc, ThreadID tid,
+                    const unsigned &currentLoopIter);
 
     void commit(unsigned fsqID, ThreadID tid);
 
     // Fetch-facing interface: consume FSQ head directly (RTL-like single queue).
     bool ftqHasFetching(ThreadID tid) const { return ftq.hasTarget(ftq.fetchId(tid), tid); }
-    FetchTargetId ftqHeadId(ThreadID tid) const { assert(ftqHasFetching(tid)); return ftq.fetchId(tid); }
-    const FetchTarget &ftqFetchingTarget(ThreadID tid) { assert(ftqHasFetching(tid)); return ftq.fetching(tid); }
+    FetchTargetId ftqHeadId(ThreadID tid) const
+    {
+        assert(ftqHasFetching(tid));
+        return ftq.fetchId(tid);
+    }
+    const FetchTarget &ftqFetchingTarget(ThreadID tid)
+    {
+        assert(ftqHasFetching(tid));
+        return ftq.fetching(tid);
+    }
 
     void dumpFsq(const char *when);
 
@@ -414,8 +468,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void btbUpdate(ThreadID tid, Addr instPC, void *&bp_history) override {}
 
-    void update(ThreadID tid, Addr instPC, bool taken, void *bp_history,
-                bool squashed, const StaticInstPtr &inst,
+    void update(ThreadID tid, Addr instPC, bool taken, void *bp_history, bool squashed, const StaticInstPtr &inst,
                 Addr corrTarget) override
     {
     }
@@ -429,18 +482,19 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     Addr getPreservedReturnAddr(const DynInstPtr &dynInst);
 
-    std::unordered_map<Addr, int> takenBranches;      // branch address -> taken count
+    std::unordered_map<Addr, int> takenBranches;  // branch address -> taken count
     std::unordered_map<Addr, int> currentPhaseTakenBranches;
     std::unordered_map<Addr, int> currentSubPhaseTakenBranches;
 
     /**
      * @brief Types of control flow instruction mispredictions
      */
-    enum MispredType {
-        DIR_WRONG,      ///< Direction prediction error (predicted taken when not taken or vice versa)
-        TARGET_WRONG,   ///< Target address prediction was wrong (branch taken but to the wrong address)
-        NO_PRED,        ///< No prediction was made (branch wasn't predicted at all)
-        FAKE_LAST       ///< Sentinel value
+    enum MispredType
+    {
+        DIR_WRONG,     ///< Direction prediction error (predicted taken when not taken or vice versa)
+        TARGET_WRONG,  ///< Target address prediction was wrong (branch taken but to the wrong address)
+        NO_PRED,       ///< No prediction was made (branch wasn't predicted at all)
+        FAKE_LAST      ///< Sentinel value
     };
 
     /**
@@ -452,27 +506,41 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     struct BranchStats
     {
-        Addr pc;                ///< Branch PC address
-        int branchType;         ///< Branch type (0=cond, 1=uncond, 2=call, 3=ind, etc.)
-        int totalCount;         ///< Total number of times branch was executed
-        int mispredCount;       ///< Total number of mispredictions for this branch
-        int dirWrongCount;      ///< Number of times direction was mispredicted
-        int targetWrongCount;   ///< Number of times target address was mispredicted
-        int noPredCount;        ///< Number of times no prediction was made
+        Addr pc;               ///< Branch PC address
+        int branchType;        ///< Branch type (0=cond, 1=uncond, 2=call, 3=ind, etc.)
+        int totalCount;        ///< Total number of times branch was executed
+        int mispredCount;      ///< Total number of mispredictions for this branch
+        int dirWrongCount;     ///< Number of times direction was mispredicted
+        int targetWrongCount;  ///< Number of times target address was mispredicted
+        int noPredCount;       ///< Number of times no prediction was made
 
         /**
          * @brief Default constructor
          */
         BranchStats()
-            : pc(0), branchType(0), totalCount(0), mispredCount(0),
-              dirWrongCount(0), targetWrongCount(0), noPredCount(0) {}
+            : pc(0),
+              branchType(0),
+              totalCount(0),
+              mispredCount(0),
+              dirWrongCount(0),
+              targetWrongCount(0),
+              noPredCount(0)
+        {
+        }
 
         /**
          * @brief Create branch stats with initial values
          */
         BranchStats(Addr _pc, int _type)
-            : pc(_pc), branchType(_type), totalCount(0), mispredCount(0),
-              dirWrongCount(0), targetWrongCount(0), noPredCount(0) {}
+            : pc(_pc),
+              branchType(_type),
+              totalCount(0),
+              mispredCount(0),
+              dirWrongCount(0),
+              targetWrongCount(0),
+              noPredCount(0)
+        {
+        }
 
         /**
          * @brief Increment total execution count
@@ -482,13 +550,21 @@ class DecoupledBPUWithBTB : public BPredUnit
         /**
          * @brief Increment misprediction count for a specific type
          */
-        void incrementMispred(MispredType type) {
+        void incrementMispred(MispredType type)
+        {
             mispredCount++;
-            switch(type) {
-                case DIR_WRONG: dirWrongCount++; break;
-                case TARGET_WRONG: targetWrongCount++; break;
-                case NO_PRED: noPredCount++; break;
-                default: break;
+            switch (type) {
+                case DIR_WRONG:
+                    dirWrongCount++;
+                    break;
+                case TARGET_WRONG:
+                    targetWrongCount++;
+                    break;
+                case NO_PRED:
+                    noPredCount++;
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -497,9 +573,7 @@ class DecoupledBPUWithBTB : public BPredUnit
          *
          * @return Misprediction rate scaled to per-mille (0-1000)
          */
-        double getMispredRate() const {
-            return totalCount > 0 ? (double)(mispredCount * 1000) / totalCount : 0;
-        }
+        double getMispredRate() const { return totalCount > 0 ? (double)(mispredCount * 1000) / totalCount : 0; }
     };
 
     /**
@@ -625,7 +699,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @brief Calculate sub-phase size in instructions
      * @return Number of instructions per sub-phase
      */
-    int subPhaseSizeByInst() { return phaseSizeByInst/subPhaseRatio; }
+    int subPhaseSizeByInst() { return phaseSizeByInst / subPhaseRatio; }
 
     /**
      * @brief Distribution of committed instructions from previous phase
@@ -684,24 +758,13 @@ class DecoupledBPUWithBTB : public BPredUnit
     // std::vector<BranchStatsMap> topMispredictsByBranchBySubPhase;
     // std::vector<std::map<Addr, int>> takenBranchesBySubPhase;
 
-    void recoverHistoryForSquash(
-        FetchTarget &target,
-        unsigned target_id,
-        const PCStateBase &squash_pc,
-        bool is_conditional,
-        bool actually_taken,
-        SquashType squash_type,
-        Addr redirect_pc);
+    void recoverHistoryForSquash(FetchTarget &target, unsigned target_id, const PCStateBase &squash_pc,
+                                 bool is_conditional, bool actually_taken, SquashType squash_type, Addr redirect_pc);
 
     // Common logic for squash handling
-    void handleSquash(ThreadID tid, unsigned target_id,
-                      SquashType squash_type,
-                      const PCStateBase &squash_pc,
-                      Addr redirect_pc,
-                      bool is_conditional = false,
-                      bool actually_taken = false,
-                      const StaticInstPtr &static_inst = nullptr,
-                      unsigned control_inst_size = 0);
+    void handleSquash(ThreadID tid, unsigned target_id, SquashType squash_type, const PCStateBase &squash_pc,
+                      Addr redirect_pc, bool is_conditional = false, bool actually_taken = false,
+                      const StaticInstPtr &static_inst = nullptr, unsigned control_inst_size = 0);
 
     void resetPC(Addr new_pc);
 
@@ -720,10 +783,10 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     enum CfiType
     {
-        COND,     ///< Conditional branch
-        UNCOND,   ///< Unconditional branch
-        RETURN,   ///< Return instruction
-        OTHER     ///< Other control flow instruction
+        COND,    ///< Conditional branch
+        UNCOND,  ///< Unconditional branch
+        RETURN,  ///< Return instruction
+        OTHER    ///< Other control flow instruction
     };
 
     /**
@@ -731,20 +794,20 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     enum class BranchClass : uint8_t
     {
-        CondBranch = 0,   ///< Conditional direct branches (TAGE focus)
-        DirectCall,       ///< Direct call instructions (RAS + BTB)
-        IndirectCall,     ///< Indirect call instructions (ITTAGE + RAS)
-        Return,           ///< Return instructions (RAS)
-        DirectJump,       ///< Direct, non-call control transfers (BTB)
-        IndirectJump,     ///< Indirect jumps that are not calls/returns (ITTAGE)
-        Unknown,          ///< Fallback for unexpected classifications
-        NumClasses        ///< Sentinel used for sizing stat containers
+        CondBranch = 0,  ///< Conditional direct branches (TAGE focus)
+        DirectCall,      ///< Direct call instructions (RAS + BTB)
+        IndirectCall,    ///< Indirect call instructions (ITTAGE + RAS)
+        Return,          ///< Return instructions (RAS)
+        DirectJump,      ///< Direct, non-call control transfers (BTB)
+        IndirectJump,    ///< Indirect jumps that are not calls/returns (ITTAGE)
+        Unknown,         ///< Fallback for unexpected classifications
+        NumClasses       ///< Sentinel used for sizing stat containers
     };
 
-    static constexpr size_t NumBranchClasses =
-        static_cast<size_t>(BranchClass::NumClasses);
+    static constexpr size_t NumBranchClasses = static_cast<size_t>(BranchClass::NumClasses);
 
-    void addCfi(CfiType type, bool mispred) {
+    void addCfi(CfiType type, bool mispred)
+    {
         switch (type) {
             case COND:
                 dbpBtbStats.condNum++;
@@ -776,9 +839,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     void addBranchClassStat(BranchClass cls, bool mispred);
     void addControlSquashCommitStat(BranchClass cls);
 
-    void addFtqNotValid() {
-        dbpBtbStats.ftqNotValid++;
-    }
+    void addFtqNotValid() { dbpBtbStats.ftqNotValid++; }
 
     /**
      * @brief Process a branch instruction during commit
@@ -802,12 +863,8 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param taken Whether the branch was taken
      * @param mispred Whether the branch was mispredicted
      */
-    void processMisprediction(
-        const FetchTarget &entry,
-        Addr branchAddr,
-        const BranchInfo &info,
-        bool taken,
-        bool mispred);
+    void processMisprediction(const FetchTarget &entry, Addr branchAddr, const BranchInfo &info, bool taken,
+                              bool mispred);
 
     /**
      * @brief Track statistics for taken branches
@@ -828,11 +885,9 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param phaseBranchesList List of all phases taken branches
      * @return true If the phase was processed
      */
-    bool processPhase(bool isSubPhase, int phaseID, int &phaseToDump,
-                     BranchStatsMap &lastPhaseStats,
-                     std::vector<BranchStatsMap> &phaseStatsList,
-                     std::unordered_map<Addr, int> &currentPhaseBranches,
-                     std::vector<std::unordered_map<Addr, int>> &phaseBranchesList);
+    bool processPhase(bool isSubPhase, int phaseID, int &phaseToDump, BranchStatsMap &lastPhaseStats,
+                      std::vector<BranchStatsMap> &phaseStatsList, std::unordered_map<Addr, int> &currentPhaseBranches,
+                      std::vector<std::unordered_map<Addr, int>> &phaseBranchesList);
 
     /**
      * @brief Process fetch instruction distributions for a phase
@@ -841,7 +896,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param currentPhaseFetchedDist Output vector for fetched instruction distribution
      */
     void processFetchDistributions(std::vector<int> &currentPhaseCommittedDist,
-                                  std::vector<int> &currentPhaseFetchedDist);
+                                   std::vector<int> &currentPhaseFetchedDist);
 
     /**
      * @brief Process BTB entries for a phase
@@ -875,7 +930,6 @@ class DecoupledBPUWithBTB : public BPredUnit
      * phase information, and other metrics.
      */
     void dumpStats();
-
 };
 
 }  // namespace btb_pred

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -86,7 +86,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     const bool dropBlock1OnIndirectWithoutIttage;
     const bool dropBlock1OnReturnWithoutRas;
 
-    const unsigned historyBits{488};  // will be overridden later by the constructor
+    const unsigned historyBits{488}; // will be overridden later by the constructor
 
     const Addr MaxAddr{~(0ULL)};
 
@@ -106,8 +106,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     bool enableBranchTrace{false};
     bool enablePredFSQTrace{false};
 
-    bool checkGivenSwitch(std::vector<std::string> switches, std::string switchName)
-    {
+    bool checkGivenSwitch(std::vector<std::string> switches, std::string switchName) {
         for (auto &sw : switches) {
             if (sw == switchName) {
                 return true;
@@ -115,8 +114,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         }
         return false;
     }
-    void removeGivenSwitch(std::vector<std::string> &switches, std::string switchName)
-    {
+    void removeGivenSwitch(std::vector<std::string> &switches, std::string switchName) {
         auto it = std::remove(switches.begin(), switches.end(), switchName);
         switches.erase(it, switches.end());
     }
@@ -126,7 +124,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void initDB();
 
-    std::vector<TimedBaseBTBPredictor *> components{};
+    std::vector<TimedBaseBTBPredictor*> components{};
     // std::vector<FullBTBPrediction> predsOfEachStage{};
     unsigned numComponents{};
     unsigned numStages{};
@@ -158,9 +156,9 @@ class DecoupledBPUWithBTB : public BPredUnit
     {
         Addr s0PC;
         std::vector<FullBTBPrediction> predsOfEachStage{};
-        boost::dynamic_bitset<> s0History;                ///< global History bits
-        boost::dynamic_bitset<> s0PHistory;               ///< path History bits
-        boost::dynamic_bitset<> s0BwHistory;              ///< global backward History bits
+        boost::dynamic_bitset<> s0History;  ///< global History bits
+        boost::dynamic_bitset<> s0PHistory;  ///< path History bits
+        boost::dynamic_bitset<> s0BwHistory;  ///< global backward History bits
         std::vector<boost::dynamic_bitset<>> s0LHistory;  ///< local History bits
         boost::dynamic_bitset<> commitHistory;
         FullBTBPrediction finalPred;  ///< Final prediction
@@ -211,8 +209,10 @@ class DecoupledBPUWithBTB : public BPredUnit
             DPRINTFR(DecoupleBPProbe, "FSQ Resolved target: ");
         }
         // TODO:fix this
-        DPRINTFR(DecoupleBPProbe, "%#lx-[%#lx, %#lx) --> %#lx, taken: %lu\n", e.startPC, e.getBranchInfo().pc,
-                 e.getEndPC(), e.getTakenTarget(), e.getTaken());
+        DPRINTFR(DecoupleBPProbe,
+                 "%#lx-[%#lx, %#lx) --> %#lx, taken: %lu\n",
+                 e.startPC, e.getBranchInfo().pc, e.getEndPC(),
+                 e.getTakenTarget(), e.getTaken());
     }
 
     /**
@@ -225,8 +225,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     void generateFinalPredAndCreateBubbles(ThreadID tid);
 
-    void clearPreds(ThreadID tid)
-    {
+    void clearPreds(ThreadID tid) {
         for (auto &stagePred : threads[tid].predsOfEachStage) {
             stagePred.condTakens.clear();
             stagePred.indirectTargets.clear();
@@ -244,11 +243,10 @@ class DecoupledBPUWithBTB : public BPredUnit
                 e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken);
     }
 
-    void printFullBTBPrediction(const FullBTBPrediction &pred)
-    {
+    void printFullBTBPrediction(const FullBTBPrediction &pred) {
         DPRINTF(DecoupleBP, "dumping FullBTBPrediction\n");
         DPRINTF(DecoupleBP, "bbStart: %#lx, btbEntry:\n", pred.bbStart);
-        for (auto &e : pred.btbEntries) {
+        for (auto &e: pred.btbEntries) {
             printBTBEntry(e);
         }
         DPRINTF(DecoupleBP, "condTakens: ");
@@ -257,7 +255,8 @@ class DecoupledBPUWithBTB : public BPredUnit
         }
         DPRINTFR(DecoupleBP, "\n");
         for (auto pair : pred.indirectTargets) {
-            DPRINTF(DecoupleBP, "indirectTarget of %#lx: %#lx\n", pair.first, pair.second);
+            DPRINTF(DecoupleBP, "indirectTarget of %#lx: %#lx\n",
+            pair.first, pair.second);
         }
         DPRINTF(DecoupleBP, "returnTarget %#lx\n", pred.returnTarget);
     }
@@ -271,25 +270,24 @@ class DecoupledBPUWithBTB : public BPredUnit
      * - Queue utilization
      * - Loop and jump-ahead prediction performance
      */
-    struct DBPBTBStats : public statistics::Group
-    {
+    struct DBPBTBStats : public statistics::Group {
         // Branch type statistics
-        statistics::Scalar condNum;    ///< Number of conditional branches
-        statistics::Scalar uncondNum;  ///< Number of unconditional branches
-        statistics::Scalar returnNum;  ///< Number of return instructions
-        statistics::Scalar otherNum;   ///< Number of other control instructions
+        statistics::Scalar condNum;      ///< Number of conditional branches
+        statistics::Scalar uncondNum;    ///< Number of unconditional branches
+        statistics::Scalar returnNum;    ///< Number of return instructions
+        statistics::Scalar otherNum;     ///< Number of other control instructions
 
         // Misprediction statistics
-        statistics::Scalar condMiss;    ///< Conditional branch mispredictions
-        statistics::Scalar uncondMiss;  ///< Unconditional branch mispredictions
-        statistics::Scalar returnMiss;  ///< Return mispredictions
-        statistics::Scalar otherMiss;   ///< Other control mispredictions
+        statistics::Scalar condMiss;     ///< Conditional branch mispredictions
+        statistics::Scalar uncondMiss;   ///< Unconditional branch mispredictions
+        statistics::Scalar returnMiss;   ///< Return mispredictions
+        statistics::Scalar otherMiss;    ///< Other control mispredictions
 
         // Fine-grained branch classification statistics
-        statistics::Vector branchClassCounts;       ///< Classified branch occurrences
-        statistics::Vector branchClassMisses;       ///< Mispredictions per class
-        statistics::Scalar branchClassCountsTotal;  ///< Total classified branches
-        statistics::Vector controlSquashByClass;    ///< Commit/Resolve-path squashes per class
+        statistics::Vector branchClassCounts; ///< Classified branch occurrences
+        statistics::Vector branchClassMisses; ///< Mispredictions per class
+        statistics::Scalar branchClassCountsTotal; ///< Total classified branches
+        statistics::Vector controlSquashByClass; ///< Commit/Resolve-path squashes per class
 
         // Branch coverage statistics
         statistics::Scalar staticBranchNum;           ///< Total static branches seen
@@ -357,7 +355,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar s3PredWrongIttage;
         statistics::Scalar s3PredWrongRas;
 
-        DBPBTBStats(statistics::Group *parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
+        DBPBTBStats(statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
     } dbpBtbStats;
 
   public:
@@ -376,7 +374,8 @@ class DecoupledBPUWithBTB : public BPredUnit
     {
         panic("Squashing decoupled BP with tightly coupled API\n");
     }
-    void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target, bool actually_taken, ThreadID tid)
+    void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target,
+                bool actually_taken, ThreadID tid)
     {
         panic("Squashing decoupled BP with tightly coupled API\n");
     }
@@ -389,9 +388,9 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     struct BpTrace : public Record
     {
-        void set(uint64_t fsqId, uint64_t startPC, uint64_t controlPC, uint64_t controlType, uint64_t taken,
-                 uint64_t mispred, uint64_t fallThruPC, uint64_t source, uint64_t target)
-        {
+        void set(uint64_t fsqId, uint64_t startPC, uint64_t controlPC, uint64_t controlType,
+            uint64_t taken, uint64_t mispred, uint64_t fallThruPC,
+            uint64_t source, uint64_t target) {
             _uint64_data["fsqId"] = fsqId;
             _uint64_data["startPC"] = startPC;
             _uint64_data["controlPC"] = controlPC;
@@ -408,9 +407,9 @@ class DecoupledBPUWithBTB : public BPredUnit
     // Prediction trace record for tracking prediction-time information
     struct PredictionTrace : public Record
     {
-        void set(uint64_t fsqId, uint64_t startPC, uint64_t predTaken, uint64_t predEndPC, uint64_t controlPC,
-                 uint64_t target, uint64_t predSource, uint64_t btbHit)
-        {
+        void set(uint64_t fsqId, uint64_t startPC, uint64_t predTaken, uint64_t predEndPC,
+                 uint64_t controlPC, uint64_t target,
+                 uint64_t predSource, uint64_t btbHit) {
             _uint64_data["fsqId"] = fsqId;
             _uint64_data["startPC"] = startPC;
             _uint64_data["predTaken"] = predTaken;
@@ -421,43 +420,39 @@ class DecoupledBPUWithBTB : public BPredUnit
             _uint64_data["btbHit"] = btbHit;
         }
 
-        PredictionTrace(uint64_t id, const FetchTarget &entry)
-        {
+        PredictionTrace(uint64_t id, const FetchTarget &entry) {
             _tick = curTick();
-            set(id, entry.startPC, entry.predTaken, entry.predEndPC, entry.getControlPC(), entry.getTakenTarget(),
+            set(id, entry.startPC, entry.predTaken, entry.predEndPC,
+                entry.getControlPC(), entry.getTakenTarget(),
                 entry.predSource, entry.isHit ? 1 : 0);
         }
     };
 
     // redirect the target
-    void controlSquash(unsigned fsq_id, const PCStateBase &control_pc, const PCStateBase &target_pc,
-                       const StaticInstPtr &static_inst, unsigned inst_bytes, bool actually_taken,
-                       const InstSeqNum &squashed_sn, ThreadID tid, const unsigned &currentLoopIter,
+    void controlSquash(unsigned fsq_id,
+                       const PCStateBase &control_pc,
+                       const PCStateBase &target_pc,
+                       const StaticInstPtr &static_inst, unsigned inst_bytes,
+                       bool actually_taken, const InstSeqNum &squashed_sn,
+                       ThreadID tid, const unsigned &currentLoopIter,
                        const bool fromCommit);
 
     // keep the target: original prediction might be right
     // For memory violation, target continues after squashing
-    void nonControlSquash(unsigned fsq_id, const PCStateBase &inst_pc, const InstSeqNum seq, ThreadID tid,
-                          const unsigned &currentLoopIter);
+    void nonControlSquash(unsigned fsq_id,
+                          const PCStateBase &inst_pc, const InstSeqNum seq,
+                          ThreadID tid, const unsigned &currentLoopIter);
 
     // Not a control. But target is actually disturbed
-    void trapSquash(unsigned fsq_id, Addr last_committed_pc, const PCStateBase &inst_pc, ThreadID tid,
-                    const unsigned &currentLoopIter);
+    void trapSquash(unsigned fsq_id, Addr last_committed_pc,
+                    const PCStateBase &inst_pc, ThreadID tid, const unsigned &currentLoopIter);
 
     void commit(unsigned fsqID, ThreadID tid);
 
     // Fetch-facing interface: consume FSQ head directly (RTL-like single queue).
     bool ftqHasFetching(ThreadID tid) const { return ftq.hasTarget(ftq.fetchId(tid), tid); }
-    FetchTargetId ftqHeadId(ThreadID tid) const
-    {
-        assert(ftqHasFetching(tid));
-        return ftq.fetchId(tid);
-    }
-    const FetchTarget &ftqFetchingTarget(ThreadID tid)
-    {
-        assert(ftqHasFetching(tid));
-        return ftq.fetching(tid);
-    }
+    FetchTargetId ftqHeadId(ThreadID tid) const { assert(ftqHasFetching(tid)); return ftq.fetchId(tid); }
+    const FetchTarget &ftqFetchingTarget(ThreadID tid) { assert(ftqHasFetching(tid)); return ftq.fetching(tid); }
 
     void dumpFsq(const char *when);
 
@@ -468,7 +463,8 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void btbUpdate(ThreadID tid, Addr instPC, void *&bp_history) override {}
 
-    void update(ThreadID tid, Addr instPC, bool taken, void *bp_history, bool squashed, const StaticInstPtr &inst,
+    void update(ThreadID tid, Addr instPC, bool taken, void *bp_history,
+                bool squashed, const StaticInstPtr &inst,
                 Addr corrTarget) override
     {
     }
@@ -482,19 +478,18 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     Addr getPreservedReturnAddr(const DynInstPtr &dynInst);
 
-    std::unordered_map<Addr, int> takenBranches;  // branch address -> taken count
+    std::unordered_map<Addr, int> takenBranches;      // branch address -> taken count
     std::unordered_map<Addr, int> currentPhaseTakenBranches;
     std::unordered_map<Addr, int> currentSubPhaseTakenBranches;
 
     /**
      * @brief Types of control flow instruction mispredictions
      */
-    enum MispredType
-    {
-        DIR_WRONG,     ///< Direction prediction error (predicted taken when not taken or vice versa)
-        TARGET_WRONG,  ///< Target address prediction was wrong (branch taken but to the wrong address)
-        NO_PRED,       ///< No prediction was made (branch wasn't predicted at all)
-        FAKE_LAST      ///< Sentinel value
+    enum MispredType {
+        DIR_WRONG,      ///< Direction prediction error (predicted taken when not taken or vice versa)
+        TARGET_WRONG,   ///< Target address prediction was wrong (branch taken but to the wrong address)
+        NO_PRED,        ///< No prediction was made (branch wasn't predicted at all)
+        FAKE_LAST       ///< Sentinel value
     };
 
     /**
@@ -506,41 +501,27 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     struct BranchStats
     {
-        Addr pc;               ///< Branch PC address
-        int branchType;        ///< Branch type (0=cond, 1=uncond, 2=call, 3=ind, etc.)
-        int totalCount;        ///< Total number of times branch was executed
-        int mispredCount;      ///< Total number of mispredictions for this branch
-        int dirWrongCount;     ///< Number of times direction was mispredicted
-        int targetWrongCount;  ///< Number of times target address was mispredicted
-        int noPredCount;       ///< Number of times no prediction was made
+        Addr pc;                ///< Branch PC address
+        int branchType;         ///< Branch type (0=cond, 1=uncond, 2=call, 3=ind, etc.)
+        int totalCount;         ///< Total number of times branch was executed
+        int mispredCount;       ///< Total number of mispredictions for this branch
+        int dirWrongCount;      ///< Number of times direction was mispredicted
+        int targetWrongCount;   ///< Number of times target address was mispredicted
+        int noPredCount;        ///< Number of times no prediction was made
 
         /**
          * @brief Default constructor
          */
         BranchStats()
-            : pc(0),
-              branchType(0),
-              totalCount(0),
-              mispredCount(0),
-              dirWrongCount(0),
-              targetWrongCount(0),
-              noPredCount(0)
-        {
-        }
+            : pc(0), branchType(0), totalCount(0), mispredCount(0),
+              dirWrongCount(0), targetWrongCount(0), noPredCount(0) {}
 
         /**
          * @brief Create branch stats with initial values
          */
         BranchStats(Addr _pc, int _type)
-            : pc(_pc),
-              branchType(_type),
-              totalCount(0),
-              mispredCount(0),
-              dirWrongCount(0),
-              targetWrongCount(0),
-              noPredCount(0)
-        {
-        }
+            : pc(_pc), branchType(_type), totalCount(0), mispredCount(0),
+              dirWrongCount(0), targetWrongCount(0), noPredCount(0) {}
 
         /**
          * @brief Increment total execution count
@@ -550,21 +531,13 @@ class DecoupledBPUWithBTB : public BPredUnit
         /**
          * @brief Increment misprediction count for a specific type
          */
-        void incrementMispred(MispredType type)
-        {
+        void incrementMispred(MispredType type) {
             mispredCount++;
-            switch (type) {
-                case DIR_WRONG:
-                    dirWrongCount++;
-                    break;
-                case TARGET_WRONG:
-                    targetWrongCount++;
-                    break;
-                case NO_PRED:
-                    noPredCount++;
-                    break;
-                default:
-                    break;
+            switch(type) {
+                case DIR_WRONG: dirWrongCount++; break;
+                case TARGET_WRONG: targetWrongCount++; break;
+                case NO_PRED: noPredCount++; break;
+                default: break;
             }
         }
 
@@ -573,7 +546,9 @@ class DecoupledBPUWithBTB : public BPredUnit
          *
          * @return Misprediction rate scaled to per-mille (0-1000)
          */
-        double getMispredRate() const { return totalCount > 0 ? (double)(mispredCount * 1000) / totalCount : 0; }
+        double getMispredRate() const {
+            return totalCount > 0 ? (double)(mispredCount * 1000) / totalCount : 0;
+        }
     };
 
     /**
@@ -699,7 +674,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @brief Calculate sub-phase size in instructions
      * @return Number of instructions per sub-phase
      */
-    int subPhaseSizeByInst() { return phaseSizeByInst / subPhaseRatio; }
+    int subPhaseSizeByInst() { return phaseSizeByInst/subPhaseRatio; }
 
     /**
      * @brief Distribution of committed instructions from previous phase
@@ -758,13 +733,24 @@ class DecoupledBPUWithBTB : public BPredUnit
     // std::vector<BranchStatsMap> topMispredictsByBranchBySubPhase;
     // std::vector<std::map<Addr, int>> takenBranchesBySubPhase;
 
-    void recoverHistoryForSquash(FetchTarget &target, unsigned target_id, const PCStateBase &squash_pc,
-                                 bool is_conditional, bool actually_taken, SquashType squash_type, Addr redirect_pc);
+    void recoverHistoryForSquash(
+        FetchTarget &target,
+        unsigned target_id,
+        const PCStateBase &squash_pc,
+        bool is_conditional,
+        bool actually_taken,
+        SquashType squash_type,
+        Addr redirect_pc);
 
     // Common logic for squash handling
-    void handleSquash(ThreadID tid, unsigned target_id, SquashType squash_type, const PCStateBase &squash_pc,
-                      Addr redirect_pc, bool is_conditional = false, bool actually_taken = false,
-                      const StaticInstPtr &static_inst = nullptr, unsigned control_inst_size = 0);
+    void handleSquash(ThreadID tid, unsigned target_id,
+                      SquashType squash_type,
+                      const PCStateBase &squash_pc,
+                      Addr redirect_pc,
+                      bool is_conditional = false,
+                      bool actually_taken = false,
+                      const StaticInstPtr &static_inst = nullptr,
+                      unsigned control_inst_size = 0);
 
     void resetPC(Addr new_pc);
 
@@ -783,10 +769,10 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     enum CfiType
     {
-        COND,    ///< Conditional branch
-        UNCOND,  ///< Unconditional branch
-        RETURN,  ///< Return instruction
-        OTHER    ///< Other control flow instruction
+        COND,     ///< Conditional branch
+        UNCOND,   ///< Unconditional branch
+        RETURN,   ///< Return instruction
+        OTHER     ///< Other control flow instruction
     };
 
     /**
@@ -794,20 +780,20 @@ class DecoupledBPUWithBTB : public BPredUnit
      */
     enum class BranchClass : uint8_t
     {
-        CondBranch = 0,  ///< Conditional direct branches (TAGE focus)
-        DirectCall,      ///< Direct call instructions (RAS + BTB)
-        IndirectCall,    ///< Indirect call instructions (ITTAGE + RAS)
-        Return,          ///< Return instructions (RAS)
-        DirectJump,      ///< Direct, non-call control transfers (BTB)
-        IndirectJump,    ///< Indirect jumps that are not calls/returns (ITTAGE)
-        Unknown,         ///< Fallback for unexpected classifications
-        NumClasses       ///< Sentinel used for sizing stat containers
+        CondBranch = 0,   ///< Conditional direct branches (TAGE focus)
+        DirectCall,       ///< Direct call instructions (RAS + BTB)
+        IndirectCall,     ///< Indirect call instructions (ITTAGE + RAS)
+        Return,           ///< Return instructions (RAS)
+        DirectJump,       ///< Direct, non-call control transfers (BTB)
+        IndirectJump,     ///< Indirect jumps that are not calls/returns (ITTAGE)
+        Unknown,          ///< Fallback for unexpected classifications
+        NumClasses        ///< Sentinel used for sizing stat containers
     };
 
-    static constexpr size_t NumBranchClasses = static_cast<size_t>(BranchClass::NumClasses);
+    static constexpr size_t NumBranchClasses =
+        static_cast<size_t>(BranchClass::NumClasses);
 
-    void addCfi(CfiType type, bool mispred)
-    {
+    void addCfi(CfiType type, bool mispred) {
         switch (type) {
             case COND:
                 dbpBtbStats.condNum++;
@@ -839,7 +825,9 @@ class DecoupledBPUWithBTB : public BPredUnit
     void addBranchClassStat(BranchClass cls, bool mispred);
     void addControlSquashCommitStat(BranchClass cls);
 
-    void addFtqNotValid() { dbpBtbStats.ftqNotValid++; }
+    void addFtqNotValid() {
+        dbpBtbStats.ftqNotValid++;
+    }
 
     /**
      * @brief Process a branch instruction during commit
@@ -863,8 +851,12 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param taken Whether the branch was taken
      * @param mispred Whether the branch was mispredicted
      */
-    void processMisprediction(const FetchTarget &entry, Addr branchAddr, const BranchInfo &info, bool taken,
-                              bool mispred);
+    void processMisprediction(
+        const FetchTarget &entry,
+        Addr branchAddr,
+        const BranchInfo &info,
+        bool taken,
+        bool mispred);
 
     /**
      * @brief Track statistics for taken branches
@@ -885,9 +877,11 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param phaseBranchesList List of all phases taken branches
      * @return true If the phase was processed
      */
-    bool processPhase(bool isSubPhase, int phaseID, int &phaseToDump, BranchStatsMap &lastPhaseStats,
-                      std::vector<BranchStatsMap> &phaseStatsList, std::unordered_map<Addr, int> &currentPhaseBranches,
-                      std::vector<std::unordered_map<Addr, int>> &phaseBranchesList);
+    bool processPhase(bool isSubPhase, int phaseID, int &phaseToDump,
+                     BranchStatsMap &lastPhaseStats,
+                     std::vector<BranchStatsMap> &phaseStatsList,
+                     std::unordered_map<Addr, int> &currentPhaseBranches,
+                     std::vector<std::unordered_map<Addr, int>> &phaseBranchesList);
 
     /**
      * @brief Process fetch instruction distributions for a phase
@@ -896,7 +890,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      * @param currentPhaseFetchedDist Output vector for fetched instruction distribution
      */
     void processFetchDistributions(std::vector<int> &currentPhaseCommittedDist,
-                                   std::vector<int> &currentPhaseFetchedDist);
+                                  std::vector<int> &currentPhaseFetchedDist);
 
     /**
      * @brief Process BTB entries for a phase
@@ -929,6 +923,7 @@ class DecoupledBPUWithBTB : public BPredUnit
      * the simulation ends. It tracks mispredictions by branch type,
      * phase information, and other metrics.
      */
+
     void dumpStats();
 };
 

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -24,16 +24,11 @@ DecoupledBPUWithBTB::initDB()
     enableBranchTrace = checkGivenSwitch(bpDBSwitches, std::string("basic"));
     if (enableBranchTrace) {
         std::vector<std::pair<std::string, DataType>> fields_vec = {
-            std::make_pair("fsqId", UINT64),
-            std::make_pair("startPC", UINT64),
-            std::make_pair("controlPC", UINT64),
-            std::make_pair("controlType", UINT64),
-            std::make_pair("taken", UINT64),
-            std::make_pair("mispred", UINT64),
-            std::make_pair("fallThruPC", UINT64),
-            std::make_pair("source", UINT64),
-            std::make_pair("target", UINT64)
-        };
+            std::make_pair("fsqId", UINT64),      std::make_pair("startPC", UINT64),
+            std::make_pair("controlPC", UINT64),  std::make_pair("controlType", UINT64),
+            std::make_pair("taken", UINT64),      std::make_pair("mispred", UINT64),
+            std::make_pair("fallThruPC", UINT64), std::make_pair("source", UINT64),
+            std::make_pair("target", UINT64)};
         bptrace = bpdb.addAndGetTrace("BPTRACE", fields_vec);
         bptrace->init_table();
         removeGivenSwitch(bpDBSwitches, std::string("basic"));
@@ -44,15 +39,10 @@ DecoupledBPUWithBTB::initDB()
     if (enablePredFSQTrace) {
         // Initialize prediction trace manager for recording predictions
         std::vector<std::pair<std::string, DataType>> pred_fields_vec = {
-            std::make_pair("fsqId", UINT64),
-            std::make_pair("startPC", UINT64),
-            std::make_pair("predTaken", UINT64),
-            std::make_pair("predEndPC", UINT64),
-            std::make_pair("controlPC", UINT64),
-            std::make_pair("target", UINT64),
-            std::make_pair("predSource", UINT64),
-            std::make_pair("btbHit", UINT64)
-        };
+            std::make_pair("fsqId", UINT64),      std::make_pair("startPC", UINT64),
+            std::make_pair("predTaken", UINT64),  std::make_pair("predEndPC", UINT64),
+            std::make_pair("controlPC", UINT64),  std::make_pair("target", UINT64),
+            std::make_pair("predSource", UINT64), std::make_pair("btbHit", UINT64)};
         predTraceManager = bpdb.addAndGetTrace("PREDTRACE", pred_fields_vec);
         predTraceManager->init_table();
         removeGivenSwitch(bpDBSwitches, std::string("predfsq"));
@@ -64,18 +54,15 @@ void
 DecoupledBPUWithBTB::dumpStats()
 {
     // Helper function: create output file and write header
-    auto createOutputFile = [](const std::string& filename, const std::string& header) {
+    auto createOutputFile = [](const std::string &filename, const std::string &header) {
         auto handle = simout.create(filename, false, true);
         *handle->stream() << header << std::endl;
         return handle;
     };
 
     // Generic sort function by key
-    auto sortByKey = [](auto& data, auto keyFn) {
-        std::sort(data.begin(), data.end(),
-            [&keyFn](const auto& a, const auto& b) {
-                return keyFn(a) > keyFn(b);
-            });
+    auto sortByKey = [](auto &data, auto keyFn) {
+        std::sort(data.begin(), data.end(), [&keyFn](const auto &a, const auto &b) { return keyFn(a) > keyFn(b); });
     };
 
     // 1. Output top mispredictions
@@ -84,78 +71,63 @@ DecoupledBPUWithBTB::dumpStats()
     // startPC: Starting address of fetch block
     // controlPC: Address of branch instruction
     // count: Number of mispredictions
-    std::vector<std::pair<std::pair<Addr, Addr>, int>> topMisPredPC(
-        topMispredicts.begin(), topMispredicts.end());
+    std::vector<std::pair<std::pair<Addr, Addr>, int>> topMisPredPC(topMispredicts.begin(), topMispredicts.end());
 
-    sortByKey(topMisPredPC, [](const auto& entry) { return entry.second; });
-    for (const auto& entry : topMisPredPC) {
-        *outFile->stream() << std::hex << entry.first.first << ","
-            << entry.first.second << ","
-            << std::dec << entry.second << std::endl;
+    sortByKey(topMisPredPC, [](const auto &entry) { return entry.second; });
+    for (const auto &entry : topMisPredPC) {
+        *outFile->stream() << std::hex << entry.first.first << "," << entry.first.second << "," << std::dec
+                           << entry.second << std::endl;
     }
     simout.close(outFile);
 
     // 2. Output mispredictions by branch
     outFile = createOutputFile("topMispredictsByBranch.csv",
-                "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
+                               "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
 
     // topMisPredPCByBranch: Detailed misprediction records per branch
     std::vector<std::tuple<Addr, int, int, int, double, int, int, int>> topMisPredPCByBranch;
     for (const auto &it : topMispredictsByBranch) {
         const auto &stats = it.second;
-        topMisPredPCByBranch.push_back(std::make_tuple(
-            stats.pc, stats.branchType,
-            stats.mispredCount, stats.totalCount,
-            stats.getMispredRate(),
-            stats.dirWrongCount, stats.targetWrongCount, stats.noPredCount));
+        topMisPredPCByBranch.push_back(std::make_tuple(stats.pc, stats.branchType, stats.mispredCount,
+                                                       stats.totalCount, stats.getMispredRate(), stats.dirWrongCount,
+                                                       stats.targetWrongCount, stats.noPredCount));
     }
 
-    sortByKey(topMisPredPCByBranch,
-        [](const auto& entry) {
-            return std::get<2>(entry);  // Sort by mispredCount
-        });
+    sortByKey(topMisPredPCByBranch, [](const auto &entry) {
+        return std::get<2>(entry);  // Sort by mispredCount
+    });
 
-    for (const auto& entry : topMisPredPCByBranch) {
-        *outFile->stream()
-            << std::hex << std::get<0>(entry) << ","
-            << std::dec << std::get<1>(entry) << ","
-            << std::get<2>(entry) << ","
-            << std::get<3>(entry) << ","
-            << std::get<4>(entry) << ","
-            << std::get<5>(entry) << ","
-            << std::get<6>(entry) << ","
-            << std::get<7>(entry) << std::endl;
+    for (const auto &entry : topMisPredPCByBranch) {
+        *outFile->stream() << std::hex << std::get<0>(entry) << "," << std::dec << std::get<1>(entry) << ","
+                           << std::get<2>(entry) << "," << std::get<3>(entry) << "," << std::get<4>(entry) << ","
+                           << std::get<5>(entry) << "," << std::get<6>(entry) << "," << std::get<7>(entry)
+                           << std::endl;
     }
     simout.close(outFile);
 
     // 3. Sort branches by misrate (per-mille)
-    outFile = createOutputFile("topMisrateByBranch.csv",
-                "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
+    outFile =
+        createOutputFile("topMisrateByBranch.csv", "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
 
     // Reuse previous data, but sort by misrate
     int mispCntThres = 100;
-    sortByKey(topMisPredPCByBranch, [](const auto& entry) { return std::get<4>(entry); });
-    for (const auto& entry : topMisPredPCByBranch) {
-        if (std::get<3>(entry) < mispCntThres) continue;
+    sortByKey(topMisPredPCByBranch, [](const auto &entry) { return std::get<4>(entry); });
+    for (const auto &entry : topMisPredPCByBranch) {
+        if (std::get<3>(entry) < mispCntThres)
+            continue;
 
-        *outFile->stream() << std::hex << std::get<0>(entry) << std::dec
-            << "," << std::get<1>(entry)
-            << "," << std::get<2>(entry)
-            << "," << std::get<3>(entry)
-            << "," << (int)std::get<4>(entry)
-            << "," << (int)std::get<5>(entry)
-            << "," << (int)std::get<6>(entry)
-            << "," << (int)std::get<7>(entry) << std::endl;
+        *outFile->stream() << std::hex << std::get<0>(entry) << std::dec << "," << std::get<1>(entry) << ","
+                           << std::get<2>(entry) << "," << std::get<3>(entry) << "," << (int)std::get<4>(entry) << ","
+                           << (int)std::get<5>(entry) << "," << (int)std::get<6>(entry) << ","
+                           << (int)std::get<7>(entry) << std::endl;
     }
     simout.close(outFile);
 
     // Create CSV header for topN tables
-    auto createTopNHeader = [](std::ostream& out, int outputTopN, const std::string& prefix) {
+    auto createTopNHeader = [](std::ostream &out, int outputTopN, const std::string &prefix) {
         out << prefix;
         for (int i = 0; i < outputTopN; i++) {
-            out << ",topMispPC_" << i
-                << ",type_" << i
-                << ",misCnt_" << i;
+            out << ",topMispPC_" << i << ",type_" << i << ",misCnt_" << i;
         }
         out << std::endl;
     };
@@ -164,51 +136,46 @@ DecoupledBPUWithBTB::dumpStats()
     int outputTopN = 5;
 
     // 4. Phase-based mispredictions
-    auto processPhaseData = [&](const std::string& filename,
-                           const auto& dataByPhase,
-                           const auto& takenBranches) {
+    auto processPhaseData = [&](const std::string &filename, const auto &dataByPhase, const auto &takenBranches) {
         outFile = simout.create(filename, false, true);
-        auto& out = *outFile->stream();
+        auto &out = *outFile->stream();
 
         // Write header
         createTopNHeader(out, outputTopN,
-                        filename.find("Sub") != std::string::npos ?
-                        "subPhaseID,numBranches,numEverTakenBranches,totalMispredicts" :
-                        "phaseID,numBranches,numEverTakenBranches,totalMispredicts");
+                         filename.find("Sub") != std::string::npos
+                             ? "subPhaseID,numBranches,numEverTakenBranches,totalMispredicts"
+                             : "phaseID,numBranches,numEverTakenBranches,totalMispredicts");
 
         int phaseID = 0;
-        for (const auto& phaseData : dataByPhase) {
+        for (const auto &phaseData : dataByPhase) {
             int numStaticBranches = phaseData.size();
             int numEverTakenStaticBranches = takenBranches[phaseID].size();
 
             // Copy data and calculate total mispredictions
             std::vector<std::pair<BranchKey, BranchStats>> phaseRecords;
-            for (const auto& record : phaseData) {
+            for (const auto &record : phaseData) {
                 phaseRecords.push_back(record);
             }
 
             // Calculate total mispredicts
             int totalMispredicts = 0;
-            for (const auto& rec : phaseRecords) {
+            for (const auto &rec : phaseRecords) {
                 totalMispredicts += rec.second.mispredCount;
             }
 
             // Output phase basic info
-            out << phaseID << "," << numStaticBranches << ","
-                << numEverTakenStaticBranches << "," << totalMispredicts;
+            out << phaseID << "," << numStaticBranches << "," << numEverTakenStaticBranches << "," << totalMispredicts;
 
             // Sort by misprediction count
             std::sort(phaseRecords.begin(), phaseRecords.end(),
-                [](const auto& a, const auto& b) {
-                    return a.second.mispredCount > b.second.mispredCount;
-                });
+                      [](const auto &a, const auto &b) { return a.second.mispredCount > b.second.mispredCount; });
 
             // Output top-N
             for (int i = 0; i < outputTopN && i < phaseRecords.size(); i++) {
-                const auto& stats = phaseRecords[i].second;
-                out << "," << std::hex << stats.pc // pc
-                    << "," << std::dec << stats.branchType // type
-                    << "," << stats.mispredCount; // count
+                const auto &stats = phaseRecords[i].second;
+                out << "," << std::hex << stats.pc          // pc
+                    << "," << std::dec << stats.branchType  // type
+                    << "," << stats.mispredCount;           // count
             }
             out << std::dec << std::endl;
             phaseID++;
@@ -216,45 +183,36 @@ DecoupledBPUWithBTB::dumpStats()
         simout.close(outFile);
     };
 
-    processPhaseData("topMispredictByPhase.csv",
-                     topMispredictsByBranchByPhase,
-                     takenBranchesByPhase);
+    processPhaseData("topMispredictByPhase.csv", topMispredictsByBranchByPhase, takenBranchesByPhase);
 
-    processPhaseData("topMispredictBySubPhase.csv",
-                     topMispredictsByBranchBySubPhase,
-                     takenBranchesBySubPhase);
+    processPhaseData("topMispredictBySubPhase.csv", topMispredictsByBranchBySubPhase, takenBranchesBySubPhase);
 
     // 5. Output history misprediction data
     outFile = createOutputFile("topMisPredictHist.csv", "Hist,count");
     // Vector of (history pattern, count) pairs
-    std::vector<std::pair<uint64_t, uint64_t>>
-        topMisPredHistVec(topMispredHist.begin(), topMispredHist.end());
+    std::vector<std::pair<uint64_t, uint64_t>> topMisPredHistVec(topMispredHist.begin(), topMispredHist.end());
 
-    sortByKey(topMisPredHistVec, [](const auto& entry) { return entry.second; });
-    for (const auto& entry : topMisPredHistVec) {
-        *outFile->stream() << std::hex << entry.first << ","
-            << std::dec << entry.second << std::endl;
+    sortByKey(topMisPredHistVec, [](const auto &entry) { return entry.second; });
+    for (const auto &entry : topMisPredHistVec) {
+        *outFile->stream() << std::hex << entry.first << "," << std::dec << entry.second << std::endl;
     }
     simout.close(outFile);
 
     // 6. Output indirect mispredictions
     outFile = createOutputFile("misPredIndirectStream.csv", "count,address");
     // Vector of (address, count) pairs for indirect branches
-    std::vector<std::pair<Addr, unsigned>>
-        indirectVec(topMispredIndirect.begin(), topMispredIndirect.end());
+    std::vector<std::pair<Addr, unsigned>> indirectVec(topMispredIndirect.begin(), topMispredIndirect.end());
 
-    sortByKey(indirectVec, [](const auto& entry) { return entry.second; });
-    for (const auto& entry : indirectVec) {
-        *outFile->stream() << std::oct << entry.second << ","
-            << std::hex << entry.first << std::endl;
+    sortByKey(indirectVec, [](const auto &entry) { return entry.second; });
+    for (const auto &entry : indirectVec) {
+        *outFile->stream() << std::oct << entry.second << "," << std::hex << entry.first << std::endl;
     }
     simout.close(outFile);
 
     // Process FSQ distribution data
-    auto processFsqDistribution = [&](const std::string& filename,
-                                  const auto& distByPhase) {
+    auto processFsqDistribution = [&](const std::string &filename, const auto &distByPhase) {
         outFile = simout.create(filename, false, true);
-        auto& out = *outFile->stream();
+        auto &out = *outFile->stream();
 
         // Write header
         out << "phaseID";
@@ -265,7 +223,7 @@ DecoupledBPUWithBTB::dumpStats()
 
         // Write data for each phase
         int phaseID = 0;
-        for (const auto& dist : distByPhase) {
+        for (const auto &dist : distByPhase) {
             out << phaseID;
 
             int numFsqEntries = 0;
@@ -285,11 +243,9 @@ DecoupledBPUWithBTB::dumpStats()
     };
 
     // 7-8. Output FSQ distribution data
-    processFsqDistribution("fsqEntryCommittedInstNumDistsByPhase.csv",
-                          fsqEntryNumCommittedInstDistByPhase);
+    processFsqDistribution("fsqEntryCommittedInstNumDistsByPhase.csv", fsqEntryNumCommittedInstDistByPhase);
 
-    processFsqDistribution("fsqEntryFetchedInstNumDistsByPhase.csv",
-                          fsqEntryNumFetchedInstDistByPhase);
+    processFsqDistribution("fsqEntryFetchedInstNumDistsByPhase.csv", fsqEntryNumFetchedInstDistByPhase);
 
     // 9. Output BTB entries
     int outputTopNEntries = 1;
@@ -301,21 +257,18 @@ DecoupledBPUWithBTB::dumpStats()
     outFile = createOutputFile("btbEntriesByPhase.csv", headerSS.str());
 
     int phaseID = 0;
-    for (auto& phase : BTBEntriesByPhase) {
-        auto& out = *outFile->stream();
+    for (auto &phase : BTBEntriesByPhase) {
+        auto &out = *outFile->stream();
         out << std::dec << phaseID << "," << phase.size();
 
         // Vector of (PC, BTBEntry, count) tuples
         std::vector<std::tuple<Addr, BTBEntry, int>> btbEntries;
-        for (auto& entry : phase) {
-            btbEntries.push_back(std::make_tuple(
-                entry.first, entry.second.first, entry.second.second));
+        for (auto &entry : phase) {
+            btbEntries.push_back(std::make_tuple(entry.first, entry.second.first, entry.second.second));
         }
 
         std::sort(btbEntries.begin(), btbEntries.end(),
-            [](const auto &a, const auto &b) {
-                 return std::get<2>(a) > std::get<2>(b);
-            });
+                  [](const auto &a, const auto &b) { return std::get<2>(a) > std::get<2>(b); });
 
         for (int i = 0; i <= outputTopNEntries && i < btbEntries.size(); i++) {
             const auto &entry = btbEntries[i];
@@ -343,7 +296,7 @@ DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchTarget &target, const
     const auto &rv_pc = inst->pcState().as<RiscvISA::PCState>();
     Addr targetpc = rv_pc.npc();
     Addr fallThru = rv_pc.getFallThruPC();
-    BranchInfo info(pc, targetpc, inst->staticInst, fallThru-pc);
+    BranchInfo info(pc, targetpc, inst->staticInst, fallThru - pc);
     set(fsqId, target.startPC, pc, info.getType(), inst->branching(), mispred, fallThru, target.predSource, targetpc);
     // for (auto it = _uint64_data.begin(); it != _uint64_data.end(); it++) {
     //     printf("%s: %ld\n", it->first.c_str(), it->second);
@@ -351,20 +304,13 @@ DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchTarget &target, const
 }
 
 
-namespace {
+namespace
+{
 
-constexpr std::array<const char*, DecoupledBPUWithBTB::NumBranchClasses>
-    BranchClassLabels = {
-        "cond_branch",
-        "direct_call",
-        "indirect_call",
-        "return",
-        "direct_jump",
-        "indirect_jump",
-        "unknown"
-    };
+constexpr std::array<const char *, DecoupledBPUWithBTB::NumBranchClasses> BranchClassLabels = {
+    "cond_branch", "direct_call", "indirect_call", "return", "direct_jump", "indirect_jump", "unknown"};
 
-template <typename InstPtr>
+template<typename InstPtr>
 DecoupledBPUWithBTB::BranchClass
 classifyBranchImpl(const InstPtr &inst)
 {
@@ -379,8 +325,7 @@ classifyBranchImpl(const InstPtr &inst)
     }
 
     if (inst->isCall()) {
-        return inst->isIndirectCtrl() ? BranchClass::IndirectCall
-                                      : BranchClass::DirectCall;
+        return inst->isIndirectCtrl() ? BranchClass::IndirectCall : BranchClass::DirectCall;
     }
 
     if (inst->isCondCtrl()) {
@@ -398,78 +343,101 @@ classifyBranchImpl(const InstPtr &inst)
     return BranchClass::Unknown;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
-    statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum):
-    statistics::Group(parent),
-    ADD_STAT(condNum, statistics::units::Count::get(), "the number of cond branches"),
-    ADD_STAT(uncondNum, statistics::units::Count::get(), "the number of uncond branches"),
-    ADD_STAT(returnNum, statistics::units::Count::get(), "the number of return branches"),
-    ADD_STAT(otherNum, statistics::units::Count::get(), "the number of other branches"),
-    ADD_STAT(condMiss, statistics::units::Count::get(), "the number of cond branch misses"),
-    ADD_STAT(uncondMiss, statistics::units::Count::get(), "the number of uncond branch misses"),
-    ADD_STAT(returnMiss, statistics::units::Count::get(), "the number of return branch misses"),
-    ADD_STAT(otherMiss, statistics::units::Count::get(), "the number of other branch misses"),
-    ADD_STAT(branchClassCounts, statistics::units::Count::get(), "branch counts by fine-grained class"),
-    ADD_STAT(branchClassMisses, statistics::units::Count::get(), "branch mispredictions by fine-grained class"),
-    ADD_STAT(branchClassCountsTotal, statistics::units::Count::get(), "total number of classified branches"),
-    ADD_STAT(controlSquashByClass, statistics::units::Count::get(), "commit/resolve-path squashes by branch class"),
-    ADD_STAT(staticBranchNum, statistics::units::Count::get(), "the number of all (different) static branches"),
-    ADD_STAT(staticBranchNumEverTaken, statistics::units::Count::get(), "the number of all (different) static branches that are once taken"),
-    ADD_STAT(predsOfEachStage, statistics::units::Count::get(), "the number of preds of each stage that account for final pred"),
-    ADD_STAT(overrideBubbleNum,  statistics::units::Count::get(), "the number of override bubbles"),
-    ADD_STAT(overrideCount, statistics::units::Count::get(), "the number of overrides"),
-    ADD_STAT(commitPredsFromEachStage, statistics::units::Count::get(),
-    "the number of preds of each stage that account for a committed target"),
-    ADD_STAT(commitOverrideBubbleNum, statistics::units::Count::get(),
-    "the number of override bubbles, on the commit path"),
-    ADD_STAT(commitOverrideCount, statistics::units::Count::get(), "the number of overrides, on the commit path"),
-    ADD_STAT(overrideFallThruMismatch, statistics::units::Count::get(),
-    "Number of overrides due to validity mismatches, on commit path"),
-    ADD_STAT(overrideControlAddrMismatch, statistics::units::Count::get(),
-    "Number of overrides due to control address mismatches, on commit path"),
-    ADD_STAT(overrideTargetMismatch, statistics::units::Count::get(),
-    "Number of overrides due to target mismatches, on commit path"),
-    ADD_STAT(overrideEndMismatch, statistics::units::Count::get(),
-    "Number of overrides due to end address mismatches, on commit path"),
-    ADD_STAT(overrideHistInfoMismatch, statistics::units::Count::get(),
-    "Number of overrides due to history info mismatches, on commit path"),
-    ADD_STAT(fsqEntryDist, statistics::units::Count::get(), "the distribution of number of entries in fsq"),
-    ADD_STAT(fsqEntryEnqueued, statistics::units::Count::get(), "the number of fsq entries enqueued"),
-    ADD_STAT(fsqEntryCommitted, statistics::units::Count::get(), "the number of fsq entries committed at last"),
-    ADD_STAT(controlSquashFromDecode, statistics::units::Count::get(), "the number of control squashes in bpu from decode"),
-    ADD_STAT(controlSquashFromCommit, statistics::units::Count::get(), "the number of control squashes in bpu from commit"),
-    ADD_STAT(nonControlSquash, statistics::units::Count::get(), "the number of non-control squashes in bpu"),
-    ADD_STAT(trapSquash, statistics::units::Count::get(), "the number of trap squashes in bpu"),
-    ADD_STAT(ftqNotValid, statistics::units::Count::get(), "fetch needs ftq req but ftq not valid"),
-    ADD_STAT(fsqNotValid, statistics::units::Count::get(), "ftq needs fsq req but fsq not valid"),
-    ADD_STAT(fsqFullCannotEnq, statistics::units::Count::get(), "bpu has req but fsq full cannot enqueue"),
-    ADD_STAT(ftqFullCannotEnq, statistics::units::Count::get(), "fsq has entry but ftq full cannot enqueue"),
-    ADD_STAT(fsqFullFetchHungry, statistics::units::Count::get(), "fetch hungry when fsq full and bpu cannot enqueue"),
-    ADD_STAT(fsqEmpty, statistics::units::Count::get(), "fsq is empty"),
-    ADD_STAT(commitFsqEntryHasInsts, statistics::units::Count::get(), "number of insts that commit fsq entries have"),
-    ADD_STAT(commitFsqEntryFetchedInsts, statistics::units::Count::get(), "number of insts that commit fsq entries fetched"),
-    ADD_STAT(commitFsqEntryOnlyHasOneJump, statistics::units::Count::get(), "number of fsq entries with only one instruction (jump)"),
-    ADD_STAT(btbHit, statistics::units::Count::get(), "btb hits (in predict block)"),
-    ADD_STAT(btbMiss, statistics::units::Count::get(), "btb misses (in predict block)"),
-    ADD_STAT(btbEntriesWithDifferentStart, statistics::units::Count::get(), "number of btb entries with different start PC"),
-    ADD_STAT(btbEntriesWithOnlyOneJump, statistics::units::Count::get(), "number of btb entries with different start PC starting with a jump"),
-    ADD_STAT(predFalseHit, statistics::units::Count::get(), "false hit detected at pred"),
-    ADD_STAT(commitFalseHit, statistics::units::Count::get(), "false hit detected at commit"),
-    ADD_STAT(predictionBlockedForUpdate, statistics::units::Count::get(), "prediction blocked for update priority"),
-    ADD_STAT(s1PredWrongFallthrough, statistics::units::Count::get(), "S1pred wrong full throughs"),
-    ADD_STAT(s1PredWrongUbtb, statistics::units::Count::get(),"S1pred wrong using ubtb "),
-    ADD_STAT(s1PredWrongAbtb, statistics::units::Count::get(), "S1pred wrong using abtb "),
-    ADD_STAT(s3PredWrongMbtb, statistics::units::Count::get(), "S3pred wrong blame mbtb "),
-    ADD_STAT(s3PredWrongTage, statistics::units::Count::get(), "S3pred wrong blame tage "),
-    ADD_STAT(s3PredWrongIttage, statistics::units::Count::get(), "S3pred wrong blame ittage "),
-    ADD_STAT(s3PredWrongRas, statistics::units::Count::get(), "S3pred wrong blame ras ")
+DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group *parent, unsigned numStages, unsigned fsqSize,
+                                              unsigned maxInstsNum)
+    : statistics::Group(parent),
+      ADD_STAT(condNum, statistics::units::Count::get(), "the number of cond branches"),
+      ADD_STAT(uncondNum, statistics::units::Count::get(), "the number of uncond branches"),
+      ADD_STAT(returnNum, statistics::units::Count::get(), "the number of return branches"),
+      ADD_STAT(otherNum, statistics::units::Count::get(), "the number of other branches"),
+      ADD_STAT(condMiss, statistics::units::Count::get(), "the number of cond branch misses"),
+      ADD_STAT(uncondMiss, statistics::units::Count::get(), "the number of uncond branch misses"),
+      ADD_STAT(returnMiss, statistics::units::Count::get(), "the number of return branch misses"),
+      ADD_STAT(otherMiss, statistics::units::Count::get(), "the number of other branch misses"),
+      ADD_STAT(branchClassCounts, statistics::units::Count::get(), "branch counts by fine-grained class"),
+      ADD_STAT(branchClassMisses, statistics::units::Count::get(), "branch mispredictions by fine-grained class"),
+      ADD_STAT(branchClassCountsTotal, statistics::units::Count::get(), "total number of classified branches"),
+      ADD_STAT(controlSquashByClass, statistics::units::Count::get(), "commit/resolve-path squashes by branch class"),
+      ADD_STAT(staticBranchNum, statistics::units::Count::get(), "the number of all (different) static branches"),
+      ADD_STAT(staticBranchNumEverTaken, statistics::units::Count::get(),
+               "the number of all (different) static branches that are once taken"),
+      ADD_STAT(predsOfEachStage, statistics::units::Count::get(),
+               "the number of preds of each stage that account for final pred"),
+      ADD_STAT(overrideBubbleNum, statistics::units::Count::get(), "the number of override bubbles"),
+      ADD_STAT(overrideCount, statistics::units::Count::get(), "the number of overrides"),
+      ADD_STAT(commitPredsFromEachStage, statistics::units::Count::get(),
+               "the number of preds of each stage that account for a committed target"),
+      ADD_STAT(commitOverrideBubbleNum, statistics::units::Count::get(),
+               "the number of override bubbles, on the commit path"),
+      ADD_STAT(commitOverrideCount, statistics::units::Count::get(), "the number of overrides, on the commit path"),
+      ADD_STAT(overrideFallThruMismatch, statistics::units::Count::get(),
+               "Number of overrides due to validity mismatches, on commit path"),
+      ADD_STAT(overrideControlAddrMismatch, statistics::units::Count::get(),
+               "Number of overrides due to control address mismatches, on commit path"),
+      ADD_STAT(overrideTargetMismatch, statistics::units::Count::get(),
+               "Number of overrides due to target mismatches, on commit path"),
+      ADD_STAT(overrideEndMismatch, statistics::units::Count::get(),
+               "Number of overrides due to end address mismatches, on commit path"),
+      ADD_STAT(overrideHistInfoMismatch, statistics::units::Count::get(),
+               "Number of overrides due to history info mismatches, on commit path"),
+      ADD_STAT(fsqEntryDist, statistics::units::Count::get(), "the distribution of number of entries in fsq"),
+      ADD_STAT(fsqEntryEnqueued, statistics::units::Count::get(), "the number of fsq entries enqueued"),
+      ADD_STAT(fsqEntryCommitted, statistics::units::Count::get(), "the number of fsq entries committed at last"),
+      ADD_STAT(controlSquashFromDecode, statistics::units::Count::get(),
+               "the number of control squashes in bpu from decode"),
+      ADD_STAT(controlSquashFromCommit, statistics::units::Count::get(),
+               "the number of control squashes in bpu from commit"),
+      ADD_STAT(nonControlSquash, statistics::units::Count::get(), "the number of non-control squashes in bpu"),
+      ADD_STAT(trapSquash, statistics::units::Count::get(), "the number of trap squashes in bpu"),
+      ADD_STAT(ftqNotValid, statistics::units::Count::get(), "fetch needs ftq req but ftq not valid"),
+      ADD_STAT(fsqNotValid, statistics::units::Count::get(), "ftq needs fsq req but fsq not valid"),
+      ADD_STAT(fsqFullCannotEnq, statistics::units::Count::get(), "bpu has req but fsq full cannot enqueue"),
+      ADD_STAT(ftqFullCannotEnq, statistics::units::Count::get(), "fsq has entry but ftq full cannot enqueue"),
+      ADD_STAT(fsqFullFetchHungry, statistics::units::Count::get(),
+               "fetch hungry when fsq full and bpu cannot enqueue"),
+      ADD_STAT(fsqEmpty, statistics::units::Count::get(), "fsq is empty"),
+      ADD_STAT(block1Attempted, statistics::units::Count::get(), "number of attempted block1 generations"),
+      ADD_STAT(block1Accepted, statistics::units::Count::get(), "number of accepted block1 predictions"),
+      ADD_STAT(block1DroppedByBlock0Override, statistics::units::Count::get(),
+               "block1 dropped because block0 was overridden"),
+      ADD_STAT(block1DroppedByCond, statistics::units::Count::get(),
+               "block1 dropped because conditional support was missing"),
+      ADD_STAT(block1DroppedByIndirect, statistics::units::Count::get(),
+               "block1 dropped because indirect support was missing"),
+      ADD_STAT(block1DroppedByReturn, statistics::units::Count::get(),
+               "block1 dropped because return support was missing"),
+      ADD_STAT(block1DroppedByFTQFull, statistics::units::Count::get(),
+               "block1 dropped because FTQ space was insufficient"),
+      ADD_STAT(block1DroppedOther, statistics::units::Count::get(), "block1 dropped for other reasons"),
+      ADD_STAT(commitFsqEntryHasInsts, statistics::units::Count::get(),
+               "number of insts that commit fsq entries have"),
+      ADD_STAT(commitFsqEntryFetchedInsts, statistics::units::Count::get(),
+               "number of insts that commit fsq entries fetched"),
+      ADD_STAT(commitFsqEntryOnlyHasOneJump, statistics::units::Count::get(),
+               "number of fsq entries with only one instruction (jump)"),
+      ADD_STAT(btbHit, statistics::units::Count::get(), "btb hits (in predict block)"),
+      ADD_STAT(btbMiss, statistics::units::Count::get(), "btb misses (in predict block)"),
+      ADD_STAT(btbEntriesWithDifferentStart, statistics::units::Count::get(),
+               "number of btb entries with different start PC"),
+      ADD_STAT(btbEntriesWithOnlyOneJump, statistics::units::Count::get(),
+               "number of btb entries with different start PC starting with a jump"),
+      ADD_STAT(predFalseHit, statistics::units::Count::get(), "false hit detected at pred"),
+      ADD_STAT(commitFalseHit, statistics::units::Count::get(), "false hit detected at commit"),
+      ADD_STAT(predictionBlockedForUpdate, statistics::units::Count::get(), "prediction blocked for update priority"),
+      ADD_STAT(s1PredWrongFallthrough, statistics::units::Count::get(), "S1pred wrong full throughs"),
+      ADD_STAT(s1PredWrongUbtb, statistics::units::Count::get(), "S1pred wrong using ubtb "),
+      ADD_STAT(s1PredWrongAbtb, statistics::units::Count::get(), "S1pred wrong using abtb "),
+      ADD_STAT(s3PredWrongMbtb, statistics::units::Count::get(), "S3pred wrong blame mbtb "),
+      ADD_STAT(s3PredWrongTage, statistics::units::Count::get(), "S3pred wrong blame tage "),
+      ADD_STAT(s3PredWrongIttage, statistics::units::Count::get(), "S3pred wrong blame ittage "),
+      ADD_STAT(s3PredWrongRas, statistics::units::Count::get(), "S3pred wrong blame ras ")
 
 {
     predsOfEachStage.init(numStages);
-    commitPredsFromEachStage.init(numStages+1);
-    commitOverrideBubbleNum = commitPredsFromEachStage[1] + 2 * commitPredsFromEachStage[2] ;
+    commitPredsFromEachStage.init(numStages + 1);
+    commitOverrideBubbleNum = commitPredsFromEachStage[1] + 2 * commitPredsFromEachStage[2];
     commitOverrideCount = commitPredsFromEachStage[1] + commitPredsFromEachStage[2];
     fsqEntryDist.init(0, fsqSize, 20).flags(statistics::total);
     commitFsqEntryHasInsts.init(0, maxInstsNum >> 1, 1);
@@ -484,47 +452,46 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     }
 }
 
-void DecoupledBPUWithBTB::overrideStats(OverrideReason overrideReason)
+void
+DecoupledBPUWithBTB::overrideStats(OverrideReason overrideReason)
 {
 
-        // Track specific override reasons for statistics
-        switch (overrideReason) {
-            case OverrideReason::FALL_THRU:
-                dbpBtbStats.overrideFallThruMismatch++;
-                break;
-            case OverrideReason::CONTROL_ADDR:
-                dbpBtbStats.overrideControlAddrMismatch++;
-                break;
-            case OverrideReason::TARGET:
-                dbpBtbStats.overrideTargetMismatch++;
-                break;
-            case OverrideReason::END:
-                dbpBtbStats.overrideEndMismatch++;
-                break;
-            case OverrideReason::HIST_INFO:
-                dbpBtbStats.overrideHistInfoMismatch++;
-                break;
-            default:
-                break;
-        }
+    // Track specific override reasons for statistics
+    switch (overrideReason) {
+        case OverrideReason::FALL_THRU:
+            dbpBtbStats.overrideFallThruMismatch++;
+            break;
+        case OverrideReason::CONTROL_ADDR:
+            dbpBtbStats.overrideControlAddrMismatch++;
+            break;
+        case OverrideReason::TARGET:
+            dbpBtbStats.overrideTargetMismatch++;
+            break;
+        case OverrideReason::END:
+            dbpBtbStats.overrideEndMismatch++;
+            break;
+        case OverrideReason::HIST_INFO:
+            dbpBtbStats.overrideHistInfoMismatch++;
+            break;
+        default:
+            break;
+    }
 }
 
 void
 DecoupledBPUWithBTB::processFetchDistributions(std::vector<int> &currentPhaseCommittedDist,
-                                              std::vector<int> &currentPhaseFetchedDist)
+                                               std::vector<int> &currentPhaseFetchedDist)
 {
     // Initialize distributions with zeros
-    currentPhaseCommittedDist.resize(maxInstsNum+1, 0);
-    currentPhaseFetchedDist.resize(maxInstsNum+1, 0);
+    currentPhaseCommittedDist.resize(maxInstsNum + 1, 0);
+    currentPhaseFetchedDist.resize(maxInstsNum + 1, 0);
 
     // Calculate the difference between current and last phase values
     for (int i = 0; i <= maxInstsNum; i++) {
-        currentPhaseCommittedDist[i] = commitFsqEntryHasInstsVector[i] -
-                                     lastPhaseFsqEntryNumCommittedInstDist[i];
+        currentPhaseCommittedDist[i] = commitFsqEntryHasInstsVector[i] - lastPhaseFsqEntryNumCommittedInstDist[i];
         lastPhaseFsqEntryNumCommittedInstDist[i] = commitFsqEntryHasInstsVector[i];
 
-        currentPhaseFetchedDist[i] = commitFsqEntryFetchedInstsVector[i] -
-                                   lastPhaseFsqEntryNumFetchedInstDist[i];
+        currentPhaseFetchedDist[i] = commitFsqEntryFetchedInstsVector[i] - lastPhaseFsqEntryNumFetchedInstDist[i];
         lastPhaseFsqEntryNumFetchedInstDist[i] = commitFsqEntryFetchedInstsVector[i];
     }
 }
@@ -558,11 +525,10 @@ DecoupledBPUWithBTB::processBTBEntries()
 }
 
 bool
-DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump,
-                                BranchStatsMap &lastPhaseStats,
-                                std::vector<BranchStatsMap> &phaseStatsList,
-                                std::unordered_map<Addr, int> &currentPhaseBranches,
-                                std::vector<std::unordered_map<Addr, int>> &phaseBranchesList)
+DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump, BranchStatsMap &lastPhaseStats,
+                                  std::vector<BranchStatsMap> &phaseStatsList,
+                                  std::unordered_map<Addr, int> &currentPhaseBranches,
+                                  std::vector<std::unordered_map<Addr, int>> &phaseBranchesList)
 {
     // Check if this phase should be processed
     if (phaseToDump > phaseID) {
@@ -570,8 +536,7 @@ DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump
     }
 
     // Debug output
-    DPRINTF(Profiling, "dump %s phase %d\n",
-            isSubPhase ? "sub" : "main", phaseToDump);
+    DPRINTF(Profiling, "dump %s phase %d\n", isSubPhase ? "sub" : "main", phaseToDump);
 
     // Create map for current phase statistics
     BranchStatsMap currentPhaseStats;
@@ -660,8 +625,7 @@ DecoupledBPUWithBTB::addBranchClassStat(BranchClass cls, bool mispred)
 {
     auto idx = static_cast<size_t>(cls);
     if (idx >= NumBranchClasses) {
-        DPRINTF(DBPBTBStats, "Skip invalid branch class stats update %d\n",
-                static_cast<int>(cls));
+        DPRINTF(DBPBTBStats, "Skip invalid branch class stats update %d\n", static_cast<int>(cls));
         return;
     }
 
@@ -671,8 +635,7 @@ DecoupledBPUWithBTB::addBranchClassStat(BranchClass cls, bool mispred)
         dbpBtbStats.branchClassCountsTotal++;
     }
 
-    DPRINTF(DBPBTBStats, "Branch classified as %s, mispred=%d\n",
-            branchClassName(cls), mispred);
+    DPRINTF(DBPBTBStats, "Branch classified as %s, mispred=%d\n", branchClassName(cls), mispred);
 }
 
 void
@@ -680,15 +643,12 @@ DecoupledBPUWithBTB::addControlSquashCommitStat(BranchClass cls)
 {
     auto idx = static_cast<size_t>(cls);
     if (idx >= NumBranchClasses) {
-        DPRINTF(DBPBTBStats,
-                "Skip invalid commit squash class stats update %d\n",
-                static_cast<int>(cls));
+        DPRINTF(DBPBTBStats, "Skip invalid commit squash class stats update %d\n", static_cast<int>(cls));
         return;
     }
 
     dbpBtbStats.controlSquashByClass[idx]++;
-    DPRINTF(DBPBTBStats, "Commit squash classified as %s\n",
-            branchClassName(cls));
+    DPRINTF(DBPBTBStats, "Commit squash classified as %s\n", branchClassName(cls));
 }
 
 void
@@ -712,8 +672,8 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
             DPRINTF(BTB, "BTB miss detected when update, target start %#lx, predTick %lu, printing branch info:\n",
                     target.startPC, target.predTick);
             auto &slot = target.exeBranchInfo;
-            DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n",
-                slot.pc, slot.size, slot.target, slot.isCond, slot.isIndirect, slot.isCall, slot.isReturn);
+            DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n", slot.pc,
+                    slot.size, slot.target, slot.isCond, slot.isIndirect, slot.isCall, slot.isReturn);
         }
 
         // Count false hits
@@ -811,7 +771,7 @@ DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
     const auto &rv_pc = inst->pcState().as<RiscvISA::PCState>();
     Addr targetAddr = rv_pc.npc();
     Addr fallThruPC = rv_pc.getFallThruPC();
-    BranchInfo info(branchAddr, targetAddr, inst->staticInst, fallThruPC-branchAddr);
+    BranchInfo info(branchAddr, targetAddr, inst->staticInst, fallThruPC - branchAddr);
     bool taken = rv_pc.branching() || inst->isUncondCtrl();
 
     // ---------- Process misprediction and update statistics ----------
@@ -826,12 +786,11 @@ DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
     for (auto component : components) {
         component->commitBranch(entry, inst);
     }
-    //here add final counter
+    // here add final counter
 
     if (mispred) {
         commitPredWrongSource(entry);
     }
-
 }
 
 void
@@ -856,7 +815,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         dbpBtbStats.s1PredWrongUbtb++;
     } else if (s1PredSource == abtbid) {
         dbpBtbStats.s1PredWrongAbtb++;
-    }else {
+    } else {
         dbpBtbStats.s1PredWrongFallthrough++;
     }
 
@@ -886,7 +845,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
-    }else if (s3PredSource == mbtbid) {
+    } else if (s3PredSource == mbtbid) {
         if (exeBranchInfo.isCond) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
@@ -898,7 +857,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
-    }else if (s3PredSource == -1) {
+    } else if (s3PredSource == -1) {
         dbpBtbStats.s3PredWrongMbtb++;
     }
 }
@@ -927,11 +886,8 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
         int currentPhaseID = numInstCommitted / phaseSizeByInst;
 
         // Process main phase statistics if needed
-        if (processPhase(false, currentPhaseID, phaseIdToDump,
-                        lastPhaseTopMispredictsByBranch,
-                        topMispredictsByBranchByPhase,
-                        currentPhaseTakenBranches,
-                        takenBranchesByPhase)) {
+        if (processPhase(false, currentPhaseID, phaseIdToDump, lastPhaseTopMispredictsByBranch,
+                         topMispredictsByBranchByPhase, currentPhaseTakenBranches, takenBranchesByPhase)) {
 
             // Process fetch instruction distributions
             std::vector<int> committedInstDist, fetchedInstDist;
@@ -951,11 +907,8 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
         int currentSubPhaseID = numInstCommitted / subPhaseSizeByInst();
 
         // Process sub-phase statistics if needed
-        processPhase(true, currentSubPhaseID, subPhaseIdToDump,
-                    lastSubPhaseTopMispredictsByBranch,
-                    topMispredictsByBranchBySubPhase,
-                    currentSubPhaseTakenBranches,
-                    takenBranchesBySubPhase);
+        processPhase(true, currentSubPhaseID, subPhaseIdToDump, lastSubPhaseTopMispredictsByBranch,
+                     topMispredictsByBranchBySubPhase, currentSubPhaseTakenBranches, takenBranchesBySubPhase);
     }
 }
 
@@ -970,12 +923,8 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
  * @param mispred Whether the branch was mispredicted
  */
 void
-DecoupledBPUWithBTB::processMisprediction(
-    const FetchTarget &entry,
-    Addr branchAddr,
-    const BranchInfo &info,
-    bool taken,
-    bool mispred)
+DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchAddr, const BranchInfo &info,
+                                          bool taken, bool mispred)
 {
     MispredType mispredType = FAKE_LAST;
 
@@ -984,11 +933,11 @@ DecoupledBPUWithBTB::processMisprediction(
         if (!taken) {
             // Only conditional branches can be not-taken
             assert(info.isCond);
-            mispredType = DIR_WRONG; // Direction was wrong
+            mispredType = DIR_WRONG;  // Direction was wrong
         } else {
             // Check if this branch was in the predicted BTB entries
             bool predBranchInBTB = false;
-            for (auto &e: entry.predBTBEntries) {
+            for (auto &e : entry.predBTBEntries) {
                 if (e.pc == branchAddr) {
                     predBranchInBTB = true;
                     break;
@@ -996,17 +945,17 @@ DecoupledBPUWithBTB::processMisprediction(
             }
 
             if (!predBranchInBTB) {
-                mispredType = NO_PRED; // Branch wasn't predicted at all
+                mispredType = NO_PRED;  // Branch wasn't predicted at all
             } else if (entry.predTaken && entry.predBranchInfo.pc == branchAddr) {
-                mispredType = TARGET_WRONG; // Branch predicted taken but wrong target
+                mispredType = TARGET_WRONG;  // Branch predicted taken but wrong target
             } else {
                 // Branch predicted not taken or different branch predicted taken
                 mispredType = DIR_WRONG;
             }
         }
 
-        DPRINTF(Profiling, "branchAddr %#lx is mispredicted, taken %d, type %d, missType %d\n",
-                branchAddr, taken, info.getType(), mispredType);
+        DPRINTF(Profiling, "branchAddr %#lx is mispredicted, taken %d, type %d, missType %d\n", branchAddr, taken,
+                info.getType(), mispredType);
         assert(mispredType != FAKE_LAST);
     }
 
@@ -1014,8 +963,7 @@ DecoupledBPUWithBTB::processMisprediction(
     auto branchKey = std::make_pair(branchAddr, info.getType());
 
     // Update branch statistics
-    DPRINTF(Profiling, "lookup topMispredictsByBranch for branchAddr %#lx, type %d\n",
-            branchAddr, info.getType());
+    DPRINTF(Profiling, "lookup topMispredictsByBranch for branchAddr %#lx, type %d\n", branchAddr, info.getType());
 
     auto statsIt = topMispredictsByBranch.find(branchKey);
 
@@ -1037,8 +985,7 @@ DecoupledBPUWithBTB::processMisprediction(
         dbpBtbStats.staticBranchNum++;
     } else {
         // Update existing statistics entry
-        DPRINTF(Profiling, "found, total %d, miss %d\n",
-                statsIt->second.totalCount, statsIt->second.mispredCount);
+        DPRINTF(Profiling, "found, total %d, miss %d\n", statsIt->second.totalCount, statsIt->second.mispredCount);
 
         // Always increment total count
         statsIt->second.incrementTotal();
@@ -1076,6 +1023,6 @@ DecoupledBPUWithBTB::trackTakenBranch(Addr branchAddr)
     updateBranchMap(currentSubPhaseTakenBranches);
 }
 
-} // namespace btb_pred
-} // namespace branch_prediction
-} // namespace gem5
+}  // namespace btb_pred
+}  // namespace branch_prediction
+}  // namespace gem5

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -24,11 +24,16 @@ DecoupledBPUWithBTB::initDB()
     enableBranchTrace = checkGivenSwitch(bpDBSwitches, std::string("basic"));
     if (enableBranchTrace) {
         std::vector<std::pair<std::string, DataType>> fields_vec = {
-            std::make_pair("fsqId", UINT64),      std::make_pair("startPC", UINT64),
-            std::make_pair("controlPC", UINT64),  std::make_pair("controlType", UINT64),
-            std::make_pair("taken", UINT64),      std::make_pair("mispred", UINT64),
-            std::make_pair("fallThruPC", UINT64), std::make_pair("source", UINT64),
-            std::make_pair("target", UINT64)};
+            std::make_pair("fsqId", UINT64),
+            std::make_pair("startPC", UINT64),
+            std::make_pair("controlPC", UINT64),
+            std::make_pair("controlType", UINT64),
+            std::make_pair("taken", UINT64),
+            std::make_pair("mispred", UINT64),
+            std::make_pair("fallThruPC", UINT64),
+            std::make_pair("source", UINT64),
+            std::make_pair("target", UINT64)
+        };
         bptrace = bpdb.addAndGetTrace("BPTRACE", fields_vec);
         bptrace->init_table();
         removeGivenSwitch(bpDBSwitches, std::string("basic"));
@@ -39,10 +44,15 @@ DecoupledBPUWithBTB::initDB()
     if (enablePredFSQTrace) {
         // Initialize prediction trace manager for recording predictions
         std::vector<std::pair<std::string, DataType>> pred_fields_vec = {
-            std::make_pair("fsqId", UINT64),      std::make_pair("startPC", UINT64),
-            std::make_pair("predTaken", UINT64),  std::make_pair("predEndPC", UINT64),
-            std::make_pair("controlPC", UINT64),  std::make_pair("target", UINT64),
-            std::make_pair("predSource", UINT64), std::make_pair("btbHit", UINT64)};
+            std::make_pair("fsqId", UINT64),
+            std::make_pair("startPC", UINT64),
+            std::make_pair("predTaken", UINT64),
+            std::make_pair("predEndPC", UINT64),
+            std::make_pair("controlPC", UINT64),
+            std::make_pair("target", UINT64),
+            std::make_pair("predSource", UINT64),
+            std::make_pair("btbHit", UINT64)
+        };
         predTraceManager = bpdb.addAndGetTrace("PREDTRACE", pred_fields_vec);
         predTraceManager->init_table();
         removeGivenSwitch(bpDBSwitches, std::string("predfsq"));
@@ -54,15 +64,18 @@ void
 DecoupledBPUWithBTB::dumpStats()
 {
     // Helper function: create output file and write header
-    auto createOutputFile = [](const std::string &filename, const std::string &header) {
+    auto createOutputFile = [](const std::string& filename, const std::string& header) {
         auto handle = simout.create(filename, false, true);
         *handle->stream() << header << std::endl;
         return handle;
     };
 
     // Generic sort function by key
-    auto sortByKey = [](auto &data, auto keyFn) {
-        std::sort(data.begin(), data.end(), [&keyFn](const auto &a, const auto &b) { return keyFn(a) > keyFn(b); });
+    auto sortByKey = [](auto& data, auto keyFn) {
+        std::sort(data.begin(), data.end(),
+            [&keyFn](const auto& a, const auto& b) {
+                return keyFn(a) > keyFn(b);
+            });
     };
 
     // 1. Output top mispredictions
@@ -71,63 +84,78 @@ DecoupledBPUWithBTB::dumpStats()
     // startPC: Starting address of fetch block
     // controlPC: Address of branch instruction
     // count: Number of mispredictions
-    std::vector<std::pair<std::pair<Addr, Addr>, int>> topMisPredPC(topMispredicts.begin(), topMispredicts.end());
+    std::vector<std::pair<std::pair<Addr, Addr>, int>> topMisPredPC(
+        topMispredicts.begin(), topMispredicts.end());
 
-    sortByKey(topMisPredPC, [](const auto &entry) { return entry.second; });
-    for (const auto &entry : topMisPredPC) {
-        *outFile->stream() << std::hex << entry.first.first << "," << entry.first.second << "," << std::dec
-                           << entry.second << std::endl;
+    sortByKey(topMisPredPC, [](const auto& entry) { return entry.second; });
+    for (const auto& entry : topMisPredPC) {
+        *outFile->stream() << std::hex << entry.first.first << ","
+            << entry.first.second << ","
+            << std::dec << entry.second << std::endl;
     }
     simout.close(outFile);
 
     // 2. Output mispredictions by branch
     outFile = createOutputFile("topMispredictsByBranch.csv",
-                               "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
+                "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
 
     // topMisPredPCByBranch: Detailed misprediction records per branch
     std::vector<std::tuple<Addr, int, int, int, double, int, int, int>> topMisPredPCByBranch;
     for (const auto &it : topMispredictsByBranch) {
         const auto &stats = it.second;
-        topMisPredPCByBranch.push_back(std::make_tuple(stats.pc, stats.branchType, stats.mispredCount,
-                                                       stats.totalCount, stats.getMispredRate(), stats.dirWrongCount,
-                                                       stats.targetWrongCount, stats.noPredCount));
+        topMisPredPCByBranch.push_back(std::make_tuple(
+            stats.pc, stats.branchType,
+            stats.mispredCount, stats.totalCount,
+            stats.getMispredRate(),
+            stats.dirWrongCount, stats.targetWrongCount, stats.noPredCount));
     }
 
-    sortByKey(topMisPredPCByBranch, [](const auto &entry) {
-        return std::get<2>(entry);  // Sort by mispredCount
-    });
+    sortByKey(topMisPredPCByBranch,
+        [](const auto& entry) {
+            return std::get<2>(entry);  // Sort by mispredCount
+        });
 
-    for (const auto &entry : topMisPredPCByBranch) {
-        *outFile->stream() << std::hex << std::get<0>(entry) << "," << std::dec << std::get<1>(entry) << ","
-                           << std::get<2>(entry) << "," << std::get<3>(entry) << "," << std::get<4>(entry) << ","
-                           << std::get<5>(entry) << "," << std::get<6>(entry) << "," << std::get<7>(entry)
-                           << std::endl;
+    for (const auto& entry : topMisPredPCByBranch) {
+        *outFile->stream()
+            << std::hex << std::get<0>(entry) << ","
+            << std::dec << std::get<1>(entry) << ","
+            << std::get<2>(entry) << ","
+            << std::get<3>(entry) << ","
+            << std::get<4>(entry) << ","
+            << std::get<5>(entry) << ","
+            << std::get<6>(entry) << ","
+            << std::get<7>(entry) << std::endl;
     }
     simout.close(outFile);
 
     // 3. Sort branches by misrate (per-mille)
-    outFile =
-        createOutputFile("topMisrateByBranch.csv", "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
+    outFile = createOutputFile("topMisrateByBranch.csv",
+                "pc,type,mispredicts,total,misPermil,dirMiss,tgtMiss,noPredMiss");
 
     // Reuse previous data, but sort by misrate
     int mispCntThres = 100;
-    sortByKey(topMisPredPCByBranch, [](const auto &entry) { return std::get<4>(entry); });
-    for (const auto &entry : topMisPredPCByBranch) {
-        if (std::get<3>(entry) < mispCntThres)
-            continue;
+    sortByKey(topMisPredPCByBranch, [](const auto& entry) { return std::get<4>(entry); });
+    for (const auto& entry : topMisPredPCByBranch) {
+        if (std::get<3>(entry) < mispCntThres) continue;
 
-        *outFile->stream() << std::hex << std::get<0>(entry) << std::dec << "," << std::get<1>(entry) << ","
-                           << std::get<2>(entry) << "," << std::get<3>(entry) << "," << (int)std::get<4>(entry) << ","
-                           << (int)std::get<5>(entry) << "," << (int)std::get<6>(entry) << ","
-                           << (int)std::get<7>(entry) << std::endl;
+        *outFile->stream() << std::hex << std::get<0>(entry) << std::dec
+            << "," << std::get<1>(entry)
+            << "," << std::get<2>(entry)
+            << "," << std::get<3>(entry)
+            << "," << (int)std::get<4>(entry)
+            << "," << (int)std::get<5>(entry)
+            << "," << (int)std::get<6>(entry)
+            << "," << (int)std::get<7>(entry) << std::endl;
     }
     simout.close(outFile);
 
     // Create CSV header for topN tables
-    auto createTopNHeader = [](std::ostream &out, int outputTopN, const std::string &prefix) {
+    auto createTopNHeader = [](std::ostream& out, int outputTopN, const std::string& prefix) {
         out << prefix;
         for (int i = 0; i < outputTopN; i++) {
-            out << ",topMispPC_" << i << ",type_" << i << ",misCnt_" << i;
+            out << ",topMispPC_" << i
+                << ",type_" << i
+                << ",misCnt_" << i;
         }
         out << std::endl;
     };
@@ -136,46 +164,51 @@ DecoupledBPUWithBTB::dumpStats()
     int outputTopN = 5;
 
     // 4. Phase-based mispredictions
-    auto processPhaseData = [&](const std::string &filename, const auto &dataByPhase, const auto &takenBranches) {
+    auto processPhaseData = [&](const std::string& filename,
+                           const auto& dataByPhase,
+                           const auto& takenBranches) {
         outFile = simout.create(filename, false, true);
-        auto &out = *outFile->stream();
+        auto& out = *outFile->stream();
 
         // Write header
         createTopNHeader(out, outputTopN,
-                         filename.find("Sub") != std::string::npos
-                             ? "subPhaseID,numBranches,numEverTakenBranches,totalMispredicts"
-                             : "phaseID,numBranches,numEverTakenBranches,totalMispredicts");
+                        filename.find("Sub") != std::string::npos ?
+                        "subPhaseID,numBranches,numEverTakenBranches,totalMispredicts" :
+                        "phaseID,numBranches,numEverTakenBranches,totalMispredicts");
 
         int phaseID = 0;
-        for (const auto &phaseData : dataByPhase) {
+        for (const auto& phaseData : dataByPhase) {
             int numStaticBranches = phaseData.size();
             int numEverTakenStaticBranches = takenBranches[phaseID].size();
 
             // Copy data and calculate total mispredictions
             std::vector<std::pair<BranchKey, BranchStats>> phaseRecords;
-            for (const auto &record : phaseData) {
+            for (const auto& record : phaseData) {
                 phaseRecords.push_back(record);
             }
 
             // Calculate total mispredicts
             int totalMispredicts = 0;
-            for (const auto &rec : phaseRecords) {
+            for (const auto& rec : phaseRecords) {
                 totalMispredicts += rec.second.mispredCount;
             }
 
             // Output phase basic info
-            out << phaseID << "," << numStaticBranches << "," << numEverTakenStaticBranches << "," << totalMispredicts;
+            out << phaseID << "," << numStaticBranches << ","
+                << numEverTakenStaticBranches << "," << totalMispredicts;
 
             // Sort by misprediction count
             std::sort(phaseRecords.begin(), phaseRecords.end(),
-                      [](const auto &a, const auto &b) { return a.second.mispredCount > b.second.mispredCount; });
+                [](const auto& a, const auto& b) {
+                    return a.second.mispredCount > b.second.mispredCount;
+                });
 
             // Output top-N
             for (int i = 0; i < outputTopN && i < phaseRecords.size(); i++) {
-                const auto &stats = phaseRecords[i].second;
-                out << "," << std::hex << stats.pc          // pc
-                    << "," << std::dec << stats.branchType  // type
-                    << "," << stats.mispredCount;           // count
+                const auto& stats = phaseRecords[i].second;
+                out << "," << std::hex << stats.pc // pc
+                    << "," << std::dec << stats.branchType // type
+                    << "," << stats.mispredCount; // count
             }
             out << std::dec << std::endl;
             phaseID++;
@@ -183,36 +216,45 @@ DecoupledBPUWithBTB::dumpStats()
         simout.close(outFile);
     };
 
-    processPhaseData("topMispredictByPhase.csv", topMispredictsByBranchByPhase, takenBranchesByPhase);
+    processPhaseData("topMispredictByPhase.csv",
+                     topMispredictsByBranchByPhase,
+                     takenBranchesByPhase);
 
-    processPhaseData("topMispredictBySubPhase.csv", topMispredictsByBranchBySubPhase, takenBranchesBySubPhase);
+    processPhaseData("topMispredictBySubPhase.csv",
+                     topMispredictsByBranchBySubPhase,
+                     takenBranchesBySubPhase);
 
     // 5. Output history misprediction data
     outFile = createOutputFile("topMisPredictHist.csv", "Hist,count");
     // Vector of (history pattern, count) pairs
-    std::vector<std::pair<uint64_t, uint64_t>> topMisPredHistVec(topMispredHist.begin(), topMispredHist.end());
+    std::vector<std::pair<uint64_t, uint64_t>>
+        topMisPredHistVec(topMispredHist.begin(), topMispredHist.end());
 
-    sortByKey(topMisPredHistVec, [](const auto &entry) { return entry.second; });
-    for (const auto &entry : topMisPredHistVec) {
-        *outFile->stream() << std::hex << entry.first << "," << std::dec << entry.second << std::endl;
+    sortByKey(topMisPredHistVec, [](const auto& entry) { return entry.second; });
+    for (const auto& entry : topMisPredHistVec) {
+        *outFile->stream() << std::hex << entry.first << ","
+            << std::dec << entry.second << std::endl;
     }
     simout.close(outFile);
 
     // 6. Output indirect mispredictions
     outFile = createOutputFile("misPredIndirectStream.csv", "count,address");
     // Vector of (address, count) pairs for indirect branches
-    std::vector<std::pair<Addr, unsigned>> indirectVec(topMispredIndirect.begin(), topMispredIndirect.end());
+    std::vector<std::pair<Addr, unsigned>>
+        indirectVec(topMispredIndirect.begin(), topMispredIndirect.end());
 
-    sortByKey(indirectVec, [](const auto &entry) { return entry.second; });
-    for (const auto &entry : indirectVec) {
-        *outFile->stream() << std::oct << entry.second << "," << std::hex << entry.first << std::endl;
+    sortByKey(indirectVec, [](const auto& entry) { return entry.second; });
+    for (const auto& entry : indirectVec) {
+        *outFile->stream() << std::oct << entry.second << ","
+            << std::hex << entry.first << std::endl;
     }
     simout.close(outFile);
 
     // Process FSQ distribution data
-    auto processFsqDistribution = [&](const std::string &filename, const auto &distByPhase) {
+    auto processFsqDistribution = [&](const std::string& filename,
+                                  const auto& distByPhase) {
         outFile = simout.create(filename, false, true);
-        auto &out = *outFile->stream();
+        auto& out = *outFile->stream();
 
         // Write header
         out << "phaseID";
@@ -223,7 +265,7 @@ DecoupledBPUWithBTB::dumpStats()
 
         // Write data for each phase
         int phaseID = 0;
-        for (const auto &dist : distByPhase) {
+        for (const auto& dist : distByPhase) {
             out << phaseID;
 
             int numFsqEntries = 0;
@@ -243,9 +285,11 @@ DecoupledBPUWithBTB::dumpStats()
     };
 
     // 7-8. Output FSQ distribution data
-    processFsqDistribution("fsqEntryCommittedInstNumDistsByPhase.csv", fsqEntryNumCommittedInstDistByPhase);
+    processFsqDistribution("fsqEntryCommittedInstNumDistsByPhase.csv",
+                          fsqEntryNumCommittedInstDistByPhase);
 
-    processFsqDistribution("fsqEntryFetchedInstNumDistsByPhase.csv", fsqEntryNumFetchedInstDistByPhase);
+    processFsqDistribution("fsqEntryFetchedInstNumDistsByPhase.csv",
+                          fsqEntryNumFetchedInstDistByPhase);
 
     // 9. Output BTB entries
     int outputTopNEntries = 1;
@@ -257,18 +301,21 @@ DecoupledBPUWithBTB::dumpStats()
     outFile = createOutputFile("btbEntriesByPhase.csv", headerSS.str());
 
     int phaseID = 0;
-    for (auto &phase : BTBEntriesByPhase) {
-        auto &out = *outFile->stream();
+    for (auto& phase : BTBEntriesByPhase) {
+        auto& out = *outFile->stream();
         out << std::dec << phaseID << "," << phase.size();
 
         // Vector of (PC, BTBEntry, count) tuples
         std::vector<std::tuple<Addr, BTBEntry, int>> btbEntries;
-        for (auto &entry : phase) {
-            btbEntries.push_back(std::make_tuple(entry.first, entry.second.first, entry.second.second));
+        for (auto& entry : phase) {
+            btbEntries.push_back(std::make_tuple(
+                entry.first, entry.second.first, entry.second.second));
         }
 
         std::sort(btbEntries.begin(), btbEntries.end(),
-                  [](const auto &a, const auto &b) { return std::get<2>(a) > std::get<2>(b); });
+            [](const auto &a, const auto &b) {
+                 return std::get<2>(a) > std::get<2>(b);
+            });
 
         for (int i = 0; i <= outputTopNEntries && i < btbEntries.size(); i++) {
             const auto &entry = btbEntries[i];
@@ -296,7 +343,7 @@ DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchTarget &target, const
     const auto &rv_pc = inst->pcState().as<RiscvISA::PCState>();
     Addr targetpc = rv_pc.npc();
     Addr fallThru = rv_pc.getFallThruPC();
-    BranchInfo info(pc, targetpc, inst->staticInst, fallThru - pc);
+    BranchInfo info(pc, targetpc, inst->staticInst, fallThru-pc);
     set(fsqId, target.startPC, pc, info.getType(), inst->branching(), mispred, fallThru, target.predSource, targetpc);
     // for (auto it = _uint64_data.begin(); it != _uint64_data.end(); it++) {
     //     printf("%s: %ld\n", it->first.c_str(), it->second);
@@ -304,13 +351,20 @@ DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchTarget &target, const
 }
 
 
-namespace
-{
+namespace {
 
-constexpr std::array<const char *, DecoupledBPUWithBTB::NumBranchClasses> BranchClassLabels = {
-    "cond_branch", "direct_call", "indirect_call", "return", "direct_jump", "indirect_jump", "unknown"};
+constexpr std::array<const char*, DecoupledBPUWithBTB::NumBranchClasses>
+    BranchClassLabels = {
+        "cond_branch",
+        "direct_call",
+        "indirect_call",
+        "return",
+        "direct_jump",
+        "indirect_jump",
+        "unknown"
+    };
 
-template<typename InstPtr>
+template <typename InstPtr>
 DecoupledBPUWithBTB::BranchClass
 classifyBranchImpl(const InstPtr &inst)
 {
@@ -325,7 +379,8 @@ classifyBranchImpl(const InstPtr &inst)
     }
 
     if (inst->isCall()) {
-        return inst->isIndirectCtrl() ? BranchClass::IndirectCall : BranchClass::DirectCall;
+        return inst->isIndirectCtrl() ? BranchClass::IndirectCall
+                                      : BranchClass::DirectCall;
     }
 
     if (inst->isCondCtrl()) {
@@ -436,8 +491,8 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group *parent, unsigne
 
 {
     predsOfEachStage.init(numStages);
-    commitPredsFromEachStage.init(numStages + 1);
-    commitOverrideBubbleNum = commitPredsFromEachStage[1] + 2 * commitPredsFromEachStage[2];
+    commitPredsFromEachStage.init(numStages+1);
+    commitOverrideBubbleNum = commitPredsFromEachStage[1] + 2 * commitPredsFromEachStage[2] ;
     commitOverrideCount = commitPredsFromEachStage[1] + commitPredsFromEachStage[2];
     fsqEntryDist.init(0, fsqSize, 20).flags(statistics::total);
     commitFsqEntryHasInsts.init(0, maxInstsNum >> 1, 1);
@@ -452,46 +507,47 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(statistics::Group *parent, unsigne
     }
 }
 
-void
-DecoupledBPUWithBTB::overrideStats(OverrideReason overrideReason)
+void DecoupledBPUWithBTB::overrideStats(OverrideReason overrideReason)
 {
 
-    // Track specific override reasons for statistics
-    switch (overrideReason) {
-        case OverrideReason::FALL_THRU:
-            dbpBtbStats.overrideFallThruMismatch++;
-            break;
-        case OverrideReason::CONTROL_ADDR:
-            dbpBtbStats.overrideControlAddrMismatch++;
-            break;
-        case OverrideReason::TARGET:
-            dbpBtbStats.overrideTargetMismatch++;
-            break;
-        case OverrideReason::END:
-            dbpBtbStats.overrideEndMismatch++;
-            break;
-        case OverrideReason::HIST_INFO:
-            dbpBtbStats.overrideHistInfoMismatch++;
-            break;
-        default:
-            break;
-    }
+        // Track specific override reasons for statistics
+        switch (overrideReason) {
+            case OverrideReason::FALL_THRU:
+                dbpBtbStats.overrideFallThruMismatch++;
+                break;
+            case OverrideReason::CONTROL_ADDR:
+                dbpBtbStats.overrideControlAddrMismatch++;
+                break;
+            case OverrideReason::TARGET:
+                dbpBtbStats.overrideTargetMismatch++;
+                break;
+            case OverrideReason::END:
+                dbpBtbStats.overrideEndMismatch++;
+                break;
+            case OverrideReason::HIST_INFO:
+                dbpBtbStats.overrideHistInfoMismatch++;
+                break;
+            default:
+                break;
+        }
 }
 
 void
 DecoupledBPUWithBTB::processFetchDistributions(std::vector<int> &currentPhaseCommittedDist,
-                                               std::vector<int> &currentPhaseFetchedDist)
+                                              std::vector<int> &currentPhaseFetchedDist)
 {
     // Initialize distributions with zeros
-    currentPhaseCommittedDist.resize(maxInstsNum + 1, 0);
-    currentPhaseFetchedDist.resize(maxInstsNum + 1, 0);
+    currentPhaseCommittedDist.resize(maxInstsNum+1, 0);
+    currentPhaseFetchedDist.resize(maxInstsNum+1, 0);
 
     // Calculate the difference between current and last phase values
     for (int i = 0; i <= maxInstsNum; i++) {
-        currentPhaseCommittedDist[i] = commitFsqEntryHasInstsVector[i] - lastPhaseFsqEntryNumCommittedInstDist[i];
+        currentPhaseCommittedDist[i] = commitFsqEntryHasInstsVector[i] -
+                                     lastPhaseFsqEntryNumCommittedInstDist[i];
         lastPhaseFsqEntryNumCommittedInstDist[i] = commitFsqEntryHasInstsVector[i];
 
-        currentPhaseFetchedDist[i] = commitFsqEntryFetchedInstsVector[i] - lastPhaseFsqEntryNumFetchedInstDist[i];
+        currentPhaseFetchedDist[i] = commitFsqEntryFetchedInstsVector[i] -
+                                   lastPhaseFsqEntryNumFetchedInstDist[i];
         lastPhaseFsqEntryNumFetchedInstDist[i] = commitFsqEntryFetchedInstsVector[i];
     }
 }
@@ -525,10 +581,11 @@ DecoupledBPUWithBTB::processBTBEntries()
 }
 
 bool
-DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump, BranchStatsMap &lastPhaseStats,
-                                  std::vector<BranchStatsMap> &phaseStatsList,
-                                  std::unordered_map<Addr, int> &currentPhaseBranches,
-                                  std::vector<std::unordered_map<Addr, int>> &phaseBranchesList)
+DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump,
+                                BranchStatsMap &lastPhaseStats,
+                                std::vector<BranchStatsMap> &phaseStatsList,
+                                std::unordered_map<Addr, int> &currentPhaseBranches,
+                                std::vector<std::unordered_map<Addr, int>> &phaseBranchesList)
 {
     // Check if this phase should be processed
     if (phaseToDump > phaseID) {
@@ -536,7 +593,8 @@ DecoupledBPUWithBTB::processPhase(bool isSubPhase, int phaseID, int &phaseToDump
     }
 
     // Debug output
-    DPRINTF(Profiling, "dump %s phase %d\n", isSubPhase ? "sub" : "main", phaseToDump);
+    DPRINTF(Profiling, "dump %s phase %d\n",
+            isSubPhase ? "sub" : "main", phaseToDump);
 
     // Create map for current phase statistics
     BranchStatsMap currentPhaseStats;
@@ -625,7 +683,8 @@ DecoupledBPUWithBTB::addBranchClassStat(BranchClass cls, bool mispred)
 {
     auto idx = static_cast<size_t>(cls);
     if (idx >= NumBranchClasses) {
-        DPRINTF(DBPBTBStats, "Skip invalid branch class stats update %d\n", static_cast<int>(cls));
+        DPRINTF(DBPBTBStats, "Skip invalid branch class stats update %d\n",
+                static_cast<int>(cls));
         return;
     }
 
@@ -635,7 +694,8 @@ DecoupledBPUWithBTB::addBranchClassStat(BranchClass cls, bool mispred)
         dbpBtbStats.branchClassCountsTotal++;
     }
 
-    DPRINTF(DBPBTBStats, "Branch classified as %s, mispred=%d\n", branchClassName(cls), mispred);
+    DPRINTF(DBPBTBStats, "Branch classified as %s, mispred=%d\n",
+            branchClassName(cls), mispred);
 }
 
 void
@@ -643,12 +703,15 @@ DecoupledBPUWithBTB::addControlSquashCommitStat(BranchClass cls)
 {
     auto idx = static_cast<size_t>(cls);
     if (idx >= NumBranchClasses) {
-        DPRINTF(DBPBTBStats, "Skip invalid commit squash class stats update %d\n", static_cast<int>(cls));
+        DPRINTF(DBPBTBStats,
+                "Skip invalid commit squash class stats update %d\n",
+                static_cast<int>(cls));
         return;
     }
 
     dbpBtbStats.controlSquashByClass[idx]++;
-    DPRINTF(DBPBTBStats, "Commit squash classified as %s\n", branchClassName(cls));
+    DPRINTF(DBPBTBStats, "Commit squash classified as %s\n",
+            branchClassName(cls));
 }
 
 void
@@ -672,8 +735,8 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
             DPRINTF(BTB, "BTB miss detected when update, target start %#lx, predTick %lu, printing branch info:\n",
                     target.startPC, target.predTick);
             auto &slot = target.exeBranchInfo;
-            DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n", slot.pc,
-                    slot.size, slot.target, slot.isCond, slot.isIndirect, slot.isCall, slot.isReturn);
+            DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n",
+                slot.pc, slot.size, slot.target, slot.isCond, slot.isIndirect, slot.isCall, slot.isReturn);
         }
 
         // Count false hits
@@ -771,7 +834,7 @@ DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
     const auto &rv_pc = inst->pcState().as<RiscvISA::PCState>();
     Addr targetAddr = rv_pc.npc();
     Addr fallThruPC = rv_pc.getFallThruPC();
-    BranchInfo info(branchAddr, targetAddr, inst->staticInst, fallThruPC - branchAddr);
+    BranchInfo info(branchAddr, targetAddr, inst->staticInst, fallThruPC-branchAddr);
     bool taken = rv_pc.branching() || inst->isUncondCtrl();
 
     // ---------- Process misprediction and update statistics ----------
@@ -786,10 +849,11 @@ DecoupledBPUWithBTB::commitBranch(const DynInstPtr &inst, bool mispred)
     for (auto component : components) {
         component->commitBranch(entry, inst);
     }
-    // here add final counter
+    //here add final counter
 
     if (mispred) {
         commitPredWrongSource(entry);
+
     }
 }
 
@@ -815,7 +879,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         dbpBtbStats.s1PredWrongUbtb++;
     } else if (s1PredSource == abtbid) {
         dbpBtbStats.s1PredWrongAbtb++;
-    } else {
+    }else {
         dbpBtbStats.s1PredWrongFallthrough++;
     }
 
@@ -845,7 +909,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
-    } else if (s3PredSource == mbtbid) {
+    }else if (s3PredSource == mbtbid) {
         if (exeBranchInfo.isCond) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
@@ -857,7 +921,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
-    } else if (s3PredSource == -1) {
+    }else if (s3PredSource == -1) {
         dbpBtbStats.s3PredWrongMbtb++;
     }
 }
@@ -886,8 +950,11 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
         int currentPhaseID = numInstCommitted / phaseSizeByInst;
 
         // Process main phase statistics if needed
-        if (processPhase(false, currentPhaseID, phaseIdToDump, lastPhaseTopMispredictsByBranch,
-                         topMispredictsByBranchByPhase, currentPhaseTakenBranches, takenBranchesByPhase)) {
+        if (processPhase(false, currentPhaseID, phaseIdToDump,
+                        lastPhaseTopMispredictsByBranch,
+                        topMispredictsByBranchByPhase,
+                        currentPhaseTakenBranches,
+                        takenBranchesByPhase)) {
 
             // Process fetch instruction distributions
             std::vector<int> committedInstDist, fetchedInstDist;
@@ -907,8 +974,11 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
         int currentSubPhaseID = numInstCommitted / subPhaseSizeByInst();
 
         // Process sub-phase statistics if needed
-        processPhase(true, currentSubPhaseID, subPhaseIdToDump, lastSubPhaseTopMispredictsByBranch,
-                     topMispredictsByBranchBySubPhase, currentSubPhaseTakenBranches, takenBranchesBySubPhase);
+        processPhase(true, currentSubPhaseID, subPhaseIdToDump,
+                    lastSubPhaseTopMispredictsByBranch,
+                    topMispredictsByBranchBySubPhase,
+                    currentSubPhaseTakenBranches,
+                    takenBranchesBySubPhase);
     }
 }
 
@@ -923,8 +993,12 @@ DecoupledBPUWithBTB::notifyInstCommit(const DynInstPtr &inst)
  * @param mispred Whether the branch was mispredicted
  */
 void
-DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchAddr, const BranchInfo &info,
-                                          bool taken, bool mispred)
+DecoupledBPUWithBTB::processMisprediction(
+    const FetchTarget &entry,
+    Addr branchAddr,
+    const BranchInfo &info,
+    bool taken,
+    bool mispred)
 {
     MispredType mispredType = FAKE_LAST;
 
@@ -933,11 +1007,11 @@ DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchA
         if (!taken) {
             // Only conditional branches can be not-taken
             assert(info.isCond);
-            mispredType = DIR_WRONG;  // Direction was wrong
+            mispredType = DIR_WRONG; // Direction was wrong
         } else {
             // Check if this branch was in the predicted BTB entries
             bool predBranchInBTB = false;
-            for (auto &e : entry.predBTBEntries) {
+            for (auto &e: entry.predBTBEntries) {
                 if (e.pc == branchAddr) {
                     predBranchInBTB = true;
                     break;
@@ -945,17 +1019,17 @@ DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchA
             }
 
             if (!predBranchInBTB) {
-                mispredType = NO_PRED;  // Branch wasn't predicted at all
+                mispredType = NO_PRED; // Branch wasn't predicted at all
             } else if (entry.predTaken && entry.predBranchInfo.pc == branchAddr) {
-                mispredType = TARGET_WRONG;  // Branch predicted taken but wrong target
+                mispredType = TARGET_WRONG; // Branch predicted taken but wrong target
             } else {
                 // Branch predicted not taken or different branch predicted taken
                 mispredType = DIR_WRONG;
             }
         }
 
-        DPRINTF(Profiling, "branchAddr %#lx is mispredicted, taken %d, type %d, missType %d\n", branchAddr, taken,
-                info.getType(), mispredType);
+        DPRINTF(Profiling, "branchAddr %#lx is mispredicted, taken %d, type %d, missType %d\n",
+                branchAddr, taken, info.getType(), mispredType);
         assert(mispredType != FAKE_LAST);
     }
 
@@ -963,7 +1037,8 @@ DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchA
     auto branchKey = std::make_pair(branchAddr, info.getType());
 
     // Update branch statistics
-    DPRINTF(Profiling, "lookup topMispredictsByBranch for branchAddr %#lx, type %d\n", branchAddr, info.getType());
+    DPRINTF(Profiling, "lookup topMispredictsByBranch for branchAddr %#lx, type %d\n",
+            branchAddr, info.getType());
 
     auto statsIt = topMispredictsByBranch.find(branchKey);
 
@@ -985,7 +1060,8 @@ DecoupledBPUWithBTB::processMisprediction(const FetchTarget &entry, Addr branchA
         dbpBtbStats.staticBranchNum++;
     } else {
         // Update existing statistics entry
-        DPRINTF(Profiling, "found, total %d, miss %d\n", statsIt->second.totalCount, statsIt->second.mispredCount);
+        DPRINTF(Profiling, "found, total %d, miss %d\n",
+                statsIt->second.totalCount, statsIt->second.mispredCount);
 
         // Always increment total count
         statsIt->second.incrementTotal();
@@ -1023,6 +1099,6 @@ DecoupledBPUWithBTB::trackTakenBranch(Addr branchAddr)
     updateBranchMap(currentSubPhaseTakenBranches);
 }
 
-}  // namespace btb_pred
-}  // namespace branch_prediction
-}  // namespace gem5
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/btb/docs/two_taken_framework.md
+++ b/src/cpu/pred/btb/docs/two_taken_framework.md
@@ -1,0 +1,214 @@
+# 2-Taken Framework
+
+## Overview
+
+The 2-Taken framework extends `DecoupledBPUWithBTB` so one prediction opportunity can produce:
+
+- `block0`: the normal finalized prediction for the current fetch block
+- `block1`: an optional next fetch block derived from the speculative post-state of `block0`
+
+The fetch side is intentionally unchanged at the interface level. It still consumes ordinary single-block `FetchTarget` entries one by one. The framework only allows the predictor side to enqueue two consecutive targets earlier.
+
+## Design Goal
+
+This framework is designed for experiments, not for a fully generalized N-block predictor. The first implementation focuses on:
+
+- keeping `FetchTarget` as the external unit of fetch, squash, and recovery
+- generating at most two blocks per prediction
+- allowing each predictor to decide independently whether it actively participates in `block1`
+- allowing unsupported `block1` branch types to be filtered conservatively
+
+## High-Level Architecture
+
+### 1. External Model Stays Single-Block
+
+The following structures remain single-block externally:
+
+- `FetchTarget`
+- `FetchTargetQueue`
+- fetch-side consumption in `src/cpu/o3/fetch.cc`
+
+The framework does not make fetch consume two targets in one cycle. Instead, the predictor may enqueue two targets in order.
+
+### 2. Internal Bundle Model
+
+`DecoupledBPUWithBTB` now has an internal bundle path:
+
+- `SpecState`
+  - `pc`
+  - `history`
+  - `phistory`
+  - `bwhistory`
+  - `lhistory`
+- `PredictionBundle`
+  - `pred0`
+  - optional `pred1`
+  - `stateAfter0`
+  - `stateAfterFinal`
+  - `pred1DropReason`
+
+`pred1` is generated from `stateAfter0`, not from the original thread state.
+
+### 3. Prediction Flow
+
+The flow is:
+
+1. Generate the normal final prediction for `block0`
+2. Compute speculative next state after `block0`
+3. Check top-level `block1` gates
+4. If allowed, run predictor `block1` hooks using `stateAfter0`
+5. Finalize `pred1`
+6. Enqueue `target0`
+7. If valid, enqueue `target1`
+8. Commit thread speculative state once using `stateAfterFinal`
+
+## Predictor Participation Model
+
+Each `TimedBaseBTBPredictor` now has a `block1Participate` control.
+
+Two modes are supported:
+
+- `active`
+  - the predictor runs its own `putPCHistoryForBlock1(...)`
+- `pass-through`
+  - the predictor does not actively predict `block1`
+  - instead, it can preserve lower-stage information from `lowerPred`
+
+### Current Implemented Behavior
+
+- `UBTB`
+  - active `block1` prediction path is implemented
+- `TAGE`
+  - active mode uses normal prediction path
+  - passive mode copies `condTakens` and `tageInfoForMgscs` from `lowerPred`
+- `ITTAGE`
+  - passive mode copies `indirectTargets` from `lowerPred`
+- `RAS`
+  - passive mode copies `returnTarget` from `lowerPred`
+- `MBTB`
+  - passive mode copies `btbEntries` from `lowerPred`
+
+## Top-Level Block1 Gating
+
+Before `block1` is accepted, the bundle logic checks:
+
+- `enableTwoTaken`
+- `dropBlock1OnBlock0Override`
+- `dropBlock1WhenFTQHasOnlyOneSlot`
+- valid next PC after `block0`
+- whether `block0` had an initial uBTB hit
+
+Then the finalized `pred1` is filtered for unsupported branch classes:
+
+- conditional branch without direction support
+- indirect branch without indirect-target support
+- return without RAS support
+
+Support can come from either:
+
+- active predictor participation, or
+- copied support preserved from `lowerPred`
+
+## Configuration Parameters
+
+The framework adds the following top-level controls in `DecoupledBPUWithBTB`:
+
+- `enableTwoTaken`
+  - enable the two-block bundle path
+- `dropBlock1OnBlock0Override`
+  - drop `block1` when `block0` is overridden by a later predictor stage
+- `dropBlock1WhenFTQHasOnlyOneSlot`
+  - require at least two free FTQ slots before creating `block1`
+- `dropBlock1OnCondWithoutTage`
+  - reject `block1` conditional branches when no valid direction support exists
+- `dropBlock1OnIndirectWithoutIttage`
+  - reject `block1` indirect branches when no valid indirect-target support exists
+- `dropBlock1OnReturnWithoutRas`
+  - reject `block1` returns when no valid return target exists
+
+Each predictor also inherits:
+
+- `block1Participate`
+  - whether that predictor actively predicts `block1`
+
+## Files Touched by the Framework
+
+Core logic:
+
+- `src/cpu/pred/btb/decoupled_bpred.hh`
+- `src/cpu/pred/btb/decoupled_bpred.cc`
+- `src/cpu/pred/btb/common.hh`
+- `src/cpu/pred/btb/timed_base_pred.hh`
+- `src/cpu/pred/btb/timed_base_pred.cc`
+
+Configuration surface:
+
+- `src/cpu/pred/BranchPredictor.py`
+
+Predictor hooks:
+
+- `src/cpu/pred/btb/btb_ubtb.hh`
+- `src/cpu/pred/btb/btb_ubtb.cc`
+- `src/cpu/pred/btb/btb_tage.hh`
+- `src/cpu/pred/btb/btb_ittage.hh`
+- `src/cpu/pred/btb/ras.hh`
+- `src/cpu/pred/btb/mbtb.hh`
+
+Queue behavior:
+
+- `src/cpu/pred/btb/ftq.hh`
+- `src/cpu/pred/btb/ftq.cc`
+
+## Statistics
+
+The framework adds first-stage block1 statistics in `DBPBTBStats`:
+
+- `block1Attempted`
+- `block1Accepted`
+- `block1DroppedByBlock0Override`
+- `block1DroppedByCond`
+- `block1DroppedByIndirect`
+- `block1DroppedByReturn`
+- `block1DroppedByFTQFull`
+- `block1DroppedOther`
+
+These counters are intended to support ablation studies and help explain performance changes.
+
+## Tests Added
+
+Current focused test coverage includes:
+
+- `src/cpu/pred/btb/test/btb.test.cc`
+  - block1 drop-reason helpers
+  - copied-support acceptance cases
+  - `UBTB` block1 prediction behavior
+  - `MBTB` block1 pass-through behavior
+- `src/cpu/pred/btb/test/btb_tage.test.cc`
+  - `TAGE` block1 active path
+  - `TAGE` block1 passive copy path
+- `src/cpu/pred/btb/test/fetch_target_queue.test.cc`
+  - two-target squash behavior
+  - FTQ free-slot accounting for two-target admission
+
+## Current Scope and Limitations
+
+This implementation intentionally does not yet do the following:
+
+- fetch consuming two targets in one cycle
+- N-block generalization beyond two blocks
+- full block1 specialization for every predictor component
+- broad end-to-end recovery validation for every history source
+
+The framework is intended to be usable for current 2-Taken experiments while leaving room for later refinement.
+
+## Suggested Experimental Starting Points
+
+Useful first configurations include:
+
+1. `UBTB` active, all other predictors passive
+2. `UBTB + TAGE` active, `ITTAGE/RAS` passive
+3. `UBTB + TAGE + ITTAGE + RAS` active
+4. `dropBlock1OnBlock0Override = true` vs `false`
+5. conservative filtering on vs off for conditional / indirect / return cases
+
+These settings should give a good first view of the latency/accuracy tradeoff introduced by the two-block framework.

--- a/src/cpu/pred/btb/docs/two_taken_framework.md
+++ b/src/cpu/pred/btb/docs/two_taken_framework.md
@@ -212,3 +212,220 @@ Useful first configurations include:
 5. conservative filtering on vs off for conditional / indirect / return cases
 
 These settings should give a good first view of the latency/accuracy tradeoff introduced by the two-block framework.
+
+---
+
+## 中文版本
+
+### 概述
+
+2-Taken 框架对 `DecoupledBPUWithBTB` 做了扩展，使一次预测机会可以产出：
+
+- `block0`：当前取指块的正常最终预测结果
+- `block1`：基于 `block0` 推测后状态导出的一个可选后继取指块
+
+取指侧接口保持不变。fetch 仍然逐个消费普通的单块 `FetchTarget`。这个框架做的事情，是让预测侧能够更早地顺序入队两个连续的 target。
+
+### 设计目标
+
+这个框架主要面向实验，而不是一个完全泛化的 N-block 预测框架。当前实现重点是：
+
+- 保持 `FetchTarget` 仍然是 fetch、squash 和 recovery 的外部基本单位
+- 一次预测最多只生成两个块
+- 允许每个 predictor 独立决定自己是否主动参与 `block1`
+- 当 `block1` 遇到不受支持的分支类型时，可以保守地将其过滤掉
+
+### 整体架构
+
+#### 1. 对外仍然保持单块模型
+
+下面这些结构对外仍然是单块语义：
+
+- `FetchTarget`
+- `FetchTargetQueue`
+- `src/cpu/o3/fetch.cc` 中的 fetch 消费逻辑
+
+本框架并没有让 fetch 在一个周期里同时消费两个 target，只是允许预测侧按顺序更早地把两个 target 放入队列。
+
+#### 2. 内部使用 bundle 模型
+
+`DecoupledBPUWithBTB` 内部新增了 bundle 路径：
+
+- `SpecState`
+  - `pc`
+  - `history`
+  - `phistory`
+  - `bwhistory`
+  - `lhistory`
+- `PredictionBundle`
+  - `pred0`
+  - 可选 `pred1`
+  - `stateAfter0`
+  - `stateAfterFinal`
+  - `pred1DropReason`
+
+其中 `pred1` 的生成输入来自 `stateAfter0`，而不是原始线程状态。
+
+#### 3. 预测流程
+
+整体流程如下：
+
+1. 生成 `block0` 的正常最终预测
+2. 计算 `block0` 之后的推测状态
+3. 检查 `block1` 的顶层 gate
+4. 如果允许，则基于 `stateAfter0` 运行各 predictor 的 `block1` hook
+5. 形成最终 `pred1`
+6. 入队 `target0`
+7. 如果 `pred1` 有效，则再入队 `target1`
+8. 用 `stateAfterFinal` 一次性提交线程推测状态
+
+### Predictor 参与模型
+
+每个 `TimedBaseBTBPredictor` 都新增了 `block1Participate` 控制位。
+
+支持两种模式：
+
+- `active`
+  - predictor 主动执行自己的 `putPCHistoryForBlock1(...)`
+- `pass-through`
+  - predictor 不主动预测 `block1`
+  - 而是从 `lowerPred` 中保留低层已经得到的信息
+
+#### 当前已经实现的行为
+
+- `UBTB`
+  - 已实现真正的 `block1` active 预测路径
+- `TAGE`
+  - active 模式走正常预测路径
+  - passive 模式复制 `lowerPred` 中的 `condTakens` 和 `tageInfoForMgscs`
+- `ITTAGE`
+  - passive 模式复制 `lowerPred` 中的 `indirectTargets`
+- `RAS`
+  - passive 模式复制 `lowerPred` 中的 `returnTarget`
+- `MBTB`
+  - passive 模式复制 `lowerPred` 中的 `btbEntries`
+
+### 顶层 Block1 Gate
+
+在接受 `block1` 之前，bundle 逻辑会检查：
+
+- `enableTwoTaken`
+- `dropBlock1OnBlock0Override`
+- `dropBlock1WhenFTQHasOnlyOneSlot`
+- `block0` 之后的 next PC 是否有效
+- `block0` 是否存在初始 uBTB hit
+
+之后还会根据 `pred1` 的最终内容，过滤不受支持的分支类型：
+
+- 没有方向支持的条件分支
+- 没有间接目标支持的 indirect 分支
+- 没有返回地址支持的 return
+
+这里的“支持”既可以来自：
+
+- predictor 主动参与 `block1`
+- 也可以来自从 `lowerPred` 中复制保留下来的 support
+
+### 配置项
+
+`DecoupledBPUWithBTB` 顶层新增了如下控制项：
+
+- `enableTwoTaken`
+  - 是否启用 two-block bundle 路径
+- `dropBlock1OnBlock0Override`
+  - 如果 `block0` 被更高阶段 override，是否丢弃 `block1`
+- `dropBlock1WhenFTQHasOnlyOneSlot`
+  - 当 FTQ 剩余空间不足两个条目时，是否丢弃 `block1`
+- `dropBlock1OnCondWithoutTage`
+  - 当 `block1` 中存在没有有效方向支持的条件分支时，是否丢弃
+- `dropBlock1OnIndirectWithoutIttage`
+  - 当 `block1` 中存在没有有效间接目标支持的 indirect 分支时，是否丢弃
+- `dropBlock1OnReturnWithoutRas`
+  - 当 `block1` 中存在没有有效 return target 的 return 时，是否丢弃
+
+每个 predictor 还继承了：
+
+- `block1Participate`
+  - 决定该 predictor 是否主动参与 `block1` 预测
+
+### 涉及的主要文件
+
+核心逻辑：
+
+- `src/cpu/pred/btb/decoupled_bpred.hh`
+- `src/cpu/pred/btb/decoupled_bpred.cc`
+- `src/cpu/pred/btb/common.hh`
+- `src/cpu/pred/btb/timed_base_pred.hh`
+- `src/cpu/pred/btb/timed_base_pred.cc`
+
+配置定义：
+
+- `src/cpu/pred/BranchPredictor.py`
+
+Predictor hook：
+
+- `src/cpu/pred/btb/btb_ubtb.hh`
+- `src/cpu/pred/btb/btb_ubtb.cc`
+- `src/cpu/pred/btb/btb_tage.hh`
+- `src/cpu/pred/btb/btb_ittage.hh`
+- `src/cpu/pred/btb/ras.hh`
+- `src/cpu/pred/btb/mbtb.hh`
+
+队列相关：
+
+- `src/cpu/pred/btb/ftq.hh`
+- `src/cpu/pred/btb/ftq.cc`
+
+### 统计项
+
+`DBPBTBStats` 中新增了第一版 block1 统计项：
+
+- `block1Attempted`
+- `block1Accepted`
+- `block1DroppedByBlock0Override`
+- `block1DroppedByCond`
+- `block1DroppedByIndirect`
+- `block1DroppedByReturn`
+- `block1DroppedByFTQFull`
+- `block1DroppedOther`
+
+这些统计项主要用于实验归因，帮助分析性能变化来自哪里。
+
+### 已有测试覆盖
+
+当前已有的聚焦测试包括：
+
+- `src/cpu/pred/btb/test/btb.test.cc`
+  - block1 drop-reason helper
+  - copied-support 接受路径
+  - `UBTB` 的 block1 预测行为
+  - `MBTB` 的 block1 pass-through 行为
+- `src/cpu/pred/btb/test/btb_tage.test.cc`
+  - `TAGE` 的 block1 active 路径
+  - `TAGE` 的 block1 passive copy 路径
+- `src/cpu/pred/btb/test/fetch_target_queue.test.cc`
+  - 双 target squash 语义
+  - two-target 准入时 FTQ 剩余空间的计数
+
+### 当前范围与限制
+
+当前实现有意没有进一步扩展到：
+
+- fetch 在一个周期里同时消费两个 target
+- 超过两个块的 N-block 泛化
+- 每个 predictor 的完整 block1 特化实现
+- 所有历史源的端到端恢复验证
+
+因此，这个框架的定位是：已经可以支撑当前 2-Taken 实验，但仍然保留后续细化空间。
+
+### 建议的实验起点
+
+建议优先尝试以下配置组合：
+
+1. 仅 `UBTB` active，其余 predictor passive
+2. `UBTB + TAGE` active，`ITTAGE/RAS` passive
+3. `UBTB + TAGE + ITTAGE + RAS` active
+4. 对比 `dropBlock1OnBlock0Override = true` 与 `false`
+5. 对比条件分支 / indirect / return 的保守过滤开关开闭
+
+这些配置有助于比较 two-block 框架带来的延迟收益和准确率损失之间的权衡。

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -31,9 +31,9 @@ class FetchTargetQueue
     } queue[MaxThreads];
 
     uint32_t roundRobinPtr = 0;
-
-  public:
-    FetchTargetQueue(uint32_t numThreads_, const uint32_t ftqSize_) : numThreads(numThreads_)
+public:
+    FetchTargetQueue(uint32_t numThreads_, const uint32_t ftqSize_)
+        : numThreads(numThreads_)
     {
         assert(numThreads <= MaxThreads);
         for (uint32_t i = 0; i < numThreads; ++i) {
@@ -48,27 +48,25 @@ class FetchTargetQueue
     inline FetchTarget& front(ThreadID tid) { return queue[tid].cap.front(); }
     inline FetchTarget& back(ThreadID tid) { return queue[tid].cap.back(); }
     inline FetchTarget& fetching(ThreadID tid) { return get(queue[tid].fetchptr, tid); }
-    inline FetchTarget& get(FetchTargetId targetId, ThreadID tid)
-    {
-        assert(targetId >= queue[tid].baseTargetId && targetId < queue[tid].baseTargetId + queue[tid].cap.size());
+    inline FetchTarget& get(FetchTargetId targetId, ThreadID tid) {
+        assert(targetId >= queue[tid].baseTargetId &&
+               targetId < queue[tid].baseTargetId + queue[tid].cap.size());
         return queue[tid].cap[targetId - queue[tid].baseTargetId];
     }
-    inline bool hasTarget(FetchTargetId targetId, ThreadID tid) const
-    {
-        return targetId >= queue[tid].baseTargetId && targetId < queue[tid].baseTargetId + queue[tid].cap.size();
+    inline bool hasTarget(FetchTargetId targetId, ThreadID tid) const {
+        return targetId >= queue[tid].baseTargetId &&
+               targetId < queue[tid].baseTargetId + queue[tid].cap.size();
     }
     inline bool empty(ThreadID tid) const { return queue[tid].cap.empty(); }
     inline bool full(ThreadID tid) const { return queue[tid].cap.size() >= ftqSize[tid]; }
-    inline bool anyEmpty() const
-    {
+    inline bool anyEmpty() const {
         for (uint32_t i = 0; i < numThreads; ++i) {
             if (!queue[i].cap.empty())
                 return false;
         }
         return true;
     }
-    inline bool allFull() const
-    {
+    inline bool allFull() const {
         for (uint32_t i = 0; i < numThreads; ++i) {
             if (queue[i].cap.size() < ftqSize[i])
                 return false;

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -31,9 +31,9 @@ class FetchTargetQueue
     } queue[MaxThreads];
 
     uint32_t roundRobinPtr = 0;
-public:
-    FetchTargetQueue(uint32_t numThreads_, const uint32_t ftqSize_)
-        : numThreads(numThreads_)
+
+  public:
+    FetchTargetQueue(uint32_t numThreads_, const uint32_t ftqSize_) : numThreads(numThreads_)
     {
         assert(numThreads <= MaxThreads);
         for (uint32_t i = 0; i < numThreads; ++i) {
@@ -48,25 +48,27 @@ public:
     inline FetchTarget& front(ThreadID tid) { return queue[tid].cap.front(); }
     inline FetchTarget& back(ThreadID tid) { return queue[tid].cap.back(); }
     inline FetchTarget& fetching(ThreadID tid) { return get(queue[tid].fetchptr, tid); }
-    inline FetchTarget& get(FetchTargetId targetId, ThreadID tid) {
-        assert(targetId >= queue[tid].baseTargetId &&
-               targetId < queue[tid].baseTargetId + queue[tid].cap.size());
+    inline FetchTarget& get(FetchTargetId targetId, ThreadID tid)
+    {
+        assert(targetId >= queue[tid].baseTargetId && targetId < queue[tid].baseTargetId + queue[tid].cap.size());
         return queue[tid].cap[targetId - queue[tid].baseTargetId];
     }
-    inline bool hasTarget(FetchTargetId targetId, ThreadID tid) const {
-        return targetId >= queue[tid].baseTargetId &&
-               targetId < queue[tid].baseTargetId + queue[tid].cap.size();
+    inline bool hasTarget(FetchTargetId targetId, ThreadID tid) const
+    {
+        return targetId >= queue[tid].baseTargetId && targetId < queue[tid].baseTargetId + queue[tid].cap.size();
     }
     inline bool empty(ThreadID tid) const { return queue[tid].cap.empty(); }
     inline bool full(ThreadID tid) const { return queue[tid].cap.size() >= ftqSize[tid]; }
-    inline bool anyEmpty() const {
+    inline bool anyEmpty() const
+    {
         for (uint32_t i = 0; i < numThreads; ++i) {
             if (!queue[i].cap.empty())
                 return false;
         }
         return true;
     }
-    inline bool allFull() const {
+    inline bool allFull() const
+    {
         for (uint32_t i = 0; i < numThreads; ++i) {
             if (queue[i].cap.size() < ftqSize[i])
                 return false;
@@ -74,6 +76,7 @@ public:
         return true;
     }
     inline uint32_t size(ThreadID tid) const { return queue[tid].cap.size(); }
+    inline uint32_t freeSlots(ThreadID tid) const { return ftqSize[tid] - queue[tid].cap.size(); }
 
     int getTargetTid();
     void insert(FetchTarget& target);

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -28,11 +28,11 @@
 
 /*
  * Main BTB (MBTB) Implementation
- *
+ * 
  * The MBTB is a half-aligned BTB that covers 64-byte blocks:
  * - Queries two consecutive 32-byte aligned blocks
  * - Fixed half-aligned behavior (no entryHalfAligned parameter)
- * - 8-way set associative organization
+ * - 8-way set associative organization  
  * - MRU (Most Recently Used) replacement policy
  * - Support for multiple branch types
  */
@@ -47,19 +47,16 @@
 #include "cpu/pred/btb/timed_base_pred.hh"
 
 #ifdef UNIT_TEST
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include "cpu/pred/btb/test/test_dprintf.hh"
-
+    #include <gmock/gmock.h>
+    #include <gtest/gtest.h>
+    #include "cpu/pred/btb/test/test_dprintf.hh"
 #else
-#include "arch/generic/pcstate.hh"
-#include "base/logging.hh"
-#include "config/the_isa.hh"
-#include "debug/BTB.hh"
-#include "debug/BTBStats.hh"
-#include "params/MBTB.hh"
-
+    #include "arch/generic/pcstate.hh"
+    #include "base/logging.hh"
+    #include "config/the_isa.hh"
+    #include "debug/BTB.hh"
+    #include "debug/BTBStats.hh"
+    #include "params/MBTB.hh"
 #endif
 
 namespace gem5
@@ -73,22 +70,23 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test
-{
+namespace test {
 #endif
 
 class MBTB : public TimedBaseBTBPredictor
 {
   private:
+
   public:
+
 #ifdef UNIT_TEST
-    // Test constructor
+    // Test constructor  
     MBTB(unsigned numEntries, unsigned tagBits, unsigned numWays, unsigned numDelay);
 #else
     // Production constructor
     typedef MBTBParams Params;
 
-    MBTB(const Params &p);
+    MBTB(const Params& p);
 #endif
 
     /*
@@ -105,9 +103,10 @@ class MBTB : public TimedBaseBTBPredictor
     typedef struct TickedBTBEntry : public BTBEntry
     {
         uint64_t tick;  // timestamp for MRU replacement
-        TickedBTBEntry(const BTBEntry &entry, uint64_t tick) : BTBEntry(entry), tick(tick) {}
+        TickedBTBEntry(const BTBEntry &entry, uint64_t tick)
+            : BTBEntry(entry), tick(tick) {}
         TickedBTBEntry() : tick(0) {}
-    } TickedBTBEntry;
+    }TickedBTBEntry;
 
     // A BTB set is a vector of entries (ways)
     using BTBSet = std::vector<TickedBTBEntry>;
@@ -135,7 +134,7 @@ class MBTB : public TimedBaseBTBPredictor
      * @param startAddr: start address of the fetch block
      * @param history: branch history register
      * @param stagePreds: predictions for each pipeline stage
-     *
+     * 
      * This function:
      * 1. Looks up BTB entries for the fetch block
      * 2. Updates prediction statistics
@@ -168,14 +167,14 @@ class MBTB : public TimedBaseBTBPredictor
     // not used
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
 
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                     bool cond_taken) override;
+    void recoverHist(const boost::dynamic_bitset<> &history,
+        const FetchTarget &entry, int shamt, bool cond_taken) override;
 
     /**
      * @brief derive new btb entry from old ones and set updateNewBTBEntry field in stream
      *        only in L1BTB will this function be called before update
-     *
-     * @param stream
+     * 
+     * @param stream 
      */
     void getAndSetNewBTBEntry(FetchTarget &stream);
 
@@ -189,37 +188,33 @@ class MBTB : public TimedBaseBTBPredictor
 
     std::vector<BTBEntry> prepareUpdateEntries(const FetchTarget &stream);
 
-    void printBTBEntry(const BTBEntry &e, uint64_t tick = 0)
-    {
-        DPRINTF(BTB,
-                "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
+    void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
+        DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
-                e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken,
-                tick);
+            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
     }
 
-    void printTickedBTBEntry(const TickedBTBEntry &e) { printBTBEntry(e, e.tick); }
+    void printTickedBTBEntry(const TickedBTBEntry &e) {
+        printBTBEntry(e, e.tick);
+    }
 
-    void dumpBTBEntries(const std::vector<BTBEntry> &es)
-    {
+    void dumpBTBEntries(const std::vector<BTBEntry> &es) {
         DPRINTF(BTB, "BTB entries:\n");
         for (const auto &entry : es) {
             printBTBEntry(entry);
         }
     }
 
-    void dumpTickedBTBEntries(const std::vector<TickedBTBEntry> &es)
-    {
+    void dumpTickedBTBEntries(const std::vector<TickedBTBEntry> &es) {
         DPRINTF(BTB, "BTB entries:\n");
         for (const auto &entry : es) {
             printTickedBTBEntry(entry);
         }
     }
 
-    void dumpMruList(const BTBHeap &list)
-    {
+    void dumpMruList(const BTBHeap &list) {
         DPRINTF(BTB, "MRU list:\n");
-        for (const auto &it : list) {
+        for (const auto &it: list) {
             printTickedBTBEntry(*it);
         }
     }
@@ -235,7 +230,9 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The branch to look up.
      *  @return Returns the index into the BTB.
      */
-    inline Addr getIndex(Addr instPC) { return (instPC >> idxShiftAmt) & idxMask; }
+    inline Addr getIndex(Addr instPC) {
+        return (instPC >> idxShiftAmt) & idxMask;
+    }
 
     /** Returns the tag bits of a given address.
      *  The tag is calculated as: (pc >> tagShiftAmt) & tagMask
@@ -243,73 +240,80 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The branch's address.
      *  @return Returns the tag bits.
      */
-    inline Addr getTag(Addr instPC) { return (instPC >> tagShiftAmt) & tagMask; }
+    inline Addr getTag(Addr instPC) {
+        return (instPC >> tagShiftAmt) & tagMask;
+    }
 
     /** Update the 2-bit saturating counter for conditional branches
      *  Counter range: [-2, 1]
      *  - Increment on taken (max 1)
      *  - Decrement on not taken (min -2)
      */
-    void updateCtr(int &ctr, bool taken)
-    {
-        if (taken && ctr < 1) {
-            ctr++;
-        }
-        if (!taken && ctr > -2) {
-            ctr--;
-        }
+    void updateCtr(int &ctr, bool taken) {
+        if (taken && ctr < 1) {ctr++;}
+        if (!taken && ctr > -2) {ctr--;}
     }
 
-    typedef struct BTBMeta
-    {
+    typedef struct BTBMeta {
         std::vector<BTBEntry> hit_entries;
-        BTBMeta()
-        {
+        BTBMeta() {
             std::vector<BTBEntry> es;
             hit_entries = es;
         }
-    } BTBMeta;
+    }BTBMeta;
 
-    std::shared_ptr<BTBMeta> meta;  // metadata for BTB, set in putPCHistory, used in update
+    std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
 
     /** Process BTB entries for prediction
      *  @param entries Vector of BTB entries to process
      *  @param startAddr Start address of the fetch block
      *  @return Vector of processed entries in program order
      */
-    std::vector<TickedBTBEntry> processEntries(const std::vector<TickedBTBEntry> &entries, Addr startAddr);
+    std::vector<TickedBTBEntry> processEntries(const std::vector<TickedBTBEntry>& entries, 
+                                              Addr startAddr);
 
     /** Fill predictions for pipeline stages
      *  @param entries Processed BTB entries
      *  @param stagePreds Vector of predictions for each stage
      */
-    void fillStagePredictions(const std::vector<TickedBTBEntry> &entries, std::vector<FullBTBPrediction> &stagePreds);
+    void fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
+                             std::vector<FullBTBPrediction>& stagePreds);
 
     /** Update prediction metadata
      *  @param entries Processed BTB entries
      */
-    void updatePredictionMeta(const std::vector<TickedBTBEntry> &entries, std::vector<FullBTBPrediction> &stagePreds);
+    void updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
+                               std::vector<FullBTBPrediction>& stagePreds);
 
     /** Check branch prediction hit status
      *  @param stream Fetch stream containing execution results
      *  @param meta BTB metadata from prediction
      */
-    void checkPredictionHit(const FetchTarget &stream, const BTBMeta *meta);
+    void checkPredictionHit(const FetchTarget &stream,
+                           const BTBMeta* meta);
 
     /** Update or replace BTB entry
      *  @param entry Entry to update/replace (PC used to select SRAM and calculate index/tag)
      *  @param stream Fetch stream with update info
      */
-    void updateBTBEntry(const BTBEntry &entry, const FetchTarget &stream);
+    void updateBTBEntry(const BTBEntry& entry, const FetchTarget &stream);
 
     // Helper: build updated entry (ctr/alwaysTaken/indirect target/tag)
-    BTBEntry buildUpdatedEntry(const BTBEntry &req_entry, const BTBEntry *existing_entry, const FetchTarget &stream);
+    BTBEntry buildUpdatedEntry(const BTBEntry& req_entry,
+                               const BTBEntry* existing_entry,
+                               const FetchTarget &stream);
 
     // Helper: update an existing entry in SRAM set
-    void updateExistingInSRAMSet(Addr btb_idx, BTBHeap &heap, BTBSetIter it_found, const TickedBTBEntry &ticked_entry);
+    void updateExistingInSRAMSet(Addr btb_idx,
+                                 BTBHeap &heap,
+                                 BTBSetIter it_found,
+                                 const TickedBTBEntry &ticked_entry);
 
     // Helper: replace the oldest entry in SRAM set
-    void replaceOldestInSRAMSet(int sram_id, Addr btb_idx, BTBHeap &heap, const TickedBTBEntry &ticked_entry);
+    void replaceOldestInSRAMSet(int sram_id,
+                                Addr btb_idx,
+                                BTBHeap &heap,
+                                const TickedBTBEntry &ticked_entry);
 
     // Helper: commit/update an entry in victim cache at given index
     void commitToVictimCache(int vc_idx, const TickedBTBEntry &ticked_entry);
@@ -321,16 +325,18 @@ class MBTB : public TimedBaseBTBPredictor
      */
     struct older
     {
-        bool operator()(const BTBSetIter &a, const BTBSetIter &b) const { return a->tick > b->tick; }
+        bool operator()(const BTBSetIter &a, const BTBSetIter &b) const
+        {
+            return a->tick > b->tick;
+        }
     };
 
     /**
      * @brief check if the entries in the vector are in ascending order, means the pc is in ascending order
-     *
-     * @param es
+     * 
+     * @param es 
      */
-    void checkAscending(std::vector<BTBEntry> &es)
-    {
+    void checkAscending(std::vector<BTBEntry> &es) {
         Addr last = 0;
         bool misorder = false;
         for (auto &entry : es) {
@@ -359,7 +365,7 @@ class MBTB : public TimedBaseBTBPredictor
 
     /** Victim cache operations */
     std::vector<TickedBTBEntry> lookupVictimCache(Addr block_pc);
-    void insertVictimCache(const TickedBTBEntry &evicted_entry);
+    void insertVictimCache(const TickedBTBEntry& evicted_entry);
     bool eraseFromVictimCacheByPC(Addr pc);
 
     /** Dual SRAM BTB structure:
@@ -386,13 +392,12 @@ class MBTB : public TimedBaseBTBPredictor
     unsigned victimCacheSize;
 
     /** BTB configuration parameters */
-    unsigned numEntries;  // Total number of entries
-    unsigned numWays;     // Number of ways per SRAM (4 for dual-SRAM)
-    unsigned numSets;     // Number of sets per SRAM (numEntries/numWays/2)
-
+    unsigned numEntries;    // Total number of entries
+    unsigned numWays;       // Number of ways per SRAM (4 for dual-SRAM)
+    unsigned numSets;       // Number of sets per SRAM (numEntries/numWays/2)
+    
     /** SRAM selection helper function */
-    inline int getSRAMId(Addr pc)
-    {
+    inline int getSRAMId(Addr pc) {
         // Use the bit after block offset to select SRAM
         // For 32B blocks: bit 5 selects SRAM (blockSize=32, log2(32)=5)
         return ((pc >> floorLog2(blockSize)) & 1);
@@ -412,7 +417,9 @@ class MBTB : public TimedBaseBTBPredictor
     /** Branch counter */
     unsigned numBr;  // Number of branches seen
 
-    enum Mode { READ, WRITE, EVICT };
+    enum Mode {
+        READ, WRITE, EVICT
+    };
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -421,12 +428,10 @@ class MBTB : public TimedBaseBTBPredictor
 #endif
 
 #ifdef UNIT_TEST
-  public:
-    struct BTBStats
-    {
+public:
+    struct BTBStats {
 #else
-    struct BTBStats : public statistics::Group
-    {
+    struct BTBStats : public statistics::Group {
 #endif
         Scalar newEntry;
         Scalar newEntryWithCond;
@@ -480,18 +485,19 @@ class MBTB : public TimedBaseBTBPredictor
 
 #ifndef UNIT_TEST
         statistics::Distribution predHitCount;
-        BTBStats(statistics::Group *parent, int numWays);
+        BTBStats(statistics::Group* parent, int numWays);
 #endif
+
     } btbStats;
 };
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-}  // namespace test
+} // namespace test
 #endif
 
-}  // namespace btb_pred
-}  // namespace branch_prediction
-}  // namespace gem5
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5
 
-#endif  // __CPU_PRED_BTB_MBTB_HH__
+#endif // __CPU_PRED_BTB_MBTB_HH__

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -28,11 +28,11 @@
 
 /*
  * Main BTB (MBTB) Implementation
- * 
+ *
  * The MBTB is a half-aligned BTB that covers 64-byte blocks:
  * - Queries two consecutive 32-byte aligned blocks
  * - Fixed half-aligned behavior (no entryHalfAligned parameter)
- * - 8-way set associative organization  
+ * - 8-way set associative organization
  * - MRU (Most Recently Used) replacement policy
  * - Support for multiple branch types
  */
@@ -46,18 +46,20 @@
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
 
-// Conditional includes based on build mode
 #ifdef UNIT_TEST
-    #include <gmock/gmock.h>
-    #include <gtest/gtest.h>
-    #include "cpu/pred/btb/test/test_dprintf.hh"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/test/test_dprintf.hh"
+
 #else
-    #include "arch/generic/pcstate.hh"
-    #include "base/logging.hh"
-    #include "config/the_isa.hh"
-    #include "debug/BTB.hh"
-    #include "debug/BTBStats.hh"
-    #include "params/MBTB.hh"
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "config/the_isa.hh"
+#include "debug/BTB.hh"
+#include "debug/BTBStats.hh"
+#include "params/MBTB.hh"
+
 #endif
 
 namespace gem5
@@ -71,23 +73,22 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test {
+namespace test
+{
 #endif
 
 class MBTB : public TimedBaseBTBPredictor
 {
   private:
-
   public:
-
 #ifdef UNIT_TEST
-    // Test constructor  
+    // Test constructor
     MBTB(unsigned numEntries, unsigned tagBits, unsigned numWays, unsigned numDelay);
 #else
     // Production constructor
     typedef MBTBParams Params;
 
-    MBTB(const Params& p);
+    MBTB(const Params &p);
 #endif
 
     /*
@@ -104,10 +105,9 @@ class MBTB : public TimedBaseBTBPredictor
     typedef struct TickedBTBEntry : public BTBEntry
     {
         uint64_t tick;  // timestamp for MRU replacement
-        TickedBTBEntry(const BTBEntry &entry, uint64_t tick)
-            : BTBEntry(entry), tick(tick) {}
+        TickedBTBEntry(const BTBEntry &entry, uint64_t tick) : BTBEntry(entry), tick(tick) {}
         TickedBTBEntry() : tick(0) {}
-    }TickedBTBEntry;
+    } TickedBTBEntry;
 
     // A BTB set is a vector of entries (ways)
     using BTBSet = std::vector<TickedBTBEntry>;
@@ -135,7 +135,7 @@ class MBTB : public TimedBaseBTBPredictor
      * @param startAddr: start address of the fetch block
      * @param history: branch history register
      * @param stagePreds: predictions for each pipeline stage
-     * 
+     *
      * This function:
      * 1. Looks up BTB entries for the fetch block
      * 2. Updates prediction statistics
@@ -143,6 +143,22 @@ class MBTB : public TimedBaseBTBPredictor
      */
     void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
                       std::vector<FullBTBPrediction> &stagePreds) override;
+    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                               const std::vector<boost::dynamic_bitset<>> &lhistory,
+                               std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
+    {
+        (void)phistory;
+        (void)bwhistory;
+        (void)lhistory;
+        if (!participatesInBlock1()) {
+            for (int s = getDelay(); s < stagePreds.size(); s++) {
+                stagePreds[s].btbEntries = lowerPred.btbEntries;
+            }
+            return;
+        }
+        putPCHistory(startAddr, history, stagePreds);
+    }
 
     /** Get prediction BTBMeta
      *  @return Returns the prediction meta
@@ -152,14 +168,14 @@ class MBTB : public TimedBaseBTBPredictor
     // not used
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
 
-    void recoverHist(const boost::dynamic_bitset<> &history,
-        const FetchTarget &entry, int shamt, bool cond_taken) override;
+    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                     bool cond_taken) override;
 
     /**
      * @brief derive new btb entry from old ones and set updateNewBTBEntry field in stream
      *        only in L1BTB will this function be called before update
-     * 
-     * @param stream 
+     *
+     * @param stream
      */
     void getAndSetNewBTBEntry(FetchTarget &stream);
 
@@ -173,33 +189,37 @@ class MBTB : public TimedBaseBTBPredictor
 
     std::vector<BTBEntry> prepareUpdateEntries(const FetchTarget &stream);
 
-    void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
-        DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
+    void printBTBEntry(const BTBEntry &e, uint64_t tick = 0)
+    {
+        DPRINTF(BTB,
+                "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
+                e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken,
+                tick);
     }
 
-    void printTickedBTBEntry(const TickedBTBEntry &e) {
-        printBTBEntry(e, e.tick);
-    }
+    void printTickedBTBEntry(const TickedBTBEntry &e) { printBTBEntry(e, e.tick); }
 
-    void dumpBTBEntries(const std::vector<BTBEntry> &es) {
+    void dumpBTBEntries(const std::vector<BTBEntry> &es)
+    {
         DPRINTF(BTB, "BTB entries:\n");
         for (const auto &entry : es) {
             printBTBEntry(entry);
         }
     }
 
-    void dumpTickedBTBEntries(const std::vector<TickedBTBEntry> &es) {
+    void dumpTickedBTBEntries(const std::vector<TickedBTBEntry> &es)
+    {
         DPRINTF(BTB, "BTB entries:\n");
         for (const auto &entry : es) {
             printTickedBTBEntry(entry);
         }
     }
 
-    void dumpMruList(const BTBHeap &list) {
+    void dumpMruList(const BTBHeap &list)
+    {
         DPRINTF(BTB, "MRU list:\n");
-        for (const auto &it: list) {
+        for (const auto &it : list) {
             printTickedBTBEntry(*it);
         }
     }
@@ -215,9 +235,7 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The branch to look up.
      *  @return Returns the index into the BTB.
      */
-    inline Addr getIndex(Addr instPC) {
-        return (instPC >> idxShiftAmt) & idxMask;
-    }
+    inline Addr getIndex(Addr instPC) { return (instPC >> idxShiftAmt) & idxMask; }
 
     /** Returns the tag bits of a given address.
      *  The tag is calculated as: (pc >> tagShiftAmt) & tagMask
@@ -225,80 +243,73 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The branch's address.
      *  @return Returns the tag bits.
      */
-    inline Addr getTag(Addr instPC) {
-        return (instPC >> tagShiftAmt) & tagMask;
-    }
+    inline Addr getTag(Addr instPC) { return (instPC >> tagShiftAmt) & tagMask; }
 
     /** Update the 2-bit saturating counter for conditional branches
      *  Counter range: [-2, 1]
      *  - Increment on taken (max 1)
      *  - Decrement on not taken (min -2)
      */
-    void updateCtr(int &ctr, bool taken) {
-        if (taken && ctr < 1) {ctr++;}
-        if (!taken && ctr > -2) {ctr--;}
+    void updateCtr(int &ctr, bool taken)
+    {
+        if (taken && ctr < 1) {
+            ctr++;
+        }
+        if (!taken && ctr > -2) {
+            ctr--;
+        }
     }
 
-    typedef struct BTBMeta {
+    typedef struct BTBMeta
+    {
         std::vector<BTBEntry> hit_entries;
-        BTBMeta() {
+        BTBMeta()
+        {
             std::vector<BTBEntry> es;
             hit_entries = es;
         }
-    }BTBMeta;
+    } BTBMeta;
 
-    std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
+    std::shared_ptr<BTBMeta> meta;  // metadata for BTB, set in putPCHistory, used in update
 
     /** Process BTB entries for prediction
      *  @param entries Vector of BTB entries to process
      *  @param startAddr Start address of the fetch block
      *  @return Vector of processed entries in program order
      */
-    std::vector<TickedBTBEntry> processEntries(const std::vector<TickedBTBEntry>& entries, 
-                                              Addr startAddr);
+    std::vector<TickedBTBEntry> processEntries(const std::vector<TickedBTBEntry> &entries, Addr startAddr);
 
     /** Fill predictions for pipeline stages
      *  @param entries Processed BTB entries
      *  @param stagePreds Vector of predictions for each stage
      */
-    void fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
-                             std::vector<FullBTBPrediction>& stagePreds);
+    void fillStagePredictions(const std::vector<TickedBTBEntry> &entries, std::vector<FullBTBPrediction> &stagePreds);
 
     /** Update prediction metadata
      *  @param entries Processed BTB entries
      */
-    void updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
-                               std::vector<FullBTBPrediction>& stagePreds);
+    void updatePredictionMeta(const std::vector<TickedBTBEntry> &entries, std::vector<FullBTBPrediction> &stagePreds);
 
     /** Check branch prediction hit status
      *  @param stream Fetch stream containing execution results
      *  @param meta BTB metadata from prediction
      */
-    void checkPredictionHit(const FetchTarget &stream,
-                           const BTBMeta* meta);
+    void checkPredictionHit(const FetchTarget &stream, const BTBMeta *meta);
 
     /** Update or replace BTB entry
      *  @param entry Entry to update/replace (PC used to select SRAM and calculate index/tag)
      *  @param stream Fetch stream with update info
      */
-    void updateBTBEntry(const BTBEntry& entry, const FetchTarget &stream);
+    void updateBTBEntry(const BTBEntry &entry, const FetchTarget &stream);
 
     // Helper: build updated entry (ctr/alwaysTaken/indirect target/tag)
-    BTBEntry buildUpdatedEntry(const BTBEntry& req_entry,
-                               const BTBEntry* existing_entry,
-                               const FetchTarget &stream);
+    BTBEntry buildUpdatedEntry(const BTBEntry &req_entry, const BTBEntry *existing_entry, const FetchTarget &stream);
 
     // Helper: update an existing entry in SRAM set
-    void updateExistingInSRAMSet(Addr btb_idx,
-                                 BTBHeap &heap,
-                                 BTBSetIter it_found,
-                                 const TickedBTBEntry &ticked_entry);
+    void updateExistingInSRAMSet(Addr btb_idx, BTBHeap &heap, BTBSetIter it_found, const TickedBTBEntry &ticked_entry);
 
     // Helper: replace the oldest entry in SRAM set
-    void replaceOldestInSRAMSet(int sram_id,
-                                Addr btb_idx,
-                                BTBHeap &heap,
-                                const TickedBTBEntry &ticked_entry);
+    void replaceOldestInSRAMSet(int sram_id, Addr btb_idx, BTBHeap &heap, const TickedBTBEntry &ticked_entry);
 
     // Helper: commit/update an entry in victim cache at given index
     void commitToVictimCache(int vc_idx, const TickedBTBEntry &ticked_entry);
@@ -310,18 +321,16 @@ class MBTB : public TimedBaseBTBPredictor
      */
     struct older
     {
-        bool operator()(const BTBSetIter &a, const BTBSetIter &b) const
-        {
-            return a->tick > b->tick;
-        }
+        bool operator()(const BTBSetIter &a, const BTBSetIter &b) const { return a->tick > b->tick; }
     };
 
     /**
      * @brief check if the entries in the vector are in ascending order, means the pc is in ascending order
-     * 
-     * @param es 
+     *
+     * @param es
      */
-    void checkAscending(std::vector<BTBEntry> &es) {
+    void checkAscending(std::vector<BTBEntry> &es)
+    {
         Addr last = 0;
         bool misorder = false;
         for (auto &entry : es) {
@@ -350,7 +359,7 @@ class MBTB : public TimedBaseBTBPredictor
 
     /** Victim cache operations */
     std::vector<TickedBTBEntry> lookupVictimCache(Addr block_pc);
-    void insertVictimCache(const TickedBTBEntry& evicted_entry);
+    void insertVictimCache(const TickedBTBEntry &evicted_entry);
     bool eraseFromVictimCacheByPC(Addr pc);
 
     /** Dual SRAM BTB structure:
@@ -377,12 +386,13 @@ class MBTB : public TimedBaseBTBPredictor
     unsigned victimCacheSize;
 
     /** BTB configuration parameters */
-    unsigned numEntries;    // Total number of entries
-    unsigned numWays;       // Number of ways per SRAM (4 for dual-SRAM)
-    unsigned numSets;       // Number of sets per SRAM (numEntries/numWays/2)
-    
+    unsigned numEntries;  // Total number of entries
+    unsigned numWays;     // Number of ways per SRAM (4 for dual-SRAM)
+    unsigned numSets;     // Number of sets per SRAM (numEntries/numWays/2)
+
     /** SRAM selection helper function */
-    inline int getSRAMId(Addr pc) {
+    inline int getSRAMId(Addr pc)
+    {
         // Use the bit after block offset to select SRAM
         // For 32B blocks: bit 5 selects SRAM (blockSize=32, log2(32)=5)
         return ((pc >> floorLog2(blockSize)) & 1);
@@ -402,9 +412,7 @@ class MBTB : public TimedBaseBTBPredictor
     /** Branch counter */
     unsigned numBr;  // Number of branches seen
 
-    enum Mode {
-        READ, WRITE, EVICT
-    };
+    enum Mode { READ, WRITE, EVICT };
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -413,10 +421,12 @@ class MBTB : public TimedBaseBTBPredictor
 #endif
 
 #ifdef UNIT_TEST
-public:
-    struct BTBStats {
+  public:
+    struct BTBStats
+    {
 #else
-    struct BTBStats : public statistics::Group {
+    struct BTBStats : public statistics::Group
+    {
 #endif
         Scalar newEntry;
         Scalar newEntryWithCond;
@@ -470,19 +480,18 @@ public:
 
 #ifndef UNIT_TEST
         statistics::Distribution predHitCount;
-        BTBStats(statistics::Group* parent, int numWays);
+        BTBStats(statistics::Group *parent, int numWays);
 #endif
     } btbStats;
-
 };
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-} // namespace test
+}  // namespace test
 #endif
 
-} // namespace btb_pred
-} // namespace branch_prediction
-} // namespace gem5
+}  // namespace btb_pred
+}  // namespace branch_prediction
+}  // namespace gem5
 
-#endif // __CPU_PRED_BTB_MBTB_HH__
+#endif  // __CPU_PRED_BTB_MBTB_HH__

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -4,213 +4,233 @@
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/timed_base_pred.hh"
 
-// Conditional includes based on build mode
 #ifdef UNIT_TEST
-    // Test mode includes
-    #include "cpu/pred/btb/test/test_dprintf.hh"
-    #include "cpu/pred/btb/timed_base_pred.hh"
+#include "cpu/pred/btb/test/test_dprintf.hh"
 
-    // Test mode type definitions
-    namespace gem5 {
-        namespace o3 {
-            class DynInst;
-        }
-    }
-    using DynInstPtr = std::shared_ptr<gem5::o3::DynInst>;
+namespace gem5
+{
+namespace o3
+{
+class DynInst;
+}
+}
+using DynInstPtr = std::shared_ptr<gem5::o3::DynInst>;
 #else
-    // Production mode includes
-    #include "cpu/pred/btb/timed_base_pred.hh"
-    #include "debug/RAS.hh"
-    #include "params/BTBRAS.hh"
+#include "debug/RAS.hh"
+#include "params/BTBRAS.hh"
+
 #endif
 
-namespace gem5 {
+namespace gem5
+{
 
-namespace branch_prediction {
+namespace branch_prediction
+{
 
-namespace btb_pred {
+namespace btb_pred
+{
 
 // Class definition with conditional inheritance and constructors
 #ifdef UNIT_TEST
-    namespace test {
-        class BTBRAS : public TimedBaseBTBPredictor
-        {
-        public:
-            // Test constructor for unit testing mode
-            BTBRAS(unsigned numEntries, unsigned ctrWidth, unsigned numInflightEntries);
+namespace test
+{
+class BTBRAS : public TimedBaseBTBPredictor
+{
+  public:
+    // Test constructor for unit testing mode
+    BTBRAS(unsigned numEntries, unsigned ctrWidth, unsigned numInflightEntries);
 #else
-    class BTBRAS : public TimedBaseBTBPredictor
+class BTBRAS : public TimedBaseBTBPredictor
+{
+  public:
+    // Production constructor
+    typedef BTBRASParams Params;
+    BTBRAS(const Params &p);
+#endif
+
+    typedef struct RASEssential
     {
-    public:
-        // Production constructor
-        typedef BTBRASParams Params;
-        BTBRAS(const Params &p);
-#endif
+        Addr retAddr;
+        unsigned ctr;
+    } RASEssential;
 
-        typedef struct RASEssential
+    typedef struct RASEntry
+    {
+        RASEssential data;
+        RASEntry(Addr retAddr, unsigned ctr)
         {
-            Addr retAddr;
-            unsigned ctr;
-        }RASEssential;
-
-        typedef struct RASEntry
-        {
-            RASEssential data;
-            RASEntry(Addr retAddr, unsigned ctr)
-            {
-                data.retAddr = retAddr;
-                data.ctr = ctr;
-            }
-            RASEntry(Addr retAddr)
-            {
-                data.retAddr = retAddr;
-                data.ctr = 0;
-            }
-            RASEntry()
-            {
-                data.retAddr = 0;
-                data.ctr = 0;
-            }
-        }RASEntry;
-
-        typedef struct RASInflightEntry
-        {
-            RASEssential data;
-            int nos; // parent node pointer
-        }RASInflightEntry;
-
-        typedef struct RASMeta {
-            int ssp;
-            int sctr;
-            // RASEntry tos; // top of stack
-            int TOSR;
-            int TOSW;
-            bool willPush;
-            Addr target;
-            // RASInflightEntry inflight; // inflight top of stack
-        }RASMeta;
-
-        void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
-                          std::vector<FullBTBPrediction> &stagePreds) override;
-        
-        std::shared_ptr<void> getPredictionMeta() override;
-
-        void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
-
-        void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) override;
-
-        void update(const FetchTarget &entry) override;
-
-        // commitBranch method - override only in production mode
-#ifdef UNIT_TEST
-        void commitBranch(const FetchTarget &stream, const DynInstPtr &inst);
-#else
-        void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
-#endif
-
-        Addr getTopAddrFromMetas(const FetchTarget &stream);
-
-    private:
-
-        void push(Addr retAddr);
-
-        void pop();
-
-        void push_stack(Addr retAddr);
-        
-        void pop_stack();
-
-        void ptrInc(int &ptr);
-
-        void ptrDec(int &ptr);
-
-        void inflightPtrInc(int &ptr);
-        
-        void inflightPtrDec(int &ptr);
-
-        bool inflightInRange(int &ptr);
-
-        int inflightPtrPlus1(int ptr);
-
-        void checkCorrectness();
-
-        RASEssential getTop();
-
-        RASEssential getTop_meta();
-
-        void printStack(const char *when) {
-            DPRINTF(RAS, "printStack when %s: \n", when);
-            for (int i = 0; i < numEntries; i++) {
-                DPRINTFR(RAS, "entry [%d], retAddr %#lx, ctr %d", i, stack[i].data.retAddr, stack[i].data.ctr);
-                if (ssp == i) {
-                    DPRINTFR(RAS, " <-- SSP");
-                }
-                if (nsp == i) {
-                    DPRINTFR(RAS, " <-- NSP");
-                }
-                DPRINTFR(RAS, "\n");
-            }
-            DPRINTFR(RAS, "non-volatile stack:\n");
-            for (int i = 0; i < numInflightEntries; i++) {
-                DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %d", i, inflightStack[i].data.retAddr, inflightStack[i].data.ctr, inflightStack[i].nos);
-                if (TOSW == i) {
-                    DPRINTFR(RAS, " <-- TOSW");
-                }
-                if (TOSR == i) {
-                    DPRINTFR(RAS, " <-- TOSR");
-                }
-                if (BOS == i) {
-                    DPRINTFR(RAS, " <-- BOS");
-                }
-                DPRINTFR(RAS, "\n");
-            }
-            /*
-            DPRINTFR(RAS, "non-volatile stack current data:\n");
-            int a = TOSR;
-            int inflightCurrentSz = 0;
-            while (inflightInRange(a)) {
-                DPRINTFR(RAS, "retAddr %#lx, ctr %d\n", inflightStack[a].data.retAddr, inflightStack[a].data.ctr);
-                ++inflightCurrentSz;
-                a = inflightStack[a].nos;
-                if (inflightCurrentSz > 30) {
-                    DPRINTFR(RAS, "...\n");
-                    break;
-                }
-            }
-            */
-            //if (ssp > nsp && (ssp - nsp != inflightCurrentSz)) {
-            //    DPRINTFR(RAS, "inflight size mismatch!\n");
-            //}
+            data.retAddr = retAddr;
+            data.ctr = ctr;
         }
+        RASEntry(Addr retAddr)
+        {
+            data.retAddr = retAddr;
+            data.ctr = 0;
+        }
+        RASEntry()
+        {
+            data.retAddr = 0;
+            data.ctr = 0;
+        }
+    } RASEntry;
 
-        unsigned numEntries;
+    typedef struct RASInflightEntry
+    {
+        RASEssential data;
+        int nos;  // parent node pointer
+    } RASInflightEntry;
 
-        unsigned ctrWidth;
-
-        unsigned numInflightEntries;
-
-        int TOSW; // inflight pointer to the write top of stack
-
-        int TOSR; // inflight pointer to the read top of stack
-
-        int BOS; // inflight pointer to the bottom of stack
-
-        int maxCtr;
-
-        int ssp; // spec sp
-        
-        int nsp; // non-spec sp
-
+    typedef struct RASMeta
+    {
+        int ssp;
         int sctr;
+        // RASEntry tos; // top of stack
+        int TOSR;
+        int TOSW;
+        bool willPush;
+        Addr target;
+        // RASInflightEntry inflight; // inflight top of stack
+    } RASMeta;
 
-        //int ndepth;
+    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+                      std::vector<FullBTBPrediction> &stagePreds) override;
+    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                               const std::vector<boost::dynamic_bitset<>> &lhistory,
+                               std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
+    {
+        (void)history;
+        (void)phistory;
+        (void)bwhistory;
+        (void)lhistory;
+        (void)lowerPred;
+        if (!participatesInBlock1()) {
+            return;
+        }
+        putPCHistory(startAddr, boost::dynamic_bitset<>(), stagePreds);
+    }
 
-        std::vector<RASEntry> stack;
-        
-        std::vector<RASInflightEntry> inflightStack;
+    std::shared_ptr<void> getPredictionMeta() override;
 
-        std::shared_ptr<RASMeta> meta;
+    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+
+    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                     bool cond_taken) override;
+
+    void update(const FetchTarget &entry) override;
+
+    // commitBranch method - override only in production mode
+#ifdef UNIT_TEST
+    void commitBranch(const FetchTarget &stream, const DynInstPtr &inst);
+#else
+    void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
+#endif
+
+    Addr getTopAddrFromMetas(const FetchTarget &stream);
+
+  private:
+    void push(Addr retAddr);
+
+    void pop();
+
+    void push_stack(Addr retAddr);
+
+    void pop_stack();
+
+    void ptrInc(int &ptr);
+
+    void ptrDec(int &ptr);
+
+    void inflightPtrInc(int &ptr);
+
+    void inflightPtrDec(int &ptr);
+
+    bool inflightInRange(int &ptr);
+
+    int inflightPtrPlus1(int ptr);
+
+    void checkCorrectness();
+
+    RASEssential getTop();
+
+    RASEssential getTop_meta();
+
+    void printStack(const char *when)
+    {
+        DPRINTF(RAS, "printStack when %s: \n", when);
+        for (int i = 0; i < numEntries; i++) {
+            DPRINTFR(RAS, "entry [%d], retAddr %#lx, ctr %d", i, stack[i].data.retAddr, stack[i].data.ctr);
+            if (ssp == i) {
+                DPRINTFR(RAS, " <-- SSP");
+            }
+            if (nsp == i) {
+                DPRINTFR(RAS, " <-- NSP");
+            }
+            DPRINTFR(RAS, "\n");
+        }
+        DPRINTFR(RAS, "non-volatile stack:\n");
+        for (int i = 0; i < numInflightEntries; i++) {
+            DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %d", i, inflightStack[i].data.retAddr,
+                     inflightStack[i].data.ctr, inflightStack[i].nos);
+            if (TOSW == i) {
+                DPRINTFR(RAS, " <-- TOSW");
+            }
+            if (TOSR == i) {
+                DPRINTFR(RAS, " <-- TOSR");
+            }
+            if (BOS == i) {
+                DPRINTFR(RAS, " <-- BOS");
+            }
+            DPRINTFR(RAS, "\n");
+        }
+        /*
+        DPRINTFR(RAS, "non-volatile stack current data:\n");
+        int a = TOSR;
+        int inflightCurrentSz = 0;
+        while (inflightInRange(a)) {
+            DPRINTFR(RAS, "retAddr %#lx, ctr %d\n", inflightStack[a].data.retAddr, inflightStack[a].data.ctr);
+            ++inflightCurrentSz;
+            a = inflightStack[a].nos;
+            if (inflightCurrentSz > 30) {
+                DPRINTFR(RAS, "...\n");
+                break;
+            }
+        }
+        */
+        // if (ssp > nsp && (ssp - nsp != inflightCurrentSz)) {
+        //     DPRINTFR(RAS, "inflight size mismatch!\n");
+        // }
+    }
+
+    unsigned numEntries;
+
+    unsigned ctrWidth;
+
+    unsigned numInflightEntries;
+
+    int TOSW;  // inflight pointer to the write top of stack
+
+    int TOSR;  // inflight pointer to the read top of stack
+
+    int BOS;  // inflight pointer to the bottom of stack
+
+    int maxCtr;
+
+    int ssp;  // spec sp
+
+    int nsp;  // non-spec sp
+
+    int sctr;
+
+    // int ndepth;
+
+    std::vector<RASEntry> stack;
+
+    std::vector<RASInflightEntry> inflightStack;
+
+    std::shared_ptr<RASMeta> meta;
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -219,8 +239,8 @@ namespace btb_pred {
 #endif
 
 #ifdef UNIT_TEST
-        struct RASStats
-        {
+    struct RASStats
+    {
 #else
     struct RASStats : public statistics::Group
     {
@@ -234,22 +254,22 @@ namespace btb_pred {
         Scalar Pops;
 
 #ifndef UNIT_TEST
-        RASStats(statistics::Group* parent);
+        RASStats(statistics::Group *parent);
 #endif
-        } rasStats;
+    } rasStats;
 
 
-}; // class BTBRAS
+};  // class BTBRAS
 
 // Close conditional namespaces
 #ifdef UNIT_TEST
-    } // namespace test
+}  // namespace test
 #endif
 
-} // namespace btb_pred
+}  // namespace btb_pred
 
-} // namespace branch_prediction
+}  // namespace branch_prediction
 
-} // namespace gem5
+}  // namespace gem5
 
-#endif // __CPU_PRED_BTB_RAS_HH__
+#endif  // __CPU_PRED_BTB_RAS_HH__

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -4,235 +4,230 @@
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/btb/common.hh"
-#include "cpu/pred/btb/timed_base_pred.hh"
 
+// Conditional includes based on build mode
 #ifdef UNIT_TEST
-#include "cpu/pred/btb/test/test_dprintf.hh"
+    // Test mode includes
+    #include "cpu/pred/btb/test/test_dprintf.hh"
+    #include "cpu/pred/btb/timed_base_pred.hh"
 
-namespace gem5
-{
-namespace o3
-{
-class DynInst;
-}
-}
-using DynInstPtr = std::shared_ptr<gem5::o3::DynInst>;
+    // Test mode type definitions
+    namespace gem5 {
+        namespace o3 {
+            class DynInst;
+        }
+    }
+    using DynInstPtr = std::shared_ptr<gem5::o3::DynInst>;
 #else
-#include "debug/RAS.hh"
-#include "params/BTBRAS.hh"
-
+    // Production mode includes
+    #include "cpu/pred/btb/timed_base_pred.hh"
+    #include "debug/RAS.hh"
+    #include "params/BTBRAS.hh"
 #endif
 
-namespace gem5
-{
+namespace gem5 {
 
-namespace branch_prediction
-{
+namespace branch_prediction {
 
-namespace btb_pred
-{
+namespace btb_pred {
 
 // Class definition with conditional inheritance and constructors
 #ifdef UNIT_TEST
-namespace test
-{
-class BTBRAS : public TimedBaseBTBPredictor
-{
-  public:
-    // Test constructor for unit testing mode
-    BTBRAS(unsigned numEntries, unsigned ctrWidth, unsigned numInflightEntries);
+    namespace test {
+        class BTBRAS : public TimedBaseBTBPredictor
+        {
+        public:
+            // Test constructor for unit testing mode
+            BTBRAS(unsigned numEntries, unsigned ctrWidth, unsigned numInflightEntries);
 #else
-class BTBRAS : public TimedBaseBTBPredictor
-{
-  public:
-    // Production constructor
-    typedef BTBRASParams Params;
-    BTBRAS(const Params &p);
+    class BTBRAS : public TimedBaseBTBPredictor
+    {
+    public:
+        // Production constructor
+        typedef BTBRASParams Params;
+        BTBRAS(const Params &p);
 #endif
 
-    typedef struct RASEssential
-    {
-        Addr retAddr;
-        unsigned ctr;
-    } RASEssential;
-
-    typedef struct RASEntry
-    {
-        RASEssential data;
-        RASEntry(Addr retAddr, unsigned ctr)
+        typedef struct RASEssential
         {
-            data.retAddr = retAddr;
-            data.ctr = ctr;
-        }
-        RASEntry(Addr retAddr)
+            Addr retAddr;
+            unsigned ctr;
+        }RASEssential;
+
+        typedef struct RASEntry
         {
-            data.retAddr = retAddr;
-            data.ctr = 0;
-        }
-        RASEntry()
-        {
-            data.retAddr = 0;
-            data.ctr = 0;
-        }
-    } RASEntry;
-
-    typedef struct RASInflightEntry
-    {
-        RASEssential data;
-        int nos;  // parent node pointer
-    } RASInflightEntry;
-
-    typedef struct RASMeta
-    {
-        int ssp;
-        int sctr;
-        // RASEntry tos; // top of stack
-        int TOSR;
-        int TOSW;
-        bool willPush;
-        Addr target;
-        // RASInflightEntry inflight; // inflight top of stack
-    } RASMeta;
-
-    void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
-                      std::vector<FullBTBPrediction> &stagePreds) override;
-    void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
-                               const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
-                               const std::vector<boost::dynamic_bitset<>> &lhistory,
-                               std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
-    {
-        (void)history;
-        (void)phistory;
-        (void)bwhistory;
-        (void)lhistory;
-        if (!participatesInBlock1()) {
-            for (int s = getDelay(); s < stagePreds.size(); s++) {
-                stagePreds[s].returnTarget = lowerPred.returnTarget;
+            RASEssential data;
+            RASEntry(Addr retAddr, unsigned ctr)
+            {
+                data.retAddr = retAddr;
+                data.ctr = ctr;
             }
-            return;
+            RASEntry(Addr retAddr)
+            {
+                data.retAddr = retAddr;
+                data.ctr = 0;
+            }
+            RASEntry()
+            {
+                data.retAddr = 0;
+                data.ctr = 0;
+            }
+        }RASEntry;
+
+        typedef struct RASInflightEntry
+        {
+            RASEssential data;
+            int nos; // parent node pointer
+        }RASInflightEntry;
+
+        typedef struct RASMeta {
+            int ssp;
+            int sctr;
+            // RASEntry tos; // top of stack
+            int TOSR;
+            int TOSW;
+            bool willPush;
+            Addr target;
+            // RASInflightEntry inflight; // inflight top of stack
+        }RASMeta;
+
+        void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+                          std::vector<FullBTBPrediction> &stagePreds) override;
+        void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                                   const boost::dynamic_bitset<> &phistory, const boost::dynamic_bitset<> &bwhistory,
+                                   const std::vector<boost::dynamic_bitset<>> &lhistory,
+                                   std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred) override
+        {
+            (void)history;
+            (void)phistory;
+            (void)bwhistory;
+            (void)lhistory;
+            if (!participatesInBlock1()) {
+                for (int s = getDelay(); s < stagePreds.size(); s++) {
+                    stagePreds[s].returnTarget = lowerPred.returnTarget;
+                }
+                return;
+            }
+            putPCHistory(startAddr, boost::dynamic_bitset<>(), stagePreds);
         }
-        putPCHistory(startAddr, boost::dynamic_bitset<>(), stagePreds);
-    }
+        
+        std::shared_ptr<void> getPredictionMeta() override;
 
-    std::shared_ptr<void> getPredictionMeta() override;
+        void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
 
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+        void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) override;
 
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                     bool cond_taken) override;
+        void update(const FetchTarget &entry) override;
 
-    void update(const FetchTarget &entry) override;
-
-    // commitBranch method - override only in production mode
+        // commitBranch method - override only in production mode
 #ifdef UNIT_TEST
-    void commitBranch(const FetchTarget &stream, const DynInstPtr &inst);
+        void commitBranch(const FetchTarget &stream, const DynInstPtr &inst);
 #else
-    void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
+        void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
 #endif
 
-    Addr getTopAddrFromMetas(const FetchTarget &stream);
+        Addr getTopAddrFromMetas(const FetchTarget &stream);
 
-  private:
-    void push(Addr retAddr);
+    private:
 
-    void pop();
+        void push(Addr retAddr);
 
-    void push_stack(Addr retAddr);
+        void pop();
 
-    void pop_stack();
+        void push_stack(Addr retAddr);
+        
+        void pop_stack();
 
-    void ptrInc(int &ptr);
+        void ptrInc(int &ptr);
 
-    void ptrDec(int &ptr);
+        void ptrDec(int &ptr);
 
-    void inflightPtrInc(int &ptr);
+        void inflightPtrInc(int &ptr);
+        
+        void inflightPtrDec(int &ptr);
 
-    void inflightPtrDec(int &ptr);
+        bool inflightInRange(int &ptr);
 
-    bool inflightInRange(int &ptr);
+        int inflightPtrPlus1(int ptr);
 
-    int inflightPtrPlus1(int ptr);
+        void checkCorrectness();
 
-    void checkCorrectness();
+        RASEssential getTop();
 
-    RASEssential getTop();
+        RASEssential getTop_meta();
 
-    RASEssential getTop_meta();
-
-    void printStack(const char *when)
-    {
-        DPRINTF(RAS, "printStack when %s: \n", when);
-        for (int i = 0; i < numEntries; i++) {
-            DPRINTFR(RAS, "entry [%d], retAddr %#lx, ctr %d", i, stack[i].data.retAddr, stack[i].data.ctr);
-            if (ssp == i) {
-                DPRINTFR(RAS, " <-- SSP");
+        void printStack(const char *when) {
+            DPRINTF(RAS, "printStack when %s: \n", when);
+            for (int i = 0; i < numEntries; i++) {
+                DPRINTFR(RAS, "entry [%d], retAddr %#lx, ctr %d", i, stack[i].data.retAddr, stack[i].data.ctr);
+                if (ssp == i) {
+                    DPRINTFR(RAS, " <-- SSP");
+                }
+                if (nsp == i) {
+                    DPRINTFR(RAS, " <-- NSP");
+                }
+                DPRINTFR(RAS, "\n");
             }
-            if (nsp == i) {
-                DPRINTFR(RAS, " <-- NSP");
+            DPRINTFR(RAS, "non-volatile stack:\n");
+            for (int i = 0; i < numInflightEntries; i++) {
+                DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %d", i, inflightStack[i].data.retAddr, inflightStack[i].data.ctr, inflightStack[i].nos);
+                if (TOSW == i) {
+                    DPRINTFR(RAS, " <-- TOSW");
+                }
+                if (TOSR == i) {
+                    DPRINTFR(RAS, " <-- TOSR");
+                }
+                if (BOS == i) {
+                    DPRINTFR(RAS, " <-- BOS");
+                }
+                DPRINTFR(RAS, "\n");
             }
-            DPRINTFR(RAS, "\n");
+            /*
+            DPRINTFR(RAS, "non-volatile stack current data:\n");
+            int a = TOSR;
+            int inflightCurrentSz = 0;
+            while (inflightInRange(a)) {
+                DPRINTFR(RAS, "retAddr %#lx, ctr %d\n", inflightStack[a].data.retAddr, inflightStack[a].data.ctr);
+                ++inflightCurrentSz;
+                a = inflightStack[a].nos;
+                if (inflightCurrentSz > 30) {
+                    DPRINTFR(RAS, "...\n");
+                    break;
+                }
+            }
+            */
+            //if (ssp > nsp && (ssp - nsp != inflightCurrentSz)) {
+            //    DPRINTFR(RAS, "inflight size mismatch!\n");
+            //}
         }
-        DPRINTFR(RAS, "non-volatile stack:\n");
-        for (int i = 0; i < numInflightEntries; i++) {
-            DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %d", i, inflightStack[i].data.retAddr,
-                     inflightStack[i].data.ctr, inflightStack[i].nos);
-            if (TOSW == i) {
-                DPRINTFR(RAS, " <-- TOSW");
-            }
-            if (TOSR == i) {
-                DPRINTFR(RAS, " <-- TOSR");
-            }
-            if (BOS == i) {
-                DPRINTFR(RAS, " <-- BOS");
-            }
-            DPRINTFR(RAS, "\n");
-        }
-        /*
-        DPRINTFR(RAS, "non-volatile stack current data:\n");
-        int a = TOSR;
-        int inflightCurrentSz = 0;
-        while (inflightInRange(a)) {
-            DPRINTFR(RAS, "retAddr %#lx, ctr %d\n", inflightStack[a].data.retAddr, inflightStack[a].data.ctr);
-            ++inflightCurrentSz;
-            a = inflightStack[a].nos;
-            if (inflightCurrentSz > 30) {
-                DPRINTFR(RAS, "...\n");
-                break;
-            }
-        }
-        */
-        // if (ssp > nsp && (ssp - nsp != inflightCurrentSz)) {
-        //     DPRINTFR(RAS, "inflight size mismatch!\n");
-        // }
-    }
 
-    unsigned numEntries;
+        unsigned numEntries;
 
-    unsigned ctrWidth;
+        unsigned ctrWidth;
 
-    unsigned numInflightEntries;
+        unsigned numInflightEntries;
 
-    int TOSW;  // inflight pointer to the write top of stack
+        int TOSW; // inflight pointer to the write top of stack
 
-    int TOSR;  // inflight pointer to the read top of stack
+        int TOSR; // inflight pointer to the read top of stack
 
-    int BOS;  // inflight pointer to the bottom of stack
+        int BOS; // inflight pointer to the bottom of stack
 
-    int maxCtr;
+        int maxCtr;
 
-    int ssp;  // spec sp
+        int ssp; // spec sp
+        
+        int nsp; // non-spec sp
 
-    int nsp;  // non-spec sp
+        int sctr;
 
-    int sctr;
+        //int ndepth;
 
-    // int ndepth;
+        std::vector<RASEntry> stack;
+        
+        std::vector<RASInflightEntry> inflightStack;
 
-    std::vector<RASEntry> stack;
-
-    std::vector<RASInflightEntry> inflightStack;
-
-    std::shared_ptr<RASMeta> meta;
+        std::shared_ptr<RASMeta> meta;
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -241,8 +236,8 @@ class BTBRAS : public TimedBaseBTBPredictor
 #endif
 
 #ifdef UNIT_TEST
-    struct RASStats
-    {
+        struct RASStats
+        {
 #else
     struct RASStats : public statistics::Group
     {
@@ -256,22 +251,22 @@ class BTBRAS : public TimedBaseBTBPredictor
         Scalar Pops;
 
 #ifndef UNIT_TEST
-        RASStats(statistics::Group *parent);
+        RASStats(statistics::Group* parent);
 #endif
-    } rasStats;
+        } rasStats;
 
 
-};  // class BTBRAS
+}; // class BTBRAS
 
 // Close conditional namespaces
 #ifdef UNIT_TEST
-}  // namespace test
+    } // namespace test
 #endif
 
-}  // namespace btb_pred
+} // namespace btb_pred
 
-}  // namespace branch_prediction
+} // namespace branch_prediction
 
-}  // namespace gem5
+} // namespace gem5
 
-#endif  // __CPU_PRED_BTB_RAS_HH__
+#endif // __CPU_PRED_BTB_RAS_HH__

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -105,8 +105,10 @@ class BTBRAS : public TimedBaseBTBPredictor
         (void)phistory;
         (void)bwhistory;
         (void)lhistory;
-        (void)lowerPred;
         if (!participatesInBlock1()) {
+            for (int s = getDelay(); s < stagePreds.size(); s++) {
+                stagePreds[s].returnTarget = lowerPred.returnTarget;
+            }
             return;
         }
         putPCHistory(startAddr, boost::dynamic_bitset<>(), stagePreds);

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -9,6 +9,7 @@ GTest('uras.test', 'uras_test.cc')
 # Add BTB test with minimal dependencies
 GTest('btb.test', 
     '../mbtb.cc',
+    '../btb_ubtb.cc',
     'btb.test.cc',
     '../timed_base_pred.cc',
 )

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -41,6 +41,11 @@ GTest('folded_hist.test',
     '../folded_hist.cc',
 )
 
+GTest('fetch_target_queue.test',
+    'fetch_target_queue.test.cc',
+    '../ftq.cc',
+)
+
 # add --unit-test to enable unit test mode for RAS
 # TODO: Fix RAS test
 # GTest('ras.test',

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -31,10 +31,9 @@ namespace test
  * @param size Instruction size
  * @return BranchInfo Initialized branch information
  */
-BranchInfo
-createBranchInfo(Addr pc, Addr target, bool isCond = false, bool isIndirect = false, bool isCall = false,
-                 bool isReturn = false, uint8_t size = 4)
-{
+BranchInfo createBranchInfo(Addr pc, Addr target, bool isCond = false,
+                           bool isIndirect = false, bool isCall = false,
+                           bool isReturn = false, uint8_t size = 4) {
     BranchInfo info;
     info.pc = pc;
     info.target = target;
@@ -56,9 +55,8 @@ createBranchInfo(Addr pc, Addr target, bool isCond = false, bool isIndirect = fa
  * @param endInstPC Last executed instruction PC, used for filtering entries
  * @return FetchTarget Initialized fetch stream
  */
-FetchTarget
-setupStream(Addr startPC, const BranchInfo& branch, bool taken, std::shared_ptr<void> meta, Addr endInstPC)
-{
+FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
+                       std::shared_ptr<void> meta, Addr endInstPC) {
     FetchTarget stream;
     stream.startPC = startPC;
     stream.resolved = true;
@@ -66,7 +64,7 @@ setupStream(Addr startPC, const BranchInfo& branch, bool taken, std::shared_ptr<
     stream.exeTaken = taken;
     stream.predMetas[0] = meta;
     stream.updateEndInstPC = endInstPC;
-    stream.squashType = SQUASH_CTRL;  // mispredict default
+    stream.squashType = SQUASH_CTRL; // mispredict default
     return stream;
 }
 
@@ -77,9 +75,7 @@ setupStream(Addr startPC, const BranchInfo& branch, bool taken, std::shared_ptr<
  * @param pc Branch PC to search for
  * @return Pair of (found, prediction) where found indicates if PC was found
  */
-std::pair<bool, bool>
-findCondTaken(const CondTakens& condTakens, Addr pc)
-{
+std::pair<bool, bool> findCondTaken(const CondTakens& condTakens, Addr pc) {
     auto it = CondTakens_find(condTakens, pc);
     if (it != condTakens.end()) {
         return {true, it->second};
@@ -94,9 +90,7 @@ findCondTaken(const CondTakens& condTakens, Addr pc)
  * @param pc Branch PC to search for
  * @return Pair of (found, target) where found indicates if PC was found
  */
-std::pair<bool, Addr>
-findIndirectTarget(const IndirectTargets& indirectTargets, Addr pc)
-{
+std::pair<bool, Addr> findIndirectTarget(const IndirectTargets& indirectTargets, Addr pc) {
     auto it = IndirectTakens_find(indirectTargets, pc);
     if (it != indirectTargets.end()) {
         return {true, it->second};
@@ -116,9 +110,12 @@ findIndirectTarget(const IndirectTargets& indirectTargets, Addr pc)
  * @return std::vector<FullBTBPrediction> Final stage predictions
  */
 std::vector<FullBTBPrediction>
-predictUpdateCycle(MBTB* btb, Addr startPC, const BranchInfo& branch, bool taken,
-                   const boost::dynamic_bitset<>& history = boost::dynamic_bitset<>(8, 0), Addr endInstPC = 0)
-{
+predictUpdateCycle(MBTB* btb,
+     Addr startPC,
+     const BranchInfo& branch,
+     bool taken,
+     const boost::dynamic_bitset<>& history = boost::dynamic_bitset<>(8, 0),
+     Addr endInstPC = 0) {
     // If endInstPC not specified, use branch.pc + branch.size
     if (endInstPC == 0) {
         endInstPC = branch.pc + branch.size;
@@ -139,7 +136,7 @@ predictUpdateCycle(MBTB* btb, Addr startPC, const BranchInfo& branch, bool taken
     stream.setUpdateBTBEntries();
     btb->getAndSetNewBTBEntry(stream);
 
-    for (auto& entry : stream.updateBTBEntries) {
+    for (auto &entry : stream.updateBTBEntries) {
         entry.resolved = true;
     }
     stream.updateNewBTBEntry.resolved = true;
@@ -161,10 +158,9 @@ predictUpdateCycle(MBTB* btb, Addr startPC, const BranchInfo& branch, bool taken
  * @param delay BTB delay (0 for L0, >0 for L1)
  * @param expectedEntries Expected branch entries
  */
-void
-verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds, unsigned delay,
-                 const std::vector<BranchInfo>& expectedEntries)
-{
+void verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds,
+                     unsigned delay,
+                     const std::vector<BranchInfo>& expectedEntries) {
     // Check predictions for stages after delay
     for (int i = delay; i < stagePreds.size(); i++) {
         ASSERT_EQ(stagePreds[i].btbEntries.size(), expectedEntries.size());
@@ -176,26 +172,23 @@ verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds, unsigned dela
 }
 
 // Test fixture for BTB tests
-class BTBTest : public ::testing::Test
-{
-  protected:
-    void SetUp() override
-    {
+class BTBTest : public ::testing::Test {
+protected:
+    void SetUp() override {
         // Create a BTB with 16 entries, 8-bit tags, and 4-way set associative
         mbtb_small = new MBTB(16, 8, 4, 1);  // mbtb (L1 BTB)
         mbtb = new MBTB(2048, 20, 4, 1);     // 2 sram, 4 way each, total 8 ways
         ubtb = new UBTB(16, 12);
     }
-
-
+    
+    
     MBTB* mbtb_small;
     MBTB* mbtb;
     UBTB* ubtb;
 };
 
 // Test basic initialization
-TEST_F(BTBTest, Initialization)
-{
+TEST_F(BTBTest, Initialization) {
     // Create a new BTB with different parameters
     MBTB testBtb(32, 12, 8, 0);
     // Basic initialization test passes if no crashes/assertions
@@ -203,14 +196,13 @@ TEST_F(BTBTest, Initialization)
 }
 
 // Test basic prediction with empty BTB
-TEST_F(BTBTest, EmptyPrediction)
-{
+TEST_F(BTBTest, EmptyPrediction) {
     Addr startAddr = 0x1000;
-    boost::dynamic_bitset<> history(8, 0);         // 8-bit history, all zeros
+    boost::dynamic_bitset<> history(8, 0);  // 8-bit history, all zeros
     std::vector<FullBTBPrediction> stagePreds(4);  // 4 stages
-
+    
     mbtb->putPCHistory(startAddr, history, stagePreds);
-
+    
     // Check predictions for all stages
     for (int i = 0; i < stagePreds.size(); i++) {
         EXPECT_TRUE(stagePreds[i].btbEntries.empty());
@@ -433,86 +425,86 @@ TEST_F(BTBTest, UBTBBlock1PredictionProducesMeta)
 // 4. update, update btb entries
 
 // Test basic prediction after update
-TEST_F(BTBTest, PredictionAfterUpdate)
-{
+TEST_F(BTBTest, PredictionAfterUpdate) {
     // Create branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // Execute prediction-update cycle
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Verify predictions
     verifyPrediction(stagePreds, mbtb->getDelay(), {branch});
 }
 
 // Test large virtual addr
-TEST_F(BTBTest, PredictionAfterUpdateLargeAddr)
-{
+TEST_F(BTBTest, PredictionAfterUpdateLargeAddr) {
     // Create branch info
     BranchInfo branch = createBranchInfo(0xffffffff8027ac64, 0xffffffff80261dee, true);
 
     // Execute prediction-update cycle
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0xffffffff8027ac60, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0xffffffff8027ac60, branch, true);
 
     // Verify predictions
     verifyPrediction(stagePreds, mbtb->getDelay(), {branch});
 }
 
 // Test conditional branch prediction counter, for mBTB
-TEST_F(BTBTest, ConditionalCounter)
-{
+TEST_F(BTBTest, ConditionalCounter) {
     // Create conditional branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // First update with taken
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Counter should be initialized to 0 and stay at 0 after taken (since alwaysTaken=true)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto& entries = stagePreds[i].btbEntries;
+        auto &entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, 0);
         EXPECT_TRUE(entries[0].alwaysTaken);
     }
-
+    
     // Then update with not taken
     stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, false);
 
     // Counter should be reduced after not taken (0 -> -1)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto& entries = stagePreds[i].btbEntries;
+        auto &entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, -1);
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
 }
 
 // Test counter saturation behavior, for mBTB
-TEST_F(BTBTest, CounterSaturation)
-{
+TEST_F(BTBTest, CounterSaturation) {
     // Create conditional branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // First entry is initialized with ctr=0
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Check counter is at 0 (alwaysTaken=true, so updateCtr not called)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto& entries = stagePreds[i].btbEntries;
+        auto &entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, 0);  // Counter should be at 0
         EXPECT_TRUE(entries[0].alwaysTaken);
     }
-
+    
     // Update multiple times with not taken to test negative saturation
     for (int i = 0; i < 3; i++) {  // 3 times should reach saturation
         stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, false);
     }
-
+    
     // Check counter is saturated at -2
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto& entries = stagePreds[i].btbEntries;
+        auto &entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, -2);  // Counter should saturate at -2
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
@@ -541,13 +533,13 @@ TEST_F(BTBTest, CounterSaturation)
 // }
 
 // Test indirect branch prediction
-TEST_F(BTBTest, IndirectBranchPrediction)
-{
+TEST_F(BTBTest, IndirectBranchPrediction) {
     // Create indirect branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, false, true);
 
     // Initial prediction and update
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Verify indirect target
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
@@ -556,7 +548,7 @@ TEST_F(BTBTest, IndirectBranchPrediction)
         ASSERT_TRUE(found1);
         EXPECT_EQ(target1, 0x2000);
     }
-
+    
     // Update with new target
     BranchInfo updatedBranch = createBranchInfo(0x1000, 0x3000, false, true);
     stagePreds = predictUpdateCycle(mbtb, 0x1000, updatedBranch, true);
@@ -570,8 +562,7 @@ TEST_F(BTBTest, IndirectBranchPrediction)
 }
 
 // Test multiple branch predictions in same fetch block
-TEST_F(BTBTest, MultipleBranchPrediction)
-{
+TEST_F(BTBTest, MultipleBranchPrediction) {
     // Create two branches in the same fetch block
     BranchInfo branch1 = createBranchInfo(0x1000, 0x2000, true);
     BranchInfo branch2 = createBranchInfo(0x1004, 0x3000, true);
@@ -589,25 +580,25 @@ TEST_F(BTBTest, MultipleBranchPrediction)
     FetchTarget stream = setupStream(0x1000, branch2, true, meta, 0x1008);
     mbtb->getAndSetNewBTBEntry(stream);
     mbtb->update(stream);
-
+    
     // Check final predictions
     stagePreds.clear();
     stagePreds.resize(4);
     mbtb->putPCHistory(0x1000, history, stagePreds);
-
+    
     // Verify both branches are predicted
     std::vector<BranchInfo> expectedBranches = {branch1, branch2};
     verifyPrediction(stagePreds, mbtb->getDelay(), expectedBranches);
 }
 
 // Test recovery from misprediction
-TEST_F(BTBTest, MispredictionRecovery)
-{
+TEST_F(BTBTest, MispredictionRecovery) {
     // Create conditional branch initially taken
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // Initial prediction and update as taken
-    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds =
+        predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Update the same branch as not taken
     branch.target = 0x1004;  // Fall through target
@@ -616,14 +607,13 @@ TEST_F(BTBTest, MispredictionRecovery)
     // Verify prediction is updated
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto& entries = stagePreds[i].btbEntries;
+        auto &entries = stagePreds[i].btbEntries;
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
 }
 
 // Test half-aligned mode basic functionality
-TEST_F(BTBTest, HalfAlignedBasicTest)
-{
+TEST_F(BTBTest, HalfAlignedBasicTest) {
 
     // Create branches in two consecutive 32B blocks
     BranchInfo branch1 = createBranchInfo(0x100, 0x200, true);
@@ -631,10 +621,12 @@ TEST_F(BTBTest, HalfAlignedBasicTest)
 
     // Add first branch
     std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x100, branch1, true, boost::dynamic_bitset<>(64, 0), 0x140);
+        predictUpdateCycle(mbtb, 0x100, branch1, true, 
+            boost::dynamic_bitset<>(64, 0), 0x140);
 
     // Add second branch
-    stagePreds = predictUpdateCycle(mbtb, 0x100, branch2, true, boost::dynamic_bitset<>(64, 0), 0x140);
+    stagePreds = predictUpdateCycle(mbtb, 0x100, branch2, true, 
+        boost::dynamic_bitset<>(64, 0), 0x140);
 
     // Verify both branches are predicted
     std::vector<BranchInfo> expectedBranches = {branch1, branch2};
@@ -642,8 +634,7 @@ TEST_F(BTBTest, HalfAlignedBasicTest)
 }
 
 // Test half-aligned mode with unaligned addresses
-TEST_F(BTBTest, HalfAlignedUnalignedTest)
-{
+TEST_F(BTBTest, HalfAlignedUnalignedTest) {
 
     // Create unaligned branches in two consecutive 32B blocks
     BranchInfo branch1 = createBranchInfo(0x104, 0x200, true);
@@ -662,8 +653,7 @@ TEST_F(BTBTest, HalfAlignedUnalignedTest)
 }
 
 // Test half-aligned mode update with branch in second block
-TEST_F(BTBTest, HalfAlignedUpdateSecondBlock)
-{
+TEST_F(BTBTest, HalfAlignedUpdateSecondBlock) {
 
     // Create branch in second 32B block
     BranchInfo branch = createBranchInfo(0x124, 0x200, true);
@@ -686,8 +676,7 @@ TEST_F(BTBTest, HalfAlignedUpdateSecondBlock)
 }
 
 // Test half-aligned mode with branches in both blocks
-TEST_F(BTBTest, HalfAlignedBothBlocks)
-{
+TEST_F(BTBTest, HalfAlignedBothBlocks) {
 
     // Create branches in both 32B blocks
     BranchInfo branch1 = createBranchInfo(0x108, 0x200, true);
@@ -706,8 +695,7 @@ TEST_F(BTBTest, HalfAlignedBothBlocks)
 }
 
 // Test half-aligned mode with unaligned start address
-TEST_F(BTBTest, HalfAlignedUnalignedStart)
-{
+TEST_F(BTBTest, HalfAlignedUnalignedStart) {
 
     // Create branch in second block
     BranchInfo branch = createBranchInfo(0x12C, 0x200, true);
@@ -721,8 +709,7 @@ TEST_F(BTBTest, HalfAlignedUnalignedStart)
 }
 
 // Test half-aligned mode with multiple updates to same branch
-TEST_F(BTBTest, HalfAlignedMultipleUpdates)
-{
+TEST_F(BTBTest, HalfAlignedMultipleUpdates) {
 
     // Create indirect branch in second block with initial target
     BranchInfo branch = createBranchInfo(0x124, 0x200, false, true);
@@ -740,8 +727,7 @@ TEST_F(BTBTest, HalfAlignedMultipleUpdates)
 }
 
 // Test victim cache effectiveness with SRAM overflow
-TEST_F(BTBTest, VictimCacheEffectivenessTest)
-{
+TEST_F(BTBTest, VictimCacheEffectivenessTest) {
     // Create 5 branches in same 32B block that all map to SRAM0
     // Use addresses with bit[5]=0 to ensure they go to SRAM0
     std::vector<BranchInfo> branches;
@@ -755,19 +741,20 @@ TEST_F(BTBTest, VictimCacheEffectivenessTest)
     // Add all 5 branches one by one
     std::vector<FullBTBPrediction> stagePreds;
     for (int i = 0; i < 5; i++) {
-        stagePreds = predictUpdateCycle(mbtb, 0x100, branches[i], true, boost::dynamic_bitset<>(64, 0), 0x140);
+        stagePreds = predictUpdateCycle(mbtb, 0x100, branches[i], true,
+            boost::dynamic_bitset<>(64, 0), 0x140);
     }
 
     // Check if victim cache had hits
-    EXPECT_EQ(mbtb->btbStats.victimCacheHit, 1) << "Expected victim cache hits when accessing evicted branch";
+    EXPECT_EQ(mbtb->btbStats.victimCacheHit, 1)
+        << "Expected victim cache hits when accessing evicted branch";
 
     // With victim cache, all branch should still be predictable
     verifyPrediction(stagePreds, mbtb->getDelay(), {branches});
 }
 
 // Test victim cache promotion mechanism
-TEST_F(BTBTest, VictimCachePromotionTest)
-{
+TEST_F(BTBTest, VictimCachePromotionTest) {
     // Create 5 branches to overflow SRAM0 (4 ways)
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 5; i++) {
@@ -791,8 +778,7 @@ TEST_F(BTBTest, VictimCachePromotionTest)
 }
 
 // Test victim cache FIFO replacement
-TEST_F(BTBTest, VictimCacheFIFOTest)
-{
+TEST_F(BTBTest, VictimCacheFIFOTest) {
     // Create 10 branches to overflow both main BTB and victim cache
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 10; i++) {
@@ -817,8 +803,7 @@ TEST_F(BTBTest, VictimCacheFIFOTest)
 }
 
 // Test: update path when entry exists only in victim cache
-TEST_F(BTBTest, UpdateFromVictimCachePath)
-{
+TEST_F(BTBTest, UpdateFromVictimCachePath) {
     // Prepare 5 branches mapping to same SRAM0 set
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 5; i++) {
@@ -828,17 +813,20 @@ TEST_F(BTBTest, UpdateFromVictimCachePath)
 
     // Insert first 4 branches into MBTB
     for (int i = 0; i < 4; i++) {
-        predictUpdateCycle(mbtb, 0x200, branches[i], true, boost::dynamic_bitset<>(64, 0), 0x240);
+        predictUpdateCycle(mbtb, 0x200, branches[i], true,
+            boost::dynamic_bitset<>(64, 0), 0x240);
     }
 
     // Insert 5th branch to evict one into VC
-    predictUpdateCycle(mbtb, 0x200, branches[4], true, boost::dynamic_bitset<>(64, 0), 0x240);
+    predictUpdateCycle(mbtb, 0x200, branches[4], true,
+        boost::dynamic_bitset<>(64, 0), 0x240);
 
     // At this point, one of the earlier branches should be in VC. Force update on that branch.
     // We choose branches[0] which is likely evicted first.
     auto before_replace = mbtb->btbStats.updateReplace;
 
-    auto stagePreds = predictUpdateCycle(mbtb, 0x200, branches[0], false, boost::dynamic_bitset<>(64, 0), 0x240);
+    auto stagePreds = predictUpdateCycle(mbtb, 0x200, branches[0], false,
+        boost::dynamic_bitset<>(64, 0), 0x240);
 
     // Ensure replacement path executed (entry was inserted back from VC to MBTB during update)
     // EXPECT_GE(mbtb->btbStats.updateReplace, before_replace + 1);
@@ -848,7 +836,7 @@ TEST_F(BTBTest, UpdateFromVictimCachePath)
 }
 
 
-}  // namespace test
-}  // namespace btb_pred
-}  // namespace branch_prediction
-}  // namespace gem5
+} // namespace test
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "cpu/pred/btb/btb_ubtb.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/mbtb.hh"
 
@@ -30,9 +31,10 @@ namespace test
  * @param size Instruction size
  * @return BranchInfo Initialized branch information
  */
-BranchInfo createBranchInfo(Addr pc, Addr target, bool isCond = false,
-                           bool isIndirect = false, bool isCall = false,
-                           bool isReturn = false, uint8_t size = 4) {
+BranchInfo
+createBranchInfo(Addr pc, Addr target, bool isCond = false, bool isIndirect = false, bool isCall = false,
+                 bool isReturn = false, uint8_t size = 4)
+{
     BranchInfo info;
     info.pc = pc;
     info.target = target;
@@ -54,8 +56,9 @@ BranchInfo createBranchInfo(Addr pc, Addr target, bool isCond = false,
  * @param endInstPC Last executed instruction PC, used for filtering entries
  * @return FetchTarget Initialized fetch stream
  */
-FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
-                       std::shared_ptr<void> meta, Addr endInstPC) {
+FetchTarget
+setupStream(Addr startPC, const BranchInfo& branch, bool taken, std::shared_ptr<void> meta, Addr endInstPC)
+{
     FetchTarget stream;
     stream.startPC = startPC;
     stream.resolved = true;
@@ -63,7 +66,7 @@ FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
     stream.exeTaken = taken;
     stream.predMetas[0] = meta;
     stream.updateEndInstPC = endInstPC;
-    stream.squashType = SQUASH_CTRL; // mispredict default
+    stream.squashType = SQUASH_CTRL;  // mispredict default
     return stream;
 }
 
@@ -74,7 +77,9 @@ FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
  * @param pc Branch PC to search for
  * @return Pair of (found, prediction) where found indicates if PC was found
  */
-std::pair<bool, bool> findCondTaken(const CondTakens& condTakens, Addr pc) {
+std::pair<bool, bool>
+findCondTaken(const CondTakens& condTakens, Addr pc)
+{
     auto it = CondTakens_find(condTakens, pc);
     if (it != condTakens.end()) {
         return {true, it->second};
@@ -89,7 +94,9 @@ std::pair<bool, bool> findCondTaken(const CondTakens& condTakens, Addr pc) {
  * @param pc Branch PC to search for
  * @return Pair of (found, target) where found indicates if PC was found
  */
-std::pair<bool, Addr> findIndirectTarget(const IndirectTargets& indirectTargets, Addr pc) {
+std::pair<bool, Addr>
+findIndirectTarget(const IndirectTargets& indirectTargets, Addr pc)
+{
     auto it = IndirectTakens_find(indirectTargets, pc);
     if (it != indirectTargets.end()) {
         return {true, it->second};
@@ -109,12 +116,9 @@ std::pair<bool, Addr> findIndirectTarget(const IndirectTargets& indirectTargets,
  * @return std::vector<FullBTBPrediction> Final stage predictions
  */
 std::vector<FullBTBPrediction>
-predictUpdateCycle(MBTB* btb,
-     Addr startPC,
-     const BranchInfo& branch,
-     bool taken,
-     const boost::dynamic_bitset<>& history = boost::dynamic_bitset<>(8, 0),
-     Addr endInstPC = 0) {
+predictUpdateCycle(MBTB* btb, Addr startPC, const BranchInfo& branch, bool taken,
+                   const boost::dynamic_bitset<>& history = boost::dynamic_bitset<>(8, 0), Addr endInstPC = 0)
+{
     // If endInstPC not specified, use branch.pc + branch.size
     if (endInstPC == 0) {
         endInstPC = branch.pc + branch.size;
@@ -135,7 +139,7 @@ predictUpdateCycle(MBTB* btb,
     stream.setUpdateBTBEntries();
     btb->getAndSetNewBTBEntry(stream);
 
-    for (auto &entry : stream.updateBTBEntries) {
+    for (auto& entry : stream.updateBTBEntries) {
         entry.resolved = true;
     }
     stream.updateNewBTBEntry.resolved = true;
@@ -157,9 +161,10 @@ predictUpdateCycle(MBTB* btb,
  * @param delay BTB delay (0 for L0, >0 for L1)
  * @param expectedEntries Expected branch entries
  */
-void verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds,
-                     unsigned delay,
-                     const std::vector<BranchInfo>& expectedEntries) {
+void
+verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds, unsigned delay,
+                 const std::vector<BranchInfo>& expectedEntries)
+{
     // Check predictions for stages after delay
     for (int i = delay; i < stagePreds.size(); i++) {
         ASSERT_EQ(stagePreds[i].btbEntries.size(), expectedEntries.size());
@@ -171,21 +176,26 @@ void verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds,
 }
 
 // Test fixture for BTB tests
-class BTBTest : public ::testing::Test {
-protected:
-    void SetUp() override {
+class BTBTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
         // Create a BTB with 16 entries, 8-bit tags, and 4-way set associative
-        mbtb_small = new MBTB(16, 8, 4, 1); // mbtb (L1 BTB)
-        mbtb = new MBTB (2048, 20, 4, 1);  // 2 sram, 4 way each, total 8 ways
+        mbtb_small = new MBTB(16, 8, 4, 1);  // mbtb (L1 BTB)
+        mbtb = new MBTB(2048, 20, 4, 1);     // 2 sram, 4 way each, total 8 ways
+        ubtb = new UBTB(16, 12);
     }
-    
-    
+
+
     MBTB* mbtb_small;
     MBTB* mbtb;
+    UBTB* ubtb;
 };
 
 // Test basic initialization
-TEST_F(BTBTest, Initialization) {
+TEST_F(BTBTest, Initialization)
+{
     // Create a new BTB with different parameters
     MBTB testBtb(32, 12, 8, 0);
     // Basic initialization test passes if no crashes/assertions
@@ -193,18 +203,165 @@ TEST_F(BTBTest, Initialization) {
 }
 
 // Test basic prediction with empty BTB
-TEST_F(BTBTest, EmptyPrediction) {
+TEST_F(BTBTest, EmptyPrediction)
+{
     Addr startAddr = 0x1000;
-    boost::dynamic_bitset<> history(8, 0);  // 8-bit history, all zeros
+    boost::dynamic_bitset<> history(8, 0);         // 8-bit history, all zeros
     std::vector<FullBTBPrediction> stagePreds(4);  // 4 stages
-    
+
     mbtb->putPCHistory(startAddr, history, stagePreds);
-    
+
     // Check predictions for all stages
     for (int i = 0; i < stagePreds.size(); i++) {
         EXPECT_TRUE(stagePreds[i].btbEntries.empty());
         EXPECT_FALSE(stagePreds[i].isTaken());
     }
+}
+
+TEST_F(BTBTest, Block1DropReasonRejectsConditionalWithoutDirectionSupport)
+{
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(BTBEntry(createBranchInfo(0x1000, 0x2000, true)));
+
+    auto reason = getBlock1DropReason(pred, true, false, false, true, false, true);
+
+    EXPECT_EQ(reason, Block1DropReason::CondNoSupport);
+}
+
+TEST_F(BTBTest, Block1DropReasonRejectsIndirectWithoutIndirectSupport)
+{
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(BTBEntry(createBranchInfo(0x1000, 0x3000, false, true)));
+
+    auto reason = getBlock1DropReason(pred, false, true, true, false, false, true);
+
+    EXPECT_EQ(reason, Block1DropReason::IndirectNoSupport);
+}
+
+TEST_F(BTBTest, Block1DropReasonRejectsReturnWithoutRasSupport)
+{
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(BTBEntry(createBranchInfo(0x1000, 0x4000, false, true, false, true)));
+
+    auto reason = getBlock1DropReason(pred, true, false, true, false, true, false);
+
+    EXPECT_EQ(reason, Block1DropReason::ReturnNoSupport);
+}
+
+TEST_F(BTBTest, Block1DropReasonAcceptsSupportedDirectPrediction)
+{
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(BTBEntry(createBranchInfo(0x1000, 0x5000)));
+
+    auto reason = getBlock1DropReason(pred, false, false, false, true, true, true);
+
+    EXPECT_EQ(reason, Block1DropReason::None);
+}
+
+TEST_F(BTBTest, DefaultBlock1PredictionFallsBackToRegularPrediction)
+{
+    Addr startAddr = 0x1000;
+    boost::dynamic_bitset<> history(8, 0);
+    boost::dynamic_bitset<> phistory(8, 0);
+    boost::dynamic_bitset<> bwhistory(8, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> regularStagePreds(4);
+    std::vector<FullBTBPrediction> block1StagePreds(4);
+    FullBTBPrediction lowerPred;
+
+    mbtb->putPCHistory(startAddr, history, regularStagePreds);
+    mbtb->putPCHistoryForBlock1(startAddr, history, phistory, bwhistory, lhistory, block1StagePreds, lowerPred);
+
+    for (int i = 0; i < regularStagePreds.size(); ++i) {
+        EXPECT_EQ(block1StagePreds[i].btbEntries.size(), regularStagePreds[i].btbEntries.size());
+        EXPECT_EQ(block1StagePreds[i].condTakens.size(), regularStagePreds[i].condTakens.size());
+        EXPECT_EQ(block1StagePreds[i].indirectTargets.size(), regularStagePreds[i].indirectTargets.size());
+    }
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonRejectsDisabledTwoTaken)
+{
+    auto reason = getInitialBlock1DropReason(false, true, false, true, 2, 0x2000, true);
+
+    EXPECT_EQ(reason, Block1DropReason::Disabled);
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonRejectsBlock0Override)
+{
+    auto reason = getInitialBlock1DropReason(true, true, true, false, 2, 0x2000, true);
+
+    EXPECT_EQ(reason, Block1DropReason::Block0Override);
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonRejectsSingleRemainingSlot)
+{
+    auto reason = getInitialBlock1DropReason(true, false, false, true, 1, 0x2000, true);
+
+    EXPECT_EQ(reason, Block1DropReason::FTQNoSpace);
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonRejectsInvalidNextPC)
+{
+    auto reason = getInitialBlock1DropReason(true, false, false, false, 2, MaxAddr, true);
+
+    EXPECT_EQ(reason, Block1DropReason::InvalidNextPC);
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonRejectsMissingUBTBHit)
+{
+    auto reason = getInitialBlock1DropReason(true, false, false, false, 2, 0x2000, false);
+
+    EXPECT_EQ(reason, Block1DropReason::NoUBTBHit);
+}
+
+TEST_F(BTBTest, InitialBlock1DropReasonAcceptsValidAttempt)
+{
+    auto reason = getInitialBlock1DropReason(true, true, false, true, 2, 0x2000, true);
+
+    EXPECT_EQ(reason, Block1DropReason::None);
+}
+
+TEST_F(BTBTest, UBTBBlock1PredictionReturnsTrainedTakenEntry)
+{
+    Addr startPC = 0x1000;
+    Addr target = 0x2000;
+    boost::dynamic_bitset<> history(8, 0);
+    boost::dynamic_bitset<> phistory(8, 0);
+    boost::dynamic_bitset<> bwhistory(8, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> warmupStagePreds(4);
+    std::vector<FullBTBPrediction> block1StagePreds(4);
+    FullBTBPrediction lowerPred;
+    FullBTBPrediction s3Pred;
+
+    ubtb->putPCHistory(startPC, history, warmupStagePreds);
+
+    s3Pred.bbStart = startPC;
+    BTBEntry takenEntry(createBranchInfo(startPC + 4, target));
+    takenEntry.valid = true;
+    s3Pred.btbEntries.push_back(takenEntry);
+    ubtb->updateUsingS3Pred(s3Pred);
+
+    ubtb->putPCHistoryForBlock1(startPC, history, phistory, bwhistory, lhistory, block1StagePreds, lowerPred);
+
+    ASSERT_EQ(block1StagePreds.back().btbEntries.size(), 1);
+    EXPECT_EQ(block1StagePreds.back().btbEntries[0].pc, startPC + 4);
+    EXPECT_EQ(block1StagePreds.back().btbEntries[0].target, target);
+}
+
+TEST_F(BTBTest, UBTBBlock1PredictionProducesMeta)
+{
+    Addr startPC = 0x1200;
+    boost::dynamic_bitset<> history(8, 0);
+    boost::dynamic_bitset<> phistory(8, 0);
+    boost::dynamic_bitset<> bwhistory(8, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> stagePreds(4);
+    FullBTBPrediction lowerPred;
+
+    ubtb->putPCHistoryForBlock1(startPC, history, phistory, bwhistory, lhistory, stagePreds, lowerPred);
+
+    EXPECT_NE(ubtb->getPredictionMeta(), nullptr);
 }
 
 // BTB actual update process:
@@ -214,86 +371,86 @@ TEST_F(BTBTest, EmptyPrediction) {
 // 4. update, update btb entries
 
 // Test basic prediction after update
-TEST_F(BTBTest, PredictionAfterUpdate) {
+TEST_F(BTBTest, PredictionAfterUpdate)
+{
     // Create branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // Execute prediction-update cycle
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Verify predictions
     verifyPrediction(stagePreds, mbtb->getDelay(), {branch});
 }
 
 // Test large virtual addr
-TEST_F(BTBTest, PredictionAfterUpdateLargeAddr) {
+TEST_F(BTBTest, PredictionAfterUpdateLargeAddr)
+{
     // Create branch info
     BranchInfo branch = createBranchInfo(0xffffffff8027ac64, 0xffffffff80261dee, true);
 
     // Execute prediction-update cycle
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0xffffffff8027ac60, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0xffffffff8027ac60, branch, true);
 
     // Verify predictions
     verifyPrediction(stagePreds, mbtb->getDelay(), {branch});
 }
 
 // Test conditional branch prediction counter, for mBTB
-TEST_F(BTBTest, ConditionalCounter) {
+TEST_F(BTBTest, ConditionalCounter)
+{
     // Create conditional branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // First update with taken
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Counter should be initialized to 0 and stay at 0 after taken (since alwaysTaken=true)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto &entries = stagePreds[i].btbEntries;
+        auto& entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, 0);
         EXPECT_TRUE(entries[0].alwaysTaken);
     }
-    
+
     // Then update with not taken
     stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, false);
 
     // Counter should be reduced after not taken (0 -> -1)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto &entries = stagePreds[i].btbEntries;
+        auto& entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, -1);
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
 }
 
 // Test counter saturation behavior, for mBTB
-TEST_F(BTBTest, CounterSaturation) {
+TEST_F(BTBTest, CounterSaturation)
+{
     // Create conditional branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // First entry is initialized with ctr=0
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Check counter is at 0 (alwaysTaken=true, so updateCtr not called)
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto &entries = stagePreds[i].btbEntries;
+        auto& entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, 0);  // Counter should be at 0
         EXPECT_TRUE(entries[0].alwaysTaken);
     }
-    
+
     // Update multiple times with not taken to test negative saturation
     for (int i = 0; i < 3; i++) {  // 3 times should reach saturation
         stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, false);
     }
-    
+
     // Check counter is saturated at -2
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto &entries = stagePreds[i].btbEntries;
+        auto& entries = stagePreds[i].btbEntries;
         EXPECT_EQ(entries[0].ctr, -2);  // Counter should saturate at -2
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
@@ -322,13 +479,13 @@ TEST_F(BTBTest, CounterSaturation) {
 // }
 
 // Test indirect branch prediction
-TEST_F(BTBTest, IndirectBranchPrediction) {
+TEST_F(BTBTest, IndirectBranchPrediction)
+{
     // Create indirect branch info
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, false, true);
 
     // Initial prediction and update
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Verify indirect target
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
@@ -337,7 +494,7 @@ TEST_F(BTBTest, IndirectBranchPrediction) {
         ASSERT_TRUE(found1);
         EXPECT_EQ(target1, 0x2000);
     }
-    
+
     // Update with new target
     BranchInfo updatedBranch = createBranchInfo(0x1000, 0x3000, false, true);
     stagePreds = predictUpdateCycle(mbtb, 0x1000, updatedBranch, true);
@@ -351,7 +508,8 @@ TEST_F(BTBTest, IndirectBranchPrediction) {
 }
 
 // Test multiple branch predictions in same fetch block
-TEST_F(BTBTest, MultipleBranchPrediction) {
+TEST_F(BTBTest, MultipleBranchPrediction)
+{
     // Create two branches in the same fetch block
     BranchInfo branch1 = createBranchInfo(0x1000, 0x2000, true);
     BranchInfo branch2 = createBranchInfo(0x1004, 0x3000, true);
@@ -369,25 +527,25 @@ TEST_F(BTBTest, MultipleBranchPrediction) {
     FetchTarget stream = setupStream(0x1000, branch2, true, meta, 0x1008);
     mbtb->getAndSetNewBTBEntry(stream);
     mbtb->update(stream);
-    
+
     // Check final predictions
     stagePreds.clear();
     stagePreds.resize(4);
     mbtb->putPCHistory(0x1000, history, stagePreds);
-    
+
     // Verify both branches are predicted
     std::vector<BranchInfo> expectedBranches = {branch1, branch2};
     verifyPrediction(stagePreds, mbtb->getDelay(), expectedBranches);
 }
 
 // Test recovery from misprediction
-TEST_F(BTBTest, MispredictionRecovery) {
+TEST_F(BTBTest, MispredictionRecovery)
+{
     // Create conditional branch initially taken
     BranchInfo branch = createBranchInfo(0x1000, 0x2000, true);
 
     // Initial prediction and update as taken
-    std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x1000, branch, true);
+    std::vector<FullBTBPrediction> stagePreds = predictUpdateCycle(mbtb, 0x1000, branch, true);
 
     // Update the same branch as not taken
     branch.target = 0x1004;  // Fall through target
@@ -396,13 +554,14 @@ TEST_F(BTBTest, MispredictionRecovery) {
     // Verify prediction is updated
     for (int i = mbtb->getDelay(); i < stagePreds.size(); i++) {
         ASSERT_FALSE(stagePreds[i].btbEntries.empty());
-        auto &entries = stagePreds[i].btbEntries;
+        auto& entries = stagePreds[i].btbEntries;
         EXPECT_FALSE(entries[0].alwaysTaken);
     }
 }
 
 // Test half-aligned mode basic functionality
-TEST_F(BTBTest, HalfAlignedBasicTest) {
+TEST_F(BTBTest, HalfAlignedBasicTest)
+{
 
     // Create branches in two consecutive 32B blocks
     BranchInfo branch1 = createBranchInfo(0x100, 0x200, true);
@@ -410,12 +569,10 @@ TEST_F(BTBTest, HalfAlignedBasicTest) {
 
     // Add first branch
     std::vector<FullBTBPrediction> stagePreds =
-        predictUpdateCycle(mbtb, 0x100, branch1, true, 
-            boost::dynamic_bitset<>(64, 0), 0x140);
+        predictUpdateCycle(mbtb, 0x100, branch1, true, boost::dynamic_bitset<>(64, 0), 0x140);
 
     // Add second branch
-    stagePreds = predictUpdateCycle(mbtb, 0x100, branch2, true, 
-        boost::dynamic_bitset<>(64, 0), 0x140);
+    stagePreds = predictUpdateCycle(mbtb, 0x100, branch2, true, boost::dynamic_bitset<>(64, 0), 0x140);
 
     // Verify both branches are predicted
     std::vector<BranchInfo> expectedBranches = {branch1, branch2};
@@ -423,7 +580,8 @@ TEST_F(BTBTest, HalfAlignedBasicTest) {
 }
 
 // Test half-aligned mode with unaligned addresses
-TEST_F(BTBTest, HalfAlignedUnalignedTest) {
+TEST_F(BTBTest, HalfAlignedUnalignedTest)
+{
 
     // Create unaligned branches in two consecutive 32B blocks
     BranchInfo branch1 = createBranchInfo(0x104, 0x200, true);
@@ -442,7 +600,8 @@ TEST_F(BTBTest, HalfAlignedUnalignedTest) {
 }
 
 // Test half-aligned mode update with branch in second block
-TEST_F(BTBTest, HalfAlignedUpdateSecondBlock) {
+TEST_F(BTBTest, HalfAlignedUpdateSecondBlock)
+{
 
     // Create branch in second 32B block
     BranchInfo branch = createBranchInfo(0x124, 0x200, true);
@@ -465,7 +624,8 @@ TEST_F(BTBTest, HalfAlignedUpdateSecondBlock) {
 }
 
 // Test half-aligned mode with branches in both blocks
-TEST_F(BTBTest, HalfAlignedBothBlocks) {
+TEST_F(BTBTest, HalfAlignedBothBlocks)
+{
 
     // Create branches in both 32B blocks
     BranchInfo branch1 = createBranchInfo(0x108, 0x200, true);
@@ -484,7 +644,8 @@ TEST_F(BTBTest, HalfAlignedBothBlocks) {
 }
 
 // Test half-aligned mode with unaligned start address
-TEST_F(BTBTest, HalfAlignedUnalignedStart) {
+TEST_F(BTBTest, HalfAlignedUnalignedStart)
+{
 
     // Create branch in second block
     BranchInfo branch = createBranchInfo(0x12C, 0x200, true);
@@ -498,7 +659,8 @@ TEST_F(BTBTest, HalfAlignedUnalignedStart) {
 }
 
 // Test half-aligned mode with multiple updates to same branch
-TEST_F(BTBTest, HalfAlignedMultipleUpdates) {
+TEST_F(BTBTest, HalfAlignedMultipleUpdates)
+{
 
     // Create indirect branch in second block with initial target
     BranchInfo branch = createBranchInfo(0x124, 0x200, false, true);
@@ -516,7 +678,8 @@ TEST_F(BTBTest, HalfAlignedMultipleUpdates) {
 }
 
 // Test victim cache effectiveness with SRAM overflow
-TEST_F(BTBTest, VictimCacheEffectivenessTest) {
+TEST_F(BTBTest, VictimCacheEffectivenessTest)
+{
     // Create 5 branches in same 32B block that all map to SRAM0
     // Use addresses with bit[5]=0 to ensure they go to SRAM0
     std::vector<BranchInfo> branches;
@@ -530,20 +693,19 @@ TEST_F(BTBTest, VictimCacheEffectivenessTest) {
     // Add all 5 branches one by one
     std::vector<FullBTBPrediction> stagePreds;
     for (int i = 0; i < 5; i++) {
-        stagePreds = predictUpdateCycle(mbtb, 0x100, branches[i], true,
-            boost::dynamic_bitset<>(64, 0), 0x140);
+        stagePreds = predictUpdateCycle(mbtb, 0x100, branches[i], true, boost::dynamic_bitset<>(64, 0), 0x140);
     }
 
     // Check if victim cache had hits
-    EXPECT_EQ(mbtb->btbStats.victimCacheHit, 1)
-        << "Expected victim cache hits when accessing evicted branch";
+    EXPECT_EQ(mbtb->btbStats.victimCacheHit, 1) << "Expected victim cache hits when accessing evicted branch";
 
     // With victim cache, all branch should still be predictable
     verifyPrediction(stagePreds, mbtb->getDelay(), {branches});
 }
 
 // Test victim cache promotion mechanism
-TEST_F(BTBTest, VictimCachePromotionTest) {
+TEST_F(BTBTest, VictimCachePromotionTest)
+{
     // Create 5 branches to overflow SRAM0 (4 ways)
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 5; i++) {
@@ -567,7 +729,8 @@ TEST_F(BTBTest, VictimCachePromotionTest) {
 }
 
 // Test victim cache FIFO replacement
-TEST_F(BTBTest, VictimCacheFIFOTest) {
+TEST_F(BTBTest, VictimCacheFIFOTest)
+{
     // Create 10 branches to overflow both main BTB and victim cache
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 10; i++) {
@@ -592,7 +755,8 @@ TEST_F(BTBTest, VictimCacheFIFOTest) {
 }
 
 // Test: update path when entry exists only in victim cache
-TEST_F(BTBTest, UpdateFromVictimCachePath) {
+TEST_F(BTBTest, UpdateFromVictimCachePath)
+{
     // Prepare 5 branches mapping to same SRAM0 set
     std::vector<BranchInfo> branches;
     for (int i = 0; i < 5; i++) {
@@ -602,20 +766,17 @@ TEST_F(BTBTest, UpdateFromVictimCachePath) {
 
     // Insert first 4 branches into MBTB
     for (int i = 0; i < 4; i++) {
-        predictUpdateCycle(mbtb, 0x200, branches[i], true,
-            boost::dynamic_bitset<>(64, 0), 0x240);
+        predictUpdateCycle(mbtb, 0x200, branches[i], true, boost::dynamic_bitset<>(64, 0), 0x240);
     }
 
     // Insert 5th branch to evict one into VC
-    predictUpdateCycle(mbtb, 0x200, branches[4], true,
-        boost::dynamic_bitset<>(64, 0), 0x240);
+    predictUpdateCycle(mbtb, 0x200, branches[4], true, boost::dynamic_bitset<>(64, 0), 0x240);
 
     // At this point, one of the earlier branches should be in VC. Force update on that branch.
     // We choose branches[0] which is likely evicted first.
     auto before_replace = mbtb->btbStats.updateReplace;
 
-    auto stagePreds = predictUpdateCycle(mbtb, 0x200, branches[0], false,
-        boost::dynamic_bitset<>(64, 0), 0x240);
+    auto stagePreds = predictUpdateCycle(mbtb, 0x200, branches[0], false, boost::dynamic_bitset<>(64, 0), 0x240);
 
     // Ensure replacement path executed (entry was inserted back from VC to MBTB during update)
     // EXPECT_GE(mbtb->btbStats.updateReplace, before_replace + 1);
@@ -625,7 +786,7 @@ TEST_F(BTBTest, UpdateFromVictimCachePath) {
 }
 
 
-} // namespace test
-} // namespace btb_pred
-} // namespace branch_prediction
-} // namespace gem5
+}  // namespace test
+}  // namespace btb_pred
+}  // namespace branch_prediction
+}  // namespace gem5

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -258,6 +258,45 @@ TEST_F(BTBTest, Block1DropReasonAcceptsSupportedDirectPrediction)
     EXPECT_EQ(reason, Block1DropReason::None);
 }
 
+TEST_F(BTBTest, Block1DropReasonAcceptsConditionalWithCopiedDirectionSupport)
+{
+    FullBTBPrediction pred;
+    auto entry = BTBEntry(createBranchInfo(0x1000, 0x2000, true));
+    entry.valid = true;
+    pred.btbEntries.push_back(entry);
+    pred.condTakens.push_back({0x1000, true});
+
+    auto reason = getBlock1DropReason(pred, true, true, false, true, false, true);
+
+    EXPECT_EQ(reason, Block1DropReason::None);
+}
+
+TEST_F(BTBTest, Block1DropReasonAcceptsIndirectWithCopiedTargetSupport)
+{
+    FullBTBPrediction pred;
+    auto entry = BTBEntry(createBranchInfo(0x1000, 0x3000, false, true));
+    entry.valid = true;
+    pred.btbEntries.push_back(entry);
+    pred.indirectTargets.push_back({0x1000, 0x3000});
+
+    auto reason = getBlock1DropReason(pred, false, true, true, true, false, true);
+
+    EXPECT_EQ(reason, Block1DropReason::None);
+}
+
+TEST_F(BTBTest, Block1DropReasonAcceptsReturnWithCopiedTargetSupport)
+{
+    FullBTBPrediction pred;
+    auto entry = BTBEntry(createBranchInfo(0x1000, 0x4000, false, true, false, true));
+    entry.valid = true;
+    pred.btbEntries.push_back(entry);
+    pred.returnTarget = 0x4000;
+
+    auto reason = getBlock1DropReason(pred, false, true, false, true, true, true);
+
+    EXPECT_EQ(reason, Block1DropReason::None);
+}
+
 TEST_F(BTBTest, DefaultBlock1PredictionFallsBackToRegularPrediction)
 {
     Addr startAddr = 0x1000;

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -318,6 +318,29 @@ TEST_F(BTBTest, DefaultBlock1PredictionFallsBackToRegularPrediction)
     }
 }
 
+TEST_F(BTBTest, MBTBBlock1PredictionCopiesLowerPredWhenDisabled)
+{
+    Addr startAddr = 0x1800;
+    boost::dynamic_bitset<> history(8, 0);
+    boost::dynamic_bitset<> phistory(8, 0);
+    boost::dynamic_bitset<> bwhistory(8, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> block1StagePreds(4);
+    FullBTBPrediction lowerPred;
+
+    mbtb->setBlock1Participate(false);
+    auto entry = BTBEntry(createBranchInfo(startAddr + 4, 0x2800));
+    entry.valid = true;
+    lowerPred.btbEntries.push_back(entry);
+
+    mbtb->putPCHistoryForBlock1(startAddr, history, phistory, bwhistory, lhistory, block1StagePreds, lowerPred);
+
+    ASSERT_EQ(block1StagePreds.back().btbEntries.size(), 1);
+    EXPECT_EQ(block1StagePreds.back().btbEntries[0].pc, startAddr + 4);
+    EXPECT_EQ(block1StagePreds.back().btbEntries[0].target, 0x2800U);
+    mbtb->setBlock1Participate(true);
+}
+
 TEST_F(BTBTest, InitialBlock1DropReasonRejectsDisabledTwoTaken)
 {
     auto reason = getInitialBlock1DropReason(false, true, false, true, 2, 0x2000, true);

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -33,9 +33,8 @@ namespace test
  * @param target Branch target address (defaults to sequential PC)
  * @return BTBEntry Initialized branch entry
  */
-BTBEntry
-createBTBEntry(Addr pc, bool isCond = true, bool valid = true, bool alwaysTaken = false, int ctr = 0, Addr target = 0)
-{
+BTBEntry createBTBEntry(Addr pc, bool isCond = true, bool valid = true,
+                        bool alwaysTaken = false, int ctr = 0, Addr target = 0) {
     BTBEntry entry;
     entry.pc = pc;
     entry.target = target ? target : (pc + 4);
@@ -57,33 +56,29 @@ createBTBEntry(Addr pc, bool isCond = true, bool valid = true, bool alwaysTaken 
  * @param squashType Type of squash (control or non-control)
  * @return FetchTarget Initialized stream for update or recovery
  */
-FetchTarget
-createStream(Addr startPC, const BTBEntry& entry, bool taken, std::shared_ptr<void> meta)
-{
+FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
+                         std::shared_ptr<void> meta) {
     FetchTarget stream;
     stream.startPC = startPC;
     stream.exeBranchInfo = entry;
     stream.exeTaken = taken;
     // Mark as resolved so recover paths use exe* info
     stream.resolved = true;
-    stream.predBranchInfo = entry;  // keep fields consistent
+    stream.predBranchInfo = entry; // keep fields consistent
     stream.updateBTBEntries = {entry};
     stream.updateIsOldEntry = true;
     stream.predMetas[0] = meta;
     return stream;
 }
 
-FetchTarget
-setMispredStream(FetchTarget stream)
-{
+FetchTarget setMispredStream(FetchTarget stream) {
     stream.squashType = SquashType::SQUASH_CTRL;
     stream.squashPC = stream.exeBranchInfo.pc;
     return stream;
 }
 
-void
-applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr target, int shamt = 2)
-{
+void applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr target,
+                           int shamt = 2) {
     boost::dynamic_bitset<> before = history;
     history <<= shamt;
     uint64_t hash = pathHash(pc, target);
@@ -101,9 +96,7 @@ applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr target, in
  * @param pc Branch PC to search for
  * @return Pair of (found, prediction) where found indicates if PC was found
  */
-std::pair<bool, bool>
-findCondTaken(const gem5::branch_prediction::btb_pred::CondTakens& condTakens, Addr pc)
-{
+std::pair<bool, bool> findCondTaken(const gem5::branch_prediction::btb_pred::CondTakens& condTakens, Addr pc) {
     auto it = CondTakens_find(condTakens, pc);
     if (it != condTakens.end()) {
         return {true, it->second};
@@ -121,10 +114,10 @@ findCondTaken(const gem5::branch_prediction::btb_pred::CondTakens& condTakens, A
  * @param stagePreds Prediction results container
  * @return bool Prediction result (taken/not taken) for the first entry
  */
-bool
-predictTAGE(BTBTAGE* tage, Addr startPC, const std::vector<BTBEntry>& entries, boost::dynamic_bitset<>& history,
-            std::vector<FullBTBPrediction>& stagePreds)
-{
+bool predictTAGE(BTBTAGE* tage, Addr startPC,
+                const std::vector<BTBEntry>& entries,
+                boost::dynamic_bitset<>& history,
+                std::vector<FullBTBPrediction>& stagePreds) {
     // Setup stage predictions with BTB entries
     stagePreds[1].btbEntries = entries;
 
@@ -153,10 +146,11 @@ predictTAGE(BTBTAGE* tage, Addr startPC, const std::vector<BTBEntry>& entries, b
  * @param history Branch history register
  * @param stagePreds Prediction results container
  */
-bool
-predictUpdateCycle(BTBTAGE* tage, Addr startPC, const BTBEntry& entry, bool actual_taken,
-                   boost::dynamic_bitset<>& history, std::vector<FullBTBPrediction>& stagePreds)
-{
+bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
+                      const BTBEntry& entry,
+                      bool actual_taken,
+                      boost::dynamic_bitset<>& history,
+                      std::vector<FullBTBPrediction>& stagePreds) {
     // 1. Make prediction
     stagePreds[1].btbEntries = {entry};
     tage->putPCHistory(startPC, history, stagePreds);
@@ -195,7 +189,8 @@ predictUpdateCycle(BTBTAGE* tage, Addr startPC, const BTBEntry& entry, bool actu
         tage->recoverHist(history, stream, 1, actual_taken);
 
         if (actual_taken) {
-            applyPathHistoryTaken(history, stream.exeBranchInfo.pc, stream.exeBranchInfo.target);
+            applyPathHistoryTaken(history, stream.exeBranchInfo.pc,
+                                  stream.exeBranchInfo.target);
         }
         tage->checkFoldedHist(history, "recover");
     }
@@ -214,9 +209,8 @@ predictUpdateCycle(BTBTAGE* tage, Addr startPC, const BTBEntry& entry, bool actu
  * @param counter Counter value
  * @param useful Useful bit value
  */
-void
-setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx, short counter, bool useful = false, int way = 0)
-{
+void setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx,
+                    short counter, bool useful = false, int way = 0) {
     Addr index = tage->getTageIndex(pc, table_idx);
     Addr tag = tage->getTageTag(pc, table_idx);
 
@@ -235,17 +229,15 @@ setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx, short counter, bool useful
  * @param pc Branch instruction address to check
  * @param expected_tables Vector of expected table indices to have valid entries
  */
-void
-verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_tables)
-{
+void verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_tables) {
     for (int t = 0; t < tage->numPredictors; t++) {
         for (int way = 0; way < tage->numWays; way++) {
             Addr index = tage->getTageIndex(pc, t);
-            auto& entry = tage->tageTable[t][index][way];
+            auto &entry = tage->tageTable[t][index][way];
 
             // Check if this table should have a valid entry
-            bool should_be_valid =
-                std::find(expected_tables.begin(), expected_tables.end(), t) != expected_tables.end();
+            bool should_be_valid = std::find(expected_tables.begin(),
+                                            expected_tables.end(), t) != expected_tables.end();
 
             if (should_be_valid) {
                 EXPECT_TRUE(entry.valid && entry.pc == pc)
@@ -263,15 +255,13 @@ verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_table
  * @param branchPC Branch instruction address being searched
  * @return int Index of the table with valid entry (-1 if not found)
  */
-int
-findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC)
-{
+int findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC) {
     auto meta = std::static_pointer_cast<BTBTAGE::TageMeta>(tage->getPredictionMeta());
     // use meta to find the table, predicted info
     for (int t = 0; t < tage->numPredictors; t++) {
         Addr index = tage->getTageIndex(startPC, t, meta->indexFoldedHist[t].get());
         for (int way = 0; way < tage->numWays; way++) {
-            auto& entry = tage->tageTable[t][index][way];
+            auto &entry = tage->tageTable[t][index][way];
             if (entry.valid && entry.pc == branchPC) {
                 return t;
             }
@@ -282,14 +272,13 @@ findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC)
 
 class BTBTAGETest : public ::testing::Test
 {
-  protected:
-    void SetUp() override
-    {
+protected:
+    void SetUp() override {
         tage = new BTBTAGE();
         // memset tageStats to 0
         memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
         history.resize(64, false);  // 64-bit history initialized to 0
-        stagePreds.resize(2);       // 2 stages
+        stagePreds.resize(2);  // 2 stages
     }
 
     BTBTAGE* tage;
@@ -298,8 +287,7 @@ class BTBTAGETest : public ::testing::Test
 };
 
 // Test basic prediction functionality
-TEST_F(BTBTAGETest, BasicPrediction)
-{
+TEST_F(BTBTAGETest, BasicPrediction) {
     // Create a conditional branch entry biased towards taken
     BTBEntry entry = createBTBEntry(0x1000, true, true, false, 1);
 
@@ -367,8 +355,7 @@ TEST_F(BTBTAGETest, Block1PredictionCopiesLowerPredWhenDisabled)
 }
 
 // Test basic history update functionality (PHR semantics)
-TEST_F(BTBTAGETest, HistoryUpdate)
-{
+TEST_F(BTBTAGETest, HistoryUpdate) {
     // Use a fixed control PC to derive PHR bits
     Addr pc = 0x1000;
     Addr target = pc + 0x40;
@@ -391,16 +378,15 @@ TEST_F(BTBTAGETest, HistoryUpdate)
 }
 
 // Test main and alternative prediction mechanism by direct setup
-TEST_F(BTBTAGETest, MainAltPredictionBehavior)
-{
+TEST_F(BTBTAGETest, MainAltPredictionBehavior) {
     // Create a branch entry for testing
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup a strong main prediction (taken) in table 3
-    setupTageEntry(tage, 0x1000, 3, 2);  // Strong taken
+    setupTageEntry(tage, 0x1000, 3, 2); // Strong taken
 
     // Setup a weak alternative prediction (not taken) in table 1
-    setupTageEntry(tage, 0x1000, 1, -1);  // Weak not taken
+    setupTageEntry(tage, 0x1000, 1, -1); // Weak not taken
 
     // Predict with these entries
     predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
@@ -416,7 +402,7 @@ TEST_F(BTBTAGETest, MainAltPredictionBehavior)
     EXPECT_EQ(pred.altInfo.table, 1) << "Alt prediction should come from table 1";
 
     // Now set main prediction to weak
-    setupTageEntry(tage, 0x1000, 3, 0);  // Weak taken
+    setupTageEntry(tage, 0x1000, 3, 0); // Weak taken
 
     // Predict again
     predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
@@ -431,14 +417,13 @@ TEST_F(BTBTAGETest, MainAltPredictionBehavior)
 }
 
 // Test useful bit update mechanism
-TEST_F(BTBTAGETest, UsefulBitMechanism)
-{
+TEST_F(BTBTAGETest, UsefulBitMechanism) {
     // Setup a test branch
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup entries in main and alternative tables
-    setupTageEntry(tage, 0x1000, 3, 2, false);   // Main: strong taken, useful=false
-    setupTageEntry(tage, 0x1000, 1, -2, false);  // Alt: strong not taken, useful=false
+    setupTageEntry(tage, 0x1000, 3, 2, false); // Main: strong taken, useful=false
+    setupTageEntry(tage, 0x1000, 1, -2, false); // Alt: strong not taken, useful=false
 
     // Verify initial useful bit state
     Addr mainIndex = tage->getTageIndex(0x1000, 3);
@@ -470,16 +455,15 @@ TEST_F(BTBTAGETest, UsefulBitMechanism)
 }
 
 // Test entry allocation mechanism
-TEST_F(BTBTAGETest, EntryAllocationAndReplacement)
-{
+TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     // Instead of creating two different PCs, we'll create two entries with the same PC
     // This ensures they map to the same indices in the tables
     BTBEntry entry1 = createBTBEntry(0x1000);
-    BTBEntry entry2 = createBTBEntry(0x1000);  // Same PC to ensure same indices
+    BTBEntry entry2 = createBTBEntry(0x1000); // Same PC to ensure same indices
 
     // Set all tables to have entries with useful=true
     for (int t = 0; t < tage->numPredictors; t++) {
-        setupTageEntry(tage, 0x1000, t, 0, true);  // Counter=0, useful=true
+        setupTageEntry(tage, 0x1000, t, 0, true); // Counter=0, useful=true
     }
 
     // Force a misprediction to trigger allocation attempt
@@ -498,19 +482,19 @@ TEST_F(BTBTAGETest, EntryAllocationAndReplacement)
     // Although it has the same PC, we'll treat it as a different branch context
     // by setting a specific tag that doesn't match existing entries
     FetchTarget stream = createStream(0x1000, entry2, !predicted, meta);
-    stream.squashType = SquashType::SQUASH_CTRL;  // Mark as control misprediction
+    stream.squashType = SquashType::SQUASH_CTRL; // Mark as control misprediction
     stream.squashPC = 0x1000;
 
     // Update the predictor (this should try to allocate but fail)
     tage->update(stream);
 
     int alloc_failed_no_valid = tage->tageStats.updateAllocFailureNoValidTable;
+
     EXPECT_GE(alloc_failed_no_valid, 1) << "Allocate failed due to no valid table to allocate (all useful)";
 }
 
 // Test history recovery mechanism
-TEST_F(BTBTAGETest, HistoryRecoveryCorrectness)
-{
+TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Record initial history state
@@ -549,7 +533,7 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness)
 
     // Expected history should be original updated with PHR if actually taken
     boost::dynamic_bitset<> expectedHistory = originalHistory;
-    if (!predicted_taken) {  // actual_taken
+    if (!predicted_taken) { // actual_taken
         applyPathHistoryTaken(expectedHistory, entry.pc, entry.target);
     }
 
@@ -562,10 +546,12 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness)
 }
 
 // Simplified test for multiple branch sequence
-TEST_F(BTBTAGETest, MultipleBranchSequence)
-{
+TEST_F(BTBTAGETest, MultipleBranchSequence) {
     // Create two branches
-    std::vector<BTBEntry> btbEntries = {createBTBEntry(0x1000), createBTBEntry(0x1004)};
+    std::vector<BTBEntry> btbEntries = {
+        createBTBEntry(0x1000),
+        createBTBEntry(0x1004)
+    };
 
     // Predict for both branches
     predictTAGE(tage, 0x1000, btbEntries, history, stagePreds);
@@ -598,8 +584,7 @@ TEST_F(BTBTAGETest, MultipleBranchSequence)
 }
 
 // Test counter update mechanism
-TEST_F(BTBTAGETest, CounterUpdateMechanism)
-{
+TEST_F(BTBTAGETest, CounterUpdateMechanism) {
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup a TAGE entry with a neutral counter
@@ -620,7 +605,8 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism)
     }
 
     // Verify counter saturates at maximum
-    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, 3) << "Counter should saturate at maximum value";
+    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, 3)
+        << "Counter should saturate at maximum value";
 
     // Train with not-taken outcomes multiple times
     for (int i = 0; i < 7; i++) {
@@ -632,7 +618,8 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism)
     }
 
     // Verify counter saturates at minimum
-    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, -4) << "Counter should saturate at minimum value";
+    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, -4)
+        << "Counter should saturate at minimum value";
 }
 
 /**
@@ -643,12 +630,11 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism)
  * 2. The prediction accuracy improves over time
  * 3. Predictor state is consistent after multiple predictions
  */
-TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions)
-{
+TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions) {
     // Create a branch entry
     BTBEntry entry = createBTBEntry(0x1000);
     // outer loop always taken
-    BTBEntry entry2 = createBTBEntry(0x1010);  // always taken
+    BTBEntry entry2 = createBTBEntry(0x1010); // always taken
 
     // Step 1: Train predictor on a fixed pattern (alternating T/N)
     const int TOTAL_ITERATIONS = 100;
@@ -668,10 +654,12 @@ TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions)
     }
 
     // Calculate accuracy in final phase
-    double accuracy = static_cast<double>(correctly_predicted) / (TOTAL_ITERATIONS - WARMUP_ITERATIONS);
+    double accuracy = static_cast<double>(correctly_predicted) /
+                     (TOTAL_ITERATIONS - WARMUP_ITERATIONS);
 
     // Verify predictor has learned the pattern with high accuracy
-    EXPECT_GT(accuracy, 0.9) << "Predictor should learn alternating pattern with >90% accuracy";
+    EXPECT_GT(accuracy, 0.9)
+        << "Predictor should learn alternating pattern with >90% accuracy";
     // print updateMispred: mispredictions times
     std::cout << "updateMispred: " << tage->tageStats.updateMispred << std::endl;
 }
@@ -682,12 +670,11 @@ TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions)
  * This test evaluates how different tables in the TAGE predictor
  * contribute to prediction accuracy for various branch patterns.
  */
-TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting)
-{
+TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting) {
     // Setup branch entry
     BTBEntry entry = createBTBEntry(0x1000);
     // outer loop always taken
-    BTBEntry entry2 = createBTBEntry(0x1010);  // always taken
+    BTBEntry entry2 = createBTBEntry(0x1010); // always taken
 
     // Define different branch patterns
     struct PatternTest
@@ -696,13 +683,15 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting)
         std::function<bool(int)> pattern;
     };
 
-    std::vector<PatternTest> patterns = {{"Alternating", [](int i) { return i % 2 == 0; }},       // T,N,T,N...
-                                         {"ThreeCycle", [](int i) { return i % 3 == 0; }},        // T,N,N,T,N,N...
-                                         {"LongCycle", [](int i) { return (i / 10) % 2 == 0; }},  // 10 Ts, 10 Ns...
-                                         {"BiasedRandom", [](int i) {
-                                              // Use deterministic but complex pattern that appears somewhat random
-                                              return ((i * 7 + 3) % 11) > 5;
-                                          }}};
+    std::vector<PatternTest> patterns = {
+        {"Alternating", [](int i) { return i % 2 == 0; }},                   // T,N,T,N...
+        {"ThreeCycle", [](int i) { return i % 3 == 0; }},                    // T,N,N,T,N,N...
+        {"LongCycle", [](int i) { return (i / 10) % 2 == 0; }},              // 10 Ts, 10 Ns...
+        {"BiasedRandom", [](int i) {
+            // Use deterministic but complex pattern that appears somewhat random
+            return ((i * 7 + 3) % 11) > 5;
+        }}
+    };
 
     const int TRAIN_ITERATIONS = 200;  // it need more iterations to train!
     const int WARMUP_ITERATIONS = 180;
@@ -723,18 +712,20 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting)
             bool predicted_taken = predictUpdateCycle(tage, 0x1000, entry, actual_taken, history, stagePreds);
             predictUpdateCycle(tage, 0x1010, entry2, true, history, stagePreds);
 
-            // Count correct predictions after warmup
+                    // Count correct predictions after warmup
             if (i >= WARMUP_ITERATIONS) {
                 correctly_predicted += (predicted_taken == actual_taken) ? 1 : 0;
             }
         }
 
         // Calculate accuracy in final phase
-        double accuracy = static_cast<double>(correctly_predicted) / (TRAIN_ITERATIONS - WARMUP_ITERATIONS);
+        double accuracy = static_cast<double>(correctly_predicted) /
+                         (TRAIN_ITERATIONS - WARMUP_ITERATIONS);
 
 
         // Verify predictor has learned the pattern with high accuracy
-        EXPECT_GE(accuracy, 0.8) << "Predictor should learn alternating pattern with >80% accuracy";
+        EXPECT_GE(accuracy, 0.8)
+            << "Predictor should learn alternating pattern with >80% accuracy";
 
         // print updateMispred: mispredictions times
         std::cout << "updateMispred: " << tage->tageStats.updateMispred << std::endl;
@@ -747,11 +738,10 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting)
  * This is particularly useful for set-associative testing when we need
  * to control exact placement of entries
  */
-void
-createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way, Addr tag, short counter, bool useful, Addr pc,
-                      unsigned lruCounter = 0)
-{
-    auto& entry = tage->tageTable[table][index][way];
+void createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way,
+                          Addr tag, short counter, bool useful, Addr pc,
+                          unsigned lruCounter = 0) {
+    auto &entry = tage->tageTable[table][index][way];
     entry.valid = true;
     entry.tag = tag;
     entry.counter = counter;
@@ -768,8 +758,7 @@ createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way, Addr tag, s
  * 1. Multiple branches mapping to the same index can be predicted correctly
  * 2. The LRU counters are updated properly when entries are accessed
  */
-TEST_F(BTBTAGETest, SetAssociativeConflictHandling)
-{
+TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
     // Create two branch entries with different PCs
     Addr startPC = 0x1000;
     BTBEntry entry1 = createBTBEntry(startPC);
@@ -786,8 +775,8 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling)
     Addr testTag2 = tage->getTageTag(startPC, testTable, 2);
 
     // Manually create entries with the same index but different tags (due to position)
-    createManualTageEntry(tage, testTable, testIndex, 0, testTag1, 2, false, 0x1000, 0);   // Way 0: Strong taken
-    createManualTageEntry(tage, testTable, testIndex, 1, testTag2, -2, false, 0x1004, 1);  // Way 1: Strong not taken
+    createManualTageEntry(tage, testTable, testIndex, 0, testTag1, 2, false, 0x1000, 0); // Way 0: Strong taken
+    createManualTageEntry(tage, testTable, testIndex, 1, testTag2, -2, false, 0x1004, 1); // Way 1: Strong not taken
 
     // Make predictions and verify directly
     // For entry1 (should predict taken)
@@ -836,10 +825,9 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling)
  * 2. Subsequent allocations fail when the selected way's usefulMask marks the table useful.
  * 3. No replacement occurs even after additional allocation attempts.
  */
-TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays)
-{
+TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     // Start with a fresh predictor
-    tage = new BTBTAGE(1, 2, 10);  // only 1 predictor table, 2 ways
+    tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
     memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
     history.resize(64, false);
     stagePreds.resize(2);
@@ -870,12 +858,11 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays)
     // Strengthen the first allocated entry to prevent it from being replaced
     // This simulates that the first branch has been trained and should be protected
     tage->tageTable[testTable][testIndex][allocatedWay].useful = true;
-    tage->tageTable[testTable][testIndex][allocatedWay].counter = 2;  // Make it strong
+    tage->tageTable[testTable][testIndex][allocatedWay].counter = 2; // Make it strong
 
     // Step 2: Attempt to fill remaining ways with different branches
     for (unsigned way = 0; way < tage->numWays; way++) {
-        if (way == allocatedWay)
-            continue;
+        if (way == allocatedWay) continue;
 
         // Create a branch with different PC
         BTBEntry newEntry = createBTBEntry(0x1004);
@@ -898,7 +885,7 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays)
     for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid) {
             tage->tageTable[testTable][testIndex][way].useful = true;
-            tage->tageTable[testTable][testIndex][way].counter = 2;  // Make it strong
+            tage->tageTable[testTable][testIndex][way].counter = 2; // Make it strong
         }
     }
 
@@ -940,10 +927,9 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays)
  * 2. Different bank access has no conflict
  * 3. Disabled flag prevents conflict detection
  */
-TEST_F(BTBTAGETest, BankConflict)
-{
+TEST_F(BTBTAGETest, BankConflict) {
     // Create TAGE with 4 banks
-    BTBTAGE* bankTage = new BTBTAGE(4, 2, 1024, 4);
+    BTBTAGE *bankTage = new BTBTAGE(4, 2, 1024, 4);
     boost::dynamic_bitset<> testHistory(128);
     std::vector<FullBTBPrediction> testStagePreds(5);
 

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -33,8 +33,9 @@ namespace test
  * @param target Branch target address (defaults to sequential PC)
  * @return BTBEntry Initialized branch entry
  */
-BTBEntry createBTBEntry(Addr pc, bool isCond = true, bool valid = true,
-                        bool alwaysTaken = false, int ctr = 0, Addr target = 0) {
+BTBEntry
+createBTBEntry(Addr pc, bool isCond = true, bool valid = true, bool alwaysTaken = false, int ctr = 0, Addr target = 0)
+{
     BTBEntry entry;
     entry.pc = pc;
     entry.target = target ? target : (pc + 4);
@@ -56,29 +57,33 @@ BTBEntry createBTBEntry(Addr pc, bool isCond = true, bool valid = true,
  * @param squashType Type of squash (control or non-control)
  * @return FetchTarget Initialized stream for update or recovery
  */
-FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
-                         std::shared_ptr<void> meta) {
+FetchTarget
+createStream(Addr startPC, const BTBEntry& entry, bool taken, std::shared_ptr<void> meta)
+{
     FetchTarget stream;
     stream.startPC = startPC;
     stream.exeBranchInfo = entry;
     stream.exeTaken = taken;
     // Mark as resolved so recover paths use exe* info
     stream.resolved = true;
-    stream.predBranchInfo = entry; // keep fields consistent
+    stream.predBranchInfo = entry;  // keep fields consistent
     stream.updateBTBEntries = {entry};
     stream.updateIsOldEntry = true;
     stream.predMetas[0] = meta;
     return stream;
 }
 
-FetchTarget setMispredStream(FetchTarget stream) {
+FetchTarget
+setMispredStream(FetchTarget stream)
+{
     stream.squashType = SquashType::SQUASH_CTRL;
     stream.squashPC = stream.exeBranchInfo.pc;
     return stream;
 }
 
-void applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr target,
-                           int shamt = 2) {
+void
+applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr target, int shamt = 2)
+{
     boost::dynamic_bitset<> before = history;
     history <<= shamt;
     uint64_t hash = pathHash(pc, target);
@@ -96,7 +101,9 @@ void applyPathHistoryTaken(boost::dynamic_bitset<>& history, Addr pc, Addr targe
  * @param pc Branch PC to search for
  * @return Pair of (found, prediction) where found indicates if PC was found
  */
-std::pair<bool, bool> findCondTaken(const gem5::branch_prediction::btb_pred::CondTakens& condTakens, Addr pc) {
+std::pair<bool, bool>
+findCondTaken(const gem5::branch_prediction::btb_pred::CondTakens& condTakens, Addr pc)
+{
     auto it = CondTakens_find(condTakens, pc);
     if (it != condTakens.end()) {
         return {true, it->second};
@@ -114,10 +121,10 @@ std::pair<bool, bool> findCondTaken(const gem5::branch_prediction::btb_pred::Con
  * @param stagePreds Prediction results container
  * @return bool Prediction result (taken/not taken) for the first entry
  */
-bool predictTAGE(BTBTAGE* tage, Addr startPC,
-                const std::vector<BTBEntry>& entries,
-                boost::dynamic_bitset<>& history,
-                std::vector<FullBTBPrediction>& stagePreds) {
+bool
+predictTAGE(BTBTAGE* tage, Addr startPC, const std::vector<BTBEntry>& entries, boost::dynamic_bitset<>& history,
+            std::vector<FullBTBPrediction>& stagePreds)
+{
     // Setup stage predictions with BTB entries
     stagePreds[1].btbEntries = entries;
 
@@ -146,11 +153,10 @@ bool predictTAGE(BTBTAGE* tage, Addr startPC,
  * @param history Branch history register
  * @param stagePreds Prediction results container
  */
-bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
-                      const BTBEntry& entry,
-                      bool actual_taken,
-                      boost::dynamic_bitset<>& history,
-                      std::vector<FullBTBPrediction>& stagePreds) {
+bool
+predictUpdateCycle(BTBTAGE* tage, Addr startPC, const BTBEntry& entry, bool actual_taken,
+                   boost::dynamic_bitset<>& history, std::vector<FullBTBPrediction>& stagePreds)
+{
     // 1. Make prediction
     stagePreds[1].btbEntries = {entry};
     tage->putPCHistory(startPC, history, stagePreds);
@@ -189,8 +195,7 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
         tage->recoverHist(history, stream, 1, actual_taken);
 
         if (actual_taken) {
-            applyPathHistoryTaken(history, stream.exeBranchInfo.pc,
-                                  stream.exeBranchInfo.target);
+            applyPathHistoryTaken(history, stream.exeBranchInfo.pc, stream.exeBranchInfo.target);
         }
         tage->checkFoldedHist(history, "recover");
     }
@@ -209,8 +214,9 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
  * @param counter Counter value
  * @param useful Useful bit value
  */
-void setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx,
-                    short counter, bool useful = false, int way = 0) {
+void
+setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx, short counter, bool useful = false, int way = 0)
+{
     Addr index = tage->getTageIndex(pc, table_idx);
     Addr tag = tage->getTageTag(pc, table_idx);
 
@@ -229,15 +235,17 @@ void setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx,
  * @param pc Branch instruction address to check
  * @param expected_tables Vector of expected table indices to have valid entries
  */
-void verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_tables) {
+void
+verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_tables)
+{
     for (int t = 0; t < tage->numPredictors; t++) {
         for (int way = 0; way < tage->numWays; way++) {
             Addr index = tage->getTageIndex(pc, t);
-            auto &entry = tage->tageTable[t][index][way];
+            auto& entry = tage->tageTable[t][index][way];
 
             // Check if this table should have a valid entry
-            bool should_be_valid = std::find(expected_tables.begin(),
-                                            expected_tables.end(), t) != expected_tables.end();
+            bool should_be_valid =
+                std::find(expected_tables.begin(), expected_tables.end(), t) != expected_tables.end();
 
             if (should_be_valid) {
                 EXPECT_TRUE(entry.valid && entry.pc == pc)
@@ -255,13 +263,15 @@ void verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_
  * @param branchPC Branch instruction address being searched
  * @return int Index of the table with valid entry (-1 if not found)
  */
-int findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC) {
+int
+findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC)
+{
     auto meta = std::static_pointer_cast<BTBTAGE::TageMeta>(tage->getPredictionMeta());
     // use meta to find the table, predicted info
     for (int t = 0; t < tage->numPredictors; t++) {
         Addr index = tage->getTageIndex(startPC, t, meta->indexFoldedHist[t].get());
         for (int way = 0; way < tage->numWays; way++) {
-            auto &entry = tage->tageTable[t][index][way];
+            auto& entry = tage->tageTable[t][index][way];
             if (entry.valid && entry.pc == branchPC) {
                 return t;
             }
@@ -272,13 +282,14 @@ int findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC) {
 
 class BTBTAGETest : public ::testing::Test
 {
-protected:
-    void SetUp() override {
+  protected:
+    void SetUp() override
+    {
         tage = new BTBTAGE();
         // memset tageStats to 0
         memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
         history.resize(64, false);  // 64-bit history initialized to 0
-        stagePreds.resize(2);  // 2 stages
+        stagePreds.resize(2);       // 2 stages
     }
 
     BTBTAGE* tage;
@@ -287,7 +298,8 @@ protected:
 };
 
 // Test basic prediction functionality
-TEST_F(BTBTAGETest, BasicPrediction) {
+TEST_F(BTBTAGETest, BasicPrediction)
+{
     // Create a conditional branch entry biased towards taken
     BTBEntry entry = createBTBEntry(0x1000, true, true, false, 1);
 
@@ -305,8 +317,37 @@ TEST_F(BTBTAGETest, BasicPrediction) {
     EXPECT_GE(table, 0) << "No TAGE table entry was allocated";
 }
 
+TEST_F(BTBTAGETest, Block1PredictionUsesRegularPathWhenEnabled)
+{
+    tage->setBlock1Participate(true);
+
+    Addr startPC = 0x1000;
+    boost::dynamic_bitset<> history(64, 0);
+    boost::dynamic_bitset<> phistory(64, 0);
+    boost::dynamic_bitset<> bwhistory(64, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> regularStagePreds(4);
+    std::vector<FullBTBPrediction> block1StagePreds(4);
+    FullBTBPrediction lowerPred;
+
+    std::vector<BTBEntry> btbEntries;
+    btbEntries.push_back(createBTBEntry(startPC + 4, true, true, false, 0, 0x2000));
+    for (auto& pred : regularStagePreds) {
+        pred.btbEntries = btbEntries;
+    }
+    for (auto& pred : block1StagePreds) {
+        pred.btbEntries = btbEntries;
+    }
+
+    tage->putPCHistory(startPC, history, regularStagePreds);
+    tage->putPCHistoryForBlock1(startPC, history, phistory, bwhistory, lhistory, block1StagePreds, lowerPred);
+
+    EXPECT_EQ(block1StagePreds.back().condTakens.size(), regularStagePreds.back().condTakens.size());
+}
+
 // Test basic history update functionality (PHR semantics)
-TEST_F(BTBTAGETest, HistoryUpdate) {
+TEST_F(BTBTAGETest, HistoryUpdate)
+{
     // Use a fixed control PC to derive PHR bits
     Addr pc = 0x1000;
     Addr target = pc + 0x40;
@@ -329,15 +370,16 @@ TEST_F(BTBTAGETest, HistoryUpdate) {
 }
 
 // Test main and alternative prediction mechanism by direct setup
-TEST_F(BTBTAGETest, MainAltPredictionBehavior) {
+TEST_F(BTBTAGETest, MainAltPredictionBehavior)
+{
     // Create a branch entry for testing
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup a strong main prediction (taken) in table 3
-    setupTageEntry(tage, 0x1000, 3, 2); // Strong taken
+    setupTageEntry(tage, 0x1000, 3, 2);  // Strong taken
 
     // Setup a weak alternative prediction (not taken) in table 1
-    setupTageEntry(tage, 0x1000, 1, -1); // Weak not taken
+    setupTageEntry(tage, 0x1000, 1, -1);  // Weak not taken
 
     // Predict with these entries
     predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
@@ -353,7 +395,7 @@ TEST_F(BTBTAGETest, MainAltPredictionBehavior) {
     EXPECT_EQ(pred.altInfo.table, 1) << "Alt prediction should come from table 1";
 
     // Now set main prediction to weak
-    setupTageEntry(tage, 0x1000, 3, 0); // Weak taken
+    setupTageEntry(tage, 0x1000, 3, 0);  // Weak taken
 
     // Predict again
     predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
@@ -368,13 +410,14 @@ TEST_F(BTBTAGETest, MainAltPredictionBehavior) {
 }
 
 // Test useful bit update mechanism
-TEST_F(BTBTAGETest, UsefulBitMechanism) {
+TEST_F(BTBTAGETest, UsefulBitMechanism)
+{
     // Setup a test branch
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup entries in main and alternative tables
-    setupTageEntry(tage, 0x1000, 3, 2, false); // Main: strong taken, useful=false
-    setupTageEntry(tage, 0x1000, 1, -2, false); // Alt: strong not taken, useful=false
+    setupTageEntry(tage, 0x1000, 3, 2, false);   // Main: strong taken, useful=false
+    setupTageEntry(tage, 0x1000, 1, -2, false);  // Alt: strong not taken, useful=false
 
     // Verify initial useful bit state
     Addr mainIndex = tage->getTageIndex(0x1000, 3);
@@ -406,15 +449,16 @@ TEST_F(BTBTAGETest, UsefulBitMechanism) {
 }
 
 // Test entry allocation mechanism
-TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
+TEST_F(BTBTAGETest, EntryAllocationAndReplacement)
+{
     // Instead of creating two different PCs, we'll create two entries with the same PC
     // This ensures they map to the same indices in the tables
     BTBEntry entry1 = createBTBEntry(0x1000);
-    BTBEntry entry2 = createBTBEntry(0x1000); // Same PC to ensure same indices
+    BTBEntry entry2 = createBTBEntry(0x1000);  // Same PC to ensure same indices
 
     // Set all tables to have entries with useful=true
     for (int t = 0; t < tage->numPredictors; t++) {
-        setupTageEntry(tage, 0x1000, t, 0, true); // Counter=0, useful=true
+        setupTageEntry(tage, 0x1000, t, 0, true);  // Counter=0, useful=true
     }
 
     // Force a misprediction to trigger allocation attempt
@@ -433,7 +477,7 @@ TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     // Although it has the same PC, we'll treat it as a different branch context
     // by setting a specific tag that doesn't match existing entries
     FetchTarget stream = createStream(0x1000, entry2, !predicted, meta);
-    stream.squashType = SquashType::SQUASH_CTRL; // Mark as control misprediction
+    stream.squashType = SquashType::SQUASH_CTRL;  // Mark as control misprediction
     stream.squashPC = 0x1000;
 
     // Update the predictor (this should try to allocate but fail)
@@ -441,11 +485,11 @@ TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
 
     int alloc_failed_no_valid = tage->tageStats.updateAllocFailureNoValidTable;
     EXPECT_GE(alloc_failed_no_valid, 1) << "Allocate failed due to no valid table to allocate (all useful)";
-
 }
 
 // Test history recovery mechanism
-TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
+TEST_F(BTBTAGETest, HistoryRecoveryCorrectness)
+{
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Record initial history state
@@ -484,7 +528,7 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
 
     // Expected history should be original updated with PHR if actually taken
     boost::dynamic_bitset<> expectedHistory = originalHistory;
-    if (!predicted_taken) { // actual_taken
+    if (!predicted_taken) {  // actual_taken
         applyPathHistoryTaken(expectedHistory, entry.pc, entry.target);
     }
 
@@ -497,12 +541,10 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
 }
 
 // Simplified test for multiple branch sequence
-TEST_F(BTBTAGETest, MultipleBranchSequence) {
+TEST_F(BTBTAGETest, MultipleBranchSequence)
+{
     // Create two branches
-    std::vector<BTBEntry> btbEntries = {
-        createBTBEntry(0x1000),
-        createBTBEntry(0x1004)
-    };
+    std::vector<BTBEntry> btbEntries = {createBTBEntry(0x1000), createBTBEntry(0x1004)};
 
     // Predict for both branches
     predictTAGE(tage, 0x1000, btbEntries, history, stagePreds);
@@ -535,7 +577,8 @@ TEST_F(BTBTAGETest, MultipleBranchSequence) {
 }
 
 // Test counter update mechanism
-TEST_F(BTBTAGETest, CounterUpdateMechanism) {
+TEST_F(BTBTAGETest, CounterUpdateMechanism)
+{
     BTBEntry entry = createBTBEntry(0x1000);
 
     // Setup a TAGE entry with a neutral counter
@@ -556,8 +599,7 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism) {
     }
 
     // Verify counter saturates at maximum
-    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, 3)
-        << "Counter should saturate at maximum value";
+    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, 3) << "Counter should saturate at maximum value";
 
     // Train with not-taken outcomes multiple times
     for (int i = 0; i < 7; i++) {
@@ -569,8 +611,7 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism) {
     }
 
     // Verify counter saturates at minimum
-    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, -4)
-        << "Counter should saturate at minimum value";
+    EXPECT_EQ(tage->tageTable[testTable][index][0].counter, -4) << "Counter should saturate at minimum value";
 }
 
 /**
@@ -581,11 +622,12 @@ TEST_F(BTBTAGETest, CounterUpdateMechanism) {
  * 2. The prediction accuracy improves over time
  * 3. Predictor state is consistent after multiple predictions
  */
-TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions) {
+TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions)
+{
     // Create a branch entry
     BTBEntry entry = createBTBEntry(0x1000);
     // outer loop always taken
-    BTBEntry entry2 = createBTBEntry(0x1010); // always taken
+    BTBEntry entry2 = createBTBEntry(0x1010);  // always taken
 
     // Step 1: Train predictor on a fixed pattern (alternating T/N)
     const int TOTAL_ITERATIONS = 100;
@@ -605,12 +647,10 @@ TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions) {
     }
 
     // Calculate accuracy in final phase
-    double accuracy = static_cast<double>(correctly_predicted) /
-                     (TOTAL_ITERATIONS - WARMUP_ITERATIONS);
+    double accuracy = static_cast<double>(correctly_predicted) / (TOTAL_ITERATIONS - WARMUP_ITERATIONS);
 
     // Verify predictor has learned the pattern with high accuracy
-    EXPECT_GT(accuracy, 0.9)
-        << "Predictor should learn alternating pattern with >90% accuracy";
+    EXPECT_GT(accuracy, 0.9) << "Predictor should learn alternating pattern with >90% accuracy";
     // print updateMispred: mispredictions times
     std::cout << "updateMispred: " << tage->tageStats.updateMispred << std::endl;
 }
@@ -621,11 +661,12 @@ TEST_F(BTBTAGETest, UpdateConsistencyAfterMultiplePredictions) {
  * This test evaluates how different tables in the TAGE predictor
  * contribute to prediction accuracy for various branch patterns.
  */
-TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting) {
+TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting)
+{
     // Setup branch entry
     BTBEntry entry = createBTBEntry(0x1000);
     // outer loop always taken
-    BTBEntry entry2 = createBTBEntry(0x1010); // always taken
+    BTBEntry entry2 = createBTBEntry(0x1010);  // always taken
 
     // Define different branch patterns
     struct PatternTest
@@ -634,15 +675,13 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting) {
         std::function<bool(int)> pattern;
     };
 
-    std::vector<PatternTest> patterns = {
-        {"Alternating", [](int i) { return i % 2 == 0; }},                   // T,N,T,N...
-        {"ThreeCycle", [](int i) { return i % 3 == 0; }},                    // T,N,N,T,N,N...
-        {"LongCycle", [](int i) { return (i / 10) % 2 == 0; }},              // 10 Ts, 10 Ns...
-        {"BiasedRandom", [](int i) {
-            // Use deterministic but complex pattern that appears somewhat random
-            return ((i * 7 + 3) % 11) > 5;
-        }}
-    };
+    std::vector<PatternTest> patterns = {{"Alternating", [](int i) { return i % 2 == 0; }},       // T,N,T,N...
+                                         {"ThreeCycle", [](int i) { return i % 3 == 0; }},        // T,N,N,T,N,N...
+                                         {"LongCycle", [](int i) { return (i / 10) % 2 == 0; }},  // 10 Ts, 10 Ns...
+                                         {"BiasedRandom", [](int i) {
+                                              // Use deterministic but complex pattern that appears somewhat random
+                                              return ((i * 7 + 3) % 11) > 5;
+                                          }}};
 
     const int TRAIN_ITERATIONS = 200;  // it need more iterations to train!
     const int WARMUP_ITERATIONS = 180;
@@ -663,20 +702,18 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting) {
             bool predicted_taken = predictUpdateCycle(tage, 0x1000, entry, actual_taken, history, stagePreds);
             predictUpdateCycle(tage, 0x1010, entry2, true, history, stagePreds);
 
-                    // Count correct predictions after warmup
+            // Count correct predictions after warmup
             if (i >= WARMUP_ITERATIONS) {
                 correctly_predicted += (predicted_taken == actual_taken) ? 1 : 0;
             }
         }
 
         // Calculate accuracy in final phase
-        double accuracy = static_cast<double>(correctly_predicted) /
-                         (TRAIN_ITERATIONS - WARMUP_ITERATIONS);
+        double accuracy = static_cast<double>(correctly_predicted) / (TRAIN_ITERATIONS - WARMUP_ITERATIONS);
 
 
         // Verify predictor has learned the pattern with high accuracy
-        EXPECT_GE(accuracy, 0.8)
-            << "Predictor should learn alternating pattern with >80% accuracy";
+        EXPECT_GE(accuracy, 0.8) << "Predictor should learn alternating pattern with >80% accuracy";
 
         // print updateMispred: mispredictions times
         std::cout << "updateMispred: " << tage->tageStats.updateMispred << std::endl;
@@ -689,10 +726,11 @@ TEST_F(BTBTAGETest, CombinedPredictionAccuracyTesting) {
  * This is particularly useful for set-associative testing when we need
  * to control exact placement of entries
  */
-void createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way,
-                          Addr tag, short counter, bool useful, Addr pc,
-                          unsigned lruCounter = 0) {
-    auto &entry = tage->tageTable[table][index][way];
+void
+createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way, Addr tag, short counter, bool useful, Addr pc,
+                      unsigned lruCounter = 0)
+{
+    auto& entry = tage->tageTable[table][index][way];
     entry.valid = true;
     entry.tag = tag;
     entry.counter = counter;
@@ -709,7 +747,8 @@ void createManualTageEntry(BTBTAGE* tage, int table, Addr index, int way,
  * 1. Multiple branches mapping to the same index can be predicted correctly
  * 2. The LRU counters are updated properly when entries are accessed
  */
-TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
+TEST_F(BTBTAGETest, SetAssociativeConflictHandling)
+{
     // Create two branch entries with different PCs
     Addr startPC = 0x1000;
     BTBEntry entry1 = createBTBEntry(startPC);
@@ -726,8 +765,8 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
     Addr testTag2 = tage->getTageTag(startPC, testTable, 2);
 
     // Manually create entries with the same index but different tags (due to position)
-    createManualTageEntry(tage, testTable, testIndex, 0, testTag1, 2, false, 0x1000, 0); // Way 0: Strong taken
-    createManualTageEntry(tage, testTable, testIndex, 1, testTag2, -2, false, 0x1004, 1); // Way 1: Strong not taken
+    createManualTageEntry(tage, testTable, testIndex, 0, testTag1, 2, false, 0x1000, 0);   // Way 0: Strong taken
+    createManualTageEntry(tage, testTable, testIndex, 1, testTag2, -2, false, 0x1004, 1);  // Way 1: Strong not taken
 
     // Make predictions and verify directly
     // For entry1 (should predict taken)
@@ -776,9 +815,10 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
  * 2. Subsequent allocations fail when the selected way's usefulMask marks the table useful.
  * 3. No replacement occurs even after additional allocation attempts.
  */
-TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
+TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays)
+{
     // Start with a fresh predictor
-    tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
+    tage = new BTBTAGE(1, 2, 10);  // only 1 predictor table, 2 ways
     memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
     history.resize(64, false);
     stagePreds.resize(2);
@@ -809,11 +849,12 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     // Strengthen the first allocated entry to prevent it from being replaced
     // This simulates that the first branch has been trained and should be protected
     tage->tageTable[testTable][testIndex][allocatedWay].useful = true;
-    tage->tageTable[testTable][testIndex][allocatedWay].counter = 2; // Make it strong
+    tage->tageTable[testTable][testIndex][allocatedWay].counter = 2;  // Make it strong
 
     // Step 2: Attempt to fill remaining ways with different branches
     for (unsigned way = 0; way < tage->numWays; way++) {
-        if (way == allocatedWay) continue;
+        if (way == allocatedWay)
+            continue;
 
         // Create a branch with different PC
         BTBEntry newEntry = createBTBEntry(0x1004);
@@ -836,7 +877,7 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid) {
             tage->tageTable[testTable][testIndex][way].useful = true;
-            tage->tageTable[testTable][testIndex][way].counter = 2; // Make it strong
+            tage->tageTable[testTable][testIndex][way].counter = 2;  // Make it strong
         }
     }
 
@@ -878,9 +919,10 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
  * 2. Different bank access has no conflict
  * 3. Disabled flag prevents conflict detection
  */
-TEST_F(BTBTAGETest, BankConflict) {
+TEST_F(BTBTAGETest, BankConflict)
+{
     // Create TAGE with 4 banks
-    BTBTAGE *bankTage = new BTBTAGE(4, 2, 1024, 4);
+    BTBTAGE* bankTage = new BTBTAGE(4, 2, 1024, 4);
     boost::dynamic_bitset<> testHistory(128);
     std::vector<FullBTBPrediction> testStagePreds(5);
 

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -345,6 +345,27 @@ TEST_F(BTBTAGETest, Block1PredictionUsesRegularPathWhenEnabled)
     EXPECT_EQ(block1StagePreds.back().condTakens.size(), regularStagePreds.back().condTakens.size());
 }
 
+TEST_F(BTBTAGETest, Block1PredictionCopiesLowerPredWhenDisabled)
+{
+    Addr startPC = 0x1000;
+    boost::dynamic_bitset<> history(64, 0);
+    boost::dynamic_bitset<> phistory(64, 0);
+    boost::dynamic_bitset<> bwhistory(64, 0);
+    std::vector<boost::dynamic_bitset<>> lhistory;
+    std::vector<FullBTBPrediction> block1StagePreds(4);
+    FullBTBPrediction lowerPred;
+
+    lowerPred.condTakens.push_back({startPC + 4, true});
+    lowerPred.tageInfoForMgscs[startPC + 4].tage_pred_taken = true;
+
+    tage->putPCHistoryForBlock1(startPC, history, phistory, bwhistory, lhistory, block1StagePreds, lowerPred);
+
+    ASSERT_EQ(block1StagePreds.back().condTakens.size(), 1);
+    EXPECT_EQ(block1StagePreds.back().condTakens[0].first, startPC + 4);
+    EXPECT_TRUE(block1StagePreds.back().condTakens[0].second);
+    EXPECT_TRUE(block1StagePreds.back().tageInfoForMgscs[startPC + 4].tage_pred_taken);
+}
+
 // Test basic history update functionality (PHR semantics)
 TEST_F(BTBTAGETest, HistoryUpdate)
 {

--- a/src/cpu/pred/btb/test/fetch_target_queue.test.cc
+++ b/src/cpu/pred/btb/test/fetch_target_queue.test.cc
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/ftq.hh"
+
+namespace gem5
+{
+namespace branch_prediction
+{
+namespace btb_pred
+{
+namespace test
+{
+
+class FetchTargetQueueTest : public ::testing::Test
+{
+  protected:
+    FetchTarget makeTarget(ThreadID tid, Addr startPC)
+    {
+        FetchTarget target;
+        target.tid = tid;
+        target.startPC = startPC;
+        return target;
+    }
+};
+
+TEST_F(FetchTargetQueueTest, SquashAfterFirstTargetDropsSecondTarget)
+{
+    FetchTargetQueue ftq(1, 8);
+    auto target0 = makeTarget(0, 0x1000);
+    auto target1 = makeTarget(0, 0x2000);
+
+    ftq.insert(target0);
+    ftq.insert(target1);
+
+    ASSERT_EQ(ftq.size(0), 2U);
+    EXPECT_EQ(ftq.frontId(0), 1U);
+    EXPECT_EQ(ftq.backId(0), 2U);
+
+    ftq.squashAfter(1, 0);
+
+    EXPECT_EQ(ftq.size(0), 1U);
+    EXPECT_TRUE(ftq.hasTarget(1, 0));
+    EXPECT_FALSE(ftq.hasTarget(2, 0));
+    EXPECT_EQ(ftq.fetchId(0), 2U);
+    EXPECT_EQ(ftq.front(0).startPC, 0x1000U);
+}
+
+TEST_F(FetchTargetQueueTest, FreeSlotsTracksTwoTakenCapacity)
+{
+    FetchTargetQueue ftq(1, 2);
+    auto target0 = makeTarget(0, 0x1000);
+
+    EXPECT_EQ(ftq.freeSlots(0), 2U);
+
+    ftq.insert(target0);
+
+    EXPECT_EQ(ftq.freeSlots(0), 1U);
+    EXPECT_FALSE(ftq.full(0));
+
+    auto target1 = makeTarget(0, 0x2000);
+    ftq.insert(target1);
+
+    EXPECT_EQ(ftq.freeSlots(0), 0U);
+    EXPECT_TRUE(ftq.full(0));
+}
+
+}  // namespace test
+}  // namespace btb_pred
+}  // namespace branch_prediction
+}  // namespace gem5

--- a/src/cpu/pred/btb/timed_base_pred.cc
+++ b/src/cpu/pred/btb/timed_base_pred.cc
@@ -13,12 +13,9 @@ namespace btb_pred
 namespace test
 {
 TimedBaseBTBPredictor::TimedBaseBTBPredictor()
-    : blockSize(32),
-      predictWidth(64),
-      numDelay(0),
-      resolvedUpdate(false),
-      enabled(true)
-{}
+    : blockSize(32), predictWidth(64), numDelay(0), resolvedUpdate(false), enabled(true), block1Participate(false)
+{
+}
 }  // namespace test
 #else
 TimedBaseBTBPredictor::TimedBaseBTBPredictor(const Params &p)
@@ -27,7 +24,8 @@ TimedBaseBTBPredictor::TimedBaseBTBPredictor(const Params &p)
       predictWidth(p.predictWidth),
       numDelay(p.numDelay),
       resolvedUpdate(p.resolvedUpdate),
-      enabled(p.enabled)
+      enabled(p.enabled),
+      block1Participate(p.block1Participate)
 {
 }
 #endif

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -1,21 +1,21 @@
 #ifndef __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
 #define __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
 
-
 #include <boost/dynamic_bitset.hpp>
 
-// Conditional includes based on build mode
 #ifdef UNIT_TEST
-    #include "base/types.hh"
-    #include "cpu/pred/btb/common.hh"
+#include "base/types.hh"
+#include "cpu/pred/btb/common.hh"
+
 #else
-    #include "base/statistics.hh"
-    #include "base/types.hh"
-    #include "cpu/inst_seq.hh"
-    #include "cpu/o3/dyn_inst_ptr.hh"
-    #include "cpu/pred/btb/common.hh"
-    #include "sim/sim_object.hh"
-    #include "params/TimedBaseBTBPredictor.hh"
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/pred/btb/common.hh"
+#include "params/TimedBaseBTBPredictor.hh"
+#include "sim/sim_object.hh"
+
 #endif
 
 namespace gem5
@@ -29,7 +29,8 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test {
+namespace test
+{
 #endif
 
 #ifndef UNIT_TEST
@@ -39,14 +40,14 @@ using DynInstPtr = o3::DynInstPtr;
 #ifdef UNIT_TEST
 class TimedBaseBTBPredictor
 #else
-class TimedBaseBTBPredictor: public SimObject
+class TimedBaseBTBPredictor : public SimObject
 #endif
 {
-    public:
-
+  public:
 #ifdef UNIT_TEST
     TimedBaseBTBPredictor();
     void setNumDelay(unsigned delay) { numDelay = delay; }
+    void setBlock1Participate(bool enable) { block1Participate = enable; }
 #else
     typedef TimedBaseBTBPredictorParams Params;
 
@@ -57,9 +58,22 @@ class TimedBaseBTBPredictor: public SimObject
     virtual void tick() {}
     virtual void dryRunCycle(Addr startAddr) {};
     // make predictions, record in stage preds
-    virtual void putPCHistory(Addr startAddr,
-                              const boost::dynamic_bitset<> &history,
-                              std::vector<FullBTBPrediction> &stagePreds) {}
+    virtual void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
+                              std::vector<FullBTBPrediction> &stagePreds)
+    {
+    }
+    virtual void putPCHistoryForBlock1(Addr startAddr, const boost::dynamic_bitset<> &history,
+                                       const boost::dynamic_bitset<> &phistory,
+                                       const boost::dynamic_bitset<> &bwhistory,
+                                       const std::vector<boost::dynamic_bitset<>> &lhistory,
+                                       std::vector<FullBTBPrediction> &stagePreds, const FullBTBPrediction &lowerPred)
+    {
+        (void)phistory;
+        (void)bwhistory;
+        (void)lhistory;
+        (void)lowerPred;
+        putPCHistory(startAddr, history, stagePreds);
+    }
 
     virtual std::shared_ptr<void> getPredictionMeta() { return nullptr; }
 
@@ -68,14 +82,26 @@ class TimedBaseBTBPredictor: public SimObject
     virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
     virtual void specUpdateIHist(FullBTBPrediction &pred) {}
     virtual void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) {}
-    virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
+    virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                             bool cond_taken)
+    {
+    }
+    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                              bool cond_taken)
+    {
+    }
+    virtual void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
+                               bool cond_taken)
+    {
+    }
     virtual void recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
+    virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt,
+                              bool cond_taken)
+    {
+    }
     virtual void update(const FetchTarget &entry) {}
-    virtual unsigned getDelay() {return numDelay;}
-    virtual bool getResolvedUpdate() {return resolvedUpdate;}
+    virtual unsigned getDelay() { return numDelay; }
+    virtual bool getResolvedUpdate() { return resolvedUpdate; }
     // Two-phase resolved update: probe first, then apply
     virtual bool canResolveUpdate(const FetchTarget &entry) { return true; }
     virtual void doResolveUpdate(const FetchTarget &entry) { update(entry); }
@@ -94,34 +120,34 @@ class TimedBaseBTBPredictor: public SimObject
     unsigned predictWidth;
 
 #ifndef UNIT_TEST
-    bool hasDB {false};
+    bool hasDB{false};
     std::string dbName;
-    bool enableDB {false};
-    void setDB(DataBase *db) {
-        _db = db;
-    }
+    bool enableDB{false};
+    void setDB(DataBase *db) { _db = db; }
     DataBase *_db;
 #endif
     virtual void setTrace() {}
 
     // Check if this component is enabled
     bool isEnabled() const { return enabled; }
+    bool participatesInBlock1() const { return block1Participate; }
 
-private:
+  private:
     unsigned numDelay;
     bool resolvedUpdate;
     bool enabled;
+    bool block1Participate;
 };
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-} // namespace test
+}  // namespace test
 #endif
 
-} // namespace btb_pred
+}  // namespace btb_pred
 
-} // namespace branch_prediction
+}  // namespace branch_prediction
 
-} // namespace gem5
+}  // namespace gem5
 
-#endif // __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
+#endif  // __CPU_PRED_BTB_TIMED_BASE_PRED_HH__

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -1,12 +1,12 @@
 #ifndef __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
 #define __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
 
+
 #include <boost/dynamic_bitset.hpp>
 
 #ifdef UNIT_TEST
-#include "base/types.hh"
-#include "cpu/pred/btb/common.hh"
-
+    #include "base/types.hh"
+    #include "cpu/pred/btb/common.hh"
 #else
 #include "base/statistics.hh"
 #include "base/types.hh"
@@ -29,8 +29,7 @@ namespace btb_pred
 
 // Conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-namespace test
-{
+namespace test {
 #endif
 
 #ifndef UNIT_TEST
@@ -40,10 +39,11 @@ using DynInstPtr = o3::DynInstPtr;
 #ifdef UNIT_TEST
 class TimedBaseBTBPredictor
 #else
-class TimedBaseBTBPredictor : public SimObject
+class TimedBaseBTBPredictor: public SimObject
 #endif
 {
-  public:
+    public:
+
 #ifdef UNIT_TEST
     TimedBaseBTBPredictor();
     void setNumDelay(unsigned delay) { numDelay = delay; }
@@ -82,26 +82,14 @@ class TimedBaseBTBPredictor : public SimObject
     virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
     virtual void specUpdateIHist(FullBTBPrediction &pred) {}
     virtual void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) {}
-    virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                             bool cond_taken)
-    {
-    }
-    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                              bool cond_taken)
-    {
-    }
-    virtual void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                               bool cond_taken)
-    {
-    }
+    virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
+    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
+    virtual void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt,
-                              bool cond_taken)
-    {
-    }
+    virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void update(const FetchTarget &entry) {}
-    virtual unsigned getDelay() { return numDelay; }
-    virtual bool getResolvedUpdate() { return resolvedUpdate; }
+    virtual unsigned getDelay() {return numDelay;}
+    virtual bool getResolvedUpdate() {return resolvedUpdate;}
     // Two-phase resolved update: probe first, then apply
     virtual bool canResolveUpdate(const FetchTarget &entry) { return true; }
     virtual void doResolveUpdate(const FetchTarget &entry) { update(entry); }
@@ -120,10 +108,12 @@ class TimedBaseBTBPredictor : public SimObject
     unsigned predictWidth;
 
 #ifndef UNIT_TEST
-    bool hasDB{false};
+    bool hasDB {false};
     std::string dbName;
-    bool enableDB{false};
-    void setDB(DataBase *db) { _db = db; }
+    bool enableDB {false};
+    void setDB(DataBase *db) {
+        _db = db;
+    }
     DataBase *_db;
 #endif
     virtual void setTrace() {}
@@ -132,7 +122,7 @@ class TimedBaseBTBPredictor : public SimObject
     bool isEnabled() const { return enabled; }
     bool participatesInBlock1() const { return block1Participate; }
 
-  private:
+private:
     unsigned numDelay;
     bool resolvedUpdate;
     bool enabled;
@@ -141,13 +131,13 @@ class TimedBaseBTBPredictor : public SimObject
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST
-}  // namespace test
+} // namespace test
 #endif
 
-}  // namespace btb_pred
+} // namespace btb_pred
 
-}  // namespace branch_prediction
+} // namespace branch_prediction
 
-}  // namespace gem5
+} // namespace gem5
 
-#endif  // __CPU_PRED_BTB_TIMED_BASE_PRED_HH__
+#endif // __CPU_PRED_BTB_TIMED_BASE_PRED_HH__

--- a/src/cpu/pred/general_arch_db.cc
+++ b/src/cpu/pred/general_arch_db.cc
@@ -125,4 +125,3 @@ DataBase::addAndGetTrace(const char *name, std::vector<std::pair<std::string, Da
 
 
 } // namespace gem5
-

--- a/src/sim/arch_db.cc
+++ b/src/sim/arch_db.cc
@@ -304,4 +304,3 @@ DBTraceManager::write_record(const Record &record)
 }
 
 } // namespace gem5
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "Two-Taken" fetch: generate a secondary fetch block from a single prediction (enableTwoTaken) with per-predictor participation control (block1Participate) and fine-grained drop filters for override, FTQ capacity, unsupported conditional/indirect/return branches.
  * New block1-related statistics tracking attempts, accepts, and drop reasons.

* **Documentation**
  * Added comprehensive Two-Taken Framework guide with configuration and usage notes.

* **Tests**
  * Added unit tests covering secondary-block behavior, drop reasons, and queue capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->