### PR TITLE
cpu: Add imHist-assisted MGSC IMLI path

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1135,6 +1135,10 @@ class BTBMGSC(TimedBaseBTBPredictor):
     iHistLen = VectorParam.Int([8], "IMLI history GEHL history lengths")
     iTableIdxWidth = Param.Unsigned(12, "Log number of IMLI GEHL entries")
 
+    imHistTableNum = Param.Unsigned(1, "Num constant-IMLI-history GEHL tables")
+    imHistHistLen = VectorParam.Int([8], "Constant-IMLI-history GEHL history lengths")
+    imHistTableIdxWidth = Param.Unsigned(12, "Log number of constant-IMLI-history GEHL entries")
+
     gTableNum = Param.Unsigned(2, "Num global branch GEHL tables")
     gHistLen = VectorParam.Int([8, 16], "Global branch GEHL history lengths")
     gTableIdxWidth = Param.Unsigned(11, "Log number of global branch GEHL entries")
@@ -1172,6 +1176,7 @@ class BTBMGSC(TimedBaseBTBPredictor):
     enableBwTable = Param.Bool(True, "Enable BW (backward) table")
     enableLTable = Param.Bool(False, "Enable L (local) table")
     enableITable = Param.Bool(True, "Enable I (IMLI) table")
+    enableIMHistTable = Param.Bool(True, "Enable constant-IMLI-history helper for the I family")
     enableGTable = Param.Bool(True, "Enable G (global) table")
     enablePTable = Param.Bool(True, "Enable P (path) table")
     enableBiasTable = Param.Bool(True, "Enable Bias table")

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -84,6 +84,26 @@ BTBMGSC::initStorage()
     }
     iIndex.resize(iTableNum);
 
+    auto imHistTableSize = allocPredTable(imHistTable, imHistTableNum, imHistTableIdxWidth);
+    for (unsigned int i = 0; i < imHistTableNum; ++i) {
+        assert(imHistHistLen[i] >= 0);
+        assert(static_cast<unsigned>(imHistHistLen[i]) < 63);
+        assert(pow2(static_cast<unsigned>(imHistHistLen[i])) <= imHistTableSize);
+    }
+    imHistIndex.resize(imHistTableNum);
+    if (!iHistLen.empty()) {
+        imHist.resize(pow2(static_cast<unsigned>(iHistLen[0])), 0);
+        imHistStoreBits = 0;
+        for (const auto &hist_len : imHistHistLen) {
+            imHistStoreBits = std::max(imHistStoreBits, static_cast<unsigned>(std::max(hist_len, 0)));
+        }
+        if (imHistStoreBits == 0 && enableIMHistTable) {
+            imHistStoreBits = 1;
+        }
+        imHistStoreMask = (imHistStoreBits == 0) ? 0 : ((1ULL << imHistStoreBits) - 1);
+    }
+    imliCount = 0;
+
     auto gTableSize = allocPredTable(gTable, gTableNum, gTableIdxWidth);
     for (unsigned int i = 0; i < gTableNum; ++i) {
         assert(gTable.size() >= gTableNum);
@@ -130,6 +150,9 @@ BTBMGSC::BTBMGSC()
       // foldedLen is small (5 - log2(8) = 2), so keep histLen=1 for unit tests.
       // Also keep it >= 2 so we can build loop-trip-count tests on IMLI.
       iHistLen({2}),
+      imHistTableNum(1),
+      imHistTableIdxWidth(6),
+      imHistHistLen({4}),
       gTableNum(1),
       // Use a slightly larger idx width so foldedLen is not too small (helps pattern-learning tests).
       gTableIdxWidth(6),
@@ -153,6 +176,7 @@ BTBMGSC::BTBMGSC()
       enableBwTable(true),
       enableLTable(true),
       enableITable(true),
+      enableIMHistTable(false),
       enableGTable(true),
       enablePTable(true),
       enableBiasTable(true),
@@ -182,6 +206,9 @@ BTBMGSC::BTBMGSC(const Params &p)
       iTableNum(p.iTableNum),
       iTableIdxWidth(p.iTableIdxWidth),
       iHistLen(p.iHistLen),
+      imHistTableNum(p.imHistTableNum),
+      imHistTableIdxWidth(p.imHistTableIdxWidth),
+      imHistHistLen(p.imHistHistLen),
       gTableNum(p.gTableNum),
       gTableIdxWidth(p.gTableIdxWidth),
       gHistLen(p.gHistLen),
@@ -201,6 +228,7 @@ BTBMGSC::BTBMGSC(const Params &p)
       enableBwTable(p.enableBwTable),
       enableLTable(p.enableLTable),
       enableITable(p.enableITable),
+      enableIMHistTable(p.enableIMHistTable),
       enableGTable(p.enableGTable),
       enablePTable(p.enablePTable),
       enableBiasTable(p.enableBiasTable),
@@ -316,6 +344,54 @@ BTBMGSC::calculateScaledPercsum(int weight, int percsum)
     return percsum; // disable weight scaling for test
 }
 
