### PR TITLE
cpu: updateOnRead parameter in BTBTAGE and tage trace

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1040,7 +1040,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
 
     needMoreHistories = Param.Bool(True, "BTBTAGE needs more histories")
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
-    updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
+    updateOnRead = Param.Bool(False, "Enable update on read, no need to save tage meta in FTQ")
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([2048]*4, "the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([8]*4, "the T0~Tn entry's tag bit size")

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -654,8 +654,9 @@ BTBTAGE::update(const FetchStream &stream) {
                 history_low50.resize(50);  // get the lower 50 bits of history
             }
             boost::to_string(history_low50, history_str);
-            auto main_info = recomputed.mainInfo;
-            auto alt_info = recomputed.altInfo;
+            TagePrediction db_trace_pred = predMeta->preds[btb_entry.pc];
+            auto main_info = db_trace_pred.mainInfo;
+            auto alt_info = db_trace_pred.altInfo;
             t.set(startAddr, btb_entry.pc, main_info.way,
                 main_info.found, main_info.entry.counter, main_info.entry.useful,
                 main_info.table, main_info.index,


### PR DESCRIPTION
Change-Id: If83b35a3e892d1917831a175da275894768dda13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified branch predictor update-on-read parameter default behavior from enabled to disabled
  * Updated debug trace capture mechanism to use stored prediction snapshots instead of recomputed values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->