### PR TITLE
cpu-o3: ways per set in BTBTAGE predictor from 2 to 4

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1052,7 +1052,7 @@ class BTBTAGE(TimedBaseBTBPredictor):
     histLengths = VectorParam.Unsigned([4, 9, 17, 29, 56, 109, 211,397],"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970, "The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
-    numWays = VectorParam.Unsigned([2] * 8,"the T0~Tn number of ways per set")
+    numWays = VectorParam.Unsigned([4] * 8,"the T0~Tn number of ways per set")
     maxBranchPositions = Param.Unsigned(32, "Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128, "Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7, "Width of the useAltOnNa table")


### PR DESCRIPTION
Change-Id: Iab0001f35b3dac17ecdde80aca914fda2d9f70c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated branch predictor configuration to enhance prediction accuracy and overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->