### PR TITLE
configs: reduce UARTLite console PIO latency for Xiangshan bare-metal runs

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -682,6 +682,10 @@ def makeXiangshanPlatformSystem(mem_mode, mdesc=None, np=1, ruby=False):
         self.bridge.cpu_side_port = self.membus.mem_side_ports
 
     self.uartlite  = UartLite()
+    # Keep debug console output from dominating short bare-metal runs.
+    # We do not study UART timing here, so prefer a near-functional UART for
+    # printf-heavy debug/program output.
+    self.uartlite.pio_latency = '1ns'
     self.uartlite.pio = self.iobus.mem_side_ports
 
     self.lint = Clint()


### PR DESCRIPTION
## Summary
- reduce Xiangshan UARTLite PIO latency to `1ns` in `makeXiangshanPlatformSystem`
- keep debug `printf`/console output from dominating short bare-metal runs
- treat UART console as near-functional debug plumbing rather than a performance target

## Motivation
On local macOS runs, short bare-metal workloads such as CoreMark can spend a disproportionate amount of simulated time in UART-backed console output. This makes `printf`-heavy debug output distort IPC/CPI and overall runtime much more than desired for CPU-focused analysis.

This change keeps the model simple and makes the console behavior closer to a fast debug channel, which is more aligned with how we use it in practice.

## Validation
Ran:
```bash
./build/RISCV/gem5.opt ./configs/example/kmhv3.py \
  --disable-difftest \
  --raw-cpt \
  --generic-rv-cpt=/Users/yanyue/workspace/cursor-test/ready-to-run/coremark-2-iteration.bin
```

Observed after this change:
- `simTicks = 199509624`
- `system.cpu.numCycles = 599129`
- `system.cpu.ipc = 1.107324`
- `system.cpu.cpi = 0.903078`

Compared with the original behavior, the short CoreMark run spent substantially less time in console-related UART accesses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized debug console output timing to prevent dominance during short bare-metal simulations, improving overall output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->