### PR TITLE
configs,arch-riscv,cpu-o3: Fix Xiangshan raw Linux boot

### DIFF
--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -8,139 +8,139 @@ on:
   workflow_dispatch:
 
 jobs:
-  # paralel_cpt_test:
-  #   # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
-  #   runs-on: [self-hosted, open]  # 所有open*的机器上运行
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Running test checkpoints
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: |
-  #         CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-  #     - name: Run paralel autotest script
-  #       run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5.cfg
+  paralel_cpt_test:
+    # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
+    runs-on: [self-hosted, open]  # 所有open*的机器上运行
+    continue-on-error: false
+    name: XS-GEM5 - Running test checkpoints
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: |
+          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: Run paralel autotest script
+        run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5.cfg
   
-  # paralel_cpt_h_test:
-  #   # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
-  #   runs-on: [self-hosted, open]  # 所有open*的机器上运行
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Running h test checkpoints
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: |
-  #         CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-  #     - name: Run paralel h autotest script
-  #       run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5-h.cfg
+  paralel_cpt_h_test:
+    # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
+    runs-on: [self-hosted, open]  # 所有open*的机器上运行
+    continue-on-error: false
+    name: XS-GEM5 - Running h test checkpoints
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: |
+          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: Run paralel h autotest script
+        run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5-h.cfg
 
-  # valgrind_memory_check:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Check memory corruption
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 debug
-  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
-  #     - name: Memory check
-  #       run: |
-  #         export GEM5_HOME=$(pwd)
-  #         bash util/memory_check/run-xs-with-valgrind.sh
-  #         cd $GEM5_HOME
+  valgrind_memory_check:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Check memory corruption
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 debug
+        run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
+      - name: Memory check
+        run: |
+          export GEM5_HOME=$(pwd)
+          bash util/memory_check/run-xs-with-valgrind.sh
+          cd $GEM5_HOME
 
-  # new_sim_script_test_gcb:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Test new simulation script on RV64GCB
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
-  #       run: |
-  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-  #         export GCB_RESTORER="/nfs/home/share/gem5_ci/tools/normal-gcb-restorer.bin"
-  #         export GEM5_HOME=$(pwd)
-  #         mkdir -p $GEM5_HOME/util/xs_scripts/test
-  #         cd $GEM5_HOME/util/xs_scripts/test
-  #         bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/gcb_test.zstd
+  new_sim_script_test_gcb:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Test new simulation script on RV64GCB
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: XS-GEM5 - Test xiangshan.py simulation scripts
+        run: |
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
+          export GCB_RESTORER="/nfs/home/share/gem5_ci/tools/normal-gcb-restorer.bin"
+          export GEM5_HOME=$(pwd)
+          mkdir -p $GEM5_HOME/util/xs_scripts/test
+          cd $GEM5_HOME/util/xs_scripts/test
+          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/gcb_test.zstd
 
-  # new_sim_script_test_gcbv:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Test new simulation script on RV64GCBV
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
-  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
-  #       run: |
-  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
-  #         export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
-  #         export GEM5_HOME=$(pwd)
-  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_v
-  #         cd $GEM5_HOME/util/xs_scripts/test_v
-  #         bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
+  new_sim_script_test_gcbv:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Test new simulation script on RV64GCBV
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
+      - name: XS-GEM5 - Test xiangshan.py simulation scripts
+        run: |
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
+          export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
+          export GEM5_HOME=$(pwd)
+          mkdir -p $GEM5_HOME/util/xs_scripts/test_v
+          cd $GEM5_HOME/util/xs_scripts/test_v
+          bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
 
-  # new_sim_script_test_gcb_multi_core:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Test Multi-core + RV64GCB
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build GEM5 opt
-  #       run: |
-  #         CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
-  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
-  #       run: |
-  #         export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
-  #         export GCB_MULTI_CORE_RESTORER="/nfs/home/share/gem5_ci/tools/gcb-2core-restorer.bin"
-  #         export GEM5_HOME=$(pwd)
-  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_multi_core
-  #         cd $GEM5_HOME/util/xs_scripts/test_multi_core
-  #         bash ../kmh-ruby-dual.sh /nfs/home/share/gem5_ci/checkpoints/multi_core_test.gz
+  new_sim_script_test_gcb_multi_core:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Test Multi-core + RV64GCB
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build GEM5 opt
+        run: |
+          CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
+      - name: XS-GEM5 - Test xiangshan.py simulation scripts
+        run: |
+          export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
+          export GCB_MULTI_CORE_RESTORER="/nfs/home/share/gem5_ci/tools/gcb-2core-restorer.bin"
+          export GEM5_HOME=$(pwd)
+          mkdir -p $GEM5_HOME/util/xs_scripts/test_multi_core
+          cd $GEM5_HOME/util/xs_scripts/test_multi_core
+          bash ../kmh-ruby-dual.sh /nfs/home/share/gem5_ci/checkpoints/multi_core_test.gz
 
 
-  # test_fix_l2tlb_bugs:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Test fix L2TLB bugs
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
-  #       run: |
-  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-  #         export GCB_RESTORER=""
-  #         export GEM5_HOME=$(pwd)
-  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
-  #         cd $GEM5_HOME/util/xs_scripts/test_l2tlb
-  #         bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
+  test_fix_l2tlb_bugs:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Test fix L2TLB bugs
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: XS-GEM5 - Test xiangshan.py simulation scripts
+        run: |
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
+          export GCB_RESTORER=""
+          export GEM5_HOME=$(pwd)
+          mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
+          cd $GEM5_HOME/util/xs_scripts/test_l2tlb
+          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
 
