### PR TITLE
arch-riscv,cpu-o3,mem-cache: add memblock PMU stats

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -77,6 +77,45 @@ namespace gem5
 
 namespace RiscvISA {
 
+Walker::WalkerStats::WalkerStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(ptwMemCount, statistics::units::Count::get(),
+               "Number of PTW memory requests sent"),
+      ADD_STAT(ptwMemCycle, statistics::units::Cycle::get(),
+               "Cycles with at least one PTW memory request in flight"),
+      ADD_STAT(ptwAvgMemLatency,
+               statistics::units::Rate<
+                   statistics::units::Cycle,
+                   statistics::units::Count>::get(),
+               "Average PTW memory latency",
+               ptwMemCycle / ptwMemCount)
+{
+}
+
+void
+Walker::updatePtwMemCycleStats()
+{
+    const Tick now = curTick();
+    if (outstandingPtwMemReqs != 0 && now > lastPtwMemCycleTick) {
+        stats.ptwMemCycle += ticksToCycles(now - lastPtwMemCycleTick);
+    }
+    lastPtwMemCycleTick = now;
+}
+
+void
+Walker::preDumpStats()
+{
+    ClockedObject::preDumpStats();
+    updatePtwMemCycleStats();
+}
+
+void
+Walker::resetStats()
+{
+    ClockedObject::resetStats();
+    lastPtwMemCycleTick = curTick();
+}
+
 std::pair<bool, Fault>
 Walker::tryCoalesce(ThreadContext *_tc, BaseMMU::Translation *translation,
                     const RequestPtr &req, BaseMMU::Mode mode, bool from_l2tlb,
@@ -199,6 +238,11 @@ Walker::recvTimingResp(PacketPtr pkt)
         dynamic_cast<WalkerSenderState *>(pkt->popSenderState());
     DPRINTF(PageTableWalker,
             "Received timing response for sender state: %#lx\n", senderState);
+    if (pkt->isRead()) {
+        updatePtwMemCycleStats();
+        assert(outstandingPtwMemReqs > 0);
+        outstandingPtwMemReqs--;
+    }
     WalkerState * senderWalk = senderState->senderWalk;
     bool walkComplete = senderWalk->recvPacket(pkt);
     delete senderState;
@@ -247,6 +291,11 @@ bool Walker::sendTiming(WalkerState* sendingState, PacketPtr pkt)
             pkt->getAddr(), walker_state);
     pkt->pushSenderState(walker_state);
     if (port.sendTimingReq(pkt)) {
+        if (pkt->isRead()) {
+            updatePtwMemCycleStats();
+            outstandingPtwMemReqs++;
+            stats.ptwMemCount++;
+        }
         return true;
     } else {
         // undo the adding of the sender state and delete it, as we

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -46,6 +46,7 @@
 #include "arch/riscv/pma_checker.hh"
 #include "arch/riscv/pmp.hh"
 #include "arch/riscv/tlb.hh"
+#include "base/statistics.hh"
 #include "base/types.hh"
 #include "mem/packet.hh"
 #include "mem/request.hh"
@@ -278,6 +279,20 @@ namespace RiscvISA
         // State for functional accesses (only need one of these per walker)
         WalkerState funcState;
 
+        /**
+         * PTW memory-side statistics. These counters intentionally track only
+         * the requests that leave the walker and the time window during which
+         * at least one walker memory request is still outstanding.
+         */
+        struct WalkerStats : public statistics::Group
+        {
+            WalkerStats(statistics::Group *parent);
+
+            statistics::Scalar ptwMemCount;
+            statistics::Scalar ptwMemCycle;
+            statistics::Formula ptwAvgMemLatency;
+        } stats;
+
         struct WalkerSenderState : public Packet::SenderState
         {
             WalkerState * senderWalk;
@@ -329,6 +344,12 @@ namespace RiscvISA
         bool ptwSquash;
         bool openNextLine;
         bool autoOpenNextLine;
+        /** Last tick at which PTW in-flight time accounting was updated. */
+        Tick lastPtwMemCycleTick;
+        /** Number of PTW memory requests currently in flight. */
+        unsigned outstandingPtwMemReqs;
+
+        void updatePtwMemCycleStats();
       public:
         bool is_from_pre_req;
 
@@ -341,6 +362,8 @@ namespace RiscvISA
         //void handlePendingSquash();
 
         void dol2TLBHit();
+        void preDumpStats() override;
+        void resetStats() override;
 
         /**
          * Event used to call startWalkWrapper.
@@ -370,7 +393,8 @@ namespace RiscvISA
 
         Walker(const Params &params) :
             ClockedObject(params), port(name() + ".port", this),
-            funcState(this, NULL, NULL, true), tlb(NULL), sys(params.system),
+            funcState(this, NULL, NULL, true), stats(this), tlb(NULL),
+            sys(params.system),
             pma(params.pma_checker),
             pmp(params.pmp),
             requestorId(sys->getRequestorId(this)),
@@ -379,6 +403,8 @@ namespace RiscvISA
             ptwSquash(params.ptw_squash),
             openNextLine(params.open_nextline),
             autoOpenNextLine(true),
+            lastPtwMemCycleTick(0),
+            outstandingPtwMemReqs(0),
             doL2TLBHitEvent([this]{dol2TLBHit();},name())
         {
         }

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -316,7 +316,7 @@ TLB::l2TLBEvictLRU(int l2TLBlevel, Addr vaddr)
 
 TlbEntry *
 TLB::lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
-            bool sign_used,uint8_t translateMode)
+            bool sign_used, uint8_t translateMode, bool is_prefetch)
 {
     TlbEntry *entry = trie.lookup(buildKey(vpn, asid, translateMode));
 
@@ -324,25 +324,46 @@ TLB::lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
         if (entry)
             entry->lruSeq = nextSeq();
 
-        if (mode == BaseMMU::Write)
-            stats.writeAccesses++;
-        else
-            stats.readAccesses++;
+        if (is_prefetch) {
+            if (mode == BaseMMU::Write)
+                stats.writeprefetchAccesses++;
+            else
+                stats.readprefetchAccesses++;
+        } else {
+            if (mode == BaseMMU::Write)
+                stats.writeAccesses++;
+            else
+                stats.readAccesses++;
+        }
 
         if (!entry) {
-            if (mode == BaseMMU::Write)
-                stats.writeMisses++;
-            else
-                stats.readMisses++;
+            if (is_prefetch) {
+                if (mode == BaseMMU::Write)
+                    stats.writeprefetchMisses++;
+                else
+                    stats.readprefetchMisses++;
+            } else {
+                if (mode == BaseMMU::Write)
+                    stats.writeMisses++;
+                else
+                    stats.readMisses++;
+            }
         }
         else {
-            if (mode == BaseMMU::Write)
-                stats.writeHits++;
-            else
-                stats.readHits++;
+            if (is_prefetch) {
+                if (mode == BaseMMU::Write)
+                    stats.writeprefetchHits++;
+                else
+                    stats.readprefetchHits++;
+            } else {
+                if (mode == BaseMMU::Write)
+                    stats.writeHits++;
+                else
+                    stats.readHits++;
+            }
         }
 
-        if (entry) {
+        if (entry && !is_prefetch) {
             if (entry->isSquashed) {
                 if (mode == BaseMMU::Write)
                     stats.writeHitsSquashed++;
@@ -1371,10 +1392,13 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *e_l2tlb = nullptr;
     TlbEntry *e_l2tlbVsstage = nullptr;
     TlbEntry *e_l2tlbGstage = nullptr;
+    const bool is_prefetch = req->isPrefetch();
     if (vsatp.mode != 0)
-        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, allstage);
+        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, allstage,
+                      is_prefetch);
     else
-        e[0] = lookup(vaddr, hgatp.vmid, mode, false, true, gstage);
+        e[0] = lookup(vaddr, hgatp.vmid, mode, false, true, gstage,
+                      is_prefetch);
 
     vs_top_level = PTW_TOP_LEVEL(vsatp.mode);
     g_top_level = PTW_TOP_LEVEL(hgatp.mode);
@@ -1416,7 +1440,8 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
         Addr pg_mask = 0;
 
 
-        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage);
+        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage,
+                      is_prefetch);
         if (e[0]){
             req->setPte(e[0]->pte);
             hit_type = h_l1VSstageHit;
@@ -1443,7 +1468,8 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
 
             DPRINTFR(TLB, "\tpass check, try to lookup for Gstage pte\n");
 
-            e[0] = lookup(gPaddr, hgatp.vmid, mode, false, true, gstage);
+            e[0] = lookup(gPaddr, hgatp.vmid, mode, false, true, gstage,
+                          is_prefetch);
             if (e[0]) {
                 hit_type = h_l1GstageHit;
                 DPRINTF(TLB, "l1tlb hit in Gstage: level %d, ppn %#x\n", e[0]->level, e[0]->pte.ppn);
@@ -1518,6 +1544,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
     TlbEntry *e_l2tlb = nullptr;
     TlbEntry *e_l2tlbVsstage = nullptr;
     TlbEntry *e_l2tlbGstage = nullptr;
+    const bool is_prefetch = req->isPrefetch();
 
     if ((!e[0]) && (l1tlbtype == h_l1VSstageHit)) {
         hit_level = PTW_TOP_LEVEL(vsatp.mode);
@@ -1580,7 +1607,8 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
 
     if (!e[0]) {
         DPRINTF(TLB, "l1tlb miss, lookup l2tlb at VSstage.\n");
-        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage);
+        e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage,
+                      is_prefetch);
         hit_level = PTW_TOP_LEVEL(vsatp.mode);
         if (!e[0]) {
             for (int i_e = 1; i_e < L_L2SUM; i_e++) {
@@ -1629,7 +1657,8 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
 
                 DPRINTFR(TLB, "\tlookup (gPaddr: %#x) in l1tlb again for Gstage.\n", gPaddr);
                 e[0] = nullptr;
-                e[0] = lookup(gPaddr, hgatp.vmid, mode, false, true, gstage);
+                e[0] = lookup(gPaddr, hgatp.vmid, mode, false, true, gstage,
+                              is_prefetch);
                 if (!e[0]) {
                     DPRINTF(TLB, "l1tlb miss, lookup (gPaddr: %#x) l2tlb for Gstage.\n", gPaddr);
                     hit_level = PTW_TOP_LEVEL(hgatp.mode);
@@ -1861,7 +1890,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *e[L_L2SUM] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
     TlbEntry *forward_pre[L_L2SUM] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
     TlbEntry *back_pre[L_L2SUM] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-    e[0] = lookup(vaddr, satp.asid, mode, false, true, direct);
+    const bool is_prefetch = req->isPrefetch();
+    e[0] = lookup(vaddr, satp.asid, mode, false, true, direct, is_prefetch);
     Addr paddr = 0;
     Fault fault = NoFault;
     Fault fault_return = NoFault;
@@ -2043,12 +2073,14 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 delayed = true;
                 return fault;
             }
-            e[0] = lookup(vaddr, satp.asid, mode, false, true, direct);
+            e[0] = lookup(vaddr, satp.asid, mode, false, true, direct,
+                          is_prefetch);
             assert(e[0] != nullptr);
         }
     }
     if (!e[0])
-        e[0] = lookup(vaddr, satp.asid, mode, false, true, direct);
+        e[0] = lookup(vaddr, satp.asid, mode, false, true, direct,
+                      is_prefetch);
     assert(e[0] != nullptr);
 
     status = tc->readMiscReg(MISCREG_STATUS);

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -123,6 +123,7 @@ class TLB : public BaseTLB
         statistics::Scalar writeHits;
         statistics::Scalar writeMisses;
         statistics::Scalar writeAccesses;
+        /** Prefetch translations are tracked separately from demand accesses. */
         statistics::Scalar readprefetchHits;
         statistics::Scalar writeprefetchHits;
         statistics::Scalar readprefetchAccesses;
@@ -252,7 +253,9 @@ class TLB : public BaseTLB
                               BaseMMU::Translation *translation, BaseMMU::Mode mode) override;
     Fault finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                            BaseMMU::Mode mode) const override;
-    TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden, bool sign_used, uint8_t translateMode);
+    TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
+                     bool sign_used, uint8_t translateMode,
+                     bool is_prefetch = false);
     TlbEntry *lookupForwardPre(Addr vpn, uint64_t asid, bool hidden);
     TlbEntry *lookupBackPre(Addr vpn, uint64_t asid, bool hidden);
     bool autoOpenNextline();

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -203,7 +203,7 @@ class BaseO3CPU(BaseCPU):
     sbufferBankWriteAccurately = Param.Bool(False, "Sbuffer write to memory with bank conflict check")
     DcacheSetBits = Param.Unsigned(8, "Dcache set bits for LSQ bank conflict model")
     DcacheSetDivNum = Param.Unsigned(1, "Dcache set div num for LSQ bank conflict model (power of two)")
