### PR TITLE
Refs/heads/tage size align repeat index fill align

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1046,13 +1046,13 @@ class BTBTAGE(TimedBaseBTBPredictor):
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([2048]*8,"the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13] * 8, "the T0~Tn entry's tag bit size")
-    TTagPcShifts = VectorParam.Unsigned([2] * 8, "when the T0~Tn entry's tag generating, PC right shift")
+    TTagPcShifts = VectorParam.Unsigned([1] * 8, "when the T0~Tn entry's tag generating, PC right shift")
     blockSize = 32 # tage index function uses 32B aligned block address
 
     histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211,397],"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = VectorParam.Unsigned([1] * 8,"the T0~Tn number of ways per set")
+    numWays = VectorParam.Unsigned([2] * 8,"the T0~Tn number of ways per set")
     maxBranchPositions = Param.Unsigned(32, "Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128, "Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7, "Width of the useAltOnNa table")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1044,7 +1044,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([2048, 2048, 2048, 2048, 2048, 2048, 2048,2048],"the TAGE T0~Tn length")
+    tableSizes = VectorParam.Unsigned([512]*8,"the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13] * 8, "the T0~Tn entry's tag bit size")
     TTagPcShifts = VectorParam.Unsigned([1] * 8, "when the T0~Tn entry's tag generating, PC right shift")
     blockSize = 32 # tage index function uses 32B aligned block address
@@ -1052,7 +1052,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211,397],"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = VectorParam.Unsigned([2] * 8,"the T0~Tn number of ways per set")
+    numWays = VectorParam.Unsigned([1] * 8,"the T0~Tn number of ways per set")
     maxBranchPositions = Param.Unsigned(32, "Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128, "Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7, "Width of the useAltOnNa table")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1096,7 +1096,7 @@ class MicroTAGE(TimedBaseBTBPredictor):
     useAltOnNaWidth = Param.Unsigned(7,"Width of the useAltOnNa table")
     numBanks = Param.Unsigned(4,"Number of banks for bank conflict simulation")
     enableBankConflict = Param.Bool(False,"Enable bank conflict simulation")
-    numDelay = Param.Unsigned(1,"Prediction latency in cycles")
+    numDelay = Param.Unsigned(0,"Prediction latency in cycles")
 
 class BTBITTAGE(TimedBaseBTBPredictor):
     type = 'BTBITTAGE'

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1044,9 +1044,9 @@ class BTBTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")    # TODO: BTBTAGE doesn't support SC
     updateOnRead = Param.Bool(True, "Enable update on read, no need to save tage meta in FTQ")
     numPredictors = Param.Unsigned(8, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([512]*8,"the TAGE T0~Tn length")
+    tableSizes = VectorParam.Unsigned([2048]*8,"the TAGE T0~Tn length")
     TTagBitSizes = VectorParam.Unsigned([13] * 8, "the T0~Tn entry's tag bit size")
-    TTagPcShifts = VectorParam.Unsigned([1] * 8, "when the T0~Tn entry's tag generating, PC right shift")
+    TTagPcShifts = VectorParam.Unsigned([2] * 8, "when the T0~Tn entry's tag generating, PC right shift")
     blockSize = 32 # tage index function uses 32B aligned block address
 
     histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211,397],"the BTB TAGE T0~Tn history length")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1096,7 +1096,7 @@ class MicroTAGE(TimedBaseBTBPredictor):
     useAltOnNaWidth = Param.Unsigned(7,"Width of the useAltOnNa table")
     numBanks = Param.Unsigned(4,"Number of banks for bank conflict simulation")
     enableBankConflict = Param.Bool(False,"Enable bank conflict simulation")
-    numDelay = Param.Unsigned(0,"Prediction latency in cycles")
+    numDelay = Param.Unsigned(1,"Prediction latency in cycles")
 
 class BTBITTAGE(TimedBaseBTBPredictor):
     type = 'BTBITTAGE'

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -903,14 +903,16 @@ BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
 
     // When the table history is shorter than the index width (for example
     // t0/t1), the folded history only affects the low bits by default.
