### PR TITLE
Spec vp flush1

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -257,6 +257,8 @@ class BaseO3CPU(BaseCPU):
 
     # value predictor
     valuePred = Param.ValuePredictor(NULL, "valuepred unit")
+    enableSelectiveVPFlush = Param.Bool(False,
+        "Enable selective rollback for value prediction misprediction")
 
     enable_loadFusion = Param.Bool(False, "Enable load fusion")
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -452,11 +452,19 @@ IEW::setScoreboard(Scoreboard *sb_ptr)
 void
 IEW::lvpWakeDependents(const DynInstPtr &inst) {
     assert(inst->numDestRegs() == 1);
-    // VP selective flush: use speculative wakeup path so consumers
-    // stay in subDepGraph. On VP misprediction, loadCancel DFS can
-    // find and cancel them.
-    scheduler->specWakeUpFromVP(inst);
-    DPRINTF(IEW,"[sn:%llu] vp specWakeUp dependents\n", inst->seqNum);
+    if (enableSelectiveVPFlush) {
+        scheduler->specWakeUpFromVP(inst);
+        DPRINTF(IEW,"[sn:%llu] vp specWakeUp dependents\n", inst->seqNum);
+    } else {
+        for (int i = 0; i < inst->numDestRegs(); i++) {
+            auto dest = inst->renamedDestIdx(i);
+            if (dest->isFixedMapping()) {
+                continue;
+            }
+            scheduler->setAllScoreBoard(dest);
+            DPRINTF(IEW,"[sn:%llu] vp set scoreboard to true\n", inst->seqNum);
+        }
+    }
 }
 
 bool