+uint64_t
+BTBMGSC::foldIntHistory(uint64_t history, unsigned histLen, unsigned foldedLen) const
+{
+    if (foldedLen == 0 || histLen == 0) {
+        return 0;
+    }
+    const uint64_t foldedMask = (1ULL << foldedLen) - 1;
+    uint64_t folded = 0;
+    unsigned bitsLeft = histLen;
+    while (bitsLeft > 0) {
+        folded ^= (history & foldedMask);
+        history >>= foldedLen;
+        bitsLeft = (bitsLeft > foldedLen) ? (bitsLeft - foldedLen) : 0;
+    }
+    return folded & foldedMask;
+}
+
+void
+BTBMGSC::updateImHistState(bool cond_taken)
+{
+    if (!enableIMHistTable || imHist.empty()) {
+        return;
+    }
+    assert(imliCount < imHist.size());
+    auto &hist = imHist[imliCount];
+    if (imHistStoreMask) {
+        hist = ((hist << 1) | static_cast<uint64_t>(cond_taken)) & imHistStoreMask;
+    } else {
+        hist = 0;
+    }
+}
+
+void
+BTBMGSC::updateImliCountState(bool bw_taken)
+{
+    if (iHistLen.empty()) {
+        return;
+    }
+    const uint64_t maxCount = (1ULL << static_cast<unsigned>(iHistLen[0])) - 1;
+    if (bw_taken) {
+        if (imliCount < maxCount) {
+            imliCount++;
+        }
+    } else {
+        imliCount = 0;
+    }
+}
+
 /**
  * Find threshold in a threshold table for a given PC
  * @param thresholdTable The threshold table to search
@@ -378,6 +454,17 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     for (unsigned int i = 0; i < iTableNum; ++i) {
         iIndex[i] = getHistIndex(startPC, iTableIdxWidth - numCtrsPerLineBits, indexIFoldedHist[i].get());
     }
+    if (enableIMHistTable && !imHist.empty()) {
+        assert(imliCount < imHist.size());
+        const uint64_t currentImHist = imHist[imliCount];
+        for (unsigned int i = 0; i < imHistTableNum; ++i) {
+            auto folded = foldIntHistory(
+                currentImHist, static_cast<unsigned>(imHistHistLen[i]), imHistTableIdxWidth - numCtrsPerLineBits);
+            imHistIndex[i] = getHistIndex(startPC, imHistTableIdxWidth - numCtrsPerLineBits, folded);
+        }
+    } else {
+        std::fill(imHistIndex.begin(), imHistIndex.end(), 0);
+    }
 
     for (unsigned int i = 0; i < gTableNum; ++i) {
         gIndex[i] = getHistIndex(startPC, gTableIdxWidth - numCtrsPerLineBits, indexGFoldedHist[i].get());
@@ -400,7 +487,10 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     int l_weight = findWeight(lWeightTable, btb_entry.pc);
     int l_scaled_percsum = calculateScaledPercsum(l_weight, l_percsum);
 
-    int i_percsum = enableITable ? calculatePercsum(iTable, iIndex, iTableNum, btb_entry.pc) : 0;
+    int i_count_percsum = enableITable ? calculatePercsum(iTable, iIndex, iTableNum, btb_entry.pc) : 0;
+    int imHist_percsum =
+        enableIMHistTable ? calculatePercsum(imHistTable, imHistIndex, imHistTableNum, btb_entry.pc) : 0;
+    int i_percsum = i_count_percsum + imHist_percsum;
     int i_weight = findWeight(iWeightTable, btb_entry.pc);
     int i_scaled_percsum = calculateScaledPercsum(i_weight, i_percsum);
 
@@ -464,9 +554,11 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken,
                           tage_info.tage_pred_conf_high, tage_info.tage_pred_conf_mid, tage_info.tage_pred_conf_low,
-                          total_thres, bwIndex, lIndex, iIndex, gIndex, pIndex, biasIndex, bw_weight_scale_diff,
-                          l_weight_scale_diff, i_weight_scale_diff, g_weight_scale_diff, p_weight_scale_diff,
-                          bias_weight_scale_diff, bw_percsum, l_percsum, i_percsum, g_percsum, p_percsum, bias_percsum);
+                          total_thres, bwIndex, lIndex, iIndex, imHistIndex, gIndex, pIndex, biasIndex,
+                          bw_weight_scale_diff, l_weight_scale_diff, i_weight_scale_diff, g_weight_scale_diff,
+                          p_weight_scale_diff, bias_weight_scale_diff, bw_percsum, l_percsum, i_percsum,
+                          imHist_percsum, g_percsum,
+                          p_percsum, bias_percsum);
 }
 
 /**
@@ -531,6 +623,8 @@ BTBMGSC::putPCHistory(Addr stream_start, const boost::dynamic_bitset<> &history,
     meta->indexIFoldedHist = indexIFoldedHist;
     meta->indexGFoldedHist = indexGFoldedHist;
     meta->indexPFoldedHist = indexPFoldedHist;
+    meta->imliCount = imliCount;
+    meta->imHist = imHist;
 
     for (int s = getDelay(); s < stagePreds.size(); s++) {
         // TODO: only lookup once for one btb entry in different stages
@@ -842,6 +936,7 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
 
         // Update I tables
         updatePredTable(iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
+        updatePredTable(imHistTable, pred.imHistIndex, imHistTableNum, entry.pc, actual_taken);
         updateWeightTable(iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
                           (pred.i_percsum >= 0) == actual_taken);
 
@@ -1145,21 +1240,28 @@ BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPredict
  * This function updates the branch history for speculative execution
  * based on the prediction information.
  *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- * Note: IMLI only uses counter, not history bits.
+ * It first updates the per-IMLI-count outcome history using the current
+ * conditional prediction, then advances the loop counter state using the
+ * backward-taken event.
  *
  * @param pred The prediction metadata containing history information
  */
 void
 BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
 {
+    int histShamt;
+    bool histTaken;
+    std::tie(histShamt, histTaken) = pred.getHistInfo();
+    if (histShamt > 0) {
+        updateImHistState(histTaken);
+    }
+
     int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getBwHistInfo();
-    // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
+    bool bw_taken;
+    std::tie(shamt, bw_taken) = pred.getBwHistInfo();
     boost::dynamic_bitset<> dummy;
-    doUpdateHist(dummy, shamt, cond_taken, indexIFoldedHist);
+    doUpdateHist(dummy, shamt, bw_taken, indexIFoldedHist);
+    updateImliCountState(bw_taken);
 }
 
 /**
@@ -1266,14 +1368,13 @@ BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget
  * @brief Recovers branch imli history state after a misprediction
  *
  * This function:
- * 1. Restores the folded histories from the saved metadata
+ * 1. Restores the folded histories and IMLI helper state from the saved metadata
  * 2. Updates the histories with the correct branch outcome
  * 3. Ensures predictor state is consistent after recovery
- * Note: IMLI only uses counter, not history bits.
  *
  * @param entry The fetch stream entry containing recovery information
  * @param shamt Number of bits to shift in history update
- * @param cond_taken The actual branch outcome
+ * @param cond_taken Whether the resolved branch contributes a backward-taken event
  */
 void
 BTBMGSC::recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken)