-    // Repeat the available history pattern so every index bit is perturbed.
+    // Repeat short history across chunks and rotate within histBits to
+    // decorrelate neighboring chunk content.
     const unsigned histBits = std::min(histLengths[t], tableIndexBits[t]);
     if (histBits > 0 && histBits < tableIndexBits[t]) {
         const Addr histMask = (1ULL << histBits) - 1;
-        const Addr baseHist = foldedHist & histMask;
+        Addr chunk = foldedHist & histMask;
         foldedBits = 0;
         for (unsigned pos = 0; pos < tableIndexBits[t]; pos += histBits) {
-            foldedBits |= (baseHist << pos);
+            foldedBits |= (chunk << pos);
+            chunk = ((chunk << 1) | (chunk >> (histBits - 1))) & histMask;
         }
         foldedBits &= mask;
     }

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -901,6 +901,20 @@ BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
     Addr pcBits = (pc >> pcShift) & mask;
     Addr foldedBits = foldedHist & mask;
 
+    // When the table history is shorter than the index width (for example
+    // t0/t1), the folded history only affects the low bits by default.
+    // Repeat the available history pattern so every index bit is perturbed.
+    const unsigned histBits = std::min(histLengths[t], tableIndexBits[t]);
+    if (histBits > 0 && histBits < tableIndexBits[t]) {
+        const Addr histMask = (1ULL << histBits) - 1;
+        const Addr baseHist = foldedHist & histMask;
+        foldedBits = 0;
+        for (unsigned pos = 0; pos < tableIndexBits[t]; pos += histBits) {
+            foldedBits |= (baseHist << pos);
+        }
+        foldedBits &= mask;
+    }
+
     // Support non-power-of-two table sizes when tuning capacities.
     return (pcBits ^ foldedBits) % tableSizes[t];
 }

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -903,16 +903,14 @@ BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist)
 
     // When the table history is shorter than the index width (for example
     // t0/t1), the folded history only affects the low bits by default.
-    // Repeat short history across chunks and rotate within histBits to
-    // decorrelate neighboring chunk content.
+    // Repeat the available history pattern so every index bit is perturbed.
     const unsigned histBits = std::min(histLengths[t], tableIndexBits[t]);
     if (histBits > 0 && histBits < tableIndexBits[t]) {
         const Addr histMask = (1ULL << histBits) - 1;
-        Addr chunk = foldedHist & histMask;
+        const Addr baseHist = foldedHist & histMask;
         foldedBits = 0;
         for (unsigned pos = 0; pos < tableIndexBits[t]; pos += histBits) {
-            foldedBits |= (chunk << pos);
-            chunk = ((chunk << 1) | (chunk >> (histBits - 1))) & histMask;
+            foldedBits |= (baseHist << pos);
         }
         foldedBits &= mask;
     }

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -406,23 +406,23 @@ TEST_F(BTBTAGETest, UsefulBitMechanism) {
         << "Useful bit should remain set when main predicts incorrectly (no decrement)";
 }
 
