### PR TITLE
Revert "cpu-o3: Refactor numWays to support per-table configuration"

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1044,21 +1044,15 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned(
-        [2048, 2048, 2048, 2048, 2048, 2048, 2048,2048],
-        "the TAGE T0~Tn length")
-    TTagBitSizes = VectorParam.Unsigned([13] * 8, "the T0~Tn entry's tag bit size")
+    tableSizes = VectorParam.Unsigned([2048]*8, "the TAGE T0~Tn length")
+    TTagBitSizes = VectorParam.Unsigned([13]*8, "the T0~Tn entry's tag bit size")
     TTagPcShifts = VectorParam.Unsigned([1] * 8, "when the T0~Tn entry's tag generating, PC right shift")
     blockSize = 32 # tage index function uses 32B aligned block address
 
-    histLengths = VectorParam.Unsigned(
-        [4, 9, 17, 29, 56, 109, 211,397],
-        "the BTB TAGE T0~Tn history length")
+    histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211, 397], "the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = VectorParam.Unsigned(
-        [2] * 8,
-        "the T0~Tn number of ways per set")
+    numWays = Param.Unsigned(2, "Number of ways per set")
     maxBranchPositions = Param.Unsigned(32, "Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128, "Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7, "Width of the useAltOnNa table")

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -34,11 +34,10 @@ namespace test {
 
 #ifdef UNIT_TEST
 // Test constructor for unit testing mode
-BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWaysPerTable,
-                 unsigned tableSize, unsigned numBanks)
+BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSize, unsigned numBanks)
     : TimedBaseBTBPredictor(),
       numPredictors(numPredictors),
-      numWays(numPredictors, numWaysPerTable),
+      numWays(numWays),
       maxBranchPositions(32),
       useAltOnNaSize(1024),
       useAltOnNaWidth(7),
@@ -99,11 +98,6 @@ tageStats(this, p.numPredictors, p.numBanks)
         warn("BTBTAGE: Bank simulation works better with updateOnRead=true");
     }
 #endif
-    if (numWays.size() == 1 && numPredictors > 1) {
-        numWays.resize(numPredictors, numWays.front());
-    }
-
-    assert(numWays.size() >= numPredictors);
     tageTable.resize(numPredictors);
     tableIndexBits.resize(numPredictors);
     tableIndexMasks.resize(numPredictors);
@@ -114,9 +108,8 @@ tageStats(this, p.numPredictors, p.numBanks)
         //initialize ittage predictor
         assert(tableSizes.size() >= numPredictors);
         tageTable[i].resize(tableSizes[i]);
-        const unsigned ways = getNumWays(i);
         for (unsigned int j = 0; j < tableSizes[i]; ++j) {
-            tageTable[i][j].resize(ways);
+            tageTable[i][j].resize(numWays);
         }
 
         tableIndexBits[i] = ceilLog2(tableSizes[i]);
@@ -230,8 +223,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
         unsigned matching_way = 0;
 
         // Search all ways for a matching entry
-        const unsigned ways = getNumWays(i);
-        for (unsigned way = 0; way < ways; way++) {
+        for (unsigned way = 0; way < numWays; way++) {
             auto &entry = tageTable[i][index][way];
             // entry valid, tag match (position already encoded in tag, no need to check pc)
             if (entry.valid && tag == entry.tag) {
@@ -286,23 +278,12 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
         }
     }
     bool taken = use_alt ? alt_pred : main_taken;
-    int final_provider_table = -1;
-    bool final_provider_is_alt = false;
-    if (!use_alt && provided) {
-        final_provider_table = main_info.table;
-    } else if (use_alt && alt_provided) {
-        final_provider_table = alt_info.table;
-        final_provider_is_alt = true;
-    }
 
     DPRINTF(TAGE, "tage predict %#lx taken %d\n", btb_entry.pc, taken);
     DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n",
         use_alt, alt_provided, alt_taken, base_taken, main_taken);
-    DPRINTF(TAGE, "tage final source %#lx table %d alt %d\n",
-        btb_entry.pc, final_provider_table, final_provider_is_alt);
 
