### PR TITLE
cpu-o3: fix store bound statistics.

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1055,8 +1055,6 @@ Scheduler::issueAndSelect()
     }
     if (instsToFu.size() < intel_fewops) {
         stats.exec_stall_cycle++;
-        if (lsq->anyStoreNotExecute())
-            stats.memstall_any_store++;
     }
     if (instsToFu.size() == 0) {
         int misslevel = lsq->anyInflightLoadsNotComplete();
@@ -1068,6 +1066,9 @@ Scheduler::issueAndSelect()
             stats.memstall_l2miss++;
         if ((misslevel & ((1 << 3) - 1)) == ((1 << 3) - 1))
             stats.memstall_l3miss++;
+    } else if (instsToFu.size() < intel_fewops) {
+        if (lsq->anyStoreNotExecute())
+            stats.memstall_any_store++;
     }
 }
 


### PR DESCRIPTION
Change-Id: I252981998ccb2f54687ed01e3f92558bb3f0eada

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of memory stall performance metrics in CPU scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->