### PR TITLE
cpu-o3: Add a move-elimination toggle for SE configs

### DIFF
--- a/configs/example/se.py
+++ b/configs/example/se.py
@@ -331,7 +331,8 @@ def setKmhV3IdealParams(args, system):
         # cpu.EnablePipeNukeCheck = False
         cpu.StoreWbStage = 4 # store writeback at s4
 
-        # enable constant folding
+        # disable rename-time operand folding/elimination for SE correctness
+        cpu.enableMoveElimination = False
         cpu.enableConstantFolding = False
 
         # ideal l1 caches

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -262,6 +262,7 @@ class BaseO3CPU(BaseCPU):
 
     enable_loadFusion = Param.Bool(False, "Enable load fusion")
 
+    enableMoveElimination = Param.Bool(True, "Enable register move elimination")
     enableConstantFolding = Param.Bool(False, "Enable Constant Folding (add-immediate elimination)")
     enableMovImmElimination = Param.Bool(False, "Enable MOVI elimination")
 

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -129,6 +129,7 @@ CPU::CPU(const BaseO3CPUParams &params)
       ipc_r("ipc", "", 1000, archDBer),
       cpi_r("cpi", "", 1000, archDBer),
       issueWidth(params.decodeWidth),
+      enableMoveElimination(params.enableMoveElimination),
       enableConstantFolding(params.enableConstantFolding),
       enableMovImmElimination(params.enableMovImmElimination),
       cpuStats(this),

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -652,6 +652,7 @@ class CPU : public BaseCPU
     /** Issue Width, using for intel topdown stats */
     int issueWidth; // issueWidth = decodeWidth = renameWidth!!!
 
+    bool enableMoveElimination; // Control flag of register move elimination
     bool enableConstantFolding; // Control flag of Constant Folding (add-immediate elimination)
     bool enableMovImmElimination;
 

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -862,7 +862,7 @@ Rename::renameDestRegs(const DynInstPtr &inst, ThreadID tid)
 
         VirtRegId bypass_reg;
         bool inc_ref_of_last_dest_phy_reg = false;
-        if (inst->isMov()) {
+        if (cpu->enableMoveElimination && inst->isMov()) {
             // Move elimination
             bypass_reg =
                 map->lookup(tc->flattenRegId(inst->srcRegIdx(0)));


### PR DESCRIPTION
## Summary
Add an explicit `enableMoveElimination` knob to the O3 CPU and disable it in `configs/example/se.py`.

## Why
In SE mode, syscall return values are written back through `ThreadContext::setReg()`. When rename-time move elimination keeps an architectural register on a folded mapping instead of a materialized physical register, that external architectural writeback can be lost. This showed up in a minimal RISC-V `mmap` userland test, where the syscall computed the correct high address but userspace still observed `a0 == 0`.

This change keeps the historical behavior by default (`enableMoveElimination=True`) and only turns it off in the SE example config.

## Validation
- Rebuilt `build/RISCV/gem5.opt`
- Re-ran `configs/example/se.py -c /tmp/libc_mmap_smoke_xsai --enable-riscv-vector --no-pf`
- Confirmed the test now prints `libc_mmap_smoke p=0x4000000000000000`

Change-Id: I43afa985b6c849c4a717dc10a2c92ab7349ddb62