### PR TITLE
mem: remove duplicated trainning req of prefetcher

### DIFF
--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -823,7 +823,9 @@ BaseCache::recvTimingReq(PacketPtr pkt)
 
         handleTimingReqMiss(pkt, blk, forward_time, request_time);
 
-        ppMiss->notify(pkt);
+        if (!pkt->mshrAliasFailed() && !pkt->mshrArbFailed() && !pkt->isHitInWriteBuffer()) {
+            ppMiss->notify(pkt);
+        }
     }
 
 


### PR DESCRIPTION
when `mshrAliasFailed`/`mshrArbFailed`/`isHitInWriteBuffer`, the request will be replayed, it should not train the prefetcher.

Change-Id: I45f209a8ed78d4f17850971b7af8f8b0b12395aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect cache miss reporting in edge cases involving MSHR arbitration failures and write buffer hits. Cache miss events will now accurately reflect actual misses, improving the reliability of cache performance metrics and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->