### PR TITLE
[codex] cpu: Align BTB TAGE useful and allocation semantics

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -487,27 +487,12 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
         // Update prediction counter
         updateCounter(actual_taken, 3, way.counter);
 
-        // Update useful bit based on several conditions
+        // Match RTL behavior: useful only increases when the provider proves
+        // itself against the alternative prediction. There is no local
+        // decrement/reset path tied to weak counters or "humility" cases.
         bool main_is_correct = main_info.taken() == actual_taken;
-        bool alt_is_correct_and_strong = alt_info.found &&
-                                     (alt_info.taken() == actual_taken) &&
-                                     (abs(2 * alt_info.entry.counter + 1) == 7);
-
-        // a. Special reset (humility mechanism)
-        if (alt_is_correct_and_strong && main_is_correct) {
-            way.useful = 0;
-            DPRINTF(TAGEUseful, "useful bit reset to 0 due to humility rule\n");
-        } else if (main_info.taken() != alt_taken) {
-            // b. Original logic to set useful bit high
-            if (main_is_correct) {
-                way.useful = 1;
-            }
-        }
-
-        // c. Reset u on counter sign flip (becomes weak)
-        if (way.counter == 0 || way.counter == -1) {
-            way.useful = 0;
-            DPRINTF(TAGEUseful, "useful bit reset to 0 due to weak counter\n");
+        if (main_info.taken() != alt_taken && main_is_correct) {
+            way.useful = 1;
         }
         DPRINTF(TAGE, "useful bit is now %d\n", way.useful);
 
@@ -553,6 +538,12 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
         return false;
     }
 
+    // Match RTL: a provider from the highest history table should not trigger
+    // longer-history allocation.
+    if (main_info.found && main_info.table == numPredictors - 1) {
+        return false;
+    }
+
     // Special case: provider is weak but direction is correct
     // In this case, provider just needs more training, not a longer history table
     // This avoids wasteful allocation and prevents ping-pong effects
@@ -583,10 +574,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way) {
-    // Simple set-associative allocation (no LFSR, no per-way table gating):
-    // - For each table from start_table upward, check the set at computed index.
-    // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
-    // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
+    // Match RTL victim priority:
+    // 1) invalid way
+    // 2) weak and not-useful way
+    // 3) any not-useful way
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
@@ -600,34 +591,45 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
         const unsigned ways = getNumWays(ti);
 
-        // Allocate into invalid way or not-useful and weak way
+        int selected_way = -1;
         for (unsigned way = 0; way < ways; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3; // -3,-2,-1,0,1,2
-            if (!cand.valid || (!cand.useful && weakish)) {
-                short newCounter = actual_taken ? 0 : -1;
-                DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
-                        ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
-                tageStats.updateAllocSuccess++;
-                allocated_table = ti;
-                allocated_index = newIndex;
-                allocated_way = way;
-                usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
-                return true;
+            if (!set[way].valid) {
+                selected_way = way;
+                break;
             }
         }
 
-        // 3) Apply age penalty to one strong, not-useful way to make it replacable later
-        for (unsigned way = 0; way < ways; ++way) {
-            auto &cand = set[way];
-            const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
-            if (!cand.useful && !weakish) {
-                if (cand.counter > 0) cand.counter--; else cand.counter++;
-                DPRINTF(TAGE, "age penalty applied on table %d[%lu][%u], new ctr %d\n",
-                        ti, newIndex, way, cand.counter);
-                break; // one penalty per table per update
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < ways; ++way) {
+                auto &cand = set[way];
+                const bool weakish = std::abs(cand.counter * 2 + 1) <= 3;
+                if (!cand.useful && weakish) {
+                    selected_way = way;
+                    break;
+                }
             }
+        }
+
+        if (selected_way == -1) {
+            for (unsigned way = 0; way < ways; ++way) {
+                if (!set[way].useful) {
+                    selected_way = way;
+                    break;
+                }
+            }
+        }
+
+        if (selected_way != -1) {
+            short newCounter = actual_taken ? 0 : -1;
+            DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
+                    ti, newIndex, selected_way, newTag, position, newCounter, entry.pc);
+            set[selected_way] = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+            tageStats.updateAllocSuccess++;
+            allocated_table = ti;
+            allocated_index = newIndex;
+            allocated_way = selected_way;
+            usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
+            return true;
         }
 
         tageStats.updateAllocFailure++;

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -406,6 +406,44 @@ TEST_F(BTBTAGETest, UsefulBitMechanism) {
         << "Useful bit should remain set when main predicts incorrectly (no decrement)";
 }
 
+TEST_F(BTBTAGETest, UsefulBitIgnoresStrongCorrectAlternative) {
+    BTBEntry entry = createBTBEntry(0x1000);
+
+    // Provider and alternative both predict taken correctly. RTL-aligned
+    // behavior keeps useful unchanged instead of clearing it.
+    setupTageEntry(tage, 0x1000, 3, 2, true);
+    setupTageEntry(tage, 0x1000, 1, 2, false);
+
+    Addr mainIndex = tage->getTageIndex(0x1000, 3);
+
+    predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
+    auto meta = tage->getPredictionMeta();
+    FetchTarget stream = createStream(0x1000, entry, true, meta);
+    tage->update(stream);
+
+    EXPECT_TRUE(tage->tageTable[3][mainIndex][0].useful)
+        << "Useful bit should not be cleared only because alt is also correct and strong";
+}
+
+TEST_F(BTBTAGETest, UsefulBitIgnoresWeakCounterTransition) {
+    BTBEntry entry = createBTBEntry(0x1000);
+
+    // Counter transitions to a weak state after update, but useful should not
+    // be cleared by that transition alone.
+    setupTageEntry(tage, 0x1000, 3, 1, true);
+
+    Addr mainIndex = tage->getTageIndex(0x1000, 3);
+
+    predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
+    auto meta = tage->getPredictionMeta();
+    FetchTarget stream = createStream(0x1000, entry, false, meta);
+    tage->update(stream);
+
+    EXPECT_EQ(tage->tageTable[3][mainIndex][0].counter, 0);
+    EXPECT_TRUE(tage->tageTable[3][mainIndex][0].useful)
+        << "Useful bit should not be cleared only because the provider becomes weak";
+}
+
 // Test entry allocation mechanism
 TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     // Instead of creating two different PCs, we'll create two entries with the same PC
@@ -437,12 +475,35 @@ TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     stream.squashType = SquashType::SQUASH_CTRL; // Mark as control misprediction
     stream.squashPC = 0x1000;
 
-    // Update the predictor (this should try to allocate but fail)
+    // Update the predictor. With RTL-aligned highest-table gating, this should
+    // not report a final allocation failure.
     tage->update(stream);
 
     int alloc_failed_no_valid = tage->tageStats.updateAllocFailureNoValidTable;
-    EXPECT_GE(alloc_failed_no_valid, 1) << "Allocate failed due to no valid table to allocate (all useful)";
+    EXPECT_EQ(alloc_failed_no_valid, 0)
+        << "A highest-table provider should suppress final allocation failure";
 
+}
+
+TEST_F(BTBTAGETest, HighestTableProviderSuppressesAllocation) {
+    BTBEntry entry = createBTBEntry(0x1000);
+
+    int highestTable = tage->numPredictors - 1;
+    setupTageEntry(tage, 0x1000, highestTable, 2, false);
+
+    predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
+    auto meta = tage->getPredictionMeta();
+
+    FetchTarget stream = createStream(0x1000, entry, false, meta);
+    stream.squashType = SquashType::SQUASH_CTRL;
+    stream.squashPC = 0x1000;
+
+    int alloc_failed_before = tage->tageStats.updateAllocFailureNoValidTable;
+    tage->update(stream);
+
+    EXPECT_EQ(tage->tageStats.updateAllocSuccess, 0);
+    EXPECT_EQ(tage->tageStats.updateAllocFailureNoValidTable, alloc_failed_before)
+        << "A highest-table provider should suppress allocation instead of reporting final failure";
 }
 
 // Test history recovery mechanism