@@ -1285,9 +1386,14 @@ BTBMGSC::recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken)
     for (int i = 0; i < iTableNum; i++) {
         indexIFoldedHist[i].recover(predMeta->indexIFoldedHist[i]);
     }
-    // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
+    imliCount = predMeta->imliCount;
+    imHist = predMeta->imHist;
+    if (entry.exeBranchInfo.isCond) {
+        updateImHistState(entry.exeTaken);
+    }
     boost::dynamic_bitset<> dummy;
     doUpdateHist(dummy, shamt, cond_taken, indexIFoldedHist);
+    updateImliCountState(cond_taken);
 }
 
 /**

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -61,6 +61,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         std::vector<unsigned> bwIndex;    // BW table indices
         std::vector<unsigned> lIndex;     // L table indices
         std::vector<unsigned> iIndex;     // I table indices
+        std::vector<unsigned> imHistIndex; // constant-IMLI-history table indices
         std::vector<unsigned> gIndex;     // G table indices
         std::vector<unsigned> pIndex;     // P table indices
         std::vector<unsigned> biasIndex;  // Bias table indices
@@ -74,6 +75,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         int bw_percsum;
         int l_percsum;
         int i_percsum;
+        int imHist_percsum;
         int g_percsum;
         int p_percsum;
         int bias_percsum;
@@ -91,6 +93,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
               bwIndex(0),
               lIndex(0),
               iIndex(0),
+              imHistIndex(0),
               gIndex(0),
               pIndex(0),
               biasIndex(0),
@@ -103,6 +106,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
               bw_percsum(0),
               l_percsum(0),
               i_percsum(0),
+              imHist_percsum(0),
               g_percsum(0),
               p_percsum(0),
               bias_percsum(0)
@@ -112,10 +116,12 @@ class BTBMGSC : public TimedBaseBTBPredictor
         MgscPrediction(Addr btb_pc, int total_sum, bool use_mgsc, bool taken, bool taken_before_sc,
                        bool tage_conf_high, bool tage_conf_mid, bool tage_conf_low, int16_t total_thres,
                        std::vector<unsigned> bwIndex, std::vector<unsigned> lIndex, std::vector<unsigned> iIndex,
-                       std::vector<unsigned> gIndex, std::vector<unsigned> pIndex, std::vector<unsigned> biasIndex,
+                       std::vector<unsigned> imHistIndex, std::vector<unsigned> gIndex, std::vector<unsigned> pIndex,
+                       std::vector<unsigned> biasIndex,
                        bool bw_weight_scale_diff, bool l_weight_scale_diff, bool i_weight_scale_diff,
                        bool g_weight_scale_diff, bool p_weight_scale_diff, bool bias_weight_scale_diff, int bw_percsum,
-                       int l_percsum, int i_percsum, int g_percsum, int p_percsum, int bias_percsum)
+                       int l_percsum, int i_percsum, int imHist_percsum, int g_percsum, int p_percsum,
+                       int bias_percsum)
             : btb_pc(btb_pc),
               total_sum(total_sum),
               use_mgsc(use_mgsc),
@@ -128,6 +134,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
               bwIndex(bwIndex),
               lIndex(lIndex),
               iIndex(iIndex),
+              imHistIndex(imHistIndex),
               gIndex(gIndex),
               pIndex(pIndex),
               biasIndex(biasIndex),
@@ -140,6 +147,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
               bw_percsum(bw_percsum),
               l_percsum(l_percsum),
               i_percsum(i_percsum),
+              imHist_percsum(imHist_percsum),
               g_percsum(g_percsum),
               p_percsum(p_percsum),
               bias_percsum(bias_percsum)
@@ -245,6 +253,10 @@ class BTBMGSC : public TimedBaseBTBPredictor
      */
     void updateGlobalThreshold(Addr pc, bool update_direction);
 
