### PR TITLE
cpu-o3: multi thread shared storebuffer

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1601,7 +1601,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         // race with the TLB invalidation.
         if ((head_inst->isMemRef() || head_inst->isReturn() ||
              head_inst->isReadBarrier() || head_inst->isWriteBarrier()) &&
-            (inst_num > 0 || !iewStage->flushAllStores(tid))) {
+            (inst_num > 0 || !iewStage->flushStores(tid))) {
             DPRINTF(Commit,
                     "[tid:%i] [sn:%llu] "
                     "Waiting for all stores to writeback.\n",
@@ -1655,7 +1655,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
 
     if (inst_fault != NoFault) {
         traceLogInstFault(head_inst, inst_fault);
-        if (!iewStage->flushAllStores(tid) || inst_num > 0) {
+        if (!iewStage->flushStores(tid) || inst_num > 0) {
             DPRINTF(Commit,
                     "[tid:%i] [sn:%llu] "
                     "Stores outstanding, fault must wait.\n",

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1758,7 +1758,7 @@ IEW::tick()
     }
 
     // update the LSQ and scheduler before we check for ready instructions to execute
-    ldstQueue.writebackStoreBuffer();
+    ldstQueue.processWriteback();
     if (exeStatus != Squashing) {
         instQueue.scheduleReadyInsts();
 

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -259,7 +259,7 @@ class IEW
      * back to the cache. returns true if there is no data in either
      * the store queue or the store buffer to write back to.
      */
-    bool flushAllStores(ThreadID tid) { return ldstQueue.flushAllStores(tid); }
+    bool flushStores(ThreadID tid) { return ldstQueue.flushStores(tid); }
 
     /** Check if we need to squash after a load/store/branch is executed. */
     void SquashCheckAfterExe(DynInstPtr inst);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -46,6 +46,7 @@
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <list>
 #include <string>
 
@@ -88,12 +89,211 @@ LSQ::DcachePort::DcachePort(LSQ *_lsq, CPU *_cpu) :
 
 std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;
 
+void
+LSQ::StoreBufferEntry::reset(ThreadID tid, uint64_t block_vaddr, uint64_t block_paddr,
+                             uint64_t offset, uint8_t *datas, uint64_t size,
+                             const std::vector<bool> &mask)
+{
+    std::fill(validMask.begin(), validMask.begin() + offset, false);
+
+    for (int i = 0; i < size; i++) {
+        validMask[offset + i] = mask[i];
+    }
+
+    std::fill(validMask.begin() + offset + size, validMask.end(), false);
+    memcpy(blockDatas.data() + offset, datas, size);
+
+    this->tid = tid;
+    this->blockVaddr = block_vaddr;
+    this->blockPaddr = block_paddr;
+    this->sending = false;
+    this->request = nullptr;
+    this->vice = nullptr;
+}
+
+void
+LSQ::StoreBufferEntry::merge(uint64_t offset, uint8_t *datas, uint64_t size,
+                             const std::vector<bool> &mask)
+{
+    assert(offset + size <= validMask.size());
+    for (uint64_t i = 0; i < size; ++i) {
+        if (mask[i]) {
+            blockDatas[offset + i] = datas[i];
+            validMask[offset + i] = true;
+        }
+    }
+}
+
+bool
+LSQ::StoreBufferEntry::recordForward(RequestPtr req, LSQRequest *lsqreq)
+{
+    int offset = req->getPaddr() & (validMask.size() - 1);
+    // the offset in the split request
+    int goffset = req->getVaddr() - lsqreq->mainReq()->getVaddr();
+    if (goffset > 0) {
+        assert(offset == 0);
+    }
+    bool full_forward = true;
+    for (int i = 0; i < req->getSize(); i++) {
+        assert(goffset + i < lsqreq->_size);
+        if (vice && vice->validMask[offset + i]) {
+            // vice is newer
+            assert(vice->blockVaddr == blockVaddr);
+            lsqreq->SBforwardPackets.push_back(
+                LSQRequest::FWDPacket{
+                    .idx = goffset + i, .byte = vice->blockDatas[offset + i]});
+        } else if (validMask[offset + i]) {
+            lsqreq->SBforwardPackets.push_back(
+                LSQRequest::FWDPacket{
+                    .idx = goffset + i, .byte = blockDatas[offset + i]});
+        } else {
+            full_forward = false;
+        }
+    }
+
+    return full_forward;
+}
+
+void
+LSQ::StoreBuffer::setData(std::vector<StoreBufferEntry *> &data_vec)
+{
+    this->data_vec = data_vec;
+    int way = data_vec.size();
+    _size = 0;
+    lru_index.set_capacity(way);
+    free_list.set_capacity(way);
+    crossRef.resize(way);
+    this->data_vec.resize(way);
+    data_vld.resize(way, false);
+    for (uint64_t i = 0; i < way; i++) {
+        free_list.push_back(i);
+    }
+}
+
+bool
+LSQ::StoreBuffer::full() const
+{
+    return free_list.size() == 0;
+}
+
+uint64_t
+LSQ::StoreBuffer::size() const
+{
+    return _size;
+}
+
+uint64_t
+LSQ::StoreBuffer::unsentSize() const
+{
+    return lru_index.size();
+}
+
+LSQ::StoreBufferEntry *
+LSQ::StoreBuffer::getEmpty()
+{
+    assert(!full());
+    uint64_t index = free_list.back();
+    free_list.pop_back();
+    return data_vec[index];
+}
+
+void
+LSQ::StoreBuffer::insert(StoreBufferEntry *entry)
+{
+    int index = entry->index;
+    ThreadID tid = entry->tid;
+    Addr addr = entry->blockPaddr;
+    assert(_size < data_vec.size());
+    assert(!data_vld[index]);
+    assert(!lru_index.full());
+    _size++;
+    auto [it, _] = data_map.insert({hashKey(tid, addr), data_vec[index]});
+    crossRef[index] = it;
+    data_vld[index] = true;
+    lru_index.push_front(index);
+}
+
+LSQ::StoreBufferEntry *
+LSQ::StoreBuffer::get(ThreadID tid, uint64_t addr) const
+{
+    auto iter = data_map.find(hashKey(tid, addr));
+    if (iter == data_map.end() || iter->second->tid != tid) {
+        return nullptr;
+    }
+    assert(data_vld[iter->second->index]);
+    return iter->second;
+}
+
+void
+LSQ::StoreBuffer::update(int index)
+{
+    assert(std::find(lru_index.begin(), lru_index.end(), index) !=
+           lru_index.end());
+    lru_index.erase(std::find(lru_index.begin(), lru_index.end(), index));
+    lru_index.push_front(index);
+}
+
+LSQ::StoreBufferEntry *
+LSQ::StoreBuffer::getEvict()
+{
+    assert(lru_index.size() > 0);
+    uint64_t index = lru_index.back();
+    lru_index.pop_back();
+    assert(data_vld[index]);
+    return data_vec[index];
+}
+
+LSQ::StoreBufferEntry *
+LSQ::StoreBuffer::createVice(StoreBufferEntry *entry)
+{
+    _size++;
+    auto vice = getEmpty();
+    assert(!entry->vice);
+    entry->vice = vice;
+    data_vld[vice->index] = true;
+    // do not insert map and lru_index
+    return vice;
+}
+
+void
+LSQ::StoreBuffer::release(StoreBufferEntry *entry)
+{
+    assert(_size > 0);
+    _size--;
+    int index = entry->index;
+    data_vld[index] = false;
+    data_map.erase(crossRef[index]);
+    assert(std::find(free_list.begin(), free_list.end(), index) ==
+           free_list.end());
+    free_list.push_back(index);
+    if (entry->vice) {
+        // make vice regular
+        auto vice = entry->vice;
+        assert(data_vld[vice->index]);
+        auto [it, _] = data_map.insert({hashKey(vice->tid, vice->blockPaddr), vice});
+        crossRef[vice->index] = it;
+        lru_index.push_front(vice->index);
+    }
+}
+
+LSQ::LSQStats::LSQStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(sbufferEvictDuetoFlush, statistics::units::Count::get(), ""),
+      ADD_STAT(sbufferEvictDuetoFull, statistics::units::Count::get(), ""),
+      ADD_STAT(sbufferEvictDuetoSQFull, statistics::units::Count::get(), ""),
+      ADD_STAT(sbufferEvictDuetoTimeout, statistics::units::Count::get(), "")
+{
+}
+
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     : cpu(cpu_ptr), iewStage(iew_ptr),
       recentlyloadAddr(8 * (params.DcacheSetDivNum ? params.DcacheSetDivNum : 1)),
       _cacheBlocked(false),
       cacheStorePorts(params.cacheStorePorts), usedStorePorts(0),
       cacheLoadPorts(params.cacheLoadPorts), usedLoadPorts(0),
+      sbufferEvictThreshold(params.SbufferEvictThreshold),
+      sbufferEntries(params.SbufferEntries),
+      storeBufferInactiveThreshold(params.storeBufferInactiveThreshold),
       enableBankConflictCheck(params.BankConflictCheck),
       sbufferBankWriteAccurately(params.sbufferBankWriteAccurately),
       dcacheSetBits(params.DcacheSetBits),
@@ -107,6 +307,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       waitingForStaleTranslation(false),
       staleTranslationWaitTxnId(0),
       lsqPolicy(params.smtLSQPolicy),
+      stats(nullptr),
       LQEntries(params.LQEntries),
       SQEntries(params.SQEntries),
       maxLQEntries(maxLSQAllocation(lsqPolicy, LQEntries, params.numThreads,
@@ -131,6 +332,8 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     panic_if(dcacheSetDivNum > (1ULL << dcacheSetBits),
              "DcacheSetDivNum (%u) must be <= num_sets (2^%u)\n",
              dcacheSetDivNum, dcacheSetBits);
+
+    cpu->addStatGroup("lsq", &stats);
 
     //**********************************************
     //************ Handle SMT Parameters ***********
@@ -159,14 +362,19 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     thread.reserve(numThreads);
     // TODO: Parameterize the load/store pipeline stages
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        thread.emplace_back(maxLQEntries, maxSQEntries, params.SbufferEntries,
-            params.SbufferEvictThreshold, params.storeBufferInactiveThreshold,
+        thread.emplace_back(maxLQEntries, maxSQEntries,
             params.LdPipeStages, params.StPipeStages, params.RARQEntries, params.RAWQEntries,
             params.RARDequeuePerCycle, params.RAWDequeuePerCycle, params.LoadCompletionWidth,
             params.StoreCompletionWidth);
         thread[tid].init(cpu, iew_ptr, params, this, tid);
         thread[tid].setDcachePort(&dcachePort);
     }
+
+    std::vector<StoreBufferEntry *> store_buffer_entries;
+    for (uint32_t i = 0; i < sbufferEntries; ++i) {
+        store_buffer_entries.push_back(new StoreBufferEntry(cpu->cacheLineSize(), i));
+    }
+    storeBuffer.setData(store_buffer_entries);
 
     bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
     pendingDcacheRefill.resize(dcacheSetDivNum, false);
@@ -180,6 +388,25 @@ std::string
 LSQ::name() const
 {
     return iewStage->name() + ".lsq";
+}
+
+void
+LSQ::recordStoreBufferEviction(StoreBufferEvictCause cause)
+{
+    switch (cause) {
+      case StoreBufferEvictCause::Flush:
+        stats.sbufferEvictDuetoFlush++;
+        break;
+      case StoreBufferEvictCause::Full:
+        stats.sbufferEvictDuetoFull++;
+        break;
+      case StoreBufferEvictCause::SQFull:
+        stats.sbufferEvictDuetoSQFull++;
+        break;
+      case StoreBufferEvictCause::Timeout:
+        stats.sbufferEvictDuetoTimeout++;
+        break;
+    }
 }
 
 void
@@ -460,21 +687,235 @@ LSQ::commitStores(InstSeqNum &youngest_inst, ThreadID tid)
 }
 
 void
-LSQ::writebackStoreBuffer()
+LSQ::processWriteback()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
     // after load sendpackets
     // before sbuffer sendpackets
     clearAddresses();
 
+    bool storeblocked = false;
+    std::list<ThreadID>::iterator threads = activeThreads->begin();
+    std::list<ThreadID>::iterator end = activeThreads->end();
     while (threads != end) {
         ThreadID tid = *threads++;
-
-        thread[tid].storeBufferEvictToCache();
-        thread[tid].offloadToStoreBuffer();
+        storeblocked |= thread[tid].writebackBlockedStore(); // amo
     }
+
+    storeBufferWriteback();
+
+
+    if (storeBufferBlocked()) {
+        // dont offload store to sbuffer when sbuffer is flushing
+        DPRINTF(StoreBuffer, "Store buffer is blocking, skip SQ offload\n");
+        return;
+    }
+    std::vector<uint32_t> offload_quota(numThreads, 0);
+    std::vector<uint32_t> offload_demand(numThreads, 0);
+    std::vector<ThreadID> requester_tids;
+    requester_tids.reserve(activeThreads->size());
+    for (ThreadID tid : *activeThreads) {
+        offload_demand[tid] = thread[tid].countStoreBufferOffloadableEntries(
+            maxStoreBufferEntriesAcceptedFromSQPerCycle);
+        if (offload_demand[tid] != 0) {
+            requester_tids.push_back(tid);
+        }
+    }
+    if (!requester_tids.empty()) {
+        size_t start_idx = 0;
+        if (nextStoreBufferOffloadTid != InvalidThreadID) {
+            auto it = std::find(requester_tids.begin(), requester_tids.end(),
+                                nextStoreBufferOffloadTid);
+            if (it != requester_tids.end()) {
+                start_idx = std::distance(requester_tids.begin(), it);
+            }
+        }
+
+        uint32_t remaining_budget = maxStoreBufferEntriesAcceptedFromSQPerCycle;
+        size_t cursor = start_idx;
+        while (remaining_budget != 0) {
+            bool granted = false;
+            for (size_t scanned = 0; scanned < requester_tids.size();
+                ++scanned) {
+                const size_t idx = (cursor + scanned) % requester_tids.size();
+                const ThreadID tid = requester_tids[idx];
+                if (offload_quota[tid] >= offload_demand[tid]) {
+                    continue;
+                }
+
+                ++offload_quota[tid];
+                --remaining_budget;
+                cursor = (idx + 1) % requester_tids.size();
+                nextStoreBufferOffloadTid = requester_tids[cursor];
+                granted = true;
+                break;
+            }
+
+            if (!granted) {
+                break;
+            }
+        }
+    }
+    threads = activeThreads->begin();
+    while (threads != end) {
+        ThreadID tid = *threads++;
+        thread[tid].offloadToStoreBuffer(offload_quota[tid]);
+    }
+}
+
+void
+LSQ::storeBufferWriteback()
+{
+    bool can_evict = true;
+    if (storeBufferFlushing() && storeBuffer.size() == 0) [[unlikely]] {
+        assert(storeBuffer.unsentSize() == 0);
+        clearStoreBufferFlushing();
+        cpu->activityThisCycle();
+    }
+
+    // write request will stall one cycle
+    // so 2 cycle send one write request
+    if (getDcacheWriteStall()) {
+        setDcacheWriteStall(false);
+        can_evict = false;
+    }
+
+    if (can_evict && retryBlockedStoreBuffer()) {
+        can_evict = false;
+    }
+
+    if (can_evict && storeBuffer.unsentSize() != 0) {
+        bool any_sq_will_full = false;
+        for (ThreadID tid : *activeThreads) {
+            if (thread[tid].storeBufferSQWillFull()) {
+                any_sq_will_full = true;
+            }
+        }
+
+        std::optional<StoreBufferEvictCause> cause;
+        if (storeBufferFlushing()) {
+            cause = StoreBufferEvictCause::Flush;
+            DPRINTF(StoreBuffer, "sbuffer flushing\n");
+        } else if (storeBuffer.unsentSize() > getSbufferEvictThreshold()) {
+            cause = StoreBufferEvictCause::Full;
+            DPRINTF(StoreBuffer, "sbuffer has reached threshold\n");
+        } else if (any_sq_will_full) {
+            cause = StoreBufferEvictCause::SQFull;
+            DPRINTF(StoreBuffer, "sbuffer has reached SQ threshold\n");
+        } else if (getStoreBufferInactiveCycles() >
+                   getStoreBufferInactiveThreshold()) {
+            cause = StoreBufferEvictCause::Timeout;
+            DPRINTF(StoreBuffer, "sbuffer has reached timeout\n");
+        } else {
+            incStoreBufferInactiveCycles();
+        }
+
+        if (cause) {
+            StoreBufferEntry *entry = storeBuffer.getEvict();
+            auto &owner_unit = thread[entry->tid];
+            recordStoreBufferEviction(*cause);
+            DPRINTF(StoreBuffer, "Evicting sbuffer entry[%#x]\n",
+                    entry->blockPaddr);
+
+            if (debug::StoreBuffer) {
+                DPRINTFR(StoreBuffer, "Dumping sbuffer entry data\n");
+                for (int i = 0; i < owner_unit.cacheLineSize(); i++) {
+                    DPRINTFR(StoreBuffer, "%s%d ",
+                             entry->validMask[i] ? "" : "!",
+                             (uint32_t)entry->blockDatas[i]);
+                }
+                DPRINTFR(StoreBuffer, "\n");
+            }
+
+            assert(entry->request == nullptr);
+            entry->request = new SbufferRequest(cpu, &owner_unit,
+                                                entry->blockPaddr,
+                                                entry->blockDatas.data());
+            entry->request->addReq(entry->blockVaddr, entry->blockPaddr,
+                                   entry->validMask);
+            entry->request->buildPackets();
+            entry->request->sbuffer_entry = entry;
+            bool success = entry->request->sendPacketToCache();
+            if (!success) {
+                setBlockedStoreBufferEntry(entry);
+                DPRINTF(StoreBuffer, "send packet fail\n");
+            } else {
+                DPRINTF(StoreBuffer, "send packet successed\n");
+                entry->sending = true;
+                sbufferWriteBank(entry->blockVaddr, entry->validMask);
+                resetStoreBufferInactiveCycles();
+            }
+        }
+    }
+}
+
+bool
+LSQ::retryBlockedStoreBuffer()
+{
+    if (!blockedSbufferEntry) {
+        return false;
+    }
+
+    bool success = blockedSbufferEntry->request->sendPacketToCache();
+    if (!success) {
+        return true;
+    }
+
+    blockedSbufferEntry->sending = true;
+    sbufferWriteBank(blockedSbufferEntry->blockVaddr,
+                     blockedSbufferEntry->validMask);
+    resetStoreBufferInactiveCycles();
+    blockedSbufferEntry = nullptr;
+    return true;
+}
+
+bool
+LSQ::sbufferSendPacket(PacketPtr data_pkt)
+{
+    bool ret = true;
+    bool cache_got_blocked = false;
+
+
+    if (!cacheBlocked() && cachePortAvailable(false)) {
+        if (!dcachePort.sendTimingReq(data_pkt)) {
+            ret = false;
+            cache_got_blocked = true;
+        }
+    } else {
+        ret = false;
+    }
+
+    if (ret) {
+        cachePortBusy(false);
+    } else if (cache_got_blocked) {
+        cacheBlocked(true);
+
+        auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
+        assert(request);
+        request->_port.recordStoreBufferBlockedByCache();
+    }
+
+    return ret;
+}
+
+void
+LSQ::completeSbufferEvict(PacketPtr pkt)
+{
+    auto request = dynamic_cast<SbufferRequest *>(pkt->senderState);
+    if (cpu->goldenMemManager() &&
+        cpu->goldenMemManager()->inPmem(request->mainReq()->getPaddr())) {
+        Addr paddr = request->mainReq()->getPaddr();
+        DPRINTF(LSQ, "StoreBuffer writing to golden memory at addr %#x\n",
+                paddr);
+        cpu->goldenMemManager()->updateGoldenMem(
+            paddr, request->_data, request->mainReq()->getByteEnable(),
+            request->_size);
+    }
+
+    storeBuffer.release(request->sbuffer_entry);
+    DPRINTF(StoreBuffer,
+            "finish entry[%#x] evict to cache, sbuffer size: %d, "
+            "unsentsize: %d\n",
+            pkt->getAddr(), storeBuffer.size(), storeBuffer.unsentSize());
 }
 
 void
@@ -614,6 +1055,8 @@ LSQ::recvReqRetry()
 {
     iewStage->cacheUnblocked();
     cacheBlocked(false);
+
+    retryBlockedStoreBuffer();
 
     for (ThreadID tid : *activeThreads) {
         thread[tid].recvRetry();
@@ -1023,10 +1466,11 @@ LSQ::hasStoresToWB(ThreadID tid)
     return thread.at(tid).hasStoresToWB();
 }
 
-bool LSQ::flushAllStores(ThreadID tid)
+bool LSQ::flushStores(ThreadID tid)
 {
-    thread.at(tid).flushStoreBuffer();
-    bool t = thread.at(tid).hasStoresToWB() == 0 && thread.at(tid).storeBufferEmpty();
+    _storeBufferFlushing = true;
+    // TODO：high performance shared SMT storebuffer flushing
+    bool t = !hasStoresToWB(tid) && storeBufferEmpty();
     return t;
 }
 
@@ -1039,6 +1483,14 @@ LSQ::numStoresToSbuffer(ThreadID tid)
 bool
 LSQ::willWB()
 {
+    if (blockedSbufferEntry && !cacheBlocked()) {
+        return true;
+    }
+
+    if (storeBufferFlushing()) {
+        return true;
+    }
+
     std::list<ThreadID>::iterator threads = activeThreads->begin();
     std::list<ThreadID>::iterator end = activeThreads->end();
 
@@ -1444,8 +1896,9 @@ LSQ::SbufferRequest::SbufferRequest(CPU* cpu, LSQUnit* port, Addr blockpaddr, ui
     : LSQRequest(port, nullptr, false, 0, port->cacheLineSize(), 0, data,
                  nullptr, nullptr, false),
       cpu(cpu) {
+    lsq = port->getLsq();
     port->numSBufferRequest++;
-    assert(port->numSBufferRequest <= port->sbufferEntries);
+    assert(port->numSBufferRequest <= port->getLsq()->getSbufferEntries());
 }
 
 LSQ::SbufferRequest::~SbufferRequest() {
@@ -1649,7 +2102,7 @@ LSQ::SbufferRequest::recvTimingResp(PacketPtr pkt)
     assert(_numOutstandingPackets == 1);
     flags.set(Flag::Complete);
     assert(pkt == _packets.front());
-    _port.completeSbufferEvict(pkt);
+    lsq->completeSbufferEvict(pkt);
     discard();
     return true;
 }
@@ -1893,10 +2346,10 @@ bool
 LSQ::SbufferRequest::sendPacketToCache()
 {
     assert(_numOutstandingPackets == 0);
-    bool success = _port.sbufferSendPacket(_packets.at(0));
+    bool success = lsq->sbufferSendPacket(_packets.at(0));
     DPRINTF(StoreBuffer, "Sbuffer Req::sendPacketToCache: entry[%#x]\n", _packets[0]->getAddr());
     if (success) {
-        _packets[0]->setLSQPtr(lsqUnit()->getLsq());
+        _packets[0]->setLSQPtr(lsq);
         _numOutstandingPackets = 1;
     }
 

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -46,17 +46,20 @@
 #include <cstdint>
 #include <list>
 #include <map>
+#include <memory>
 #include <queue>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include <boost/circular_buffer.hpp>
 #include <boost/compute/detail/lru_cache.hpp>
 
 #include "arch/generic/mmu.hh"
 #include "arch/generic/tlb.hh"
 #include "base/flags.hh"
+#include "base/statistics.hh"
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
@@ -78,13 +81,22 @@ namespace o3
 class CPU;
 class IEW;
 class LSQUnit;
-class StoreBufferEntry;
 
 
 class LSQ
 {
   public:
     class LSQRequest;
+    class SbufferRequest;
+    class StoreBufferEntry;
+    class StoreBuffer;
+    enum class StoreBufferEvictCause
+    {
+        Flush,
+        Full,
+        SQFull,
+        Timeout
+    };
 
     /**
      * DcachePort class for the load/store queue.
@@ -127,6 +139,72 @@ class LSQ
          * @return true since we have to snoop
          */
         virtual bool isSnooping() const { return true; }
+    };
+
+    class StoreBufferEntry
+    {
+      public:
+        const int index;
+        ThreadID tid;
+        Addr blockVaddr;
+        Addr blockPaddr;
+        std::vector<uint8_t> blockDatas;
+        std::vector<bool> validMask;
+        bool sending;
+        // the another same addr entry when sending
+        // another cannot sending until self sending finished
+        StoreBufferEntry *vice = nullptr;
+        // merged request
+        SbufferRequest *request = nullptr;
+
+        StoreBufferEntry(int size, int index) : index(index)
+        {
+            blockDatas.resize(size, 0);
+            validMask.resize(size, false);
+        }
+
+        void reset(ThreadID tid, uint64_t block_vaddr, uint64_t block_paddr,
+                   uint64_t offset, uint8_t *datas, uint64_t size,
+                   const std::vector<bool> &mask);
+
+        void merge(uint64_t offset, uint8_t *datas, uint64_t size,
+                   const std::vector<bool> &mask);
+
+        bool recordForward(RequestPtr req, LSQRequest *lsqreq);
+    };
+
+    class StoreBuffer
+    {
+        using mapIter =
+            typename std::unordered_map<uint64_t, StoreBufferEntry *>::iterator;
+
+        // key = (paddr & cacheblockmask)
+        uint64_t _size = 0;
+        std::unordered_map<uint64_t, StoreBufferEntry *> data_map;
+        std::vector<mapIter> crossRef;
+        boost::circular_buffer<int> lru_index;
+        boost::circular_buffer<int> free_list;
+        std::vector<StoreBufferEntry *> data_vec;
+        std::vector<bool> data_vld;
+
+        uint64_t hashKey(ThreadID tid, Addr block_paddr) const
+        {
+            // block_paddr[5:0] is 0, so we can use it to store tid
+            return (block_paddr | tid);
+        }
+
+      public:
+        void setData(std::vector<StoreBufferEntry *> &data_vec);
+        bool full() const;
+        uint64_t size() const;
+        uint64_t unsentSize() const;
+        StoreBufferEntry *getEmpty();
+        void insert(StoreBufferEntry *entry);
+        StoreBufferEntry *get(ThreadID tid, uint64_t addr) const;
+        void update(int index);
+        StoreBufferEntry *getEvict();
+        StoreBufferEntry *createVice(StoreBufferEntry *entry);
+        void release(StoreBufferEntry *entry);
     };
 
     /** Memory operation metadata.
@@ -695,6 +773,7 @@ class LSQ
     class SbufferRequest : public LSQRequest
     {
         CPU* cpu;
+        LSQ* lsq;
       public:
         StoreBufferEntry* sbuffer_entry=nullptr;
         SbufferRequest(CPU* cpu, LSQUnit* port, Addr blockpaddr, uint8_t* data);
@@ -771,7 +850,9 @@ class LSQ
      * Attempts to write back stores until all cache ports are used or the
      * interface becomes blocked.
      */
-    void writebackStoreBuffer();
+    void processWriteback();
+
+    void storeBufferWriteback();
 
     /**
      * Squash instructions from a thread until the specified sequence number.
@@ -893,7 +974,7 @@ class LSQ
     bool hasStoresToWB(ThreadID tid);
 
     // true if all stores are flushed
-    bool flushAllStores(ThreadID tid);
+    bool flushStores(ThreadID tid);
 
     /** Returns the number of stores a specific thread has to write back. */
     int numStoresToSbuffer(ThreadID tid);
@@ -994,6 +1075,34 @@ class LSQ
 
     void setDcacheWriteStall(bool t) { dcacheWriteStall = t; }
     bool getDcacheWriteStall() { return dcacheWriteStall; }
+    StoreBuffer &getStoreBuffer() { return storeBuffer; }
+    bool storeBufferEmpty() const { return storeBuffer.size() == 0; }
+    bool storeBufferFlushing() const { return _storeBufferFlushing; }
+    void clearStoreBufferFlushing() { _storeBufferFlushing = false; }
+    uint32_t getSbufferEvictThreshold() const { return sbufferEvictThreshold; }
+    uint32_t getSbufferEntries() const { return sbufferEntries; }
+    uint64_t getStoreBufferInactiveCycles() const
+    {
+        return storeBufferWritebackInactive;
+    }
+    uint64_t getStoreBufferInactiveThreshold() const
+    {
+        return storeBufferInactiveThreshold;
+    }
+    void resetStoreBufferInactiveCycles() { storeBufferWritebackInactive = 0; }
+    void incStoreBufferInactiveCycles() { ++storeBufferWritebackInactive; }
+    bool storeBufferBlocked() const
+    {
+        return blockedSbufferEntry != nullptr;
+    }
+    void setBlockedStoreBufferEntry(StoreBufferEntry *entry)
+    {
+        blockedSbufferEntry = entry;
+    }
+    void clearBlockedStoreBufferEntry() { blockedSbufferEntry = nullptr; }
+    bool retryBlockedStoreBuffer();
+    bool sbufferSendPacket(PacketPtr data_pkt);
+    void completeSbufferEvict(PacketPtr pkt);
 
     unsigned getLQEntries() const { return LQEntries; }
 
@@ -1054,6 +1163,15 @@ class LSQ
 
     const int numBank = 8;
     bool dcacheWriteStall = false;
+    const uint32_t sbufferEvictThreshold;
+    const uint32_t sbufferEntries;
+    const uint64_t storeBufferInactiveThreshold;
+    const uint32_t maxStoreBufferEntriesAcceptedFromSQPerCycle = 2;
+    StoreBuffer storeBuffer;
+    bool _storeBufferFlushing = false;
+    uint64_t storeBufferWritebackInactive = 0;
+    StoreBufferEntry *blockedSbufferEntry = nullptr;
+    ThreadID nextStoreBufferOffloadTid = InvalidThreadID;
 
     bool enableBankConflictCheck;
     bool sbufferBankWriteAccurately;
@@ -1099,6 +1217,18 @@ class LSQ
         }
         return 0;
     }
+
+    struct LSQStats : public statistics::Group
+    {
+        LSQStats(statistics::Group *parent);
+
+        statistics::Scalar sbufferEvictDuetoFlush;
+        statistics::Scalar sbufferEvictDuetoFull;
+        statistics::Scalar sbufferEvictDuetoSQFull;
+        statistics::Scalar sbufferEvictDuetoTimeout;
+    } stats;
+
+    void recordStoreBufferEviction(StoreBufferEvictCause cause);
 
     /** List of Active Threads in System. */
     std::list<ThreadID> *activeThreads;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -39,8 +39,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "cpu/o3/lsq_unit.hh"
-
 #include <cassert>
 
 #include "arch/generic/debugfaults.hh"
@@ -165,183 +163,6 @@ LSQUnit::checkStoreLoadForwardingRange(typename StoreQueue::iterator store_it,
 
     // No overlap between store and load addresses
     return AddrRangeCoverage::NoAddrRangeCoverage;
-}
-
-void
-StoreBufferEntry::reset(uint64_t block_vaddr, uint64_t block_paddr, uint64_t offset, uint8_t *datas, uint64_t size,
-                        const std::vector<bool> &mask)
-{
-    std::fill(validMask.begin(), validMask.begin() + offset, false);
-
-    for (int i = 0; i < size; i++) {
-        validMask[offset + i] = mask[i];
-    }
-
-    std::fill(validMask.begin() + offset + size, validMask.end(), false);
-    memcpy(blockDatas.data() + offset, datas, size);
-
-    this->blockVaddr = block_vaddr;
-    this->blockPaddr = block_paddr;
-    this->sending = false;
-    this->request = nullptr;
-    this->vice = nullptr;
-}
-
-void
-StoreBufferEntry::merge(uint64_t offset, uint8_t *datas, uint64_t size, const std::vector<bool> &mask)
-{
-    assert(offset + size <= validMask.size());
-    for (uint64_t i = 0; i < size; ++i) {
-        if (mask[i]) {
-            blockDatas[offset + i] = datas[i];
-            validMask[offset + i] = true;
-        }
-    }
-}
-
-bool
-StoreBufferEntry::recordForward(RequestPtr req, LSQ::LSQRequest *lsqreq)
-{
-    int offset = req->getPaddr() & (validMask.size() - 1);
-    // the offset in the split request
-    int goffset = req->getVaddr() - lsqreq->mainReq()->getVaddr();
-    if (goffset > 0) {
-        assert(offset == 0);
-    }
-    bool full_forward = true;
-    for (int i = 0; i < req->getSize(); i++) {
-        assert(goffset + i < lsqreq->_size);
-        if (vice && vice->validMask[offset + i]) {
-            // vice is newer
-            assert(vice->blockVaddr == blockVaddr);
-            lsqreq->SBforwardPackets.push_back(
-                LSQ::LSQRequest::FWDPacket{.idx = goffset + i, .byte = vice->blockDatas[offset + i]});
-        } else if (validMask[offset + i]) {
-            lsqreq->SBforwardPackets.push_back(
-                LSQ::LSQRequest::FWDPacket{.idx = goffset + i, .byte = blockDatas[offset + i]});
-        } else {
-            full_forward = false;
-        }
-    }
-
-    return full_forward;
-}
-
-void
-StoreBuffer::setData(std::vector<StoreBufferEntry *> &data_vec)
-{
-    this->data_vec = data_vec;
-    int way = data_vec.size();
-    _size = 0;
-    lru_index.set_capacity(way);
-    free_list.set_capacity(way);
-    crossRef.resize(way);
-    data_vec.resize(way);
-    data_vld.resize(way, false);
-    for (uint64_t i = 0; i < way; i++) {
-        free_list.push_back(i);
-    }
-}
-
-bool
-StoreBuffer::full()
-{
-    return free_list.size() == 0;
-}
-
-uint64_t
-StoreBuffer::size()
-{
-    return this->_size;
-}
-
-uint64_t
-StoreBuffer::unsentSize()
-{
-    return lru_index.size();
-}
-
-StoreBufferEntry *
-StoreBuffer::getEmpty()
-{
-    assert(!full());
-    uint64_t index = free_list.back();
-    free_list.pop_back();
-    return data_vec[index];
-}
-
-void
-StoreBuffer::insert(int index, uint64_t addr)
-{
-    assert(_size < data_vec.size());
-    assert(!data_vld[index]);
-    assert(!lru_index.full());
-    _size++;
-    auto [it, _] = data_map.insert({addr, data_vec[index]});
-    crossRef[index] = it;
-    data_vld[index] = true;
-    lru_index.push_front(index);
-}
-
-StoreBufferEntry *
-StoreBuffer::get(uint64_t addr)
-{
-    auto iter = data_map.find(addr);
-    if (iter == data_map.end()) {
-        return nullptr;
-    }
-    assert(data_vld[iter->second->index]);
-    return iter->second;
-}
-
-void
-StoreBuffer::update(int index)
-{
-    assert(std::find(lru_index.begin(), lru_index.end(), index) != lru_index.end());
-    lru_index.erase(std::find(lru_index.begin(), lru_index.end(), index));
-    lru_index.push_front(index);
-}
-
-StoreBufferEntry *
-StoreBuffer::getEvict()
-{
-    assert(lru_index.size() > 0);
-    uint64_t index = lru_index.back();
-    lru_index.pop_back();
-    assert(data_vld[index]);
-    return data_vec[index];
-}
-
-StoreBufferEntry *
-StoreBuffer::createVice(StoreBufferEntry *entry)
-{
-    _size++;
-    auto vice = getEmpty();
-    assert(!entry->vice);
-    entry->vice = vice;
-    data_vld[vice->index] = true;
-    // do not insert map and lru_index
-    return vice;
-}
-
-void
-StoreBuffer::release(StoreBufferEntry *entry)
-{
-    assert(_size > 0);
-    _size--;
-    int index = entry->index;
-    data_vld[index] = false;
-    data_map.erase(crossRef[index]);
-    assert(std::find(free_list.begin(), free_list.end(), index) == free_list.end());
-    free_list.push_back(index);
-    if (entry->vice) {
-        // make vice regular
-        auto vice = entry->vice;
-        assert(data_vld[vice->index]);
-        auto [it, _] = data_map.insert({vice->blockPaddr, vice});
-        crossRef[vice->index] = it;
-        lru_index.push_front(vice->index);
-    }
 }
 
 void
@@ -570,17 +391,13 @@ LSQUnit::completeDataAccess(PacketPtr pkt)
     }
 }
 
-LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries, uint32_t sbufferEvictThreshold,
-    uint64_t storeBufferInactiveThreshold, uint32_t ldPipeStages, uint32_t stPipeStages,
+LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
+    uint32_t ldPipeStages, uint32_t stPipeStages,
     uint32_t maxRARQEntries, uint32_t maxRAWQEntries, unsigned rarDequeuePerCycle,
     unsigned rawDequeuePerCycle, unsigned loadCompletionWidth, unsigned storeCompletionWidth)
-    : sbufferEvictThreshold(sbufferEvictThreshold),
-      sbufferEntries(sbufferEntries),
-      numSBufferRequest(0),
+    : numSBufferRequest(0),
       numSingleRequest(0),
       numSplitRequest(0),
-      storeBufferWritebackInactive(0),
-      storeBufferInactiveThreshold(storeBufferInactiveThreshold),
       lsqID(-1),
       storeQueue(sqEntries),
       loadQueue(lqEntries),
@@ -597,7 +414,6 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
       cacheBlockMask(0),
       stalled(false),
       isStoreBlocked(false),
-      storeBlockedfromQue(false),
       storeInFlight(false),
       lastClockSQPopEntries(0),
       lastClockLQPopEntries(0),
@@ -611,7 +427,6 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
 {
     // reserve space, we want if sq will be full, sbuffer will start evicting
     sqFullUpperLimit = sqEntries - 4;
-    sqFullLowerLimit = sqFullUpperLimit - 4;
 
     loadPipeSx.resize(ldPipeStages);
     storePipeSx.resize(stPipeStages);
@@ -623,7 +438,6 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries
         storePipeSx[i] = storePipe.getWire(-i);
     }
     assert(ldPipeStages >= 4 && stPipeStages >= 5);
-    assert(sqFullLowerLimit > 0);
 }
 
 void
@@ -661,11 +475,6 @@ LSQUnit::init(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params,
     RAWReplayQueue.clear();
 
     enableStorePrefetchTrain = params.store_prefetch_train;
-    std::vector<StoreBufferEntry*> sbufer;
-    for (int i = 0; i < sbufferEntries; i++) {
-        sbufer.push_back(new StoreBufferEntry(cpu->cacheLineSize(), i));
-    }
-    storeBuffer.setData(sbufer);
 
     resetState();
 }
@@ -766,10 +575,6 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
                "being blocked"),
       ADD_STAT(sbufferFull, statistics::units::Count::get(), "blocked cycle"),
       ADD_STAT(sbufferCreateVice, statistics::units::Count::get(), "create vice"),
-      ADD_STAT(sbufferEvictDuetoFlush, statistics::units::Count::get(), ""),
-      ADD_STAT(sbufferEvictDuetoFull, statistics::units::Count::get(), ""),
-      ADD_STAT(sbufferEvictDuetoSQFull, statistics::units::Count::get(), ""),
-      ADD_STAT(sbufferEvictDuetoTimeout, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferFullForward, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferPartiForward, statistics::units::Count::get(), ""),
       ADD_STAT(loadToUse, "Distribution of cycle latency between the "
@@ -1960,25 +1765,18 @@ LSQUnit::commitStores(InstSeqNum &youngest_inst)
     }
 }
 
-void
+bool
 LSQUnit::writebackBlockedStore()
 {
-    assert(isStoreBlocked);
-
-    if (storeBlockedfromQue) {
-        storeWBIt->request()->sendPacketToCache();
-        if (storeWBIt->request()->isSent()) {
-            storePostSend();
-        }
-    } else {
-        assert(blockedsbufferEntry);
-        bool success = blockedsbufferEntry->request->sendPacketToCache();
-        if (!success) {
-            return;
-        }
-        blockedsbufferEntry->sending = true;
-        blockedsbufferEntry = nullptr;
+    if (!isStoreBlocked) {
+        return false;
     }
+
+    storeWBIt->request()->sendPacketToCache();
+    if (storeWBIt->request()->isSent()) {
+        storePostSend();
+    }
+    return isStoreBlocked;
 }
 
 bool
@@ -2060,24 +1858,47 @@ LSQUnit::directStoreToCache()
     return true;
 }
 
-void
-LSQUnit::offloadToStoreBuffer()
+uint32_t
+LSQUnit::countStoreBufferOffloadableEntries(uint32_t max_entries) const
 {
-    if (isStoreBlocked) {
-        writebackBlockedStore();
-        if (isStoreBlocked) return;
-    }
-    if (storeBufferFlushing) {
-        return;
+    if (max_entries == 0 || isStoreBlocked) {
+        return 0;
     }
 
-    // write the committed store to storebuffer
-    int offloaded = 0;
+    uint32_t count = 0;
+    int stores_to_wb = storesToWB;
+    auto store_wb_it = storeWBIt;
+
+    while (count < max_entries &&
+           stores_to_wb > 0 &&
+           store_wb_it.dereferenceable() &&
+           store_wb_it->valid() &&
+           store_wb_it->canWB()) {
+
+        if (store_wb_it->size() == 0 ||
+            store_wb_it->instruction()->isDataPrefetch()) {
+            ++store_wb_it;
+            continue;
+        }
+
+        ++count;
+        ++store_wb_it;
+    }
+
+    return count;
+}
+
+void
+LSQUnit::offloadToStoreBuffer(uint32_t max_entries)
+{
+    assert(!lsq->storeBufferBlocked());
+    if (isStoreBlocked) return;
+
+    uint32_t accepted_entries = 0;
     while (storesToWB > 0 &&
            storeWBIt.dereferenceable() &&
            storeWBIt->valid() &&
-           storeWBIt->canWB() &&
-           offloaded < maxSQoffload) {
+           storeWBIt->canWB()) {
 
         if (storeWBIt->size() == 0) {
             completeStore(storeWBIt);
@@ -2087,6 +1908,10 @@ LSQUnit::offloadToStoreBuffer()
         if (storeWBIt->instruction()->isDataPrefetch()) {
             storeWBIt++;
             continue;
+        }
+
+        if (accepted_entries >= max_entries) {
+            break;
         }
 
         assert(!storeWBIt->committed());
@@ -2105,14 +1930,13 @@ LSQUnit::offloadToStoreBuffer()
             }
             if (!storeBufferEmpty()) {
                 DPRINTF(StoreBuffer, "sbuffer need flush\n");
-                flushStoreBuffer();
+                lsq->flushStores(lsqID);
                 break;
             } else {
                 DPRINTF(StoreBuffer, "sbuffer finishing flushed\n");
             }
             bool contin = directStoreToCache();
             if (isStoreBlocked) {
-                assert(storeBlockedfromQue);
                 break;
             }
             if (contin) {
@@ -2125,7 +1949,6 @@ LSQUnit::offloadToStoreBuffer()
 
         if (request->isSplit()) {
             Addr vbase = request->_addr;
-            bool all_send = true;
             for (int i = request->_numOutstandingPackets; i < request->_reqs.size(); i++) {
                 auto req = request->_reqs[i];
                 Addr vaddr = req->getVaddr();
@@ -2142,13 +1965,13 @@ LSQUnit::offloadToStoreBuffer()
                 }
             }
             if (request->_numOutstandingPackets == request->_reqs.size()) {
+                ++accepted_entries;
                 request->_numOutstandingPackets = 0;
                 completeStore(storeWBIt, true);
                 storeWBIt++;
             } else {
                 break;
             }
-            offloaded++;
         } else {
             assert(inst->isSplitStoreAddr() ? storeWBIt->splitStoreFinish() : true);
             Addr vaddr = request->getVaddr();
@@ -2159,23 +1982,24 @@ LSQUnit::offloadToStoreBuffer()
             if (!success) {
                 break;
             }
+            ++accepted_entries;
             // finish once store
             completeStore(storeWBIt, true);
             storeWBIt++;
-            offloaded++;
         }
     }
 }
 
 bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t size, const std::vector<bool>& mask)
 {
+    auto &storeBuffer = lsq->getStoreBuffer();
     // access range must in a cache block
     assert((vaddr & cacheBlockMask) == ((vaddr + size - 1) & cacheBlockMask));
     Addr blockVaddr = vaddr & cacheBlockMask;
     Addr blockPaddr = paddr & cacheBlockMask;
     Addr offset = paddr & ~cacheBlockMask;
     // check request is not already in the storebuffer
-    auto entry = storeBuffer.get(blockPaddr);
+    auto entry = storeBuffer.get(lsqID, blockPaddr);
     if (entry) {
         if (entry->sending) {
             if (entry->vice) {
@@ -2193,7 +2017,7 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
                 }
                 stats.sbufferCreateVice++;
                 auto vice = storeBuffer.createVice(entry);
-                vice->reset(blockVaddr, blockPaddr, offset, datas, size, mask);
+                vice->reset(lsqID, blockVaddr, blockPaddr, offset, datas, size, mask);
                 DPRINTF(StoreBuffer, "Create new vice entry[%#x] for addr %#x\n",
                         blockPaddr, paddr);
             }
@@ -2213,8 +2037,8 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
         }
         // insert
         auto entry = storeBuffer.getEmpty();
-        entry->reset(blockVaddr, blockPaddr, offset, datas, size, mask);
-        storeBuffer.insert(entry->index, blockPaddr);
+        entry->reset(lsqID, blockVaddr, blockPaddr, offset, datas, size, mask);
+        storeBuffer.insert(entry);
         DPRINTF(StoreBuffer, "Create new entry[%#x] for addr %#x\n",
                 blockPaddr, paddr);
     }
@@ -2223,93 +2047,6 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
         "insert %#x to entry[%#x] successed, sbuffer size: %d unsentsize: %d\n",
         paddr, blockPaddr, storeBuffer.size(), storeBuffer.unsentSize());
     return true;
-}
-
-void
-LSQUnit::storeBufferEvictToCache()
-{
-    if (storeBufferFlushing && storeBuffer.size() == 0) [[unlikely]] {
-        assert(storeBuffer.unsentSize() == 0);
-        storeBufferFlushing = false;
-        cpu->activityThisCycle();
-    }
-
-    // write request will stall one cycle
-    // so 2 cycle send one write request
-    if (lsq->getDcacheWriteStall()) {
-        lsq->setDcacheWriteStall(false);
-        return;
-    }
-
-    if (isStoreBlocked || storeBuffer.unsentSize() == 0) {
-        return;
-    }
-
-    if (storeQueue.size() > sqFullUpperLimit) {
-        sqWillFull = true;
-    } else if (storeQueue.size() < sqFullLowerLimit) {
-        sqWillFull = false;
-    }
-
-    if ((storeBuffer.unsentSize() > sbufferEvictThreshold) ||
-        (storeBufferWritebackInactive > storeBufferInactiveThreshold) ||
-        (sqWillFull) ||
-        storeBufferFlushing) {
-
-        if (storeBufferFlushing) {
-            stats.sbufferEvictDuetoFlush++;
-            DPRINTF(StoreBuffer, "sbuffer flushing\n");
-        } else if (storeBuffer.unsentSize() > sbufferEvictThreshold) {
-            stats.sbufferEvictDuetoFull++;
-            DPRINTF(StoreBuffer, "sbuffer has reached threshold\n");
-        } else if (sqWillFull) {
-            stats.sbufferEvictDuetoSQFull++;
-            DPRINTF(StoreBuffer, "sbuffer has reached SQ threshold\n");
-        } else {
-            stats.sbufferEvictDuetoTimeout++;
-            DPRINTF(StoreBuffer, "sbuffer has reached timeout\n");
-        }
-
-        // evict entry to cache
-        auto entry = storeBuffer.getEvict();
-        DPRINTF(StoreBuffer, "Evicting sbuffer entry[%#x]\n",
-                entry->blockPaddr);
-
-        if (debug::StoreBuffer) {
-            DPRINTFR(StoreBuffer, "Dumping sbuffer entry data\n");
-            for (int i = 0; i < cacheLineSize(); i++) {
-                DPRINTFR(StoreBuffer, "%s%d ", entry->validMask[i] ? "" : "!", (uint32_t)entry->blockDatas[i]);
-            }
-            DPRINTFR(StoreBuffer, "\n");
-        }
-
-        // send packet to cache
-        assert(entry->request == nullptr);
-
-        entry->request = new LSQ::SbufferRequest(cpu, this, entry->blockPaddr, entry->blockDatas.data());
-        entry->request->addReq(entry->blockVaddr, entry->blockPaddr, entry->validMask);
-        entry->request->buildPackets();
-        entry->request->sbuffer_entry = entry;
-        bool success = entry->request->sendPacketToCache();
-        if (!success) {
-            blockedsbufferEntry = entry;
-            DPRINTF(StoreBuffer, "send packet fail\n");
-            return;
-        }
-        DPRINTF(StoreBuffer, "send packet successed\n");
-        entry->sending = true;
-        lsq->sbufferWriteBank(entry->blockVaddr, entry->validMask);
-        storeBufferWritebackInactive = 0;
-    } else {
-        // Timeout
-        storeBufferWritebackInactive++;
-    }
-}
-
-void
-LSQUnit::flushStoreBuffer()
-{
-    storeBufferFlushing = true;
 }
 
 void
