### PR TITLE
Tage tunning and L3 Cache size change

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -85,6 +85,9 @@ def setKmhV3IdealParams(args, system):
         if args.bp_type == 'DecoupledBPUWithBTB':
             cpu.branchPred.ftq_size = 64
             cpu.branchPred.fsq_size = 64
+            # TAGE table sizes and numWays tunning
+            cpu.branchPred.tage.tableSizes = [2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048]
+            cpu.branchPred.tage.numWays = [2, 2, 4, 2, 2, 2, 2, 2]
             # cpu.branchPred.microtage.enabled = False
 
         # l1 cache per core
@@ -138,6 +141,8 @@ if __name__ == '__m5_main__':
     # If user didn't specify bp_type, set default based on ideal_kmhv3
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
+
+    args.l3_size = '64MB'
 
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -142,7 +142,7 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
 
-    args.l3_size = '64MB'
+    args.l3_size = '32MB'
 
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)


### PR DESCRIPTION
apply tage tunning and enlarge L3 Cache size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch predictor configuration parameters for enhanced prediction accuracy
  * Established default L3 cache memory size (32MB) during system initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->