+    uint64_t foldIntHistory(uint64_t history, unsigned histLen, unsigned foldedLen) const;
+    void updateImHistState(bool cond_taken);
+    void updateImliCountState(bool bw_taken);
+
     // Look up predictions in MGSC tables for a stream of instructions
     void lookupHelper(const Addr &stream_start, const std::vector<BTBEntry> &btbEntries,
                       const std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs, CondTakens &results);
@@ -310,6 +322,11 @@ class BTBMGSC : public TimedBaseBTBPredictor
     unsigned iTableIdxWidth;
     std::vector<int> iHistLen;
 
+    /** constant-IMLI-history indexed tables param */
+    unsigned imHistTableNum;
+    unsigned imHistTableIdxWidth;
+    std::vector<int> imHistHistLen;
+
     /** global history indexed table param*/
     unsigned gTableNum;
     unsigned gTableIdxWidth;
@@ -347,6 +364,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     bool enableBwTable;
     bool enableLTable;
     bool enableITable;
+    bool enableIMHistTable;
     bool enableGTable;
     bool enablePTable;
     bool enableBiasTable;
@@ -374,6 +392,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<std::vector<std::vector<int16_t>>> iTable;
     // The actual MGSC prediction tables (index x line)
     std::vector<int16_t> iWeightTable;