@@ -2631,21 +2368,6 @@ LSQUnit::writebackReg(const DynInstPtr &inst, PacketPtr pkt)
 }
 
 void
-LSQUnit::completeSbufferEvict(PacketPtr pkt)
-{
-    auto request = dynamic_cast<LSQ::SbufferRequest *>(pkt->senderState);
-    if (cpu->goldenMemManager() && cpu->goldenMemManager()->inPmem(request->mainReq()->getPaddr())) {
-        Addr paddr = request->mainReq()->getPaddr();
-        DPRINTF(LSQUnit, "StoreBuffer writing to golden memory at addr %#x\n", paddr);
-        cpu->goldenMemManager()->updateGoldenMem(paddr, request->_data, request->mainReq()->getByteEnable(),
-                                                 request->_size);
-    }
-    storeBuffer.release(request->sbuffer_entry);
-    DPRINTF(StoreBuffer, "finish entry[%#x] evict to cache, sbuffer size: %d, unsentsize: %d\n", pkt->getAddr(),
-            storeBuffer.size(), storeBuffer.unsentSize());
-}
-
-void
 LSQUnit::completeStore(typename StoreQueue::iterator store_idx, bool from_sbuffer)
 {
     assert(store_idx->valid());
@@ -2772,7 +2494,6 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
             if (!isLoad) {
                 assert(request == storeWBIt->request());
                 isStoreBlocked = true;
-                storeBlockedfromQue = true;
             }
             bank_conflict = true;
             ret = false;
@@ -2801,7 +2522,8 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
         request->packetSent();
 
         if (isLoad) {
-            auto entry = storeBuffer.get(pkt->getAddr() & cacheBlockMask);
+            auto &storeBuffer = lsq->getStoreBuffer();
+            auto entry = storeBuffer.get(lsqID, pkt->getAddr() & cacheBlockMask);
             if (entry) {
                 DPRINTF(StoreBuffer, "sbuffer entry[%#x] coverage %s\n", entry->blockPaddr, pkt->print());
                 if (entry->recordForward(pkt->req, request)) {
@@ -2820,7 +2542,6 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
         if (!isLoad) {
             assert(request == storeWBIt->request());
             isStoreBlocked = true;
-            storeBlockedfromQue = true;
         }
         request->packetNotSent();
     }
@@ -2830,35 +2551,6 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
             " mshr_used: %d, mshr_alias_fail: %d, hit_in_write_buffer: %d)\n",
             data_pkt->print(), request->instruction()->seqNum, ret ? "" : "not ", lsq->cacheBlocked(),
             cache_got_blocked, bank_conflict, tag_read_fail, mshr_used, mshr_alias_fail, hit_in_write_buffer);
-    return ret;
-}
-
-bool
-LSQUnit::sbufferSendPacket(PacketPtr data_pkt)
-{
-    bool ret = true;
-    bool cache_got_blocked = false;
-
-    if (!lsq->cacheBlocked() && lsq->cachePortAvailable(false)) {
-        if (!dcachePort->sendTimingReq(data_pkt)) {
-            ret = false;
-            cache_got_blocked = true;
-        }
-    } else {
-        ret = false;
-    }
-
-    if (ret) {
-        isStoreBlocked = false;
-        lsq->cachePortBusy(false);
-    } else {
-        if (cache_got_blocked) {
-            lsq->cacheBlocked(true);
-            ++stats.blockedByCache;
-        }
-        isStoreBlocked = true;
-        storeBlockedfromQue = false;
-    }
     return ret;
 }
 
@@ -3440,7 +3132,8 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
     if (!load_inst->isDataPrefetch() && !request->isSplit()) {
         Addr blk_addr = request->mainReq()->getPaddr() & cacheBlockMask;
         int offset = request->mainReq()->getPaddr() & ~cacheBlockMask;
-        auto entry = storeBuffer.get(blk_addr);
+        auto &storeBuffer = lsq->getStoreBuffer();
+        auto entry = storeBuffer.get(lsqID, blk_addr);
         if (entry) {
             if (entry->recordForward(request->mainReq(), request)) {
                 // full forward

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -92,62 +92,6 @@ enum class SplitStoreStatus
 
 class IEW;
 
-class StoreBufferEntry
-{
-  public:
-    const int index;
-    Addr blockVaddr;
-    Addr blockPaddr;
-    std::vector<uint8_t> blockDatas;
-    std::vector<bool> validMask;
-    bool sending;
-    // the another same addr entry when sending
-    // another cannot sending until self sending finished
-    StoreBufferEntry* vice = nullptr;
-    // merged request
-    LSQ::SbufferRequest* request = nullptr;
-
-    StoreBufferEntry(int size, int index) : index(index) {
-        blockDatas.resize(size, 0);
-        validMask.resize(size, false);
-    }
-
-    void reset(uint64_t blockVaddr, uint64_t blockPaddr, uint64_t offset, uint8_t *datas, uint64_t size,
-               const std::vector<bool> &mask);
-
-    void merge(uint64_t offset, uint8_t *datas, uint64_t size, const std::vector<bool> &mask);
-
-    bool recordForward(RequestPtr req, LSQ::LSQRequest *lsqreq);
-};
-
-class StoreBuffer
-{
-    using mapIter = typename std::unordered_map<uint64_t, StoreBufferEntry*>::iterator;
-
-    // key = (paddr & cacheblockmask)
-    uint64_t _size;
-    std::unordered_map<uint64_t, StoreBufferEntry*> data_map;
-    std::vector<mapIter> crossRef;
-    boost::circular_buffer<int> lru_index;
-    boost::circular_buffer<int> free_list;
-    std::vector<StoreBufferEntry*> data_vec;
-    std::vector<bool> data_vld;
-
-public:
-
-    void setData(std::vector<StoreBufferEntry*>& data_vec);
-    bool full();
-    uint64_t size();
-    uint64_t unsentSize();
-    StoreBufferEntry* getEmpty();
-    void insert(int index, uint64_t addr);
-    StoreBufferEntry* get(uint64_t addr);
-    void update(int index);
-    StoreBufferEntry* getEvict();
-    StoreBufferEntry* createVice(StoreBufferEntry* entry);
-    void release(StoreBufferEntry* entry);
-};
-
 /**
  * Class that implements the actual LQ and SQ for each specific
  * thread.  Both are circular queues; load entries are freed upon
@@ -288,8 +232,7 @@ class LSQUnit
     using LQEntry = LSQEntry;
 
   public:
-    // storeQue -> storeBuffer -> cache
-    const int maxSQoffload = 2;
+    // storeQue -> shared storeBuffer -> cache
     const int sqFullBufferSize = 4;
 
     // loadpipe
@@ -300,22 +243,10 @@ class LSQUnit
     const int storeWhenToReplay = 2;
 
     int sqFullUpperLimit = 0;
-    int sqFullLowerLimit = 0;
-    bool storeBufferFlushing = false;
-    bool sqWillFull = false;
-    const uint32_t sbufferEvictThreshold = 0;
-    const uint32_t sbufferEntries = 0;
 
     uint64_t numSBufferRequest = 0;
     uint64_t numSingleRequest = 0;
     uint64_t numSplitRequest = 0;
-
-    StoreBuffer storeBuffer;
-    // Store Buffer Writeback Timeout
-    uint64_t storeBufferWritebackInactive;
-    uint64_t storeBufferInactiveThreshold;
-
-    StoreBufferEntry* blockedsbufferEntry = nullptr;
 
     /** Coverage of one address range with another */
     enum class AddrRangeCoverage
@@ -333,8 +264,7 @@ class LSQUnit
 
   public:
     /** Constructs an LSQ unit. init() must be called prior to use. */
-    LSQUnit(uint32_t lqEntries, uint32_t sqEntries, uint32_t sbufferEntries,
-      uint32_t sbufferEvictThreshold, uint64_t storeBufferInactiveThreshold,
+    LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
       uint32_t ldPipeStages, uint32_t stPipeStages, uint32_t maxRARQEntries, uint32_t maxRAWQEntries,
       unsigned rarDequeuePerCycle, unsigned rawDequeuePerCycle,
       unsigned loadCompletionWidth, unsigned storeCompletionWidth);
@@ -418,18 +348,19 @@ class LSQUnit
 
     bool directStoreToCache();
 
+    uint32_t countStoreBufferOffloadableEntries(uint32_t max_entries) const;
+
     /** Writes back stores. */
-    void offloadToStoreBuffer();
+    void offloadToStoreBuffer(uint32_t max_entries);
 
     bool insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t size, const std::vector<bool>& mask);
 
-    void storeBufferEvictToCache();
-
-    void flushStoreBuffer();
-
-    bool storeBufferEmpty() { return storeBuffer.size() == 0; }
-
-    void completeSbufferEvict(PacketPtr pkt);
+    bool storeBufferEmpty() { return lsq->storeBufferEmpty(); }
+    bool storeBufferSQWillFull() const
+    {
+        return storeQueue.size() > sqFullUpperLimit;
+    }
+    void recordStoreBufferBlockedByCache() { ++stats.blockedByCache; }
 
     /** Completes the data access that has been returned from the
      * memory system. */
@@ -524,7 +455,7 @@ class LSQUnit
                         storeWBIt->canWB() &&
                         !storeWBIt->completed() &&
                         !isStoreBlocked;
-        return t || storeBufferFlushing;
+        return t;
     }
 
     /** Handles doing the retry. */
@@ -540,9 +471,6 @@ class LSQUnit
     /** Writes back the instruction, sending it to IEW. */
     void writebackReg(const DynInstPtr &inst, PacketPtr pkt);
 
-    /** Try to finish a previously blocked write back attempt */
-    void writebackBlockedStore();
-
     /** Completes the store at the specified index. */
     void completeStore(typename StoreQueue::iterator store_idx, bool from_sbuffer = false);
 
@@ -550,6 +478,9 @@ class LSQUnit
     void storePostSend();
 
   public:
+    /** Try to finish a previously blocked write back attempt */
+    bool writebackBlockedStore();
+
     /** Attempts to send a packet to the cache.
      * Check if there are ports available. Return true if
      * there are, false if there are not.
@@ -560,8 +491,6 @@ class LSQUnit
 
     bool trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, bool &tag_read_fail,
                        bool &mshr_used, bool &mshr_alias_fail, bool &hit_in_write_buffer);
-
-    bool sbufferSendPacket(PacketPtr data_pkt);
 
     bool forwardFromStoreBuffer(const DynInstPtr &inst);
 
@@ -778,8 +707,6 @@ class LSQUnit
     /** Whehter or not a store is blocked due to the memory system. */
     bool isStoreBlocked;
 
-    bool storeBlockedfromQue;
-
     bool sbufferStall;
 
     /** Whether or not a store is in flight. */
@@ -877,10 +804,6 @@ class LSQUnit
 
         statistics::Scalar sbufferCreateVice;
 
-        statistics::Scalar sbufferEvictDuetoFlush;
-        statistics::Scalar sbufferEvictDuetoFull;
-        statistics::Scalar sbufferEvictDuetoSQFull;
-        statistics::Scalar sbufferEvictDuetoTimeout;
         statistics::Scalar sbufferFullForward;
         statistics::Scalar sbufferPartiForward;
 

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -427,11 +427,13 @@ ROB::isHeadGroupReady(ThreadID tid)
 
     if (!threadGroups[tid].empty() && threadGroups[tid].front() != 0) {
         auto it = instList[tid].begin();
-
         for (int i = 0; i < threadGroups[tid].front(); i++, it++) {
             auto& inst = *it;
             // first inst must be readyToCommit
             if (!inst->readyToCommit()) {
+                if (i > 0 && inst->isSerializeBefore()) {
+                    return true;
+                }
                 return false;
             }
 


### PR DESCRIPTION
Change-Id: Ic6b89d58d55f18268f17612fa09e02d9e27f0349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized store-buffer management with per-entry lifecycle, eviction reasons (flush, full, queue-full, timeout), capacity-aware eviction, coordinated per-cycle offload, retry, and eviction accounting.

* **Behavior**
  * Flush/writeback now routes through the centralized store-buffer flow.
  * Commit readiness relaxed to allow earlier commits for safe, non-first group instructions, reducing stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->