-  # new_sim_script_test_gcbh:
-  #   runs-on: [self-hosted, open]
-  #   continue-on-error: false
-  #   name: XS-GEM5 - Test new simulation script on RV64GCBH
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/build-dramsim
-  #     - name: Build GEM5 opt
-  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
-  #       run: |
-  #         export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
-  #         export GCBH_RESTORER="/nfs/home/share/gem5_ci/tools/gcpt.bin"
-  #         export GEM5_HOME=$(pwd)
-  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_h
-  #         cd $GEM5_HOME/util/xs_scripts/test_h
-  #         bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
+  new_sim_script_test_gcbh:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    name: XS-GEM5 - Test new simulation script on RV64GCBH
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: XS-GEM5 - Test xiangshan.py simulation scripts
+        run: |
+          export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
+          export GCBH_RESTORER="/nfs/home/share/gem5_ci/tools/gcpt.bin"
+          export GEM5_HOME=$(pwd)
+          mkdir -p $GEM5_HOME/util/xs_scripts/test_h
+          cd $GEM5_HOME/util/xs_scripts/test_h
+          bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
 
   raw_linux_boot_test:
     runs-on: [self-hosted, open]

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -145,7 +145,7 @@ jobs:
   raw_linux_boot_test:
     runs-on: [self-hosted, open]
     continue-on-error: false
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: XS-GEM5 - Boot raw Linux
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -163,12 +163,14 @@ jobs:
           fi
 
           mkdir -p debug/raw_linux_ci
-          ./build/RISCV/gem5.opt -d debug/raw_linux_ci \
+          ./build/RISCV/gem5.opt -r -d debug/raw_linux_ci \
             ./configs/example/kmhv3.py \
             --raw-cpt \
             --generic-rv-cpt "$RAW_LINUX_BIN" \
             --disable-difftest
       - name: Check boot result
         run: |
+          test -f debug/raw_linux_ci/simout
+          tail -n 200 debug/raw_linux_ci/simout
           grep -q "Hello, XiangShan!" debug/raw_linux_ci/simout
           grep -q "m5_exit instruction encountered" debug/raw_linux_ci/simout

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -8,139 +8,139 @@ on:
   workflow_dispatch:
 
 jobs:
-  paralel_cpt_test:
-    # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
-    runs-on: [self-hosted, open]  # 所有open*的机器上运行
-    continue-on-error: false
-    name: XS-GEM5 - Running test checkpoints
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: |
-          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: Run paralel autotest script
-        run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5.cfg
+  # paralel_cpt_test:
+  #   # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
+  #   runs-on: [self-hosted, open]  # 所有open*的机器上运行
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Running test checkpoints
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: |
+  #         CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+  #     - name: Run paralel autotest script
+  #       run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5.cfg
   
-  paralel_cpt_h_test:
-    # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
-    runs-on: [self-hosted, open]  # 所有open*的机器上运行
-    continue-on-error: false
-    name: XS-GEM5 - Running h test checkpoints
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: |
-          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: Run paralel h autotest script
-        run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5-h.cfg
+  # paralel_cpt_h_test:
+  #   # 由于gem5.cfg使用的切片ck_path都在小机房上，默认使用小机房运行这个测试
+  #   runs-on: [self-hosted, open]  # 所有open*的机器上运行
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Running h test checkpoints
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: |
+  #         CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+  #     - name: Run paralel h autotest script
+  #       run: python3 .github/workflows/autotest/script/autotest.py -f .github/workflows/autotest/gem5-h.cfg
 
-  valgrind_memory_check:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Check memory corruption
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 debug
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
-      - name: Memory check
-        run: |
-          export GEM5_HOME=$(pwd)
-          bash util/memory_check/run-xs-with-valgrind.sh
-          cd $GEM5_HOME
+  # valgrind_memory_check:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Check memory corruption
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 debug
+  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
+  #     - name: Memory check
+  #       run: |
+  #         export GEM5_HOME=$(pwd)
+  #         bash util/memory_check/run-xs-with-valgrind.sh
+  #         cd $GEM5_HOME
 
-  new_sim_script_test_gcb:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test new simulation script on RV64GCB
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GCB_RESTORER="/nfs/home/share/gem5_ci/tools/normal-gcb-restorer.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test
-          cd $GEM5_HOME/util/xs_scripts/test
-          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/gcb_test.zstd
+  # new_sim_script_test_gcb:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Test new simulation script on RV64GCB
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
+  #       run: |
+  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
+  #         export GCB_RESTORER="/nfs/home/share/gem5_ci/tools/normal-gcb-restorer.bin"
+  #         export GEM5_HOME=$(pwd)
+  #         mkdir -p $GEM5_HOME/util/xs_scripts/test
+  #         cd $GEM5_HOME/util/xs_scripts/test
+  #         bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/gcb_test.zstd
 
-  new_sim_script_test_gcbv:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test new simulation script on RV64GCBV
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
-          export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_v
-          cd $GEM5_HOME/util/xs_scripts/test_v
-          bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
+  # new_sim_script_test_gcbv:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Test new simulation script on RV64GCBV
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
+  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
+  #       run: |
+  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
+  #         export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
+  #         export GEM5_HOME=$(pwd)
+  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_v
+  #         cd $GEM5_HOME/util/xs_scripts/test_v
+  #         bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
 