+    // Constant-IMLI-history tables share the I-family weighting path.
+    std::vector<std::vector<std::vector<int16_t>>> imHistTable;
 
     // The actual MGSC prediction tables (table x index x line)
     std::vector<std::vector<std::vector<int16_t>>> gTable;
@@ -413,9 +433,15 @@ class BTBMGSC : public TimedBaseBTBPredictor
     std::vector<unsigned> bwIndex;
     std::vector<unsigned> lIndex;
     std::vector<unsigned> iIndex;
+    std::vector<unsigned> imHistIndex;
     std::vector<unsigned> gIndex;
     std::vector<unsigned> pIndex;
     std::vector<unsigned> biasIndex;
+
+    uint64_t imliCount{0};
+    std::vector<uint64_t> imHist;
+    unsigned imHistStoreBits{0};
+    uint64_t imHistStoreMask{0};
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;
@@ -519,6 +545,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         static bool &enableBwTable(BTBMGSC &mgsc) { return mgsc.enableBwTable; }
         static bool &enableLTable(BTBMGSC &mgsc) { return mgsc.enableLTable; }
         static bool &enableITable(BTBMGSC &mgsc) { return mgsc.enableITable; }
+        static bool &enableIMHistTable(BTBMGSC &mgsc) { return mgsc.enableIMHistTable; }
         static bool &enableGTable(BTBMGSC &mgsc) { return mgsc.enableGTable; }
         static bool &enablePTable(BTBMGSC &mgsc) { return mgsc.enablePTable; }
         static bool &enableBiasTable(BTBMGSC &mgsc) { return mgsc.enableBiasTable; }
@@ -528,6 +555,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
         static auto &bwTable(BTBMGSC &mgsc) { return mgsc.bwTable; }
         static auto &lTable(BTBMGSC &mgsc) { return mgsc.lTable; }
         static auto &iTable(BTBMGSC &mgsc) { return mgsc.iTable; }
+        static auto &imHistTable(BTBMGSC &mgsc) { return mgsc.imHistTable; }
         static auto &gTable(BTBMGSC &mgsc) { return mgsc.gTable; }
         static auto &pTable(BTBMGSC &mgsc) { return mgsc.pTable; }
         static auto &biasTable(BTBMGSC &mgsc) { return mgsc.biasTable; }
@@ -570,16 +598,20 @@ class BTBMGSC : public TimedBaseBTBPredictor
         std::vector<ImliFoldedHist> indexIFoldedHist;
         std::vector<GlobalFoldedHist> indexGFoldedHist;
         std::vector<PathFoldedHist> indexPFoldedHist;
