### PR TITLE
arch-riscv: Remove enable sv48

### DIFF
--- a/configs/common/CpuConfig.py
+++ b/configs/common/CpuConfig.py
@@ -75,10 +75,5 @@ def deprecated_config_difftest(cpu_cls, cpu_list, options):
         cpu_list[0].difftest_ref_so = options.difftest_ref_so
 
 
-def deprecated_config_48(cpu_cls, cpu_list, options):
-    if not options.open_sv48:
-        return
-    else:
-        assert len(cpu_list) == 1
-        cpu_list[0].enable_sv48 = True
+
 

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -290,9 +290,6 @@ def addCommonOptions(parser, configure_xiangshan=False):
     parser.add_argument("--functional-tlb", action="store_true", default=False,
                         help="""
                         Use functional TLB""")
-    parser.add_argument("--open-sv48", action="store_true", default=False,
-                        help="""
-                        Enable sv48""")
     parser.add_argument("--list-hwp-types",
                         action=ListHWP, nargs=0,
                         help="List available hardware prefetcher types")

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -423,7 +423,6 @@ def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
     np = args.num_cpus
     # Set the cache line size for the entire system
     test_sys.cache_line_size = args.cacheline_size
-    test_sys.enable_sv48 = args.open_sv48
 
     # Create a top-level voltage domain
     test_sys.voltage_domain = VoltageDomain(voltage = args.sys_voltage)
@@ -448,8 +447,6 @@ def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
         cpu.mmu.pma_checker = PMAChecker(
             uncacheable=[AddrRange(0, size=0x80000000)])
         cpu.mmu.functional = args.functional_tlb
-        cpu.enable_sv48 = args.open_sv48
-        cpu.mmu.enable_sv48 = args.open_sv48
 
         if hasattr(args, 'enable_trace_mode') and args.enable_trace_mode:
             timing_ptw = bool(getattr(args, 'trace_timing_ptw', False))

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -187,7 +187,7 @@ def generate_xiangshan_dtb(system, *, cmdline: str, outdir: str = None) -> str:
     cpus_node.append(cpus_state.sizeCellsProperty())
     cpus_node.append(FdtPropertyWords("timebase-frequency", [10000000]))
 
-    mmu_type = "riscv,sv48" if bool(getattr(system, "enable_sv48", False)) else "riscv,sv39"
+    mmu_type = "riscv,sv48"
     isa_string = "rv64imafdc"
 
     for i, cpu in enumerate(system.cpu):

--- a/src/arch/generic/BaseMMU.py
+++ b/src/arch/generic/BaseMMU.py
@@ -49,7 +49,6 @@ class BaseMMU(SimObject):
     dtb = Param.BaseTLB("Data TLB")
 
     functional = Param.Bool(False, "Functional MMU")
-    enable_sv48 = Param.Bool(False, "enable_sv48")
 
     @classmethod
     def walkerPorts(cls):

--- a/src/arch/generic/isa.hh
+++ b/src/arch/generic/isa.hh
@@ -65,13 +65,11 @@ class BaseISA : public SimObject
     ThreadContext *tc = nullptr;
 
     RegClasses _regClasses;
-    bool enableSv48 = false;
 
   public:
     virtual PCStateBase *newPCState(Addr new_inst_addr=0) const = 0;
     virtual void takeOverFrom(ThreadContext *new_tc, ThreadContext *old_tc) {}
     virtual void setThreadContext(ThreadContext *_tc) { tc = _tc; }
-    virtual void setEnableSv48(bool _enableSv48) {  enableSv48= _enableSv48; }
 
     virtual uint64_t getExecutingAsid() const { return 0; }
     virtual bool inUserMode() const = 0;

