### PR TITLE
util: migrate spec06 benchmark_type to gcc12/gcc15

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,13 +39,13 @@
 
 **目标**: 在合入前，按需检查有性能风险的 PR
 
-**触发**: 在 PR 上添加 `perf` 标签（默认跑 spec06-0.8c），或手动触发 workflow 选择 benchmark
+**触发**: 在 PR 上添加 `perf` 标签（默认跑 gcc12-spec06-0.8c），或手动触发 workflow 选择 benchmark
 
 ### 支持的命令
 
 ```bash
-/run-spec                    # 默认：SPEC06 INT 80%覆盖率 (~500 checkpoints)
-/run-spec spec06-1.0c        # SPEC06 100%覆盖率
+/run-spec                              # 默认：gcc12 SPEC06 INT 80%覆盖率 (~500 checkpoints)
+/run-spec gcc12-spec06-1.0c            # gcc12 SPEC06 100%覆盖率
 /run-spec spec17-1.0c        # SPEC17 100%覆盖率
 /run-spec spec06-rvv-1.0c    # SPEC06 RVV扩展 100%
 /run-spec spec06int-rvv-0.8c # SPEC06 INT RVV 80%
@@ -57,7 +57,7 @@
 
 ### 当前实现
 
-- 添加 `perf` 标签会自动触发 spec06-0.8c，workflow 会记录标签创建时 PR 的 head SHA 确保结果对应正确的 commit
+- 添加 `perf` 标签会自动触发 gcc12-spec06-0.8c，workflow 会记录标签创建时 PR 的 head SHA 确保结果对应正确的 commit
 - 需要其他 benchmark 时，可通过 Actions -> On-Demand SPEC workflow 手动输入 PR 号和类型
 
 ### 性能结果
@@ -139,8 +139,8 @@ git push origin xs-dev
 # 只需要通过 Tier 1 快速检查即可
 
 # 场景2: 性能相关改动
-/run-spec                    # 标准性能测试
-/run-spec spec06-1.0c        # 完整覆盖率测试
+/run-spec                    # 标准性能测试（默认 gcc12-spec06-0.8c）
+/run-spec gcc12-spec06-1.0c  # 完整覆盖率测试
 
 # 或者把当前分支改名为*-perf, 这样每次push 会自动运行v3 的性能。
 ```

--- a/.github/workflows/gem5-ideal-btb-0.3c.yml
+++ b/.github/workflows/gem5-ideal-btb-0.3c.yml
@@ -12,4 +12,4 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/kmhv3.py
-      benchmark_type: "spec06-0.3c"
+      benchmark_type: "gcc12-spec06-0.3c"

--- a/.github/workflows/gem5-ideal-btb-perf-weekly.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-weekly.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/kmhv3.py
-      benchmark_type: "spec06-1.0c"
+      benchmark_type: "gcc15-spec06-1.0c"
 
   align_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
@@ -24,11 +24,10 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
-      benchmark_type: "spec06-1.0c"
+      benchmark_type: "gcc15-spec06-1.0c"
 
   perf_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
-      benchmark_type: "spec17-1.0c" 
-
+      benchmark_type: "spec17-1.0c"

--- a/.github/workflows/gem5-ideal-btb-perf.yml
+++ b/.github/workflows/gem5-ideal-btb-perf.yml
@@ -14,4 +14,4 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
-      benchmark_type: "spec06-0.8c"
+      benchmark_type: "gcc12-spec06-0.8c"

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -15,7 +15,7 @@ on:
       benchmark_type:
         required: true
         type: string
-        description: "Benchmark type: spec06-0.3c, spec06-0.8c, spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+        description: "Benchmark type: gcc12-spec06-0.3c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
       vector_type:
         required: false
         type: string
@@ -43,29 +43,53 @@ jobs:
         id: config
         run: |
           case "${{ inputs.benchmark_type }}" in
-              "spec06-0.3c")
+              "gcc12-spec06-0.3c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/spec06_0.3c_int.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-0.3c" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc12-spec06-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
               ;;