-    EnableLdMissReplay = Param.Bool(True, "Replay Cache missed load instrution from ReplayQ if True")
+    EnableLdMissReplay = Param.Bool(True, "Replay Cache missed load instrution from ReplayQueue if True")
     EnablePipeNukeCheck = Param.Bool(True, "Replay load if Raw violation is detected in loadPipe if True")
     EnableReplayBasedMDP = Param.Bool(True,
         "Use replay-based mem dependency prediction (loads don't stall in IQ, "

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -251,6 +251,8 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
       ADD_STAT(memRefs, statistics::units::Count::get(),
                "Number of memory references committed"),
       ADD_STAT(loads, statistics::units::Count::get(), "Number of loads committed"),
+      ADD_STAT(stores, statistics::units::Count::get(),
+               "Number of stores committed"),
       ADD_STAT(amos, statistics::units::Count::get(),
                "Number of atomic instructions committed"),
       ADD_STAT(membars, statistics::units::Count::get(),
@@ -345,6 +347,10 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
         .flags(total);
 
     loads
+        .init(cpu->numThreads)
+        .flags(total);
+
+    stores
         .init(cpu->numThreads)
         .flags(total);
 
@@ -2055,6 +2061,10 @@ Commit::updateComInstStats(const DynInstPtr &inst)
 
         if (inst->isLoad()) {
             stats.loads[tid]++;
+        }
+
+        if (inst->isStore()) {
+            stats.stores[tid]++;
         }
 
         if (inst->isAtomic()) {

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -601,6 +601,8 @@ class Commit
         statistics::Vector memRefs;
         /** Stat for the total number of committed loads. */
         statistics::Vector loads;
+        /** Stat for the total number of committed stores. */
+        statistics::Vector stores;
         /** Stat for the total number of committed atomics. */
         statistics::Vector amos;
         /** Total number of committed memory barriers. */

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -243,6 +243,14 @@ class DynInst : public ExecContext, public RefCounted
         MaxFlags
     };
 
+  public:
+    enum class LoadPipeSource
+    {
+        IssueQueue,
+        ReplayQueue,
+        FastReplay
+    };
+
   private:
     /* An amalgamation of a lot of boolean values into one */
     std::bitset<MaxFlags> instFlags;
@@ -252,6 +260,9 @@ class DynInst : public ExecContext, public RefCounted
 
     /* replay type of this instruction */
     std::optional<LdStReplayType> replayType;
+    std::bitset<LdStReplayTypeCount> replayFlags;
+
+    LoadPipeSource loadPipeSource = LoadPipeSource::IssueQueue;
 
     bool _hasProducerStorePC = false;
     Addr _producerStorePC = 0;
@@ -1039,6 +1050,7 @@ class DynInst : public ExecContext, public RefCounted
                     (1 << SkipFollowingPipe));
         status.set(InPipe);
         clearReplayType();
+        clearReplayFlags();
     }
 
     void endPipelining() {
@@ -1051,6 +1063,7 @@ class DynInst : public ExecContext, public RefCounted
     bool cacheHit() const { return status[CacheHit]; }
 
     void setReplay(LdStReplayType type) {
+        markReplayFlag(type);
         setNeedReplay();
         replayType = type;
     }
@@ -1058,6 +1071,77 @@ class DynInst : public ExecContext, public RefCounted
         return replayType;
     }
     void clearReplayType() { replayType.reset(); }
