### PR TITLE
configs: set idealkmhv3 fetchToDecodeDelay to 5

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -32,6 +32,7 @@ def setKmhV3IdealParams(args, system):
         cpu.fetchQueueSize = 64
 
         # decode
+        cpu.fetchToDecodeDelay = 5
         cpu.decodeWidth = 8
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False


### PR DESCRIPTION
Adjust idealkmhv3 configuration by setting fetchToDecodeDelay to 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KMHV3 CPU pipeline timing configuration with explicit fetch-to-decode stage delay setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->