### PR TITLE
arch-riscv: Calibrate xs-rvv

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -813,6 +813,20 @@ Commit::squashAfter(ThreadID tid, const DynInstPtr &head_inst)
     squashAfterInst[tid] = head_inst;
 }
 
+bool
+Commit::hasExecutedYoungerInst(ThreadID tid, InstSeqNum seq_num) const
+{
+    for (const auto &inst : rob->getInstList(tid)) {
+        if (!inst || inst->isSquashed()) {
+            continue;
+        }
+        if (inst->seqNum > seq_num && inst->isExecuted()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void
 Commit::tick()
 {
@@ -1378,6 +1392,13 @@ Commit::commitInsts()
                         auto tc = head_inst->tcBase();
                         RiscvISA::VTYPE new_vtype = head_inst->readMiscReg(RiscvISA::MISCREG_VTYPE);
                         tc->getDecoderPtr()->as<RiscvISA::Decoder>().setVtype(new_vtype);
+                    }
+                    if (hasExecutedYoungerInst(tid, head_inst->seqNum)) {
+                        DPRINTF(Commit,
+                                "[tid:%i] [sn:%llu] Vector config committed with executed younger instructions in "
+                                "ROB, squash younger instructions.\n",
+                                tid, head_inst->seqNum);
+                        squashAfter(tid, head_inst);
                     }
                 }
                 if (head_inst->isFloating() && head_inst->isLoad()){

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -372,6 +372,7 @@ class Commit
 
     /** Commits as many instructions as possible. */
     void commitInsts();
+    bool hasExecutedYoungerInst(ThreadID tid, InstSeqNum seq_num) const;
     void updateMstatusSd(ThreadID tid);
 
     /** Tries to commit the head ROB instruction passed in.

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -616,6 +616,18 @@ Decode::decodeInsts(ThreadID tid)
         }
 #endif
 
+        if (inst->staticInst->isVectorConfig()) {
+            inst->setSerializeBefore();
+            inst->setSerializeAfter();
+            decode_stalls.push(StallReason::SerializeStall);
+            breakDecode = StallReason::SerializeStall;
+            DPRINTF(Decode,
+                    "[tid:%i] [sn:%llu] Vector config decoded, set serialize barrier and stop decoding younger "
+                    "instructions.\n",
+                    tid, inst->seqNum);
+            break;
+        }
+
         // Ensure that if it was predicted as a branch, it really is a
         // branch.
         if (inst->readPredTaken() && !inst->isControl()) {


### PR DESCRIPTION
The vector configuration instruction stalls the Decode stage, and the stall is released once the instruction has finished executing.

Change-Id: Ifa60a3cc85c36b0fb82bd9612124906b3a406e0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced vector configuration instruction handling throughout the CPU pipeline by implementing proper serialization barriers during the decode stage and adding instruction ordering constraints during the commit phase. These improvements ensure vector operations execute with correct semantics and eliminate potential ordering conflicts between vector configuration instructions and younger processor instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->