-  new_sim_script_test_gcb_multi_core:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test Multi-core + RV64GCB
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build GEM5 opt
-        run: |
-          CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
-          export GCB_MULTI_CORE_RESTORER="/nfs/home/share/gem5_ci/tools/gcb-2core-restorer.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_multi_core
-          cd $GEM5_HOME/util/xs_scripts/test_multi_core
-          bash ../kmh-ruby-dual.sh /nfs/home/share/gem5_ci/checkpoints/multi_core_test.gz
+  # new_sim_script_test_gcb_multi_core:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Test Multi-core + RV64GCB
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Build GEM5 opt
+  #       run: |
+  #         CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
+  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
+  #       run: |
+  #         export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
+  #         export GCB_MULTI_CORE_RESTORER="/nfs/home/share/gem5_ci/tools/gcb-2core-restorer.bin"
+  #         export GEM5_HOME=$(pwd)
+  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_multi_core
+  #         cd $GEM5_HOME/util/xs_scripts/test_multi_core
+  #         bash ../kmh-ruby-dual.sh /nfs/home/share/gem5_ci/checkpoints/multi_core_test.gz
 
 
-  test_fix_l2tlb_bugs:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test fix L2TLB bugs
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GCB_RESTORER=""
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
-          cd $GEM5_HOME/util/xs_scripts/test_l2tlb
-          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
+  # test_fix_l2tlb_bugs:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Test fix L2TLB bugs
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
+  #       run: |
+  #         export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
+  #         export GCB_RESTORER=""
+  #         export GEM5_HOME=$(pwd)
+  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
+  #         cd $GEM5_HOME/util/xs_scripts/test_l2tlb
+  #         bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
 
-  new_sim_script_test_gcbh:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test new simulation script on RV64GCBH
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
-          export GCBH_RESTORER="/nfs/home/share/gem5_ci/tools/gcpt.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_h
-          cd $GEM5_HOME/util/xs_scripts/test_h
-          bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
+  # new_sim_script_test_gcbh:
+  #   runs-on: [self-hosted, open]
+  #   continue-on-error: false
+  #   name: XS-GEM5 - Test new simulation script on RV64GCBH
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ./.github/actions/build-dramsim
+  #     - name: Build GEM5 opt
+  #       run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+  #     - name: XS-GEM5 - Test xiangshan.py simulation scripts
+  #       run: |
+  #         export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
+  #         export GCBH_RESTORER="/nfs/home/share/gem5_ci/tools/gcpt.bin"
+  #         export GEM5_HOME=$(pwd)
+  #         mkdir -p $GEM5_HOME/util/xs_scripts/test_h
+  #         cd $GEM5_HOME/util/xs_scripts/test_h
+  #         bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
 
   raw_linux_boot_test:
     runs-on: [self-hosted, open]

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -142,3 +142,33 @@ jobs:
           cd $GEM5_HOME/util/xs_scripts/test_h
           bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
 
+  raw_linux_boot_test:
+    runs-on: [self-hosted, open]
+    continue-on-error: false
+    timeout-minutes: 10
+    name: XS-GEM5 - Boot raw Linux
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-dramsim
+      - name: Build GEM5 opt
+        run: |
+          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
+      - name: Boot Xiangshan raw Linux
+        run: |
+          export RAW_LINUX_BIN="${XS_LINUX_BIN:-/nfs/home/share/gem5_ci/ready-to-run/linux.bin}"
+          if [ ! -r "$RAW_LINUX_BIN" ]; then
+            echo "Missing raw linux image: $RAW_LINUX_BIN"
+            echo "Please provision the image at the default path or set XS_LINUX_BIN on the runner."
+            exit 1
+          fi
+
+          mkdir -p debug/raw_linux_ci
+          ./build/RISCV/gem5.opt -d debug/raw_linux_ci \
+            ./configs/example/kmhv3.py \
+            --raw-cpt \
+            --generic-rv-cpt "$RAW_LINUX_BIN" \
+            --disable-difftest
+      - name: Check boot result
+        run: |
+          grep -q "Hello, XiangShan!" debug/raw_linux_ci/simout
+          grep -q "m5_exit instruction encountered" debug/raw_linux_ci/simout

--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -658,6 +658,13 @@ def makeBareMetalRiscvSystem(mem_mode, mdesc=None, cmdline=None):
     return self
 
 def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=False):
+    self = makeXiangshanPlatformSystem(mem_mode, mdesc, np=np, ruby=ruby)
+    self.workload = RiscvBareMetal()
+    self.workload.reset_vect = 0x80000000
+    return self
+
+
+def makeXiangshanPlatformSystem(mem_mode, mdesc=None, np=1, ruby=False):
     self = System()
     if not mdesc:
         # generic system
@@ -665,7 +672,6 @@ def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=
     self.mem_mode = mem_mode
     self.mem_ranges = [AddrRange(start=0x80000000, size=mdesc.mem())]
     print(self.mem_ranges)
-    self.workload = RiscvBareMetal()
 
     self.iobus = IOXBar()
     if not ruby:
@@ -698,7 +704,6 @@ def makeBareMetalXiangshanSystem(mem_mode, mdesc=None, cmdline=None, np=1, ruby=
             AddrRange(self.plic.pio_addr, self.plic.pio_addr + self.plic.pio_size),
             ]
 
-    self.workload.reset_vect = 0x80000000
     if not ruby:
         self.system_port = self.membus.cpu_side_ports
     return self

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -632,10 +632,34 @@ def addFSOptions(parser):
     parser.add_argument("--wait-gdb", default=False, action='store_true',
                         help="Wait for remote GDB to connect.")
 
-def addXiangshanFSOptions(parser):
+def addXiangshanCommonOptions(parser):
     # Xiangshan related options
