### PR TITLE
mem-cache: Filter foreign snoops in aligned L2 slices

### DIFF
--- a/src/mem/cache/xs_l2/L2CacheSlice.cc
+++ b/src/mem/cache/xs_l2/L2CacheSlice.cc
@@ -56,6 +56,42 @@ L2CacheSlice::innerMemPortRecvTimingReq(PacketPtr pkt)
     return CacheWrapper::innerMemPortRecvTimingReq(pkt);
 }
 
+void
+L2CacheSlice::memSidePortRecvTimingSnoopReq(PacketPtr pkt)
+{
+    if (ownsAddr && !ownsAddr(pkt->getAddr())) {
+        DPRINTF(L2CacheSlice,
+                "Dropping foreign timing snoop for addr %#x on slice %s\n",
+                pkt->getAddr(), name());
+        return;
+    }
+    CacheWrapper::memSidePortRecvTimingSnoopReq(pkt);
+}
+
+void
+L2CacheSlice::memSidePortRecvFunctionalSnoop(PacketPtr pkt)
+{
+    if (ownsAddr && !ownsAddr(pkt->getAddr())) {
+        DPRINTF(L2CacheSlice,
+                "Dropping foreign functional snoop for addr %#x on slice %s\n",
+                pkt->getAddr(), name());
+        return;
+    }
+    CacheWrapper::memSidePortRecvFunctionalSnoop(pkt);
+}
+
+Tick
+L2CacheSlice::memSidePortRecvAtomicSnoop(PacketPtr pkt)
+{
+    if (ownsAddr && !ownsAddr(pkt->getAddr())) {
+        DPRINTF(L2CacheSlice,
+                "Dropping foreign atomic snoop for addr %#x on slice %s\n",
+                pkt->getAddr(), name());
+        return 0;
+    }
+    return CacheWrapper::memSidePortRecvAtomicSnoop(pkt);
+}
+
 bool
 L2CacheSlice::memSidePortRecvTimingResp(PacketPtr pkt)
 {

--- a/src/mem/cache/xs_l2/L2CacheSlice.hh
+++ b/src/mem/cache/xs_l2/L2CacheSlice.hh
@@ -54,6 +54,10 @@ class L2CacheSlice : public CacheWrapper
         dirReadBypass = bypass;
     }
 
+    void setOwnAddrFunc(std::function<bool(Addr)> func) {
+        ownsAddr = func;
+    }
+
   protected:
     // For request buffering logic
     RequestBuffer requestBuffer;
@@ -99,6 +103,7 @@ class L2CacheSlice : public CacheWrapper
     std::function<Addr(Addr)> getSetIdx;
     std::function<Addr(Addr)> getDataBankIdx;
     std::function<Addr(Addr)> getDirBankIdx;
+    std::function<bool(Addr)> ownsAddr;
 
     uint64_t pipeDirWriteStage = 3;
     bool dirReadBypass = false;
@@ -107,6 +112,9 @@ class L2CacheSlice : public CacheWrapper
     void innerCpuPortRecvReqRetry() override;
     bool innerCpuPortSendTimingReq(PacketPtr pkt, TaskSource source);
     bool innerMemPortRecvTimingReq(PacketPtr pkt) override;
+    void memSidePortRecvTimingSnoopReq(PacketPtr pkt) override;
+    void memSidePortRecvFunctionalSnoop(PacketPtr pkt) override;
+    Tick memSidePortRecvAtomicSnoop(PacketPtr pkt) override;
     bool memSidePortRecvTimingResp(PacketPtr pkt) override;
     void innerMemPortRecvRespRetry() override;
 

--- a/src/mem/cache/xs_l2/L2CacheWrapper.hh
+++ b/src/mem/cache/xs_l2/L2CacheWrapper.hh
@@ -77,9 +77,13 @@ class L2CacheWrapper : public ClockedObject
 
     void addSliceAccessor(L2CacheSlice* slice)
     {
+        const auto slice_id = slice_accessors.size();
         slice_accessors.push_back(slice);
         slice->setPipeDirWriteStage(pipe_dir_write_stage);
         slice->setDirReadBypass(dirReadBypass);
+        slice->setOwnAddrFunc([this, slice_id](Addr addr) -> bool {
+            return getSliceId(addr) == static_cast<PortID>(slice_id);
+        });
         slice->setGetSetIdxFunc([this](Addr addr) -> Addr {
             Addr slice_bits = popCount(sliceMask);
             Addr set_idx = (addr >> (block_bits + slice_bits)) & setMask;


### PR DESCRIPTION
## Summary
Filter memory-side snoops in aligned L2 slices so a slice only forwards snoops for addresses it owns.

## Problem
`MSCE32` uses the functional memory path. In the aligned-L2 configuration, functional snoops from the lower memory hierarchy are broadcast to all L2 slices. A foreign slice may then perform a local tag lookup on an address that belongs to another slice.

Because slice bits are implicit in each slice's local indexing/tag view, this can alias a foreign address to a different local cache line and corrupt the cache-visible data.

## Fix
Add a per-slice ownership check in `L2CacheSlice` and drop foreign memory-side snoops before forwarding them to the inner cache:
- functional snoops
- timing snoops
- atomic snoops

The ownership predicate is provided by `L2CacheWrapper` based on the wrapper's slice-id mapping.

## Validation
Validated on the matrix SE bring-up tree where the issue was reproduced:
- `precomp_rand_repro`: passes after the fix
- `gemm_precomp`: all 8 precomputed cases pass after the fix

Also verified that the issue is specific to aligned/sliced L2 behavior rather than the classic-L2 path.