-            "spec06-0.8c")
+            "gcc12-spec06-0.8c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/spec_0.8c_int.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-0.8c" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc12-spec06-0.8c" >> $GITHUB_OUTPUT
               echo "comment=run 80% coverage spec06 checkpoints, 500+ checkpoints" >> $GITHUB_OUTPUT
               ;;
-            "spec06-1.0c")
+            "gcc12-spec06-1.0c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/checkpoint-0-0-0.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-1.0c" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc12-spec06-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage spec06 checkpoints" >> $GITHUB_OUTPUT
+              ;;
+            "gcc15-spec06-0.3c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/spec06_0.3c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/gcc15-spec06-0.3.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc15-spec06-0.3c" >> $GITHUB_OUTPUT
+              echo "comment=run 30% coverage spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
+              ;;
+            "gcc15-spec06-0.8c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/spec06_0.8c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/gcc15-spec06-0.8.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc15-spec06-0.8c" >> $GITHUB_OUTPUT
+              echo "comment=run 80% coverage spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
+              ;;
+            "gcc15-spec06-1.0c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/checkpoint.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/gcc15/cluster-0-0.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc15-spec06-1.0c" >> $GITHUB_OUTPUT
+              echo "comment=run 100% coverage spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "spec17-1.0c")
               echo "checkpoint_list=/nfs/home/yanyue/spec17_cpts/checkpoint-0-0-0/checkpoint.lst" >> $GITHUB_OUTPUT
@@ -92,7 +116,7 @@ jobs:
               echo "comment=run 80% coverage spec06 int rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
             *)
-              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: spec06-0.8c, spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: gcc12-spec06-0.3c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
               exit 1
               ;;
           esac

--- a/.github/workflows/gem5-perf.yml
+++ b/.github/workflows/gem5-perf.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/kmhv2.py
-      benchmark_type: "spec06-0.8c"
+      benchmark_type: "gcc12-spec06-0.8c"

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -16,11 +16,14 @@ on:
         description: 'Benchmark coverage type'
         required: true
         type: choice
-        default: 'spec06-0.8c'
+        default: 'gcc12-spec06-0.8c'
         options:
-          - spec06-0.3c
-          - spec06-0.8c
-          - spec06-1.0c
+          - gcc12-spec06-0.3c
+          - gcc12-spec06-0.8c
+          - gcc12-spec06-1.0c
+          - gcc15-spec06-0.3c
+          - gcc15-spec06-0.8c
+          - gcc15-spec06-1.0c
           - spec17-1.0c
           - spec06-rvv-1.0c
           - spec06int-rvv-0.8c

--- a/.github/workflows/on-demand-spec.yml
+++ b/.github/workflows/on-demand-spec.yml
@@ -1,7 +1,7 @@
 name: On-Demand SPEC Test (Tier 1.5)
 
 on:
-  # Label触发: 添加 'perf' 标签自动跑 spec06-0.8c
+  # Label触发: 添加 'perf' 标签自动跑 gcc12-spec06-0.8c
   pull_request_target:
     types: [labeled]
   
@@ -16,10 +16,10 @@ on:
         description: 'Benchmark type'
         required: false
         type: choice
-        default: 'spec06-0.8c'
+        default: 'gcc12-spec06-0.8c'
         options:
-          - spec06-0.8c
-          - spec06-1.0c
+          - gcc12-spec06-0.8c
+          - gcc12-spec06-1.0c
           - spec17-1.0c
           - spec06-rvv-1.0c
           - spec06int-rvv-0.8c
@@ -61,14 +61,14 @@ jobs:
             } else {
               // Label触发 (pull_request_target)
               prNumber = context.payload.pull_request.number;
-              benchmark = 'spec06-0.8c';
+              benchmark = 'gcc12-spec06-0.8c';
               prSha = context.payload.pull_request.head.sha;
               
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body: '🚀 Performance test triggered: **spec06-0.8c**'
+                body: '🚀 Performance test triggered: **gcc12-spec06-0.8c**'
               });
             }
             

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ XS-GEM5 is enhanced with
 
 We maintain three main Kunminghu configuration scripts to mirror RTL progress and performance targets. Each is covered by a distinct CI workflow so their results are easy to track (SPECCPU06 coverage shown in parentheses).
 