-    parser.add_argument("--xiangshan-system", action= "store_true",
+    parser.add_argument("--xiangshan-system", action="store_true",
                         help="Use memory layout of Xiangshan system")
+    parser.add_argument("--mmc-img", action="store", type=str,
+                        default=None, help="The path of mmc img")
+    parser.add_argument("--mmc-cptbin", action="store",
+                        type=str, default=None, help="The path of mmc cptbin")
+
+    # Difftest option
+    parser.set_defaults(enable_difftest=None)
+    parser.add_argument("--enable-difftest",
+                        action="store_true",
+                        dest="enable_difftest",
+                        help="use NEMU as ref to do difftest")
+    parser.add_argument("--disable-difftest",
+                        action="store_false",
+                        dest="enable_difftest",
+                        help="disable NEMU difftest")
+
+    parser.add_argument("--difftest-ref-so",
+                        action="store",
+                        default=None,
+                        help="The shared lib file used to do difftest")
+
+
+def addXiangshanFSOptions(parser):
+    addXiangshanCommonOptions(parser)
 
     parser.add_argument("--enable-h-gcpt", action= "store_true",
                         help="enable h checkpoint")
@@ -648,21 +672,6 @@ def addXiangshanFSOptions(parser):
 
     parser.add_argument("--raw-cpt", action= "store_true",
                         help = "The checkpoint file is not gz but binary")
-
-    parser.add_argument("--mmc-img", action="store", type=str,
-                        default=None, help="The path of mmc img")
-    parser.add_argument("--mmc-cptbin", action="store",
-                        type=str, default=None, help="The path of mmc cptbin")
-
-    # Difftest option
-    parser.add_argument("--enable-difftest",
-                        action="store_true",
-                        help="use NEMU as ref to do difftest")
-
-    parser.add_argument("--difftest-ref-so",
-                        action="store",
-                        default=None,
-                        help="The shared lib file used to do difftest")
 
 def addXiangshanTraceOptions(parser):
     # Add trace-specific arguments for trace-driven simulation

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -448,6 +448,7 @@ def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
         cpu.mmu.pma_checker = PMAChecker(
             uncacheable=[AddrRange(0, size=0x80000000)])
         cpu.mmu.functional = args.functional_tlb
+        cpu.enable_sv48 = args.open_sv48
         cpu.mmu.enable_sv48 = args.open_sv48
 
         if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -133,35 +133,196 @@ def _apply_trace_timing_ptw_cpu_params(args: argparse.Namespace, cpus, *, shrink
         cpu.traceAddrSize = int(cpu.traceAddrSize) - reserved_bytes
 
 
+def resolve_linux_cmdline(args: argparse.Namespace, default_cmdline: str) -> str:
+    command_line = getattr(args, "command_line", None)
+    command_line_file = getattr(args, "command_line_file", None)
+
+    if command_line and command_line_file:
+        fatal("--command-line and --command-line-file are mutually exclusive")
+
+    if command_line:
+        return command_line.strip()
+
+    if command_line_file:
+        with open(command_line_file) as cmdline_file:
+            return cmdline_file.read().strip()
+
+    return default_cmdline
+
+
+def generate_xiangshan_dtb(system, *, cmdline: str, outdir: str = None) -> str:
+    if outdir is None:
+        outdir = m5.options.outdir
+    dtb_path = os.path.join(outdir, "device.dtb")
+    dts_path = os.path.join(outdir, "device.dts")
+    state = FdtState(addr_cells=2, size_cells=2, cpu_cells=1)
+    root = FdtNode("/")
+    root.append(state.addrCellsProperty())
+    root.append(state.sizeCellsProperty())
+    root.appendCompatible(["freechips,rocketchip-unknown-soc"])
+    root.append(FdtPropertyStrings("model", "xiangshan-raw-linux"))
+
+    chosen = FdtNode("chosen")
+    if cmdline:
+        chosen.append(FdtPropertyStrings("bootargs", cmdline))
+    chosen.append(FdtPropertyStrings("stdout-path", "/soc/serial@40600000"))
+    chosen.append(FdtPropertyStrings("linux,stdout-path", "/soc/serial@40600000"))
+    root.append(chosen)
+
+    for mem_range in system.mem_ranges:
+        node = FdtNode("memory@%x" % int(mem_range.start))
+        node.append(FdtPropertyStrings("device_type", ["memory"]))
+        node.append(
+            FdtPropertyWords(
+                "reg",
+                state.addrCells(mem_range.start) +
+                state.sizeCells(mem_range.size())
+            )
+        )
+        root.append(node)
+
+    cpus_node = FdtNode("cpus")
+    cpus_state = FdtState(addr_cells=1, size_cells=0)
+    cpus_node.append(cpus_state.addrCellsProperty())
+    cpus_node.append(cpus_state.sizeCellsProperty())
+    cpus_node.append(FdtPropertyWords("timebase-frequency", [10000000]))
+
+    mmu_type = "riscv,sv48" if bool(getattr(system, "enable_sv48", False)) else "riscv,sv39"
+    isa_string = "rv64imafdc"
+
+    for i, cpu in enumerate(system.cpu):
+        node = FdtNode(f"cpu@{i}")
+        node.append(FdtPropertyStrings("device_type", "cpu"))
+        node.append(FdtPropertyWords("reg", state.CPUAddrCells(i)))
+        node.append(FdtPropertyStrings("mmu-type", mmu_type))
+        node.append(FdtPropertyStrings("status", "okay"))
+        node.append(FdtPropertyStrings("riscv,isa", isa_string))
+        freq = int(cpu.clk_domain.unproxy(cpu).clock[0].frequency)
+        node.append(FdtPropertyWords("clock-frequency", freq))
+        node.appendCompatible(["riscv"])
+        node.appendPhandle(f"cpu@{i}")
+
+        int_node = FdtNode("interrupt-controller")
+        int_state = FdtState(interrupt_cells=1)
+        int_phandle = int_state.phandle(f"cpu@{i}.int_state")
+        int_node.append(int_state.interruptCellsProperty())
+        int_node.append(FdtProperty("interrupt-controller"))
+        int_node.appendCompatible("riscv,cpu-intc")
+        int_node.append(FdtPropertyWords("phandle", [int_phandle]))
+
+        node.append(int_node)
+        cpus_node.append(node)
+
+    root.append(cpus_node)
+
+    soc_node = FdtNode("soc")
+    soc_state = FdtState(addr_cells=2, size_cells=2)
+    soc_node.append(soc_state.addrCellsProperty())
+    soc_node.append(soc_state.sizeCellsProperty())
+    soc_node.append(FdtProperty("ranges"))
+    soc_node.appendCompatible(["simple-bus"])
+
+    clint = system.lint
+    clint_node = clint.generateBasicPioDeviceNode(
+        soc_state, "clint", clint.pio_addr, clint.pio_size
+    )
+    clint_interrupts = []
+    for i, _cpu in enumerate(system.cpu):
+        phandle = soc_state.phandle(f"cpu@{i}.int_state")
+        clint_interrupts.extend([phandle, 0x3, phandle, 0x7])
+    clint_node.append(FdtPropertyWords("interrupts-extended", clint_interrupts))
+    clint_node.appendCompatible(["riscv,clint0"])
+    soc_node.append(clint_node)
+
+    plic = system.plic
+    plic_node = plic.generateBasicPioDeviceNode(
+        soc_state, "plic", plic.pio_addr, plic.pio_size
+    )
+    plic_int_state = FdtState(addr_cells=0, interrupt_cells=1)
+    plic_node.append(plic_int_state.addrCellsProperty())
+    plic_node.append(plic_int_state.interruptCellsProperty())
+    plic_phandle = plic_int_state.phandle("xiangshan-plic")
+    plic_node.append(FdtPropertyWords("phandle", [plic_phandle]))
+    plic_node.append(FdtPropertyWords("riscv,ndev", [31]))
+    plic_interrupts = []
+    for i, _cpu in enumerate(system.cpu):
+        phandle = state.phandle(f"cpu@{i}.int_state")
+        plic_interrupts.extend([phandle, 0xB, phandle, 0x9])
+    plic_node.append(FdtPropertyWords("interrupts-extended", plic_interrupts))
+    plic_node.append(FdtProperty("interrupt-controller"))
+    plic_node.appendCompatible(["riscv,plic0"])
+    soc_node.append(plic_node)
+
+    uart = system.uartlite
+    uart_node = uart.generateBasicPioDeviceNode(
+        soc_state, "serial", uart.pio_addr, uart.pio_size
+    )
+    uart_node.append(FdtPropertyWords("clock-frequency", [0]))
+    uart_node.append(FdtPropertyStrings("status", "okay"))
+    uart_node.appendCompatible(["xlnx,xps-uartlite-1.00.a"])
+    soc_node.append(uart_node)
+
+    root.append(soc_node)
+
+    fdt = Fdt()
+    fdt.add_rootnode(root)
+    fdt.writeDtsFile(dts_path)
+    fdt.writeDtbFile(dtb_path)
+    return dtb_path
+
+
+def configure_xiangshan_linux_workload(system, args: argparse.Namespace,
+                                       default_cmdline: str = "console=ttyS0 earlycon=sbi loglevel=7") -> None:
+    cmdline = resolve_linux_cmdline(args, default_cmdline)
+    if hasattr(system.workload, "command_line"):
+        system.workload.command_line = cmdline
+    system.workload.dtb_addr = 0x87e00000
+
+    if getattr(args, "dtb_filename", None):
+        dtb_path = args.dtb_filename
+    else:
+        dtb_path = generate_xiangshan_dtb(system, cmdline=cmdline)
+    system.workload.dtb_filename = dtb_path
+
+
+def resolve_xiangshan_ref_so(args: argparse.Namespace):
+    ref_so = None
+    if args.difftest_ref_so is not None:
+        ref_so = args.difftest_ref_so
+        print("Obtained ref_so from args.difftest_ref_so: ", ref_so)
+    elif args.num_cpus > 1 and "GCBV_MULTI_CORE_REF_SO" in os.environ:
+        ref_so = os.environ["GCBV_MULTI_CORE_REF_SO"]
+        print("Obtained ref_so from GCBV_MULTI_CORE_REF_SO: ", ref_so)
+    elif "GCBV_REF_SO" in os.environ:
+        ref_so = os.environ["GCBV_REF_SO"]
+        print("Obtained ref_so from GCBV_REF_SO: ", ref_so)
+    elif "GCBH_REF_SO" in os.environ:
+        ref_so = os.environ["GCBH_REF_SO"]
+        print("Obtained ref_so from GCBH_REF_SO: ", ref_so)
+    elif "NEMU_HOME" in os.environ:
+        ref_so = os.path.join(os.environ["NEMU_HOME"], "build/riscv64-nemu-interpreter-so")
+        print("Obtained ref_so from NEMU_HOME: ", ref_so)
+    else:
+        fatal("No valid ref_so file specified for the functional model to "
+              "compare against. Please 1) either specify a valid ref_so file using "
+              "the --difftest-ref-so option;\n"
+              "2) or specify GCBV_REF_SO/GCBV_MULTI_CORE_REF_SO/GCBH_REF_SO that points to the ref_so file;\n"
+              "3) or specify NEMU_HOME that contains build/riscv64-nemu-interpreter-so")
+    return ref_so
+
+
+def get_xiangshan_cpu_class(args: argparse.Namespace):
+    if args.xiangshan_ecore:
+        args.cpu_clock = '2.4GHz'
+        return XiangshanECore
+    return XiangshanCore
+
+
 def config_xiangshan_inputs(args: argparse.Namespace, sys):
     ref_so = None
 
-    # configure difftest input
-    if args.enable_difftest and args.difftest_ref_so is None:
-        # ref so should be either provided from the command line or from the env
-        if args.num_cpus > 1 and "GCBV_MULTI_CORE_REF_SO" in os.environ:
-            ref_so = os.environ["GCBV_MULTI_CORE_REF_SO"]
-            print("Obtained ref_so from GCBV_MULTI_CORE_REF_SO: ", ref_so)
-        elif "GCBV_REF_SO" in os.environ:
-            ref_so = os.environ["GCBV_REF_SO"]
-            print("Obtained ref_so from GCBV_REF_SO: ", ref_so)
-        elif "GCBH_REF_SO" in os.environ:
-            ref_so = os.environ["GCBH_REF_SO"]
-            print("Obtained ref_so from GCBH_REF_SO: ", ref_so)
-        elif "NEMU_HOME" in os.environ:
-            ref_so = os.path.join(os.environ["NEMU_HOME"], "build/riscv64-nemu-interpreter-so")
-            print("Obtained ref_so from NEMU_HOME: ", ref_so)
-        else:
-            if "GCBV_REF_SO" in os.environ:
-                print("Currently XS-GEM5 always turn on RVV and require a ref_so with RVV support")
-            fatal("No valid ref_so file specified for the functional model to "
-                  "compare against. Please 1) either specify a valid ref_so file using "
-                  "the --difftest-ref-so option;\n"
-                  "2) or specify GCBV_REF_SO/GCBV_MULTI_CORE_REF_SO/GCBH_REF_SO that points to the ref_so file;\n"
-                  "3) or specify NEMU_HOME that contains build/riscv64-nemu-interpreter-so")
-    elif args.enable_difftest and args.difftest_ref_so is not None:
-        ref_so = args.difftest_ref_so
-        print("Obtained ref_so from args.difftest_ref_so: ", ref_so)
+    if args.enable_difftest:
+        ref_so = resolve_xiangshan_ref_so(args)
 
     args.difftest_ref_so = ref_so
 
@@ -258,72 +419,11 @@ def config_difftest(cpu_list, args, sys):
             cpu_list[0].enable_difftest = True
             cpu_list[0].difftest_ref_so = args.difftest_ref_so
 
-def build_xiangshan_system(args):
+def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
     np = args.num_cpus
-    assert buildEnv['TARGET_ISA'] == "riscv"
-
-    # override cpu class and clock
-    if args.xiangshan_ecore:
-        TestCPUClass = XiangshanECore
-        args.cpu_clock = '2.4GHz'
-    else:
-        TestCPUClass = XiangshanCore
-
-    ruby = False
-    if hasattr(args, 'ruby') and args.ruby:
-        ruby = True
-
-    # Create system using FS mode with trace-specific memory configuration
-    test_sys = makeBareMetalXiangshanSystem('timing', SysConfig(mem=args.mem_size), None, np=np, ruby=ruby)
-
-    # CRITICAL FIX: Configure trace-specific memory ranges and functional TLB for trace mode
-    if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:
-        if bool(getattr(args, 'trace_timing_ptw', False)):
-            print("Trace mode: Using FS mode with timing MMU (timing-PTW enabled)")
-        else:
-            print("Trace mode: Using FS mode with functional TLB to bypass MMU translation issues")
-        print("Trace mode: Configuring expanded memory ranges for trace address mapping")
-        # Force functional TLB to bypass complex MMU translation
-        args.functional_tlb = True
-    else:
-        print("Checkpoint mode: Using standard FS mode with normal MMU translation")
-    test_sys.num_cpus = np
-
-    test_sys.xiangshan_system = True
-    # args.enable_difftest should be normalized by xiangshan_system_init().
-    test_sys.enable_difftest = args.enable_difftest
-
-    # Configure XiangShan inputs - skip checkpoint loading in trace mode
-    if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:
-        args.difftest_ref_so = None
-
-        # Trace mode FS configuration with functional TLB.
-        # We run without a bootloader but must still set the bootloader
-        # parameter explicitly, since RiscvBareMetal.bootloader has no
-        # default. An empty string is treated as "no bootloader" and we
-        # reuse the xiangshan_cpt flag to take the no-bootloader path in
-        # the BareMetal workload implementation.
-        test_sys.workload.bootloader = ''
-        test_sys.workload.xiangshan_cpt = True   # Reuse GCPT path to skip bootloader
-        test_sys.restore_from_gcpt = False       # Disable GCPT restoration
-        print("Trace mode: Running without bootloader (no GCPT)")
-
-        # Configure DRAMsim3 if needed for memory controller
-        if args.mem_type == 'DRAMsim3' and args.dramsim3_ini is None:
-            root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-            args.dramsim3_ini = os.path.join(root_dir,
-                                             'ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_2ch.ini')
-
-        if bool(getattr(args, 'trace_timing_ptw', False)):
-            print("Trace mode: Timing MMU will be applied for timing-PTW")
-        else:
-            print("Trace mode: FS mode with functional TLB configured to bypass MMU translation issues")
-    else:
-        # Standard checkpoint-based configuration
-        config_xiangshan_inputs(args, test_sys)
-
-     # Set the cache line size for the entire system
+    # Set the cache line size for the entire system
     test_sys.cache_line_size = args.cacheline_size
+    test_sys.enable_sv48 = args.open_sv48
 
     # Create a top-level voltage domain
     test_sys.voltage_domain = VoltageDomain(voltage = args.sys_voltage)
@@ -698,6 +798,50 @@ CREATE TABLE LoadLifeTimeCommitTrace(
     return test_sys
 
 
+def build_xiangshan_system(args):
+    np = args.num_cpus
+    assert buildEnv['TARGET_ISA'] == "riscv"
+
+    TestCPUClass = get_xiangshan_cpu_class(args)
+    ruby = bool(hasattr(args, 'ruby') and args.ruby)
+
+    test_sys = makeBareMetalXiangshanSystem('timing', SysConfig(mem=args.mem_size), None, np=np, ruby=ruby)
+
+    if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:
+        if bool(getattr(args, 'trace_timing_ptw', False)):
+            print("Trace mode: Using FS mode with timing MMU (timing-PTW enabled)")
+        else:
+            print("Trace mode: Using FS mode with functional TLB to bypass MMU translation issues")
+        print("Trace mode: Configuring expanded memory ranges for trace address mapping")
+        args.functional_tlb = True
+    else:
+        print("Checkpoint mode: Using standard FS mode with normal MMU translation")
+    test_sys.num_cpus = np
+    test_sys.xiangshan_system = True
+    test_sys.enable_difftest = args.enable_difftest
+
+    if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:
+        args.difftest_ref_so = None
+        test_sys.workload.bootloader = ''
+        test_sys.workload.xiangshan_cpt = True
+        test_sys.restore_from_gcpt = False
+        print("Trace mode: Running without bootloader (no GCPT)")
+
+        if args.mem_type == 'DRAMsim3' and args.dramsim3_ini is None:
+            root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            args.dramsim3_ini = os.path.join(root_dir,
+                                             'ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_2ch.ini')
+
+        if bool(getattr(args, 'trace_timing_ptw', False)):
+            print("Trace mode: Timing MMU will be applied for timing-PTW")
+        else:
+            print("Trace mode: FS mode with functional TLB configured to bypass MMU translation issues")
+    else:
+        config_xiangshan_inputs(args, test_sys)
+
+    return _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby)
+
+
 def xiangshan_system_init():
     _warn_if_deprecated_xiangshan_entrypoint()
     # Add args
@@ -717,7 +861,8 @@ def xiangshan_system_init():
     args.xiangshan_system = True
     # Only enable difftest if not in trace mode - trace mode doesn't need reference model verification
     if not (hasattr(args, 'enable_trace_mode') and args.enable_trace_mode):
-        args.enable_difftest = True
+        if args.enable_difftest is None:
+            args.enable_difftest = True
     else:
         args.enable_difftest = False
         print("Trace mode: Difftest disabled for trace execution")

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 import m5
@@ -187,6 +188,8 @@ if __name__ == '__m5_main__':
     TestMemClass = Simulation.setMemClass(args)
 
     test_sys = build_xiangshan_system(args)
+    if args.raw_cpt and args.generic_rv_cpt and os.path.basename(args.generic_rv_cpt) == "linux.bin":
+        configure_xiangshan_linux_workload(test_sys, args)
     # Set ideal parameters here with the highest priority, over command-line arguments
     setKmhV3Params(args, test_sys)
 

--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -43,6 +43,9 @@ class RiscvBareMetal(Workload):
     xiangshan_cpt = Param.Bool(False, "Using Xiangshan checkpoint")
     raw_bootloader = Param.Bool(
         False, "kernel or bbl provided is binary not elf")
+    dtb_filename = Param.String("",
+        "File that contains the Device Tree Blob. Don't use DTB if empty.")
+    dtb_addr = Param.Addr(0x87e00000, "DTB address")
 
 class RiscvLinux(KernelWorkload):
     type = 'RiscvLinux'

--- a/src/arch/riscv/bare_metal/fs_workload.cc
+++ b/src/arch/riscv/bare_metal/fs_workload.cc
@@ -30,6 +30,7 @@
 #include "arch/riscv/bare_metal/fs_workload.hh"
 
 #include "arch/riscv/faults.hh"
+#include "base/loader/dtb_file.hh"
 #include "base/loader/object_file.hh"
 #include "debug/MemoryAccess.hh"
 #include "sim/system.hh"
@@ -88,8 +89,21 @@ BareMetal::initState()
         }
     }
 
