### PR TITLE
Disable dispatch stage in idealkmhv3

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -42,7 +42,7 @@ def setKmhV3IdealParams(args, system):
         cpu.numPhysFloatRegs = 256
 
         # dispatch
-        cpu.enableDispatchStage = True
+        cpu.enableDispatchStage = False
         cpu.numDQEntries = [8, 8, 8]
         cpu.dispWidth = [8, 8, 8]
 


### PR DESCRIPTION
## Summary
- set `cpu.enableDispatchStage` to `False` in `configs/example/idealkmhv3.py`

## Why
- evaluate the performance impact of disabling the dispatch stage in the ideal kmhv3 configuration

## Validation
- not run locally by request
- rely on Tier 1 PR quick check
- perf label will trigger Tier 1.5 performance test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CPU dispatch stage configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->