### PR TITLE
cpu: Align BTB TAGE allocation with RTL

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -564,10 +564,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way) {
-    // Simple set-associative allocation (no LFSR, no per-way table gating):
-    // - For each table from start_table upward, check the set at computed index.
-    // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
-    // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
+    // Match RTL allocation priority:
+    // 1) invalid way
+    // 2) weak and not-useful way
+    // 3) any not-useful way
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
@@ -579,34 +579,42 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
         auto &set = tageTable[ti][newIndex];
 
-        // Allocate into invalid way or not-useful and weak way
+        int selected_way = -1;
         for (unsigned way = 0; way < numWays; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
-            if (!cand.valid || (!cand.useful && weakish)) {
-                short newCounter = actual_taken ? 0 : -1;
-                DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
-                        ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
-                tageStats.updateAllocSuccess++;
-                allocated_table = ti;
-                allocated_index = newIndex;
-                allocated_way = way;
-                usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
-                return true;
+            if (!set[way].valid) {
+                selected_way = way;
+                break;
             }
         }
-
-        // 3) Apply age penalty to one strong, not-useful way to make it replacable later
-        for (unsigned way = 0; way < numWays; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
-            if (!cand.useful && !weakish) {
-                if (cand.counter > 0) cand.counter--; else cand.counter++;
-                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n",
-                        ti, newIndex, way, cand.counter);
-                break; // one penalty per table per update
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < numWays; ++way) {
+                auto &cand = set[way];
+                const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
+                if (!cand.useful && weakish) {
+                    selected_way = way;
+                    break;
+                }
             }
+        }
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < numWays; ++way) {
+                if (!set[way].useful) {
+                    selected_way = way;
+                    break;
+                }
+            }
+        }
+        if (selected_way != -1) {
+            short newCounter = actual_taken ? 0 : -1;
+            DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
+                    ti, newIndex, selected_way, newTag, position, newCounter, entry.pc);
+            set[selected_way] = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+            tageStats.updateAllocSuccess++;
+            allocated_table = ti;
+            allocated_index = newIndex;
+            allocated_way = selected_way;
+            usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
+            return true;
         }
 
         tageStats.updateAllocFailure++;

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -498,10 +498,10 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way) {
-    // Simple set-associative allocation (no LFSR, no per-way table gating):
-    // - For each table from start_table upward, check the set at computed index.
-    // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
-    // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
+    // Match RTL allocation priority:
+    // 1) invalid way
+    // 2) weak and not-useful way
+    // 3) any not-useful way
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
@@ -514,34 +514,42 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
 
         auto &set = tageTable[ti][newIndex];
 
-        // Allocate into invalid way or not-useful and weak way
+        int selected_way = -1;
         for (unsigned way = 0; way < numWays; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
-            if (!cand.valid || (!cand.useful && weakish)) {
-                short newCounter = actual_taken ? 0 : -1;
-                DPRINTF(UTAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
-                        ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
-                tageStats.updateAllocSuccess++;
-                allocated_table = ti;
-                allocated_index = newIndex;
-                allocated_way = way;
-                usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
-                return true;
+            if (!set[way].valid) {
+                selected_way = way;
+                break;
             }
         }
-
-        // 3) Apply age penalty to one strong, not-useful way to make it replaceable later
-        for (unsigned way = 0; way < numWays; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
-            if (!cand.useful && !weakish) {
-                if (cand.counter > 0) cand.counter--; else cand.counter++;
-                DPRINTF(UTAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n",
-                        ti, newIndex, way, cand.counter);
-                break; // one penalty per table per update
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < numWays; ++way) {
+                auto &cand = set[way];
+                const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
+                if (!cand.useful && weakish) {
+                    selected_way = way;
+                    break;
+                }
             }
+        }
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < numWays; ++way) {
+                if (!set[way].useful) {
+                    selected_way = way;
+                    break;
+                }
+            }
+        }
+        if (selected_way != -1) {
+            short newCounter = actual_taken ? 0 : -1;
+            DPRINTF(UTAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
+                    ti, newIndex, selected_way, newTag, position, newCounter, entry.pc);
+            set[selected_way] = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+            tageStats.updateAllocSuccess++;
+            allocated_table = ti;
+            allocated_index = newIndex;
+            allocated_way = selected_way;
+            usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
+            return true;
         }
 
         tageStats.updateAllocFailure++;

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -768,9 +768,10 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
  * @brief Test allocation behavior with multiple ways (new policy)
  *
  * New allocation policy highlights:
- * - Allocation consults the selected way's usefulMask for each table.
- * - Only invalid entries, or (useful==0 and weak counter) can be allocated.
- * - No LRU-based replacement is performed when all considered entries are useful.
+ * - Allocation prefers invalid entries first.
+ * - Then it prefers weak and not-useful entries.
+ * - If neither exists, any not-useful entry can still be replaced.
+ * - No replacement occurs only when all candidate entries remain useful.
  *
  * This test verifies:
  * 1. First mispredict allocates into an invalid way.
@@ -869,6 +870,44 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     int alloc_failure_after_step3 = tage->tageStats.updateAllocFailure;
     EXPECT_GE(alloc_failure_after_step3, alloc_failure_after_step2 + 1)
         << "Allocation failures should increase after additional failed attempt";
+}
+
+TEST_F(BTBTAGETest, AllocationReplacesStrongNotUsefulEntry) {
+    tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
+    memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
+    history.resize(64, false);
+    stagePreds.resize(2);
+
+    Addr startPC = 0x1000;
+    int testTable = 0;
+    Addr testIndex = tage->getTageIndex(startPC, testTable);
+
+    // Fill both ways with valid, strong, but not-useful entries.
+    createManualTageEntry(
+        tage, testTable, testIndex, 0, tage->getTageTag(startPC, testTable, 0), 2, false, 0x1000);
+    createManualTageEntry(
+        tage, testTable, testIndex, 1, tage->getTageTag(startPC, testTable, 2), -2, false, 0x1004);
+
+    BTBEntry newEntry = createBTBEntry(0x1008);
+    int alloc_success_before = tage->tageStats.updateAllocSuccess;
+    int alloc_failure_before = tage->tageStats.updateAllocFailureNoValidTable;
+
+    // Base prediction defaults to taken, so actual not-taken forces allocation.
+    predictUpdateCycle(tage, startPC, newEntry, false, history, stagePreds);
+
+    bool found = false;
+    for (unsigned way = 0; way < tage->numWays; ++way) {
+        if (tage->tageTable[testTable][testIndex][way].valid &&
+            tage->tageTable[testTable][testIndex][way].pc == newEntry.pc) {
+            found = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(found)
+        << "A strong but not-useful entry should be replaceable after RTL-aligned allocation";
+    EXPECT_EQ(tage->tageStats.updateAllocSuccess, alloc_success_before + 1);
+    EXPECT_EQ(tage->tageStats.updateAllocFailureNoValidTable, alloc_failure_before);
 }
 
 /**


### PR DESCRIPTION
## Background

This PR aligns the BTB TAGE allocation policy in gem5 with the RTL fix from XiangShan PR #5677.

During perf comparison against RTL, gem5 showed significantly higher allocation failure and noticeably worse MPKI. The main mismatch was in the replacement eligibility of TAGE entries during allocation.

## Root Cause

Before this patch, gem5 only allowed allocation into:
- an invalid entry, or
- an entry with `useful == 0` and a weak prediction counter.

This is too restrictive.

After global useful reset, many entries may become `useful == 0` but still keep a strong counter. In that case, they should become replaceable again. However, the old gem5 logic still blocked replacing them, so useful reset could not effectively free space for new allocations.

This leads to two visible problems:
- `updateAllocFailureNoValidTable` stays unnecessarily high
- longer-history entries are harder to allocate, which can hurt prediction accuracy and increase MPKI

gem5 also had an extra "age penalty" path that slowly weakened strong-but-not-useful entries instead of allowing immediate replacement. That behavior does not match the RTL after the fix.

## Fix

This patch changes the allocation priority to match RTL:
1. prefer an invalid entry
2. otherwise prefer an entry with `useful == 0` and a weak counter
3. otherwise allow replacing any entry with `useful == 0`

In other words, `strong && !useful` entries are now directly replaceable, which is the key behavior change.

The same allocation rule is applied to both:
- `BTBTAGE`
- `MicroTAGE`

The old age-penalty path is removed because it is no longer needed and does not match RTL behavior.

## Validation

Added/updated unit tests to cover the new behavior, including the case where a strong-but-not-useful entry must be replaceable.

Local checks performed:
- `scons build/RISCV/cpu/pred/btb/test/tage.test.debug --unit-test -j100`
- `./build/RISCV/cpu/pred/btb/test/tage.test.debug --gtest_filter=BTBTAGETest.AllocationBehaviorWithMultipleWays:BTBTAGETest.AllocationReplacesStrongNotUsefulEntry`

## Expected Impact

This patch is expected to:
- reduce allocation failure caused by stale strong-but-not-useful entries
- make useful reset effective again
- bring gem5 BTB TAGE behavior closer to RTL
- potentially improve MPKI on perf workloads