@@ -870,6 +931,37 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     int alloc_failure_after_step3 = tage->tageStats.updateAllocFailure;
     EXPECT_GE(alloc_failure_after_step3, alloc_failure_after_step2 + 1)
         << "Allocation failures should increase after additional failed attempt";
+}
+
+TEST_F(BTBTAGETest, AllocationReplacesStrongNotUsefulEntry) {
+    tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
+    memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
+    history.resize(64, false);
+    stagePreds.resize(2);
+
+    Addr startPC = 0x1000;
+    int testTable = 0;
+    Addr testIndex = tage->getTageIndex(startPC, testTable);
+
+    createManualTageEntry(
+        tage, testTable, testIndex, 0, tage->getTageTag(startPC, testTable, 0), 2, false, 0x1000);
+    createManualTageEntry(
+        tage, testTable, testIndex, 1, tage->getTageTag(startPC, testTable, 2), -2, false, 0x1004);
+
+    BTBEntry newEntry = createBTBEntry(0x1008);
+    predictUpdateCycle(tage, startPC, newEntry, false, history, stagePreds);
+
+    bool found = false;
+    for (unsigned way = 0; way < tage->numWays[testTable]; way++) {
+        if (tage->tageTable[testTable][testIndex][way].valid &&
+            tage->tageTable[testTable][testIndex][way].pc == newEntry.pc) {
+            found = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(found)
+        << "A strong but not-useful entry should be replaceable";
 }
 
 TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {


### PR DESCRIPTION
## What changed

This PR applies a small BTB TAGE semantic alignment pass against the current XiangShan RTL behavior.

It intentionally keeps the scope narrow:

- remove gem5-only local useful-bit clearing paths
- suppress longer-history allocation when the provider already comes from the highest table
- allow allocation to replace strong-but-not-useful victims directly
- add focused unit tests for the aligned behavior

## Why

Recent gcc15-spec06-0.3c comparisons show that the major gem5/RTL MPKI gap has already largely closed on xs-dev. This makes it a good point to upstream the remaining low-complexity, known semantic mismatches without bringing along the heavier trace and diagnostics work used during investigation.

Concretely, current xs-dev still differed from RTL in a few places:

- useful could be cleared by a local "humility" path even though RTL only increments useful locally
- useful could be cleared when the provider counter became weak, which RTL does not do locally
- allocation could age a strong not-useful entry instead of replacing it directly
- a mispredict on the highest history table could still fall through to final allocation failure accounting

## Impact

This keeps BTB TAGE behavior closer to RTL while keeping code complexity controlled:

- no useful width migration
- no reset cadence change
- no large trace or stats additions

The change is meant to reduce semantic drift, not to force a broader predictor refactor.

## Validation

Built and ran:

```bash
./build/RISCV/cpu/pred/btb/test/tage.test.debug
```

Observed:

- 25 tests from 3 test suites passed

Added coverage for:

- useful should not clear just because a strong correct alternative exists
- useful should not clear just because the provider becomes weak
- highest-table providers should suppress longer-history allocation
- strong but not-useful victims should be directly replaceable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for branch prediction "useful" bit behavior and allocation scenarios.

* **Improvements**
  * Refined branch prediction allocation logic and decision-making for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->