-// Test short folded history is repeated to cover the full index width.
+// Test short folded history is repeated and rotated to cover full index width.
 TEST_F(BTBTAGETest, IndexRepeatsShortFoldedHistory) {
     const Addr pc = 0x0;
 
     // Test table 0: histLen=4, indexBits=10 in unit-test constructor.
     const int t0 = 0;
     const Addr t0FoldedHist = 0xa;
-    const Addr t0ExpectedFolded = 0x2aa;
+    const Addr t0ExpectedFolded = 0x25a;
     EXPECT_EQ(tage->getTageIndex(pc, t0, t0FoldedHist), t0ExpectedFolded)
-        << "t0 index should repeat 4-bit history to cover all index bits";
+        << "t0 index should repeat and rotate 4-bit chunks across index bits";
 
     // Test table 1: histLen=8, indexBits=10 in unit-test constructor.
     const int t1 = 1;
     const Addr t1FoldedHist = 0xa5;
-    const Addr t1ExpectedFolded = 0x1a5;
+    const Addr t1ExpectedFolded = 0x3a5;
     EXPECT_EQ(tage->getTageIndex(pc, t1, t1FoldedHist), t1ExpectedFolded)
-        << "t1 index should repeat 8-bit history to cover all index bits";
+        << "t1 index should repeat and rotate 8-bit chunks across index bits";
 }
 
 // Test entry allocation mechanism

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -406,23 +406,23 @@ TEST_F(BTBTAGETest, UsefulBitMechanism) {
         << "Useful bit should remain set when main predicts incorrectly (no decrement)";
 }
 
-// Test short folded history is repeated and rotated to cover full index width.
+// Test short folded history is repeated to cover the full index width.
 TEST_F(BTBTAGETest, IndexRepeatsShortFoldedHistory) {
     const Addr pc = 0x0;
 
     // Test table 0: histLen=4, indexBits=10 in unit-test constructor.
     const int t0 = 0;
     const Addr t0FoldedHist = 0xa;
-    const Addr t0ExpectedFolded = 0x25a;
+    const Addr t0ExpectedFolded = 0x2aa;
     EXPECT_EQ(tage->getTageIndex(pc, t0, t0FoldedHist), t0ExpectedFolded)
-        << "t0 index should repeat and rotate 4-bit chunks across index bits";
+        << "t0 index should repeat 4-bit history to cover all index bits";
 
     // Test table 1: histLen=8, indexBits=10 in unit-test constructor.
     const int t1 = 1;
     const Addr t1FoldedHist = 0xa5;
-    const Addr t1ExpectedFolded = 0x3a5;
+    const Addr t1ExpectedFolded = 0x1a5;
     EXPECT_EQ(tage->getTageIndex(pc, t1, t1FoldedHist), t1ExpectedFolded)
-        << "t1 index should repeat and rotate 8-bit chunks across index bits";
+        << "t1 index should repeat 8-bit history to cover all index bits";
 }
 
 // Test entry allocation mechanism

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -406,6 +406,25 @@ TEST_F(BTBTAGETest, UsefulBitMechanism) {
         << "Useful bit should remain set when main predicts incorrectly (no decrement)";
 }
 
+// Test short folded history is repeated to cover the full index width.
+TEST_F(BTBTAGETest, IndexRepeatsShortFoldedHistory) {
+    const Addr pc = 0x0;
+
+    // Test table 0: histLen=4, indexBits=10 in unit-test constructor.
+    const int t0 = 0;
+    const Addr t0FoldedHist = 0xa;
+    const Addr t0ExpectedFolded = 0x2aa;
+    EXPECT_EQ(tage->getTageIndex(pc, t0, t0FoldedHist), t0ExpectedFolded)
+        << "t0 index should repeat 4-bit history to cover all index bits";
+
+    // Test table 1: histLen=8, indexBits=10 in unit-test constructor.
+    const int t1 = 1;
+    const Addr t1FoldedHist = 0xa5;
+    const Addr t1ExpectedFolded = 0x1a5;
+    EXPECT_EQ(tage->getTageIndex(pc, t1, t1FoldedHist), t1ExpectedFolded)
+        << "t1 index should repeat 8-bit history to cover all index bits";
+}
+
 // Test entry allocation mechanism
 TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     // Instead of creating two different PCs, we'll create two entries with the same PC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified branch predictor configuration by allowing repeated table-size declarations.

* **Bug Fixes**
  * Fixed index computation so short history values are tiled to fill the required index width before combining with PC bits.

* **Tests**
  * Added a unit test that verifies index calculation when folded history is shorter than the index width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->