+        uint64_t imliCount{0};
+        std::vector<uint64_t> imHist;
         MgscMeta(std::unordered_map<Addr, MgscPrediction> preds, std::vector<GlobalBwFoldedHist> indexBwFoldedHist,
                  std::vector<std::vector<LocalFoldedHist>> indexLFoldedHist,
                  std::vector<ImliFoldedHist> indexIFoldedHist, std::vector<GlobalFoldedHist> indexGFoldedHist,
-                 std::vector<PathFoldedHist> indexPFoldedHist)
+                 std::vector<PathFoldedHist> indexPFoldedHist, uint64_t imliCount, std::vector<uint64_t> imHist)
             : preds(preds),
               indexBwFoldedHist(indexBwFoldedHist),
               indexLFoldedHist(indexLFoldedHist),
               indexIFoldedHist(indexIFoldedHist),
               indexGFoldedHist(indexGFoldedHist),
-              indexPFoldedHist(indexPFoldedHist)
+              indexPFoldedHist(indexPFoldedHist),
+              imliCount(imliCount),
+              imHist(imHist)
         {
         }
         MgscMeta() {}
@@ -591,6 +623,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
             indexIFoldedHist = other.indexIFoldedHist;
             indexGFoldedHist = other.indexGFoldedHist;
             indexPFoldedHist = other.indexPFoldedHist;
+            imliCount = other.imliCount;
+            imHist = other.imHist;
         }
     } MgscMeta;
 

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <iostream>
 #include <vector>
 
@@ -172,6 +173,21 @@ struct MgscHarness
         BTBMGSC::TestAccess::enableBwTable(mgsc) = false;
         BTBMGSC::TestAccess::enableLTable(mgsc) = false;
         BTBMGSC::TestAccess::enableITable(mgsc) = true;