+    if (params().dtb_filename != "") {
+        inform("Loading DTB file: %s at address %#x\n",
+               params().dtb_filename, params().dtb_addr);
+
+        auto *dtb_file = new loader::DtbFile(params().dtb_filename);
+        dtb_file->buildImage().offset(params().dtb_addr)
+            .write(system->physProxy);
+        delete dtb_file;
+    }
+
     for (auto *tc: system->threads) {
         RiscvISA::Reset().invoke(tc);
+        if (params().dtb_filename != "") {
+            tc->setReg(int_reg::A1, params().dtb_addr);
+        }
         tc->activate();
     }
 }

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -574,9 +574,10 @@ ISA::setMiscReg(int misc_reg, RegVal val)
         write_val = write_val | write_val2;
         setMiscRegNoEffect(MISCREG_VSSTATUS, write_val);
     } else if ((v == 1) && ((misc_reg == MISCREG_SATP))) {
-        if ((val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_BARE ||
-            (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_SV39 ||
-            (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_SV48) {
+        auto satp_mode = (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET;
+        if (satp_mode == NEMU_SATP_BARE ||
+            satp_mode == NEMU_SATP_SV39 ||
+            (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
             setMiscRegNoEffect(MISCREG_VSATP, val & NEMU_SATP_MASK);
         }
     } else if ((v == 1) && (misc_reg == MISCREG_SEPC)) {
@@ -709,9 +710,10 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 if (cur_val != new_val) {
                     tc->getCpuPtr()->flushTLBs();
                 }
-                if ((val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_BARE ||
-                    (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_SV39 ||
-                    (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET == NEMU_SATP_SV48) {
+                auto satp_mode = (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET;
+                if (satp_mode == NEMU_SATP_BARE ||
+                    satp_mode == NEMU_SATP_SV39 ||
+                    (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
                     RegVal writeVal = val & NEMU_SATP_MASK;
                     setMiscRegNoEffect(misc_reg, writeVal);
                 }

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -579,6 +579,9 @@ ISA::setMiscReg(int misc_reg, RegVal val)
             satp_mode == NEMU_SATP_SV39 ||
             (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
             setMiscRegNoEffect(MISCREG_VSATP, val & NEMU_SATP_MASK);
+        } else if (satp_mode == NEMU_SATP_SV48) {
+            warn("Ignoring VSATP Sv48 write %#lx because Sv48 is disabled; "
+                 "enable it with --open-sv48.\n", val);
         }
     } else if ((v == 1) && (misc_reg == MISCREG_SEPC)) {
         setMiscRegNoEffect(MISCREG_VSEPC, val);
@@ -716,6 +719,9 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                     (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
                     RegVal writeVal = val & NEMU_SATP_MASK;
                     setMiscRegNoEffect(misc_reg, writeVal);
+                } else if (satp_mode == NEMU_SATP_SV48) {
+                    warn("Ignoring SATP Sv48 write %#lx because Sv48 is disabled; "
+                         "enable it with --open-sv48.\n", val);
                 }
 
             }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2216,7 +2216,8 @@ decode QUADRANT {
                                         machInst);
                         }
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
-                    }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+                    }}, IsNonSpeculative, IsSerializeBefore, IsSerializeAfter,
+                        IsReadBarrier, IsWriteBarrier, No_OpClass);
                     0x18: mret({{
                         if (xc->readMiscReg(MISCREG_PRV) != PRV_M) {
                             return std::make_shared<IllegalInstFault>(

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2179,6 +2179,9 @@ decode QUADRANT {
                                     xc->setMiscReg(MISCREG_PRV, status.spp);
                                     status.sie = status.spie;
                                     status.spie = 1;
+                                    if (status.spp != PRV_M) {
+                                        status.mprv = 0;
+                                    }
                                     status.spp = PRV_U;
                                     xc->setMiscReg(MISCREG_STATUS, status);
                                     NPC = xc->readMiscReg(MISCREG_SEPC);
@@ -2209,8 +2212,15 @@ decode QUADRANT {
                     }
                     0x9: sfence_vma({{
                         STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                        HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+                        int v = xc->readMiscReg(MISCREG_VIRMODE);
                         auto pm = (PrivilegeMode)xc->readMiscReg(MISCREG_PRV);
-                        if (pm == PRV_U || (pm == PRV_S && status.tvm == 1)) {
+                        if (v &&
+                            (pm == PRV_U || (pm == PRV_S && hstatus.vtvm == 1))) {
+                            return std::make_shared<HVFault>();
+                        }
+                        if (!v &&
+                            (pm == PRV_U || (pm == PRV_S && status.tvm == 1))) {
                             return std::make_shared<IllegalInstFault>(
                                         "sfence in user mode or TVM enabled",
                                         machInst);
@@ -2229,6 +2239,9 @@ decode QUADRANT {
                             xc->setMiscReg(MISCREG_NMIE, 1);
                             status.mie = status.mpie;
                             status.mpie = 1;
+                            if (status.mpp != PRV_M) {
+                                status.mprv = 0;
+                            }
                             status.mpp = PRV_U;
                             auto status_mpv = status.mpv;
 

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -395,7 +395,12 @@ def template CSRExecute {{
           }
           case CSR_SATP: {
             STATUS status = xc->readMiscReg(MISCREG_STATUS);
-            if (pm == PRV_S && status.tvm == 1) {
+            HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+            int v = xc->readMiscReg(MISCREG_VIRMODE);
+            if (v && pm == PRV_S && hstatus.vtvm == 1) {
+                return std::make_shared<HVFault>();
+            }
+            if (!v && pm == PRV_S && status.tvm == 1) {
                 return std::make_shared<IllegalInstFault>(
                         "SATP access with TVM enabled\n",
                         machInst);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1582,8 +1582,12 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 "at the head of the ROB, PC %s.\n",
                 tid, head_inst->seqNum, head_inst->pcState());
 
-        // amo, mmio, mret
-        if ((head_inst->isMemRef() || head_inst->isReturn()) && (inst_num > 0 || !iewStage->flushAllStores(tid))) {
+        // Memory-ordering instructions such as sfence.vma must not execute
+        // until older stores are visible; otherwise page-table updates may
+        // race with the TLB invalidation.
+        if ((head_inst->isMemRef() || head_inst->isReturn() ||
+             head_inst->isReadBarrier() || head_inst->isWriteBarrier()) &&
+            (inst_num > 0 || !iewStage->flushAllStores(tid))) {
             DPRINTF(Commit,
                     "[tid:%i] [sn:%llu] "
                     "Waiting for all stores to writeback.\n",


### PR DESCRIPTION
Restore the raw linux.bin bringup path used by kmhv3.py.

Inject a Xiangshan DTB for raw checkpoints, pass its address through A1, and make sfence.vma wait for older stores before committing so Linux can finish early page-table setup and boot to userspace again.

Change-Id: Ie0c5105ff20df242bb37b29ae0fcae75332ce087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux workload support for Xiangshan with automatic DTB generation and new DTB configuration inputs (filename & address)
  * New CLI flow to resolve Linux kernel command line and DTB handling

* **Refactor**
  * Separated platform construction from workload assignment for Xiangshan
  * Consolidated Xiangshan CLI options and made difftest enable/disable explicit
  * Modularized system build/finalization and CPU-class selection

* **Behavior Changes**
  * Stronger fence/barrier and commit ordering semantics affecting sfence and memory-ordering instructions

* **Chores**
  * Added CI job to run a raw Linux boot smoke test
<!-- end of auto-generated comment: release notes by coderabbit.ai -->