-- `configs/example/kmhv2.py`: Kunminghu V2 baseline; used by the Tier 2 post-merge regression workflow `gem5 Performance Test (Tier 2 - Post-Merge)` (spec06-0.8c). If further development under the kmh-v2–related configuration is required, please switch to the KMH-V2-CONFIG branch.
-- `configs/example/kmhv3.py`: Kunminghu V3 RTL-aligned mainline; keeps some BPU/backend/performance knobs conservative to match the in-progress RTL, so scores are currently close to V2. CI: `gem5 Align BTB Performance Test(0.3c)` (spec06-0.3c). 
-- `configs/example/idealkmhv3.py`: Ideal/performance-tuned V3 with aggressive microarchitectural settings enabled; currently the highest-scoring variant. CI: `gem5 Ideal BTB Performance Test` (spec06-0.8c).
+- `configs/example/kmhv2.py`: Kunminghu V2 baseline; used by the Tier 2 post-merge regression workflow `gem5 Performance Test (Tier 2 - Post-Merge)` (gcc12-spec06-0.8c). If further development under the kmh-v2–related configuration is required, please switch to the KMH-V2-CONFIG branch.
+- `configs/example/kmhv3.py`: Kunminghu V3 RTL-aligned mainline; keeps some BPU/backend/performance knobs conservative to match the in-progress RTL, so scores are currently close to V2. CI: `gem5 Align BTB Performance Test(0.3c)` (gcc12-spec06-0.3c).
+- `configs/example/idealkmhv3.py`: Ideal/performance-tuned V3 with aggressive microarchitectural settings enabled; currently the highest-scoring variant. CI: `gem5 Ideal BTB Performance Test` (gcc12-spec06-0.8c).
 
 Note: 
 - The V3 RTL BPU predictor and backend updates are still being implemented. Several performance switches remain off in `kmhv3.py` to stay aligned with the RTL snapshot; as RTL work lands, we will re-enable them and expect the mainline V3 scores to pull ahead of V2.


### PR DESCRIPTION
- gem5-perf-template.yml: renamed SPEC06 baseline benchmark keys from spec06-{0.3c,0.8c,1.0c} to gcc12-spec06-{0.3c,0.8c,1.0c}; added gcc15-spec06-{0.3c,0.8c,1.0c} mappings with dedicated checkpoint_list/checkpoint_root_node/score_script/cluster_config/artifact_name/comment outputs; updated benchmark_type input description and Invalid benchmark_type error list to the new full option set.

- gem5-perf.yml: updated benchmark_type from spec06-0.8c to gcc12-spec06-0.8c.

- gem5-ideal-btb-perf.yml: updated benchmark_type from spec06-0.8c to gcc12-spec06-0.8c.

- gem5-ideal-btb-0.3c.yml: updated benchmark_type from spec06-0.3c to gcc12-spec06-0.3c.

- gem5-ideal-btb-perf-weekly.yml: switched both SPEC06 jobs to gcc15-spec06-1.0c; kept SPEC17 jobs unchanged.

- manual-perf.yml: changed benchmark_type default to gcc12-spec06-0.8c; replaced SPEC06 options with explicit gcc12/gcc15 variants (gcc12-spec06-{0.3c,0.8c,1.0c} and gcc15-spec06-{0.3c,0.8c,1.0c}); kept spec17/rvv options.

- on-demand-spec.yml: migrated on-demand SPEC06 naming to gcc12-only scope (default/options/label-trigger default/comment text), without adding gcc15 options.

Change-Id: Ie086b2fca06178f9dc47338da93a3af6f0f7327e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI performance workflows and inputs to adopt new gcc-based benchmark names (gcc12-spec06 and gcc15-spec06 variants).
  * Changed default benchmark selection across manual and automated perf runs to the gcc12-spec06 default.

* **Documentation**
  * Updated README and workflow docs/examples to reflect the new benchmark naming and updated trigger/label text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->