@@ -718,22 +726,30 @@ IEW::readyToFinish(const DynInstPtr& inst)
 
     ThreadID tid = inst->threadNumber;
     if (inst->vpMisprediction) {
-        // VP selective flush: cancel data-dependent consumers when possible.
-        // If any dependent consumer is already issued, fallback to squash.
-        DPRINTF(IEW, "[sn:%llu] VP misprediction detected, "
-                "selective cancel via loadCancel\n", inst->seqNum);
-        bool needSquashFallback = scheduler->loadCancel(inst);
-        if (needSquashFallback) {
-            DPRINTF(IEW, "[sn:%llu] VP fallback to squash due to issued dependent\n",
-                    inst->seqNum);
+        if (!enableSelectiveVPFlush) {
             if (!fetchRedirect[tid] || !toCommit->squash[tid] ||
                 toCommit->squashedSeqNum[tid] > inst->seqNum) {
                 fetchRedirect[tid] = true;
                 squashDueToValuePrediction(inst, tid);
             }
         } else {
-            // Writeback with real value to re-wake consumers
-            scheduler->writebackWakeup(inst);
+            // VP selective flush: cancel data-dependent consumers when possible.
+            // If any dependent consumer is already issued, fallback to squash.
+            DPRINTF(IEW, "[sn:%llu] VP misprediction detected, "
+                    "selective cancel via loadCancel\n", inst->seqNum);
+            bool needSquashFallback = scheduler->loadCancel(inst);
+            if (needSquashFallback) {
+                DPRINTF(IEW, "[sn:%llu] VP fallback to squash due to issued dependent\n",
+                        inst->seqNum);
+                if (!fetchRedirect[tid] || !toCommit->squash[tid] ||
+                    toCommit->squashedSeqNum[tid] > inst->seqNum) {
+                    fetchRedirect[tid] = true;
+                    squashDueToValuePrediction(inst, tid);
+                }
+            } else {
+                // Writeback with real value to re-wake consumers
+                scheduler->writebackWakeup(inst);
+            }
         }
     }
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -452,16 +452,11 @@ IEW::setScoreboard(Scoreboard *sb_ptr)
 void
 IEW::lvpWakeDependents(const DynInstPtr &inst) {
     assert(inst->numDestRegs() == 1);
-    for (int i = 0; i < inst->numDestRegs(); i++) {
-        auto dest = inst->renamedDestIdx(i);
-        if (dest->isFixedMapping()) {
-            continue;
-        }
-
-        scheduler->setAllScoreBoard(dest);
-
-        DPRINTF(IEW,"[sn:%llu] vp set scoreboard to true\n", inst->seqNum);
-    }
+    // VP selective flush: use speculative wakeup path so consumers
+    // stay in subDepGraph. On VP misprediction, loadCancel DFS can
+    // find and cancel them.
+    scheduler->specWakeUpFromVP(inst);
+    DPRINTF(IEW,"[sn:%llu] vp specWakeUp dependents\n", inst->seqNum);
 }
 
 bool
@@ -723,10 +718,22 @@ IEW::readyToFinish(const DynInstPtr& inst)
 
     ThreadID tid = inst->threadNumber;
     if (inst->vpMisprediction) {
-        if (!fetchRedirect[tid] || !toCommit->squash[tid] || toCommit->squashedSeqNum[tid] > inst->seqNum) {
-            // deal with value prediction error
-            fetchRedirect[tid] = true;
-            squashDueToValuePrediction(inst, tid);
+        // VP selective flush: cancel data-dependent consumers when possible.
+        // If any dependent consumer is already issued, fallback to squash.
+        DPRINTF(IEW, "[sn:%llu] VP misprediction detected, "
+                "selective cancel via loadCancel\n", inst->seqNum);
+        bool needSquashFallback = scheduler->loadCancel(inst);
+        if (needSquashFallback) {
+            DPRINTF(IEW, "[sn:%llu] VP fallback to squash due to issued dependent\n",
+                    inst->seqNum);
+            if (!fetchRedirect[tid] || !toCommit->squash[tid] ||
+                toCommit->squashedSeqNum[tid] > inst->seqNum) {
+                fetchRedirect[tid] = true;
+                squashDueToValuePrediction(inst, tid);
+            }
+        } else {
+            // Writeback with real value to re-wake consumers
+            scheduler->writebackWakeup(inst);
         }
     }
 

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -410,6 +410,9 @@ class IEW
     /** Value predictor */
     valuepred::VPUnit *valuePred;
 
+    /** Enable selective VP flush path */
+    bool enableSelectiveVPFlush;
+
   private:
     /** CPU pointer. */
     CPU *cpu;

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -508,6 +508,10 @@ IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative)
 void
 IssueQue::addIfReady(const DynInstPtr& inst)
 {
+    if (inst->isIssued()) {
+        return;
+    }
+
     if (inst->readyToIssue()) {
         if (inst->readyTick == -1) {
             inst->readyTick = curTick();
@@ -1259,6 +1263,32 @@ Scheduler::specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_que
 }
 
 void
+Scheduler::specWakeUpFromVP(const DynInstPtr& inst)
+{
+    DPRINTF(Schedule, "[sn:%llu] VP speculative wakeup dependents\n", inst->seqNum);
+    // Wake consumers already in IQ via speculative wakeup (preserves subDepGraph)
+    for (auto to : issueQues) {
+        to->wakeUpDependents(inst, true);  // speculative=true -> depgraph preserved
+    }
+    // Set earlyScoreboard + bypassScoreboard (but NOT scoreboard) so that
+    // future consumers entering IQ via insert() will:
+    //   - see scoreboard[src]=false -> enter the else branch
+    //   - see earlyScoreboard[src]=true -> markSrcRegReady AND added to subDepGraph
+    // This ensures loadCancel DFS can find them.
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        PhysRegIdPtr dst = inst->renamedDestIdx(i);
+        if (dst->isFixedMapping()) [[unlikely]] {
+            continue;
+        }
+        earlyScoreboard[dst->flatIndex()] = true;
+        bypassScoreboard[dst->flatIndex()] = true;
+        // NOTE: intentionally NOT setting scoreboard[dst] = true
+        // so consumers go through the earlyScoreboard path in insert()
+        // which adds them to subDepGraph
+    }
+}
+
+void
 Scheduler::specWakeUpFromLoadPipe(const DynInstPtr& inst)
 {
     assert(inst->isLoad());
@@ -1360,7 +1390,7 @@ Scheduler::useRfWrPort(const DynInstPtr& inst, const PhysRegIdPtr& regid, int ty
     t_lat = lat;
 }
 
-void
+bool
 Scheduler::loadCancel(const DynInstPtr& inst)
 {
     DPRINTF(Schedule, "[sn:%llu] %s cache miss, cancel consumers\n", inst->seqNum,
@@ -1369,10 +1399,12 @@ Scheduler::loadCancel(const DynInstPtr& inst)
         inst->issueQue->iqstats->loadmiss++;
     }
 
-    // speculative value prediction load should not be cancel
-    // because the dependency issue has been resolved
-    if (inst->vpResult.speculative) {
-        return;
+    bool needSquashFallback = false;
+
+    // For VP load: if prediction is correct (no misprediction), skip cancel.
+    // If VP misprediction detected, allow DFS to cancel dependent consumers.
+    if (inst->vpResult.speculative && !inst->vpMisprediction) {
+        return false;
     }
 
     dfs.push(inst);
@@ -1398,6 +1430,18 @@ Scheduler::loadCancel(const DynInstPtr& inst)
                     if (depInst->readySrcIdx(srcIdx)) {
                         DPRINTF(Schedule, "cancel [sn:%llu], clear src p%d ready\n", depInst->seqNum,
                                 depInst->renamedSrcIdx(srcIdx)->flatIndex());
+                        if (depInst->isIssued()) {
+                            if (inst->vpMisprediction) {
+                                // VP misprediction: consumer may already be in-flight.
+                                // Mark canceled and propagate to its dependents.
+                                depInst->setCancel();
+                                depInst->clearSrcRegReady(srcIdx);
+                                dfs.push(depInst);
+                                needSquashFallback = true;
+                            }
+                            continue;
+                        }
+
                         depInst->issueQue->cancel(depInst);
                         depInst->clearSrcRegReady(srcIdx);
                         dfs.push(depInst);
@@ -1418,6 +1462,8 @@ Scheduler::loadCancel(const DynInstPtr& inst)
             }
         }
     }
+
+    return needSquashFallback;
 }
 
 void
@@ -1456,14 +1502,14 @@ Scheduler::bypassWriteback(const DynInstPtr& inst)
     }
     if (inst->canLVP()) {
         RegVal actualValue = cpu->getReg(inst->extRenamedDestIdx(0));
-        // RegVal actualValue_2 = inst->getResult().as<RegVal>();
-        // assert(actualValue == actualValue_2);
         inst->actualValue = actualValue;
-        if (inst->vpResult.speculative && inst->fault == NoFault) {
-            if (actualValue != inst->vpResult.value) {
-                // check error
-                inst->vpMisprediction = true;
-            }
+        inst->vpMisprediction = false;
+        if (inst->vpResult.speculative && inst->fault == NoFault &&
+            actualValue != inst->vpResult.value) {
+            DPRINTF(schedule, "actual value: 0x%lx, predicted value: 0x%lx pc %lx\n", actualValue,
+                    inst->vpResult.value, inst->pcState().instAddr());
+            inst->vpMisprediction = true;
+            inst->vpResult.speculative = false;
         }
     }
 }

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1506,7 +1506,7 @@ Scheduler::bypassWriteback(const DynInstPtr& inst)
         inst->vpMisprediction = false;
         if (inst->vpResult.speculative && inst->fault == NoFault &&
             actualValue != inst->vpResult.value) {
-            DPRINTF(schedule, "actual value: 0x%lx, predicted value: 0x%lx pc %lx\n", actualValue,
+            DPRINTF(Schedule, "actual value: 0x%lx, predicted value: 0x%lx pc %lx\n", actualValue,
                     inst->vpResult.value, inst->pcState().instAddr());
             inst->vpMisprediction = true;
             inst->vpResult.speculative = false;

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -346,8 +346,9 @@ class Scheduler : public SimObject
     void useRfRdPort(const DynInstPtr& inst, const PhysRegIdPtr& regid, int typePortId, int pri);
     void useRfWrPort(const DynInstPtr& inst, const PhysRegIdPtr& regid, int typePortId, int pri);
 
+    void specWakeUpFromVP(const DynInstPtr& inst);
     void specWakeUpFromLoadPipe(const DynInstPtr& inst);
-    void loadCancel(const DynInstPtr& inst);
+    bool loadCancel(const DynInstPtr& inst);
 
     void writebackWakeup(const DynInstPtr& inst);
     void bypassWriteback(const DynInstPtr& inst);

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -67,7 +67,8 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
       releaseWidth(params.phyregReleaseWidth),
       numThreads(params.numThreads),
       stats(_cpu),
-      valuePred(params.valuePred)
+      valuePred(params.valuePred),
+        enableSelectiveVPFlush(params.enableSelectiveVPFlush)
 {
     if (renameWidth > MaxWidth)
         fatal("renameWidth (%d) is larger than compiled limit (%d),\n"
@@ -943,9 +944,10 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
 
             inst->vpSupported = true;
             if (inst->vpResult.speculative) {
-                // VP: Do NOT set scoreboard here. Let consumers enter subDepGraph
-                // so loadCancel DFS can find them on VP misprediction.
-                // scoreboard->setReg(rename_result.first.PhyReg());
+                if (!enableSelectiveVPFlush) {
+                    // old behavior: let back-to-back rename consumers see ready
+                    scoreboard->setReg(rename_result.first.PhyReg());
+                }
                 inst->setRegOperand(inst->staticInst.get(), 0, inst->vpResult.value);
                 // must pop result here
                 inst->popResult();

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -943,8 +943,9 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
 
             inst->vpSupported = true;
             if (inst->vpResult.speculative) {
-                // set the scoreboard, let the back-to-back rename inst mark reg ready
-                scoreboard->setReg(rename_result.first.PhyReg());
+                // VP: Do NOT set scoreboard here. Let consumers enter subDepGraph
+                // so loadCancel DFS can find them on VP misprediction.
+                // scoreboard->setReg(rename_result.first.PhyReg());
                 inst->setRegOperand(inst->staticInst.get(), 0, inst->vpResult.value);
                 // must pop result here
                 inst->popResult();

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -455,6 +455,9 @@ class Rename
 
     /** Value predictor */
     valuepred::VPUnit *valuePred;
+
+    /** Enable selective VP flush path */
+    bool enableSelectiveVPFlush;
 };
 
 } // namespace o3


### PR DESCRIPTION
Current behavior: When a value prediction (VP load) is mispredicted, squashDueToValuePrediction() triggers a global squash, which flushes all subsequent instructions.
Goal: Flush only the instructions that have a true read-after-write (RAW) data dependency on the mispredicted VP load, including dependencies propagated transitively through intermediate instructions, while leaving unrelated instructions untouched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `enableSelectiveVPFlush` configuration parameter to control value prediction misprediction recovery strategy.

* **Changes**
  * Enhanced value prediction misprediction recovery with selective rollback and optimized wakeup mechanisms for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->