### PR TITLE
Tage way tunning and enlarge L3 size to 32MB

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -139,6 +139,8 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
 
+    args.l3_size = '32MB'
+
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1044,7 +1044,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([2048, 2048, 2048, 2048, 2048, 2048, 2048,2048],"the TAGE T0~Tn length")
+    tableSizes = VectorParam.Unsigned([2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048], "the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13] * 8, "the T0~Tn entry's tag bit size")
     TTagPcShifts = VectorParam.Unsigned([1] * 8, "when the T0~Tn entry's tag generating, PC right shift")
     blockSize = 32 # tage index function uses 32B aligned block address
@@ -1052,7 +1052,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211,397],"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = VectorParam.Unsigned([2] * 8,"the T0~Tn number of ways per set")
+    numWays = VectorParam.Unsigned([2, 2, 4, 2, 2, 2, 2, 2], "the T0~Tn number of ways per set")
     maxBranchPositions = Param.Unsigned(32, "Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128, "Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7, "Width of the useAltOnNa table")


### PR DESCRIPTION
tage way tunning and enlarge L3 size to 32MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * L3 cache size now explicitly set to 32MB in default system configuration.
  * Branch predictor table parameters optimized with adjusted capacity allocation and associativity for improved cache performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->