--- a/src/arch/generic/mmu.cc
+++ b/src/arch/generic/mmu.cc
@@ -111,7 +111,6 @@ void
 BaseMMU::translateTiming(const RequestPtr &req, ThreadContext *tc,
                          BaseMMU::Translation *translation, BaseMMU::Mode mode)
 {
-    getTlb(mode)->setPTWmode(enableSv48);
     if (functional) {
         return getTlb(mode)->translateFunctional(req, tc, translation, mode);
     } else {

--- a/src/arch/generic/mmu.hh
+++ b/src/arch/generic/mmu.hh
@@ -88,7 +88,7 @@ class BaseMMU : public SimObject
     typedef BaseMMUParams Params;
 
     BaseMMU(const Params &p)
-      : SimObject(p), dtb(p.dtb), itb(p.itb), functional(p.functional),enableSv48(p.enable_sv48)
+      : SimObject(p), dtb(p.dtb), itb(p.itb), functional(p.functional)
     {}
 
     BaseTLB*
@@ -166,7 +166,6 @@ class BaseMMU : public SimObject
     BaseTLB* dtb;
     BaseTLB* itb;
     bool functional;
-    bool enableSv48;
 
   protected:
     /**

--- a/src/arch/generic/tlb.hh
+++ b/src/arch/generic/tlb.hh
@@ -87,11 +87,7 @@ class BaseTLB : public SimObject
     {
         panic("Not implemented.\n");
     }
-    virtual void
-    setPTWmode(bool _enable_sv48)
-    {
-      panic("Not implemented.\n");
-    }
+
 
     /**
      * Do post-translation physical address finalization.

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -575,13 +575,15 @@ ISA::setMiscReg(int misc_reg, RegVal val)
         setMiscRegNoEffect(MISCREG_VSSTATUS, write_val);
     } else if ((v == 1) && ((misc_reg == MISCREG_SATP))) {
         auto satp_mode = (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET;
-        if (satp_mode == NEMU_SATP_BARE ||
-            satp_mode == NEMU_SATP_SV39 ||
-            (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
+        if (satp_mode == NEMU_SATP_BARE) {
             setMiscRegNoEffect(MISCREG_VSATP, val & NEMU_SATP_MASK);
+            warn("enable SATP BARE\n");
+        } else if (satp_mode == NEMU_SATP_SV39) {
+            setMiscRegNoEffect(MISCREG_VSATP, val & NEMU_SATP_MASK);
+            warn("enable SV39\n");
         } else if (satp_mode == NEMU_SATP_SV48) {
-            warn("Ignoring VSATP Sv48 write %#lx because Sv48 is disabled; "
-                 "enable it with --open-sv48.\n", val);
+            setMiscRegNoEffect(MISCREG_VSATP, val & NEMU_SATP_MASK);
+            warn("enable SV48\n");
         }
     } else if ((v == 1) && (misc_reg == MISCREG_SEPC)) {
         setMiscRegNoEffect(MISCREG_VSEPC, val);
@@ -716,7 +718,7 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 auto satp_mode = (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET;
                 if (satp_mode == NEMU_SATP_BARE ||
                     satp_mode == NEMU_SATP_SV39 ||
-                    (enableSv48 && satp_mode == NEMU_SATP_SV48)) {
+                    satp_mode == NEMU_SATP_SV48) {
                     RegVal writeVal = val & NEMU_SATP_MASK;
                     setMiscRegNoEffect(misc_reg, writeVal);
                 } else if (satp_mode == NEMU_SATP_SV48) {

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -707,23 +707,20 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 // shall have no effect (see 4.1.12 in priv ISA manual)
                 SATP cur_val = readMiscRegNoEffect(misc_reg);
                 SATP new_val = val;
-                //change the mode update , only support sv39
-                //if (new_val.mode != AddrXlateMode::BARE &&
-                //    new_val.mode != AddrXlateMode::SV39)
-                //    new_val.mode = cur_val.mode;
-                //setMiscRegNoEffect(misc_reg, new_val);
                 if (cur_val != new_val) {
                     tc->getCpuPtr()->flushTLBs();
                 }
                 auto satp_mode = (val & SATP_MODE_MASK) >> NEMU_SATP_RIGHT_OFFSET;
-                if (satp_mode == NEMU_SATP_BARE ||
-                    satp_mode == NEMU_SATP_SV39 ||
-                    satp_mode == NEMU_SATP_SV48) {
-                    RegVal writeVal = val & NEMU_SATP_MASK;
+                RegVal writeVal = val & NEMU_SATP_MASK;
+                if (satp_mode == NEMU_SATP_BARE) {
                     setMiscRegNoEffect(misc_reg, writeVal);
+                    warn("enable SATP BARE\n");
+                } else if (satp_mode == NEMU_SATP_SV39) {
+                    setMiscRegNoEffect(misc_reg, writeVal);
+                    warn("enable SV39\n");
                 } else if (satp_mode == NEMU_SATP_SV48) {
-                    warn("Ignoring SATP Sv48 write %#lx because Sv48 is disabled; "
-                         "enable it with --open-sv48.\n", val);
+                    setMiscRegNoEffect(misc_reg, writeVal);
+                    warn("enable SV48\n");
                 }
 
             }

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -330,7 +330,6 @@ namespace RiscvISA
         bool openNextLine;
         bool autoOpenNextLine;
       public:
-        bool openSv48;
         bool is_from_pre_req;
 
         Tick squashHandleTick;
@@ -380,7 +379,6 @@ namespace RiscvISA
             ptwSquash(params.ptw_squash),
             openNextLine(params.open_nextline),
             autoOpenNextLine(true),
-            openSv48(false),
             doL2TLBHitEvent([this]{dol2TLBHit();},name())
         {
         }

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1903,17 +1903,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *pre_back = l2tlb->lookupBackPre(back_pre_block, satp.asid, true);
     backPrePrecision = checkPrePrecision(l2tlb->removeNoUseBackPre, l2tlb->usedBackPre);
     forwardPrePrecision = checkPrePrecision(l2tlb->removeNoUseForwardPre, l2tlb->forwardUsedPre);
-    if (walker->openSv48) {
-        fault = walker->start(0, tc, translation, req, mode, false, false, 3, false, 0);
 
-        if (translation != nullptr || fault != NoFault) {
-            // This gets ignored in atomic mode.
-            delayed = true;
-            return fault;
-        } else {
-            panic("sv48 goes wrong\n");
-        }
-    }
 
     for (int i_e = 1; i_e < L_L2SUM; i_e++) {
         if ((satp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -161,10 +161,7 @@ TLB::getWalker()
 {
     return walker;
 }
-void
-TLB::setPTWmode(bool _enable_sv48){
-    walker->openSv48 = _enable_sv48;
-}
+
 void
 TLB::configL2Tlb(EntryList *List_choose, TlbEntryTrie *Trie_l2_choose, std::vector<TlbEntry> &l2Tlb_choose,
                  size_t size, bool sp)

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -180,7 +180,6 @@ class TLB : public BaseTLB
     Walker *getWalker();
 
     void takeOverFrom(BaseTLB *old) override {}
-    void setPTWmode(bool _enable_sv48) override;
 
     TlbEntry *insert(Addr vpn, const TlbEntry &entry, bool suqashed_update, uint8_t translateMode);
     TlbEntry *insertForwardPre(Addr vpn, const TlbEntry &entry);

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -151,7 +151,6 @@ class BaseCPU(ClockedObject):
         "reset stats when any thread has reached this inst count")
 
     enable_difftest = Param.Bool(False,"use NEMU as ref to difftest")
-    enable_sv48 = Param.Bool(False, "enable sv48")
     dump_commit = Param.Bool(False,"dump commit log")
     dump_start = Param.Int(0,"dump start num")
     difftest_ref_so = Param.String("", "The reference so for online difftest")

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -162,7 +162,6 @@ BaseCPU::BaseCPU(const Params &p, bool is_checker)
       enterPwrGatingEvent([this] { enterPwrGating(); }, name()),
       warmupInstCount(p.warmupInstCount),
       enableDifftest(p.enable_difftest),
-      enableSv48(p.enable_sv48),
       dumpCommitFlag(p.dump_commit),
       dumpStartNum(p.dump_start),
       enableRVV(p.enable_riscv_vector),
@@ -530,7 +529,6 @@ BaseCPU::registerThreadContexts()
             tc->getProcessPtr()->assignThreadContext(tc->contextId());
 
         interrupts[tid]->setThreadContext(tc);
-        tc->getIsaPtr()->setEnableSv48(enableSv48);
 
         tc->getIsaPtr()->setThreadContext(tc);
     }

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -688,7 +688,6 @@ class BaseCPU : public ClockedObject
     // difftest
   protected:
     bool enableDifftest;
-    bool enableSv48;
     bool dumpCommitFlag;
     int dumpStartNum;
     bool enableRVV{false};

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -145,4 +145,3 @@ class System(SimObject):
 
     num_cpus = Param.Unsigned(1, "Number of CPUs in the system")
     enable_difftest = Param.Bool(False, "Enable RISC-V difftest")
-    enable_sv48 = Param.Bool(False, "enable sv48")


### PR DESCRIPTION
Remove the enable_sv48 switch and detect it automatically.

Change-Id: I2b2f538a1d2ac624107d825496251473456bd402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * SV48 configuration support and the --open-sv48 command-line option have been removed; SV48 is no longer user-toggleable.
  * Per-CPU and per-MMU SV48 enablement parameters have been removed from the configuration surface.

* **Behavior Change**
  * The system now operates with SV48 behavior by default; writes and mode handling for SV48 are no longer gated by a user option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->