+        BTBMGSC::TestAccess::enableIMHistTable(mgsc) = false;
+        BTBMGSC::TestAccess::enableGTable(mgsc) = false;
+        BTBMGSC::TestAccess::enablePTable(mgsc) = false;
+        BTBMGSC::TestAccess::enableBiasTable(mgsc) = false;
+        BTBMGSC::TestAccess::enablePCThreshold(mgsc) = false;
+        BTBMGSC::TestAccess::forceUseSC(mgsc) = true;
+    }
+
+    void
+    setOnlyIMHistTable()
+    {
+        BTBMGSC::TestAccess::enableBwTable(mgsc) = false;
+        BTBMGSC::TestAccess::enableLTable(mgsc) = false;
+        BTBMGSC::TestAccess::enableITable(mgsc) = false;
+        BTBMGSC::TestAccess::enableIMHistTable(mgsc) = true;
         BTBMGSC::TestAccess::enableGTable(mgsc) = false;
         BTBMGSC::TestAccess::enablePTable(mgsc) = false;
         BTBMGSC::TestAccess::enableBiasTable(mgsc) = false;
@@ -672,6 +688,77 @@ TEST(BTBMGSCTest, ITableLearnsFixedTripCountLoop)
     EXPECT_GE(seen_i_indices.size(), 3u);
     double acc = static_cast<double>(correct_after_warmup) / static_cast<double>(total_after_warmup);
     EXPECT_GE(acc, 0.85) << "Accuracy too low for fixed-trip loop: " << acc;
+}
+
+TEST(BTBMGSCTest, IMHistTableSeparatesOuterPhaseAtSameIteration)
+{
+    MgscHarness sic_only;
+    sic_only.setOnlyITable();
+
+    MgscHarness enhanced_i;
+    enhanced_i.setOnlyITable();
+    BTBMGSC::TestAccess::enableIMHistTable(enhanced_i.mgsc) = true;
+
+    const Addr target_start_pc = 0x1000;
+    const Addr target_branch_pc = 0x1000;
+    auto target_entry = makeCondBTBEntry(target_branch_pc);
+    target_entry.target = target_branch_pc + 4;
+
+    const Addr loop_start_pc = 0x1100;
+    const Addr loop_branch_pc = 0x1100;
+    auto loop_entry = makeCondBTBEntry(loop_branch_pc);
+    loop_entry.target = loop_branch_pc - 4; // backward loop branch
+
+    const TageInfoForMGSC tage_info(
+        /*tage_pred_taken=*/false,
+        /*tage_main_taken=*/false,
+        /*tage_pred_conf_high=*/true,
+        /*tage_pred_conf_mid=*/false,
+        /*tage_pred_conf_low=*/false,
+        /*tage_pred_alt_diff=*/false);
+
+    constexpr int trip_count = 4;
+    constexpr int outer_iters = 160;
+    constexpr int warmup_iters = 40;
+    std::array<bool, trip_count> slot_state = {false, true, false, true};
+
+    int sic_correct = 0;
+    int enhanced_correct = 0;
+    int total = 0;
+
+    for (int outer = 0; outer < outer_iters; ++outer) {
+        for (int pos = 0; pos < trip_count; ++pos) {
+            bool actual_taken = slot_state[pos];
+            slot_state[pos] = !slot_state[pos];
+
+            auto sic_step = sic_only.step(target_start_pc, target_entry, tage_info, actual_taken);
+            auto enhanced_step = enhanced_i.step(target_start_pc, target_entry, tage_info, actual_taken);
+
+            if (outer >= warmup_iters) {
+                total++;
+                if (sic_step.predicted_taken == actual_taken) {
+                    sic_correct++;
+                }
+                if (enhanced_step.predicted_taken == actual_taken) {
+                    enhanced_correct++;
+                }
+            }
+
+            bool loop_taken = (pos + 1) < trip_count;
+            sic_only.step(loop_start_pc, loop_entry, tage_info, loop_taken);
+            enhanced_i.step(loop_start_pc, loop_entry, tage_info, loop_taken);
+        }
+    }
+
+    ASSERT_GT(total, 0);
+    const double sic_acc = static_cast<double>(sic_correct) / static_cast<double>(total);
+    const double enhanced_acc = static_cast<double>(enhanced_correct) / static_cast<double>(total);
+    EXPECT_LT(sic_acc, 0.75) << "Count-only IMLI unexpectedly handled outer-phase aliasing: " << sic_acc;
+    EXPECT_GT(enhanced_acc, sic_acc + 0.15)
+        << "IMHIST-assisted IMLI did not materially improve outer-phase correlation: sic=" << sic_acc
+        << " enhanced=" << enhanced_acc;
+    EXPECT_GT(enhanced_acc, 0.85)
+        << "Combined SIC+IMHIST path still failed to learn outer-phase correlation: " << enhanced_acc;
 }
 
 TEST(BTBMGSCTest, BiasTableLearnsTwoTageContexts)


### PR DESCRIPTION
## Summary

This PR adds an optional `imHist`-assisted helper table for the MGSC IMLI path.

The change is mainly useful as an IMLI modeling/alignment experiment: it makes the I-family much stronger in standalone SC / no-TAGE mode, but the current SPEC-level gain on the normal TAGE-on mainline path is very small. So this PR is not urgent to merge; it is mostly here to document and preserve the mechanism and data.

## Basic Principle

The old MGSC IMLI path was effectively indexed by:

```text
PC + imliCount
```

`imliCount` separates positions inside a loop, but it cannot distinguish cases where the same inner-loop position has different behavior under different outer-loop phases. For example, "iteration 3" may be taken in one outer phase and not-taken in another. Count-only IMLI aliases those samples together.

This PR adds a small helper history per IMLI count:

```text
imHist[imliCount]
```

Prediction then uses an additional GEHL-style helper table indexed by:

```text
PC + folded(imHist[imliCount])
```

The helper contribution is added into the existing I-family perceptron sum:

```text
i_percsum = i_count_percsum + imHist_percsum
```

So this is not a separate new SC family. It is an auxiliary path for the existing IMLI/I-family, sharing the same I-family weight path.

## Focused Micro-Test Results

The focused `mgsc_test` probes show the intended mechanism clearly when isolating `i_only`:

