### PR TITLE
configs: Initialize classic L2 DRRIP slice params

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -92,6 +92,10 @@ def config_classic_l2(options, system, l2_cache_class):
         # system.tol2bus_list.append(L2XBar(clk_domain = system.cpu_clk_domain, width=256))
         system.l2_caches[i].cpu_side = system.tol2bus_list[i].mem_side_ports
         system.tol2bus_list[i].snoop_filter.max_capacity = "16MB"
+        if isinstance(system.l2_caches[i].replacement_policy, DRRIPRP):
+            system.l2_caches[i].replacement_policy.num_slices = 1
+            system.l2_caches[i].replacement_policy.num_sets_per_slice = \
+                system.l2_caches[i].size // (64 * system.l2_caches[i].assoc)
         system.l2_caches[i].do_fast_writeline = not options.kmh_align
         if options.ideal_cache:
             system.l2_caches[i].response_latency = 0


### PR DESCRIPTION
## Summary
Initialize DRRIP slice-related parameters for the classic-L2 configuration.

## Problem
The default L2 cache uses `DRRIPRP`, which inherits from `DuelingRP`. In the classic-L2 configuration, the replacement policy did not initialize `num_slices` and `num_sets_per_slice`.

As a result, the simulator could hit `floorLog2(0)` during initialization and abort at tick 0 when running with `--classic-l2`.

## Fix
When classic L2 is configured, initialize the DRRIP replacement policy with:
- `num_slices = 1`
- `num_sets_per_slice = size / (64 * assoc)`

This keeps the classic-L2 configuration consistent with the assumptions made by the replacement-policy implementation.

## Validation
Validated with SE matrix tests using `--classic-l2`:
- `precomp_rand_repro`: passes
- `gemm_precomp`: all 8 precomputed cases pass