-    return TagePrediction(btb_entry.pc, main_info, alt_info, use_alt, taken, alt_pred,
-        final_provider_table, final_provider_is_alt);
+    return TagePrediction(btb_entry.pc, main_info, alt_info, use_alt, taken, alt_pred);
 }
 
 /**
@@ -598,10 +579,8 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
         auto &set = tageTable[ti][newIndex];
 
-        const unsigned ways = getNumWays(ti);
-
         // Allocate into invalid way or not-useful and weak way
-        for (unsigned way = 0; way < ways; ++way) {
+        for (unsigned way = 0; way < numWays; ++way) {
             auto &cand = set[way];
             const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
             if (!cand.valid || (!cand.useful && weakish)) {
@@ -619,7 +598,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
         }
 
         // 3) Apply age penalty to one strong, not-useful way to make it replacable later
-        for (unsigned way = 0; way < ways; ++way) {
+        for (unsigned way = 0; way < numWays; ++way) {
             auto &cand = set[way];
             const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
             if (!cand.useful && !weakish) {
@@ -722,37 +701,17 @@ BTBTAGE::update(const FetchTarget &stream) {
     bool hasRecomputedVsOriginalDiff = false;
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
-        auto orig_it = predMeta->preds.find(btb_entry.pc);
-        if (orig_it == predMeta->preds.end()) {
-            DPRINTF(TAGE, "update: missing original prediction for pc %#lx, skip\n", btb_entry.pc);
-            continue;
-        }
-        const TagePrediction &original_pred = orig_it->second;
-
-#ifndef UNIT_TEST
-        if (original_pred.finalProviderTable >= 0) {
-            if (original_pred.taken == actual_taken) {
-                tageStats.updateFinalSourceTableCorrect[original_pred.finalProviderTable]++;
-            } else {
-                tageStats.updateFinalSourceTableWrong[original_pred.finalProviderTable]++;
-            }
-        } else if (original_pred.taken == actual_taken) {
-            tageStats.updateFinalSourceBaseCorrect++;
-        } else {
-            tageStats.updateFinalSourceBaseWrong++;
-        }
-#endif
-
         TagePrediction recomputed;
         if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta);
             // Track differences for statistics
-            if (recomputed.taken != original_pred.taken) {
+            auto it = predMeta->preds.find(btb_entry.pc);
+            if (it != predMeta->preds.end() && recomputed.taken != it->second.taken) {
                 hasRecomputedVsOriginalDiff = true;
             }
         } else { // otherwise, use the prediction from the prediction-time main/alt
-            recomputed = original_pred;
+            recomputed = predMeta->preds[btb_entry.pc];
         }
         if (recomputed.taken != actual_taken) {
             hasRecomputedVsActualDiff = true;
@@ -893,8 +852,7 @@ BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
     Addr pcBits = (pc >> pcShift) & mask;
     Addr foldedBits = foldedHist & mask;
 
-    // Support non-power-of-two table sizes when tuning capacities.
-    return (pcBits ^ foldedBits) % tableSizes[t];
+    return pcBits ^ foldedBits;
 }
 
 Addr
@@ -1070,9 +1028,6 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     ADD_STAT(updateAllocSuccess, statistics::units::Count::get(), "alloc success when update"),
     ADD_STAT(updateMispred, statistics::units::Count::get(), "mispred when update"),
     ADD_STAT(updateResetU, statistics::units::Count::get(), "reset u when update"),
-    ADD_STAT(predFinalSourceBase, statistics::units::Count::get(), "predictions whose final source is base BTB"),
-    ADD_STAT(updateFinalSourceBaseCorrect, statistics::units::Count::get(), "base BTB final-source predictions that are correct"),
-    ADD_STAT(updateFinalSourceBaseWrong, statistics::units::Count::get(), "base BTB final-source predictions that are wrong"),
     ADD_STAT(recomputedVsActualDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != actual_taken"),
     ADD_STAT(recomputedVsOriginalDiff, statistics::units::Count::get(), "fetchBlocks where recomputed.taken != original pred.taken"),
     ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
@@ -1083,9 +1038,6 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     ADD_STAT(predTableHits, statistics::units::Count::get(), "hit of each tage table on prediction"),
     ADD_STAT(updateTableHits, statistics::units::Count::get(), "hit of each tage table on update"),
     ADD_STAT(updateTableMispreds, statistics::units::Count::get(), "mispreds of each table when update"),
-    ADD_STAT(predFinalSourceTable, statistics::units::Count::get(), "predictions whose final source is a TAGE table"),
-    ADD_STAT(updateFinalSourceTableCorrect, statistics::units::Count::get(), "correct predictions grouped by final-source table"),
-    ADD_STAT(updateFinalSourceTableWrong, statistics::units::Count::get(), "wrong predictions grouped by final-source table"),
 
     ADD_STAT(condPredwrong, statistics::units::Count::get(), "number of conditional branch mispredictions committed"),
     ADD_STAT(condMissTakens, statistics::units::Count::get(), "number of conditional branch mispredictions committed with no prediction"),
@@ -1097,9 +1049,6 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     predTableHits.init(0, numPredictors-1, 1);
     updateTableHits.init(0, numPredictors-1, 1);
     updateTableMispreds.init(numPredictors);
-    predFinalSourceTable.init(numPredictors);
-    updateFinalSourceTableCorrect.init(numPredictors);
-    updateFinalSourceTableWrong.init(numPredictors);
 
     // Initialize per-bank statistics vectors
     updateBankConflictPerBank.init(numBanks);
@@ -1126,13 +1075,6 @@ BTBTAGE::TageStats::updateStatsWithTagePrediction(const TagePrediction &pred, bo
         if (!hit || useAlt) {
             predUseAlt++;
         }
-#ifndef UNIT_TEST
-        if (pred.finalProviderTable >= 0) {
-            predFinalSourceTable[pred.finalProviderTable]++;
-        } else {
-            predFinalSourceBase++;
-        }
-#endif
     } else {
         if (hit) {
 #ifndef UNIT_TEST
@@ -1152,8 +1094,7 @@ void
 BTBTAGE::updateLRU(int table, Addr index, unsigned way)
 {
     // Increment LRU counters for all entries in the set
-    const unsigned ways = getNumWays(table);
-    for (unsigned i = 0; i < ways; i++) {
+    for (unsigned i = 0; i < numWays; i++) {
         if (i != way && tageTable[table][index][i].valid) {
             tageTable[table][index][i].lruCounter++;
         }
@@ -1168,10 +1109,9 @@ BTBTAGE::getLRUVictim(int table, Addr index)
 {
     unsigned victim = 0;
     unsigned maxLRU = 0;
-    const unsigned ways = getNumWays(table);
 
     // Find the entry with the highest LRU counter
-    for (unsigned i = 0; i < ways; i++) {
+    for (unsigned i = 0; i < numWays; i++) {
         if (!tageTable[table][index][i].valid) {
             return i; // Use invalid entry if available
         }
@@ -1181,13 +1121,6 @@ BTBTAGE::getLRUVictim(int table, Addr index)
         }
     }
     return victim;
-}
-
-unsigned
-BTBTAGE::getNumWays(unsigned table) const
-{
-    assert(table < numWays.size());
-    return numWays[table];
 }
 
 #ifndef UNIT_TEST

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -46,8 +46,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
   public:
 #ifdef UNIT_TEST
     // Test constructor
-    BTBTAGE(unsigned numPredictors = 4, unsigned numWays = 2,
-            unsigned tableSize = 1024, unsigned numBanks = 4);
+    BTBTAGE(unsigned numPredictors = 4, unsigned numWays = 2, unsigned tableSize = 1024, unsigned numBanks = 4);
 #else
     // Production constructor
     typedef BTBTAGEParams Params;
@@ -101,20 +100,14 @@ class BTBTAGE : public TimedBaseBTBPredictor
             bool useAlt;           // Whether to use alternative prediction, true if main is weak or no main prediction
             bool taken;            // Final prediction (taken/not taken) = use_alt ? alt_provided ? alt_taken : base_taken : main_taken
             bool altPred;          // Alternative prediction = alt_provided ? alt_taken : base_taken;
-            int finalProviderTable; // Table that supplied the final prediction, -1 means base BTB
-            bool finalProviderIsAlt; // Whether final prediction came from alternate provider
 
 
-            TagePrediction() : btb_pc(0), useAlt(false), taken(false), altPred(false),
-                               finalProviderTable(-1), finalProviderIsAlt(false) {}
+            TagePrediction() : btb_pc(0), useAlt(false), taken(false), altPred(false) {}
 
             TagePrediction(Addr btb_pc, TageTableInfo mainInfo, TageTableInfo altInfo,
-                            bool useAlt, bool taken, bool altPred,
-                            int finalProviderTable, bool finalProviderIsAlt) :
+                            bool useAlt, bool taken, bool altPred) :
                             btb_pc(btb_pc), mainInfo(mainInfo), altInfo(altInfo),
-                            useAlt(useAlt), taken(taken), altPred(altPred),
-                            finalProviderTable(finalProviderTable),
-                            finalProviderIsAlt(finalProviderIsAlt) {}
+                            useAlt(useAlt), taken(taken), altPred(altPred){}
     };
 
 
@@ -247,8 +240,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Maximum history length, not used
     unsigned maxHistLen;
 
-    // Number of ways for each table in the set associative design
-    std::vector<unsigned> numWays;
+    // Number of ways for set associative design
+    const unsigned numWays;
 
     // The actual TAGE prediction tables (table x index x way)
     std::vector<std::vector<std::vector<TageEntry>>> tageTable;
@@ -349,9 +342,6 @@ class BTBTAGE : public TimedBaseBTBPredictor
         Scalar updateAllocSuccess;
         Scalar updateMispred;
         Scalar updateResetU;
-        Scalar predFinalSourceBase;
-        Scalar updateFinalSourceBaseCorrect;
-        Scalar updateFinalSourceBaseWrong;
 
         // Recomputed prediction difference statistics (per fetchBlock)
         Scalar recomputedVsActualDiff;   // recomputed.taken != actual_taken
@@ -371,9 +361,6 @@ class BTBTAGE : public TimedBaseBTBPredictor
         statistics::Distribution updateTableHits;
 
         statistics::Vector updateTableMispreds;
-        statistics::Vector predFinalSourceTable;
-        statistics::Vector updateFinalSourceTableCorrect;
-        statistics::Vector updateFinalSourceTableWrong;
 #endif
 
         Scalar condPredwrong;
@@ -452,7 +439,6 @@ private:
     // Helper methods for LRU management
     void updateLRU(int table, Addr index, unsigned way);
     unsigned getLRUVictim(int table, Addr index);
-    unsigned getNumWays(unsigned table) const;
 
     std::shared_ptr<TageMeta> meta;
 };

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -232,7 +232,7 @@ void setupTageEntry(BTBTAGE* tage, Addr pc, int table_idx,
  */
 void verifyTageEntries(BTBTAGE* tage, Addr pc, const std::vector<int>& expected_tables) {
     for (int t = 0; t < tage->numPredictors; t++) {
-        for (unsigned way = 0; way < tage->getNumWays(t); way++) {
+        for (int way = 0; way < tage->numWays; way++) {
             Addr index = tage->getTageIndex(pc, t);
             auto &entry = tage->tageTable[t][index][way];
 
@@ -261,7 +261,7 @@ int findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC) {
     // use meta to find the table, predicted info
     for (int t = 0; t < tage->numPredictors; t++) {
         Addr index = tage->getTageIndex(startPC, t, meta->indexFoldedHist[t].get());
-        for (unsigned way = 0; way < tage->getNumWays(t); way++) {
+        for (int way = 0; way < tage->numWays; way++) {
             auto &entry = tage->tageTable[t][index][way];
             if (entry.valid && entry.pc == branchPC) {
                 return t;
@@ -797,7 +797,7 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
 
     // Check if allocation happened
     int allocatedWay = -1;
-    for (unsigned way = 0; way < tage->getNumWays(testTable); way++) {
+    for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid &&
             tage->tageTable[testTable][testIndex][way].pc == 0x1000) {
             allocatedWay = way;
@@ -813,7 +813,7 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     tage->tageTable[testTable][testIndex][allocatedWay].counter = 2; // Make it strong
 
     // Step 2: Attempt to fill remaining ways with different branches
-    for (unsigned way = 0; way < tage->getNumWays(testTable); way++) {
+    for (unsigned way = 0; way < tage->numWays; way++) {
         if (way == allocatedWay) continue;
 
         // Create a branch with different PC
@@ -825,17 +825,16 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
 
     // Verify now both ways can be filled under miss policy (consider any way's useful=0)
     int filledWays = 0;
-    for (unsigned way = 0; way < tage->getNumWays(testTable); way++) {
+    for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid) {
             filledWays++;
         }
     }
 
-    EXPECT_EQ(filledWays, tage->getNumWays(testTable))
-        << "All ways should be filled after multiple allocations under miss policy";
+    EXPECT_EQ(filledWays, tage->numWays) << "All ways should be filled after multiple allocations under miss policy";
 
     // Strengthen all allocated entries to prevent replacement in Step 3
-    for (unsigned way = 0; way < tage->getNumWays(testTable); way++) {
+    for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid) {
             tage->tageTable[testTable][testIndex][way].useful = true;
             tage->tageTable[testTable][testIndex][way].counter = 2; // Make it strong
@@ -855,7 +854,7 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     // Check if the new entry was allocated
     bool found = false;
     unsigned foundWay = 0;
-    for (unsigned way = 0; way < tage->getNumWays(testTable); way++) {
+    for (unsigned way = 0; way < tage->numWays; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid &&
             tage->tageTable[testTable][testIndex][way].pc == 0x1008) {
             found = true;


### PR DESCRIPTION
Reverts OpenXiangShan/GEM5#793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified branch predictor configuration by consolidating per-table settings into unified global parameters
  * Removed final-source tracking statistics from predictor output
  * Streamlined prediction structure by eliminating provider table information
  * Updated predictor initialization parameters and constructor logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->