| Test | Old count-only IMLI condMiss | imHist-assisted IMLI condMiss |
| --- | ---: | ---: |
| `imli_threshold` | 20001 | 4049 |
| `imli_phase_shift` | 20488 | 2050 |
| `imli_iter` | 3083 | 2198 |
| `imli_two_hot_positions` | 5128 | 4107 |

The strongest evidence is `imli_phase_shift`: the old IMLI aliases different outer phases at the same inner position, while `imHist[imliCount]` separates them and flips the key PCs to the expected I-table-driven behavior.

## SPEC06 CI Results

### no-TAGE / standalone SC

Baseline: `run529`  
imHist branch: `run542`

| Metric | run529 | run542 | Delta |
| --- | ---: | ---: | ---: |
| SPECint score/GHz | 16.2086 | 16.4736 | +0.2650 |
| Overall score/GHz | 18.1067 | 18.3297 | +0.2230 |

Branch-counter changes line up with a real predictor improvement:

| Benchmark | `cond_MPKI` delta |
| --- | ---: |
| `h264ref` | -33.6% |
| `astar` | -25.7% |
| `perlbench` | -28.0% |
| `sjeng` | -13.4% |
| `gobmk` | -4.9% |

The frontend counters also move in the expected direction. For example, `fetch_nisn_total` drops by about `-8.1%` on `astar`, `-5.6%` on `perlbench`, `-5.2%` on `sjeng`, `-3.5%` on `h264ref`, and `-2.6%` on `gobmk`.

### normal TAGE-on mainline path

Baseline: `run544`  
imHist branch: `run543`

| Metric | run544 | run543 | Delta |
| --- | ---: | ---: | ---: |
| SPECint score/GHz | 18.729385 | 18.729351 | ~0 |
| Overall score/GHz | 19.93025 | 19.93676 | +0.0065 |

Branch/frontend changes are mostly noise-level:

| Benchmark | `cond_MPKI` delta |
| --- | ---: |
| `h264ref` | -0.28% |
| `astar` | +0.10% |
| `perlbench` | +0.71% |
| `sjeng` | -0.06% |
| `gobmk` | -0.41% |

The frontend group mean absolute change is only about `0.17%`.

## Counter-Based Explanation

The MGSC raw counters confirm that the helper is working, but the normal TAGE-on path leaves little remaining correction headroom.

In no-TAGE mode, imHist makes IMLI percsum more accurate and increases SC net fixes:

| Benchmark | IMLI percsum accuracy | `scCorrectTageWrong - scWrongTageCorrect` |
| --- | ---: | ---: |
| `h264ref` | 78.4% -> 86.7% | 361k -> 375k |
| `astar` | 59.9% -> 62.7% | 1067k -> 1114k |

With TAGE enabled, IMLI percsum can still improve, but the net correction space is much smaller because TAGE already predicts most of those branches correctly:

| Benchmark | IMLI percsum accuracy | `scCorrectTageWrong - scWrongTageCorrect` |
| --- | ---: | ---: |
| `h264ref` | 52.6% -> 73.0% | 7.7k -> 6.3k |
| `astar` | 63.8% -> 69.8% | 2.0k -> 1.9k |
| `sjeng` | 75.4% -> 76.7% | 9.9k -> 10.5k |

Also, many SC uses are in TAGE high-confidence regions. For example, in the TAGE-on imHist run, weighted high/mid/low SC-use counts are approximately:

| Benchmark | high / mid / low SC use |
| --- | ---: |
| `h264ref` | 659k / 27k / 124k |
| `gobmk` | 2330k / 348k / 1149k |

So the current interpretation is: imHist-assisted IMLI is a real improvement for standalone SC/no-TAGE behavior, but on the normal mainline path most of that information is already captured by TAGE or becomes same-direction confirmation rather than a new final correction.

## Merge Note

This PR is probably better treated as an alignment/data point for now rather than an urgent performance patch. The mechanism is useful and the micro-test evidence is strong, but the mainline TAGE-on SPEC gain is currently close to noise.

Change-Id: If70a82b86d47732edce31a7f1c848be2698d5fda