+    void clearReplayFlags() { replayFlags.reset(); }
+    void markReplayFlag(LdStReplayType type) {
+        replayFlags.set(static_cast<size_t>(type));
+    }
+    bool hasReplayFlag(LdStReplayType type) const {
+        return replayFlags.test(static_cast<size_t>(type));
+    }
+    std::optional<LdStReplayType> selectReplayTypeFromFlags() const {
+        auto rtlReplayPriority = [](LdStReplayType type) -> int {
+            switch (type) {
+              case LdStReplayType::MdpAddrReplay:
+                return 2;  // C_MA
+              case LdStReplayType::TLBMissReplay:
+                return 3;  // C_TM
+              case LdStReplayType::STLFReplay:
+                return 4;  // C_FF
+              case LdStReplayType::CacheBlockedReplay:
+              case LdStReplayType::MshrAliasFailReplay:
+              case LdStReplayType::HitInWriteBufferReplay:
+              case LdStReplayType::MshrArbFailReplay:
+                return 5;  // C_DR
+              case LdStReplayType::CacheMissReplay:
+                return 6;  // C_DM
+              case LdStReplayType::BankConflictReplay:
+                return 8;  // C_BC
+              case LdStReplayType::RARReplay:
+                return 9;  // C_RAR
+              case LdStReplayType::RAWReplay:
+                return 10; // C_RAW
+              case LdStReplayType::NukeReplay:
+                return 11; // C_NK
+              default:
+                return 100 + static_cast<int>(type);
+            }
+        };
+
+        std::optional<LdStReplayType> selected;
+        int bestPriority = 1000;
+        for (int i = 0; i < LdStReplayTypeCount; ++i) {
+            auto type = static_cast<LdStReplayType>(i);
+            if (!replayFlags.test(i)) {
+                continue;
+            }
+
+            const int priority = rtlReplayPriority(type);
+            if (!selected || priority < bestPriority) {
+                selected = type;
+                bestPriority = priority;
+            }
+        }
+
+        if (selected) {
+            return selected;
+        }
+
+        return {};
+    }
+
+    bool finalizeReplayTypeFromFlags() {
+        auto selected = selectReplayTypeFromFlags();
+        if (!selected) {
+            return false;
+        }
+
+        replayType = *selected;
+        status.set(NeedReplay);
+        return true;
+    }
+
+    void setLoadPipeSource(LoadPipeSource source) { loadPipeSource = source; }
+    LoadPipeSource getLoadPipeSource() const { return loadPipeSource; }
 
     // only can be set once!!!
     void setNeedReplay() {

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -195,6 +195,17 @@ IssueQue::IssueQue(const IssueQueParams& params)
       inflightIssues(scheduleToExecDelay, 0),
       selector(params.sel)
 {
+    // TODO: keep this in sync with the current load IQ naming convention.
+    // This should become an explicit IssueQue parameter when the config grows
+    // more load pipes or renames the queues.
+    if (iqname == "ld0" || iqname == "load0") {
+        loadPipeId = 0;
+    } else if (iqname == "ld1" || iqname == "load1") {
+        loadPipeId = 1;
+    } else if (iqname == "ld2" || iqname == "load2") {
+        loadPipeId = 2;
+    }
+
     toIssue = inflightIssues.getWire(0);
     toFu = inflightIssues.getWire(-scheduleToExecDelay);
     if (outports > 8) {
@@ -445,6 +456,19 @@ IssueQue::retryMem(const DynInstPtr& inst)
 {
     assert(!inst->isNonSpeculative());
     iqstats->retryMem++;
+    if (inst->isLoad()) {
+        const auto replay_type = inst->getReplayType();
+        const bool is_fast_replay = replay_type &&
+            (*replay_type == LdStReplayType::BankConflictReplay ||
+             *replay_type == LdStReplayType::MshrArbFailReplay ||
+             *replay_type == LdStReplayType::MshrAliasFailReplay ||
+             *replay_type == LdStReplayType::HitInWriteBufferReplay ||
+             *replay_type == LdStReplayType::NukeReplay);
+
+        inst->setLoadPipeSource(is_fast_replay ?
+            DynInst::LoadPipeSource::FastReplay :
+            DynInst::LoadPipeSource::ReplayQueue);
+    }
     DPRINTF(Schedule, "retry %s [sn:%llu]\n", enums::OpClassStrings[inst->opClass()], inst->seqNum);
     replayQ.push(inst);
 }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -119,6 +119,7 @@ class IssueQue : public SimObject
 
     int numLoadPipe = 0;
     int numStorePipe = 0;
+    int loadPipeId = -1;
 
     struct select_policy
     {
@@ -222,6 +223,7 @@ class IssueQue : public SimObject
 
     int getIssueStages() { return scheduleToExecDelay; }
     int getId() { return IQID; }
+    int getLoadPipeId() const { return loadPipeId; }
     // return IQ's name
     std::string getName() { return iqname; }
     // return gem5 simobject's name

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -278,10 +278,28 @@ LSQ::StoreBuffer::release(StoreBufferEntry *entry)
 
 LSQ::LSQStats::LSQStats(statistics::Group *parent)
     : statistics::Group(parent),
+      ADD_STAT(lqAvgEntryNum, statistics::units::Count::get(),
+               "Average number of entries in load queue"),
+      ADD_STAT(sqAvgEntryNum, statistics::units::Count::get(),
+               "Average number of entries in store queue"),
+      ADD_STAT(sbufferAvgEntryNum, statistics::units::Count::get(),
+               "Average number of valid entries in store buffer"),
+      ADD_STAT(lqFullCycles, statistics::units::Cycle::get(),
+               "Cycles that LQ cannot accept a full enqueue bundle"),
+      ADD_STAT(sqFullCycles, statistics::units::Cycle::get(),
+               "Cycles that SQ cannot accept a full enqueue bundle"),
+      ADD_STAT(lsqFullCycles, statistics::units::Cycle::get(),
+               "Cycles that LSQ cannot accept a full enqueue bundle"),
+      ADD_STAT(sbufferFullCycles, statistics::units::Cycle::get(),
+               "Number of cycles that store buffer is physically full"),
       ADD_STAT(sbufferEvictDuetoFlush, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferEvictDuetoFull, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferEvictDuetoSQFull, statistics::units::Count::get(), ""),
-      ADD_STAT(sbufferEvictDuetoTimeout, statistics::units::Count::get(), "")
+      ADD_STAT(sbufferEvictDuetoTimeout, statistics::units::Count::get(), ""),
+      ADD_STAT(sbufferDcacheReqFire, statistics::units::Count::get(),
+               "Number of sbuffer write requests accepted by dcache"),
+      ADD_STAT(sbufferDcacheReqBlocked, statistics::units::Count::get(),
+               "Number of sbuffer write request attempts rejected by dcache")
 {
 }
 
@@ -310,6 +328,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       stats(nullptr),
       LQEntries(params.LQEntries),
       SQEntries(params.SQEntries),
+      enqueueWidth(params.renameWidth),
       maxLQEntries(maxLSQAllocation(lsqPolicy, LQEntries, params.numThreads,
                   params.smtLSQThreshold)),
       maxSQEntries(maxLSQAllocation(lsqPolicy, SQEntries, params.numThreads,
@@ -466,10 +485,43 @@ LSQ::tick()
     // tick lsq_unit
     std::list<ThreadID>::iterator threads = activeThreads->begin();
     std::list<ThreadID>::iterator end = activeThreads->end();
+    unsigned lq_entry_num = 0;
+    unsigned sq_entry_num = 0;
+    bool lq_full = false;
+    bool sq_full = false;
 
     while (threads != end) {
         ThreadID tid = *threads++;
+        lq_entry_num += thread[tid].numLoads();
+        sq_entry_num += thread[tid].numStores();
+        // TODO: this per-thread OR is an approximation for SMT/shared-LSQ
+        // configurations. With multiple active threads it may not match the
+        // aggregate free-entry condition seen by rename/dispatch.
+        lq_full = lq_full || thread[tid].numFreeLoadEntries() < enqueueWidth;
+        sq_full = sq_full || thread[tid].numFreeStoreEntries() < enqueueWidth;
         thread[tid].tick();
+    }
+
+    // Sample current load queue occupancy once per cycle.
+    stats.lqAvgEntryNum = lq_entry_num;
+
+    // Sample current store queue occupancy once per cycle.
+    stats.sqAvgEntryNum = sq_entry_num;
+
+    // Sample current store buffer occupancy once per cycle.
+    stats.sbufferAvgEntryNum = storeBuffer.size();
+    if (storeBuffer.full()) {
+        ++stats.sbufferFullCycles;
+    }
+
+    if (lq_full) {
+        ++stats.lqFullCycles;
+    }
+    if (sq_full) {
+        ++stats.sqFullCycles;
+    }
+    if (lq_full || sq_full) {
+        ++stats.lsqFullCycles;
     }
 
 }
@@ -885,13 +937,17 @@ LSQ::sbufferSendPacket(PacketPtr data_pkt)
     }
 
     if (ret) {
+        stats.sbufferDcacheReqFire++;
         cachePortBusy(false);
-    } else if (cache_got_blocked) {
-        cacheBlocked(true);
+    } else {
+        stats.sbufferDcacheReqBlocked++;
+        if (cache_got_blocked) {
+            cacheBlocked(true);
 
-        auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
-        assert(request);
-        request->_port.recordStoreBufferBlockedByCache();
+            auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
+            assert(request);
+            request->_port.recordStoreBufferBlockedByCache();
+        }
     }
 
     return ret;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1222,10 +1222,22 @@ class LSQ
     {
         LSQStats(statistics::Group *parent);
 
+        /** Per-cycle occupancy samples for the aggregated LSQ structures. */
+        statistics::Average lqAvgEntryNum;
+        statistics::Average sqAvgEntryNum;
+        statistics::Average sbufferAvgEntryNum;
+        /** Per-cycle full signals based on whether a full enqueue bundle fits. */
+        statistics::Scalar lqFullCycles;
+        statistics::Scalar sqFullCycles;
+        statistics::Scalar lsqFullCycles;
+        statistics::Scalar sbufferFullCycles;
         statistics::Scalar sbufferEvictDuetoFlush;
         statistics::Scalar sbufferEvictDuetoFull;
         statistics::Scalar sbufferEvictDuetoSQFull;
         statistics::Scalar sbufferEvictDuetoTimeout;
+        /** Handshake-level sbuffer to dcache request outcomes. */
+        statistics::Scalar sbufferDcacheReqFire;
+        statistics::Scalar sbufferDcacheReqBlocked;
     } stats;
 
     void recordStoreBufferEviction(StoreBufferEvictCause cause);
@@ -1237,6 +1249,9 @@ class LSQ
     unsigned LQEntries;
     /** Total Size of SQ Entries. */
     unsigned SQEntries;
+
+    /** Max number of memory instructions that may enter LSQ in one cycle. */
+    const unsigned enqueueWidth;
 
     /** Max LQ Size - Used to Enforce Sharing Policies. */
     unsigned maxLQEntries;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -443,6 +443,7 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
 void
 LSQUnit::tick()
 {
+    countedStLdViolationThisCycle = false;
     loadPipe.advance();
     storePipe.advance();
 }
@@ -558,6 +559,10 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
                "squashed"),
       ADD_STAT(memOrderViolation, statistics::units::Count::get(),
                "Number of memory ordering violations"),
+      ADD_STAT(ldLdViolation, statistics::units::Count::get(),
+               "Number of load-load violation events"),
+      ADD_STAT(stLdViolation, statistics::units::Count::get(),
+               "Number of store-load violation events"),
       ADD_STAT(busForwardSuccess, statistics::units::Count::get(),
                "Number of successfully forwarding from bus"),
       ADD_STAT(cacheMissReplayEarly, statistics::units::Count::get(),
@@ -574,6 +579,10 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
                "Number of times an access to memory failed due to the cache "
                "being blocked"),
       ADD_STAT(sbufferFull, statistics::units::Count::get(), "blocked cycle"),
+      ADD_STAT(sbufferMerge, statistics::units::Count::get(),
+               "Number of stores merged into an existing store buffer line"),
+      ADD_STAT(sbufferNewline, statistics::units::Count::get(),
+               "Number of stores that allocate a new store buffer line"),
       ADD_STAT(sbufferCreateVice, statistics::units::Count::get(), "create vice"),
       ADD_STAT(sbufferFullForward, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferPartiForward, statistics::units::Count::get(), ""),
@@ -589,12 +598,34 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(unitStrideAligned, "Number of vector unitStride 16-byte aligned"),
       ADD_STAT(skipRawWhenLoadAtS0, "Number of times RAW check skipped because load is at S0"),
       ADD_STAT(RARQueueFull, "Number of times RAR queue was full"),
+      ADD_STAT(RARQueueFullCycles, statistics::units::Cycle::get(),
+               "Number of cycles that RAR queue is physically full"),
       ADD_STAT(RARQueueReplay, "Number of instructions replayed from RAR queue"),
       ADD_STAT(RARQueueLatency, statistics::units::Cycle::get(), "RAR queue latency distribution"),
+      ADD_STAT(RARQueueAvgEntryNum, statistics::units::Count::get(),
+               "Average number of entries in RAR queue"),
       ADD_STAT(RAWQueueFull, "Number of times RAW queue was full"),
+      ADD_STAT(RAWQueueFullCycles, statistics::units::Cycle::get(),
+               "Number of cycles that RAW queue is physically full"),
       ADD_STAT(RAWQueueReplay, "Number of instructions replayed from RAW queue"),
       ADD_STAT(RAWQueueLatency, statistics::units::Cycle::get(), "RAW queue latency distribution"),
-      ADD_STAT(loadReplayEvents, statistics::units::Count::get(), "event distribution of load replay")
+      ADD_STAT(RAWQueueAvgEntryNum, statistics::units::Count::get(),
+               "Average number of entries in RAW queue"),
+      ADD_STAT(loadPipeAccepted, statistics::units::Count::get(),
+               "Number of load requests accepted by each load pipe"),
+      ADD_STAT(storePipeAccepted, statistics::units::Count::get(),
+               "Number of store requests accepted by each store pipe slot"),
+      ADD_STAT(storeReplayTotal, statistics::units::Count::get(),
+               "Number of store replay events at the store pipe replay exit"),
+      ADD_STAT(storeReplayTlbMiss, statistics::units::Count::get(),
+               "Number of store TLB miss replay events at the store pipe replay exit"),
+      ADD_STAT(loadPipeReplayAccepted, statistics::units::Count::get(),
+               "Number of replayQ load requests accepted by load pipe"),
+      ADD_STAT(loadPipeFastReplayAccepted, statistics::units::Count::get(),
+               "Number of fast replay load requests accepted by load pipe"),
+      ADD_STAT(loadReplayEvents, statistics::units::Count::get(), "event distribution of load replay"),
+      ADD_STAT(loadReplayEventsFromIssueQueue, statistics::units::Count::get(),
+               "load replay events counted only when the load enters from issue queue")
 {
     loadToUse
         .init(0, 299, 10)
@@ -610,11 +641,46 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
     RAWQueueLatency
         .init(0, 500, 20)
         .flags(statistics::nozero);
+    // TODO: load-pipe PMU vectors currently assume exactly three load pipes.
+    // Extend the vector sizing and IssueQue loadPipeId mapping together if the
+    // model grows more load pipes; the replay pipe counters below share this
+    // same assumption.
+    loadPipeAccepted
+        .init(3)
+        .flags(statistics::total | statistics::nozero);
+    for (int i = 0; i < 3; i++) {
+        loadPipeAccepted.subname(i, csprintf("pipe%d", i));
+    }
+    storePipeAccepted
+        .init(MaxPipeWidth)
+        .flags(statistics::total | statistics::nozero);
+    for (int i = 0; i < MaxPipeWidth; i++) {
+        storePipeAccepted.subname(i, csprintf("pipe%d", i));
+    }
+    loadPipeReplayAccepted
+        .init(3)
+        .flags(statistics::total | statistics::nozero);
+    for (int i = 0; i < 3; i++) {
+        loadPipeReplayAccepted.subname(i, csprintf("pipe%d", i));
+    }
+    loadPipeFastReplayAccepted
+        .init(3)
+        .flags(statistics::total | statistics::nozero);
+    for (int i = 0; i < 3; i++) {
+        loadPipeFastReplayAccepted.subname(i, csprintf("pipe%d", i));
+    }
     loadReplayEvents
         .init(LdStReplayTypeCount)
         .flags(statistics::total);
     for (int i = 0; i < LdStReplayTypeCount; i++) {
         loadReplayEvents.subname(i, load_store_replay_event_str[static_cast<LdStReplayType>(i)]);
+    }
+    loadReplayEventsFromIssueQueue
+        .init(LdStReplayTypeCount)
+        .flags(statistics::total);
+    for (int i = 0; i < LdStReplayTypeCount; i++) {
+        loadReplayEventsFromIssueQueue.subname(
+            i, load_store_replay_event_str[static_cast<LdStReplayType>(i)]);
     }
 }
 
@@ -930,6 +996,7 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                                 memDepViolator = ld_inst;
 
                                 ++stats.memOrderViolation;
+                                ++stats.ldLdViolation;
 
                                 return std::make_shared<GenericISA::M5PanicFault>(
                                     "Detected fault with inst [sn:%lli] and "
@@ -978,6 +1045,10 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                         memDepViolator = ld_inst;
 
                         ++stats.memOrderViolation;
+                        if (inst->isStore() && !countedStLdViolationThisCycle) {
+                            ++stats.stLdViolation;
+                            countedStLdViolationThisCycle = true;
+                        }
 
                         return std::make_shared<GenericISA::M5PanicFault>(
                             "Detected fault with "
@@ -1025,6 +1096,19 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
     loadPipeSx[0]->insts[idx] = inst;
     loadPipeSx[0]->size++;
 
+    const int load_pipe_id = inst->issueQue->getLoadPipeId();
+    panic_if(load_pipe_id < 0,
+        "Per-load-pipe PMU stats require dedicated load IQ naming; "
+        "unsupported issue queue %s for load [sn:%llu]\n",
+        inst->issueQue->getName().c_str(), inst->seqNum);
+    stats.loadPipeAccepted[load_pipe_id]++;
+    const auto load_pipe_source = inst->getLoadPipeSource();
+    if (load_pipe_source == DynInst::LoadPipeSource::ReplayQueue) {
+        stats.loadPipeReplayAccepted[load_pipe_id]++;
+    } else if (load_pipe_source == DynInst::LoadPipeSource::FastReplay) {
+        stats.loadPipeFastReplayAccepted[load_pipe_id]++;
+    }
+
     DPRINTF(LoadPipeline, "issueToLoadPipe: [sn:%llu]\n", inst->seqNum);
 }
 
@@ -1039,6 +1123,7 @@ LSQUnit::issueToStorePipe(const DynInstPtr &inst)
     int idx = storePipeSx[0]->size;
     storePipeSx[0]->insts[idx] = inst;
     storePipeSx[0]->size++;
+    stats.storePipeAccepted[idx]++;
 
     DPRINTF(LSQUnit, "issueToStorePipe: [sn:%lli]\n", inst->seqNum);
 }
@@ -1166,6 +1251,7 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
 
     assert(!inst->isSquashed());
     LSQRequest* request = inst->savedRequest;
+    bool earlyWakeupCacheMissReplay = false;
 
     if (inst->wakeUpEarly()) {
         auto& bus = getLsq()->bus;
@@ -1177,12 +1263,7 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
 
             DPRINTF(LoadPipeline, "Load [sn:%ld]: Early wakeup, no data on bus\n",
                     inst->seqNum);
-
-            loadSetReplay(inst, request,true);
-            inst->setCacheMissReplay();
-            inst->setWaitingCacheRefill();
-            stats.cacheMissReplayEarly++;
-            return fault;
+            earlyWakeupCacheMissReplay = true;
         } else {
             // Load received TimingResp any time at [s1, s2], forward from data bus
             DPRINTF(LoadPipeline, "Load [sn:%ld]: Forward from bus at load s2, data: %lx\n",
@@ -1192,66 +1273,93 @@ LSQUnit::loadDoRecvData(const DynInstPtr &inst)
         }
     }
 
-    // check if cache hit & get cache response?
-    // NOTE: cache miss replay has higher priority than nuke replay!
-    if (lsq->enableLdMissReplay() && request && request->isNormalLd() && !inst->fullForward() && !inst->cacheHit()) {
-        // cannot get cache data at load s2, replay this load
-        loadSetReplay(inst, request, false);
-        inst->setCacheMissReplay();
-        inst->setWaitingCacheRefill();
-        DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
-        return fault;
-    } else if (inst->isNormalLd() && !request) {
-        loadSetReplay(inst, request, false);
-        inst->setBankConflictReplay();// fast replay
-        DPRINTF(LoadPipeline, "Load [sn:%llu] setBankConflictReplay\n", inst->seqNum);
-        return fault;
-    }
+    const bool cacheMissReplay =
+        earlyWakeupCacheMissReplay ||
+        (lsq->enableLdMissReplay() && request && request->isNormalLd() &&
+         !inst->fullForward() && !inst->cacheHit());
+    const bool bankConflictReplay = inst->isNormalLd() && !request;
 
+    bool nukeReplay = false;
     for (int i = 0; i < storePipeSx[1]->size; i++) {
         auto& store_inst = storePipeSx[1]->insts[i];
         if (pipeLineNukeCheck(inst, store_inst)) {
-            DPRINTF(LoadPipeline, "Load [sn:%llu] Nuke need replay\n", inst->seqNum);
-            inst->setNukeReplay();
+            nukeReplay = true;
+            break;
+        }
+    }
+
+    const bool trackRAR =
+        loadCompletedIdx != loadQueue.tail() && inst->isNormalLd() &&
+        inst->lqIt.idx() > loadCompletedIdx + 1;
+    const bool rarReplay = trackRAR && RARQueue.size() >= maxRARQEntries;
+    const bool trackRAW =
+        storeCompletedIdx != storeQueue.tail() && inst->isNormalLd() &&
+        inst->sqIt.idx() > storeCompletedIdx + 1;
+    const bool rawReplay = trackRAW && RAWQueue.size() >= maxRAWQEntries;
+
+    if (cacheMissReplay) {
+        inst->markReplayFlag(LdStReplayType::CacheMissReplay);
+    }
+    if (bankConflictReplay) {
+        inst->markReplayFlag(LdStReplayType::BankConflictReplay);
+    }
+    if (nukeReplay) {
+        inst->markReplayFlag(LdStReplayType::NukeReplay);
+    }
+    if (rarReplay) {
+        inst->markReplayFlag(LdStReplayType::RARReplay);
+    }
+    if (rawReplay) {
+        inst->markReplayFlag(LdStReplayType::RAWReplay);
+    }
+
+    if (inst->finalizeReplayTypeFromFlags()) {
+        switch (*inst->getReplayType()) {
+          case LdStReplayType::CacheMissReplay:
+            loadSetReplay(inst, request, earlyWakeupCacheMissReplay);
+            inst->setWaitingCacheRefill();
+            if (earlyWakeupCacheMissReplay) {
+                stats.cacheMissReplayEarly++;
+            }
+            DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheMissReplay\n", inst->seqNum);
             return fault;
+          case LdStReplayType::BankConflictReplay:
+            loadSetReplay(inst, request, false);
+            DPRINTF(LoadPipeline, "Load [sn:%llu] setBankConflictReplay\n", inst->seqNum);
+            return fault;
+          case LdStReplayType::RARReplay:
+            DPRINTF(LSQUnit, "RARQueue full, reschedule [sn:%llu], LoadCompletedItIdx: %d, inst->lqItIdx: %d\n",
+                    inst->seqNum, loadCompletedIdx, inst->lqIt._idx);
+            stats.RARQueueFull++;
+            loadSetReplay(inst, request, true);
+            addToRARReplayQueue(inst);
+            return fault;
+          case LdStReplayType::RAWReplay:
+            DPRINTF(LSQUnit, "RAWQueue full, reschedule [sn:%lli], StoreCompletedItIdx: %d, inst->sqItIdx: %d\n",
+                    inst->seqNum, storeCompletedIdx, inst->sqIt.idx());
+            stats.RAWQueueFull++;
+            loadSetReplay(inst, request, true);
+            addToRAWReplayQueue(inst);
+            return fault;
+          case LdStReplayType::NukeReplay:
+            DPRINTF(LoadPipeline, "Load [sn:%llu] Nuke need replay\n", inst->seqNum);
+            return fault;
+          default:
+            panic("Unsupported load replay type selected in s2");
         }
     }
 
-    if (loadCompletedIdx != loadQueue.tail() && inst->isNormalLd()) {
-        if (inst->lqIt.idx() > loadCompletedIdx + 1) {
-            if (RARQueue.size() >= maxRARQEntries) {
-                DPRINTF(LSQUnit, "RARQueue full, reschedule [sn:%llu], LoadCompletedItIdx: %d, inst->lqItIdx: %d\n",
-                        inst->seqNum, loadCompletedIdx, inst->lqIt._idx);
-                stats.RARQueueFull++;
-                loadSetReplay(inst, request, true);
-                addToRARReplayQueue(inst);
-                inst->setRARReplay();
-                return fault;
-            } else {
-                auto existingIt = std::find(RARQueue.begin(), RARQueue.end(), inst);
-                if (existingIt == RARQueue.end()) {
-                    RARQueue.push_back(inst);
-                }
-            }
+    if (trackRAR) {
+        auto existingIt = std::find(RARQueue.begin(), RARQueue.end(), inst);
+        if (existingIt == RARQueue.end()) {
+            RARQueue.push_back(inst);
         }
     }
 
-    if (storeCompletedIdx != storeQueue.tail() && inst->isNormalLd()) {
-        if (inst->sqIt.idx() > storeCompletedIdx + 1) {
-            if (RAWQueue.size() >= maxRAWQEntries) {
-                DPRINTF(LSQUnit, "RAWQueue full, reschedule [sn:%lli], StoreCompletedItIdx: %d, inst->sqItIdx: %d\n",
-                        inst->seqNum, storeCompletedIdx, inst->sqIt.idx());
-                stats.RAWQueueFull++;
-                loadSetReplay(inst, request, true);
-                addToRAWReplayQueue(inst);
-                inst->setRAWReplay();
-                return fault;
-            } else {
-                auto existingIt = std::find(RAWQueue.begin(), RAWQueue.end(), inst);
-                if (existingIt == RAWQueue.end()) {
-                    RAWQueue.push_back(inst);
-                }
-            }
+    if (trackRAW) {
+        auto existingIt = std::find(RAWQueue.begin(), RAWQueue.end(), inst);
+        if (existingIt == RAWQueue.end()) {
+            RAWQueue.push_back(inst);
         }
     }
 
@@ -1343,6 +1451,11 @@ LSQUnit::executeLoadPipeSx()
                 // record replay stats
                 assert(inst->getReplayType());
                 stats.loadReplayEvents[*inst->getReplayType()]++;
+                // RTL only increments the main replay_* counters when a load
+                // first enters slow replay from the IssueQueue.
+                if (inst->getLoadPipeSource() == DynInst::LoadPipeSource::IssueQueue) {
+                    stats.loadReplayEventsFromIssueQueue[*inst->getReplayType()]++;
+                }
 
                 if (inst->needCacheBlockedReplay()) {
                     cpu->perfCCT->updateInstMeta(inst->seqNum, InstDetail::ReplayStr, TT_DcacheStall);
@@ -1369,6 +1482,11 @@ LSQUnit::executeLoadPipeSx()
                 // record replay stats
                 assert(inst->getReplayType());
                 stats.loadReplayEvents[*inst->getReplayType()]++;
+                // Use the load-pipe entry source to detect that first entry
+                // and match RTL, which only counts replay_* on first issue.
+                if (inst->getLoadPipeSource() == DynInst::LoadPipeSource::IssueQueue) {
+                    stats.loadReplayEventsFromIssueQueue[*inst->getReplayType()]++;
+                }
 
                 if (inst->needBankConflictReplay()) inst->issueQue->retryMem(inst);
                 else if (inst->needMshrArbFailReplay()) inst->issueQue->retryMem(inst);
@@ -1571,7 +1689,11 @@ LSQUnit::executeStorePipeSx()
 
 
             if (i == storeWhenToReplay && inst->needReplay()) [[unlikely]] {
-                if (inst->needTLBMissReplay()) iewStage->deferMemInst(inst);
+                stats.storeReplayTotal++;
+                if (inst->needTLBMissReplay()) {
+                    iewStage->deferMemInst(inst);
+                    stats.storeReplayTlbMiss++;
+                }
                 inst->endPipelining();
                 inst = nullptr;
                 continue;
@@ -2004,6 +2126,7 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
         if (entry->sending) {
             if (entry->vice) {
                 // merge into vice
+                stats.sbufferMerge++;
                 entry = entry->vice;
                 entry->merge(offset, datas, size, mask);
                 DPRINTF(StoreBuffer, "Merging vice entry[%#x] for addr %#x\n",
@@ -2015,6 +2138,7 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
                     stats.sbufferFull++;
                     return false;
                 }
+                stats.sbufferNewline++;
                 stats.sbufferCreateVice++;
                 auto vice = storeBuffer.createVice(entry);
                 vice->reset(lsqID, blockVaddr, blockPaddr, offset, datas, size, mask);
@@ -2023,6 +2147,7 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
             }
         } else {
             // merge into unsent
+            stats.sbufferMerge++;
             storeBuffer.update(entry->index);
             entry->merge(offset, datas, size, mask);
             DPRINTF(StoreBuffer, "Merging entry[%#x] for addr %#x\n",
@@ -2036,6 +2161,7 @@ bool LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas, uint64_t
             return false;
         }
         // insert
+        stats.sbufferNewline++;
         auto entry = storeBuffer.getEmpty();
         entry->reset(lsqID, blockVaddr, blockPaddr, offset, datas, size, mask);
         storeBuffer.insert(entry);
@@ -2664,6 +2790,20 @@ LSQUnit::updateCompletedIdx()
     }
 
     processReplayQueues();
+
+    if (RARQueue.size() >= maxRARQEntries) {
+        ++stats.RARQueueFullCycles;
+    }
+
+    if (RAWQueue.size() >= maxRAWQEntries) {
+        ++stats.RAWQueueFullCycles;
+    }
+
+    // Sample the tracked RAR queue occupancy once per cycle.
+    stats.RARQueueAvgEntryNum = RARQueue.size();
+
+    // Sample the tracked RAW queue occupancy once per cycle.
+    stats.RAWQueueAvgEntryNum = RAWQueue.size();
 }
 
 void

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -718,6 +718,9 @@ class LSQUnit
     /** Flag for memory model. */
     bool needsTSO;
 
+    /** Avoid counting the same store-load violation more than once per cycle. */
+    bool countedStLdViolationThisCycle = false;
+
     unsigned lastClockSQPopEntries;
     unsigned lastClockLQPopEntries;
     /** Store requests for potential RAR violations */
@@ -779,6 +782,12 @@ class LSQUnit
         /** Tota number of memory ordering violations. */
         statistics::Scalar memOrderViolation;
 
+        /** Total number of load-load violation events. */
+        statistics::Scalar ldLdViolation;
+
+        /** Total number of store-load violation events. */
+        statistics::Scalar stLdViolation;
+
         /** Tota number of successfully forwarding from bus. */
         statistics::Scalar busForwardSuccess;
 
@@ -802,6 +811,9 @@ class LSQUnit
 
         statistics::Scalar sbufferFull;
 
+        /** Store-buffer line management counters. */
+        statistics::Scalar sbufferMerge;
+        statistics::Scalar sbufferNewline;
         statistics::Scalar sbufferCreateVice;
 
         statistics::Scalar sbufferFullForward;
@@ -825,15 +837,33 @@ class LSQUnit
 
         /** RAR replay queue related stats */
         statistics::Scalar RARQueueFull;
+        statistics::Scalar RARQueueFullCycles;
         statistics::Scalar RARQueueReplay;
         statistics::Distribution RARQueueLatency;
+        statistics::Average RARQueueAvgEntryNum;
 
         /** RAW replay queue related stats */
         statistics::Scalar RAWQueueFull;
+        statistics::Scalar RAWQueueFullCycles;
         statistics::Scalar RAWQueueReplay;
         statistics::Distribution RAWQueueLatency;
+        statistics::Average RAWQueueAvgEntryNum;
 
+        /** Pipe-entry counters sampled at the actual pipe accept point. */
+        statistics::Vector loadPipeAccepted;
+        statistics::Vector storePipeAccepted;
+        /** Store replay counters recorded at the replay exit. */
+        statistics::Scalar storeReplayTotal;
+        statistics::Scalar storeReplayTlbMiss;
+        statistics::Vector loadPipeReplayAccepted;
+        statistics::Vector loadPipeFastReplayAccepted;
         statistics::Vector loadReplayEvents;
+        /**
+         * Replay causes counted only on the first IssueQueue -> load-pipe
+         * attempt, to better align with the RTL counters that count only the
+         * first enqueue into LRQ.
+         */
+        statistics::Vector loadReplayEventsFromIssueQueue;
     } stats;
 
     void bankConflictReplay();

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -178,6 +178,7 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
       blocked(0),
       order(0),
       noTargetMSHR(nullptr),
+      noMshrBlockedStartCycle(Cycles(0)),
       missCount(p.max_miss_count),
       addrRanges(p.addr_ranges.begin(), p.addr_ranges.end()),
       archDBer(p.arch_db),
@@ -310,6 +311,14 @@ BaseCache::init()
         fatal("Cache ports on %s are not connected\n", name());
     cpuSidePort.sendRangeChange();
     forwardSnoops = cpuSidePort.isSnooping();
+    mshrQueue.resetOccupancyStats(curTick());
+}
+
+void
+BaseCache::resetStats()
+{
+    ClockedObject::resetStats();
+    mshrQueue.resetOccupancyStats(curTick());
 }
 
 Port &
@@ -333,6 +342,30 @@ BaseCache::inRange(Addr addr) const
        }
     }
     return false;
+}
+
+double
+BaseCache::getMshrAvgEntryNum() const
+{
+    const Tick now = curTick();
+    const Tick elapsed = mshrQueue.getOccupancyElapsedTicks(now);
+    if (elapsed == 0) {
+        return 0.0;
+    }
+
+    return static_cast<double>(mshrQueue.getOccupancyEntryTicks(now)) /
+        static_cast<double>(elapsed);
+}
+
+double
+BaseCache::getMshrOccupancyRatio() const
+{
+    const int num_entries = mshrQueue.getNumEntries();
+    if (num_entries <= 0) {
+        return 0.0;
+    }
+
+    return getMshrAvgEntryNum() / static_cast<double>(num_entries);
 }
 
 bool
@@ -2862,6 +2895,12 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
     ADD_STAT(overallAvgMshrUncacheableLatency, statistics::units::Rate<
                 statistics::units::Tick, statistics::units::Count>::get(),
              "average overall mshr uncacheable latency"),
+    ADD_STAT(mshrAvgEntryNum, statistics::units::Ratio::get(),
+             "average number of allocated MSHR entries"),
+    ADD_STAT(mshrOccupancyRatio, statistics::units::Ratio::get(),
+             "average allocated MSHR entry ratio"),
+    ADD_STAT(noMshrBlockedCycles, statistics::units::Cycle::get(),
+             "number of cycles blocked by no MSHR entries"),
     ADD_STAT(bytesRecvPerCycle, statistics::units::Ratio::get(),
              "average bandwidth receiving data from lower cache."),
     ADD_STAT(replacements, statistics::units::Count::get(),
@@ -3158,6 +3197,14 @@ BaseCache::CacheStats::regStats()
         overallAvgMshrUncacheableLatency.subname(i,
             system->getRequestorName(i));
     }
+
+    mshrAvgEntryNum
+        .flags(nonan)
+        .functor([this]() { return cache.getMshrAvgEntryNum(); });
+
+    mshrOccupancyRatio
+        .flags(nonan)
+        .functor([this]() { return cache.getMshrOccupancyRatio(); });
 
     bytesRecvPerCycle.flags(total | nozero | nonan);
     bytesRecvPerCycle = bytesRecv / simTicks * cache.clockPeriod();

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1095,11 +1095,14 @@ class BaseCache : public ClockedObject, public CacheAccessor
     /** Increasing order number assigned to each incoming request. */
     uint64_t order;
 
+    /** The MSHR that blocked because it has no targets. */
+    MSHR *noTargetMSHR;
+
     /** Stores time the cache blocked for statistics. */
     Cycles blockedCycle;
 
-    /** Pointer to the MSHR that has no targets. */
-    MSHR *noTargetMSHR;
+    /** Start cycle of the current NoMSHR blocked interval, if any. */
+    Cycles noMshrBlockedStartCycle;
 
     /** The number of misses to trigger an exit event. */
     Counter missCount;
@@ -1268,6 +1271,13 @@ class BaseCache : public ClockedObject, public CacheAccessor
         /** The average overall latency of an MSHR miss. */
         statistics::Formula overallAvgMshrUncacheableLatency;
 
+        /** Average number of allocated MSHR entries over the dump window. */
+        statistics::Value mshrAvgEntryNum;
+        /** Average allocated-entry ratio normalized by queue capacity. */
+        statistics::Value mshrOccupancyRatio;
+        /** Cycles for which the cache stayed blocked due to no free MSHR. */
+        statistics::Scalar noMshrBlockedCycles;
+
         /** The average bandwidth receiving data from lower cache. */
         statistics::Formula bytesRecvPerCycle;
 
@@ -1363,6 +1373,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
     ~BaseCache();
 
     void init() override;
+    void resetStats() override;
 
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
@@ -1454,6 +1465,9 @@ class BaseCache : public ClockedObject, public CacheAccessor
     void setBlocked(BlockedCause cause)
     {
         uint8_t flag = 1 << cause;
+        if (cause == Blocked_NoMSHRs && !(blocked & flag)) {
+            noMshrBlockedStartCycle = curCycle();
+        }
         if (blocked == 0) {
             stats.blockedCauses[cause]++;
             blockedCycle = curCycle();
@@ -1473,6 +1487,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
     void clearBlocked(BlockedCause cause)
     {
         uint8_t flag = 1 << cause;
+        if (cause == Blocked_NoMSHRs && (blocked & flag)) {
+            stats.noMshrBlockedCycles += curCycle() - noMshrBlockedStartCycle;
+            noMshrBlockedStartCycle = Cycles(0);
+        }
         blocked &= ~flag;
         DPRINTF(Cache,"Unblocking for cause %d, mask=%d\n", cause, blocked);
         if (blocked == 0) {
@@ -1683,6 +1701,10 @@ public:
     }
 
     bool coalesce() const override;
+
+    double getMshrAvgEntryNum() const;
+
+    double getMshrOccupancyRatio() const;
 
     const uint8_t* findBlock(Addr addr, bool is_secure) const override {
         auto blk = tags->findBlock(addr, is_secure);

--- a/src/mem/cache/mshr_queue.cc
+++ b/src/mem/cache/mshr_queue.cc
@@ -48,6 +48,7 @@
 
 #include "debug/MSHR.hh"
 #include "mem/cache/mshr.hh"
+#include "sim/cur_tick.hh"
 
 namespace gem5
 {
@@ -56,8 +57,22 @@ MSHRQueue::MSHRQueue(const std::string &_label,
                      int num_entries, int reserve,
                      int demand_reserve, std::string cache_name = "")
     : Queue<MSHR>(_label, num_entries, reserve, cache_name + ".mshr_queue"),
-      demandReserve(demand_reserve)
+      demandReserve(demand_reserve),
+      occupancyStartTick(curTick()),
+      occupancyLastUpdate(curTick()),
+      occupancyEntryTicks(0)
 {}
+
+void
+MSHRQueue::updateOccupancyStats(Tick now)
+{
+    if (now > occupancyLastUpdate) {
+        occupancyEntryTicks +=
+            static_cast<Counter>(allocated) *
+            static_cast<Counter>(now - occupancyLastUpdate);
+    }
+    occupancyLastUpdate = now;
+}
 
 MSHR *
 MSHRQueue::allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
@@ -71,6 +86,7 @@ MSHRQueue::allocate(Addr blk_addr, unsigned blk_size, PacketPtr pkt,
     DPRINTF(MSHR, "Allocating new MSHR. Number in use will be %lu/%lu\n",
             allocatedList.size() + 1, numEntries);
 
+    updateOccupancyStats(curTick());
     mshr->allocate(blk_addr, blk_size, pkt, when_ready, order, alloc_on_fill);
     mshr->allocIter = allocatedList.insert(allocatedList.end(), mshr);
     mshr->readyIter = addToReadyList(mshr);
@@ -84,9 +100,35 @@ MSHRQueue::deallocate(MSHR* mshr)
 {
 
     DPRINTF(MSHR, "Deallocating all targets: %s", mshr->print());
+    updateOccupancyStats(curTick());
     Queue<MSHR>::deallocate(mshr);
     DPRINTF(MSHR, "MSHR deallocated. Number in use: %lu/%lu\n",
             allocatedList.size(), numEntries);
+}
+
+void
+MSHRQueue::resetOccupancyStats(Tick now)
+{
+    occupancyStartTick = now;
+    occupancyLastUpdate = now;
+    occupancyEntryTicks = 0;
+}
+
+Counter
+MSHRQueue::getOccupancyEntryTicks(Tick now) const
+{
+    Counter total = occupancyEntryTicks;
+    if (now > occupancyLastUpdate) {
+        total += static_cast<Counter>(allocated) *
+            static_cast<Counter>(now - occupancyLastUpdate);
+    }
+    return total;
+}
+
+Tick
+MSHRQueue::getOccupancyElapsedTicks(Tick now) const
+{
+    return now > occupancyStartTick ? now - occupancyStartTick : 0;
 }
 
 

--- a/src/mem/cache/mshr_queue.hh
+++ b/src/mem/cache/mshr_queue.hh
@@ -68,6 +68,15 @@ class MSHRQueue : public Queue<MSHR>
      */
     const int demandReserve;
 
+    /** Tick at which the current occupancy accounting window starts. */
+    Tick occupancyStartTick;
+    /** Tick of the last occupancy integral update. */
+    Tick occupancyLastUpdate;
+    /** Time integral of allocated-entry count over the accounting window. */
+    Counter occupancyEntryTicks;
+
+    void updateOccupancyStats(Tick now);
+
   public:
 
     /**
@@ -103,6 +112,20 @@ class MSHRQueue : public Queue<MSHR>
      * Deallocate a MSHR and its targets
      */
     void deallocate(MSHR *mshr) override;
+
+    /** Reset the occupancy integration window to start at @p now. */
+    void resetOccupancyStats(Tick now);
+
+    /** Return accumulated entry*tick integral up to @p now. */
+    Counter getOccupancyEntryTicks(Tick now) const;
+
+    /** Return elapsed ticks in the current occupancy accounting window. */
+    Tick getOccupancyElapsedTicks(Tick now) const;
+
+    int getNumEntries() const
+    {
+        return numEntries;
+    }
 
     /**
      * Moves the MSHR to the front of the pending list if it is not


### PR DESCRIPTION
Add memblock-related PMU counters across TLB, issue/commit, LSQ, MSHR and cache paths.

Also fix noMshrBlockedCycles to use a scalar stat type so the new cache stat builds correctly.

Change-Id: I8cbeb574304ae6e99a783137816aa261a1859171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page-table walker PTW memory request latency and in-flight cycle tracking with average latency metric.
  * TLB metrics split for prefetch vs demand accesses.
  * Explicit committed-store counting.
  * Load-pipeline/source classification and expanded replay observability.
  * LSQ per-cycle occupancy averages, full-cycle counters, and sbuffer fire/blocked stats.
  * MSHR occupancy averages, occupancy ratio, and No-MSHR blocked-duration reporting.
  * Separate counting for load-load and store-load violations.

* **Bug Fixes**
  * Added missing trailing newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->