### PR TITLE
Sc test align

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -113,8 +113,8 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mgsc.enabled = True
             # SC table ablation config for gcc15 slice CI.
             cpu.branchPred.mgsc.enableBwTable = False
-            cpu.branchPred.mgsc.enableLTable = True
-            cpu.branchPred.mgsc.enableITable = False
+            cpu.branchPred.mgsc.enableLTable = False
+            cpu.branchPred.mgsc.enableITable = True
             cpu.branchPred.mgsc.enableGTable = False
             cpu.branchPred.mgsc.enablePTable = False
             cpu.branchPred.mgsc.enableBiasTable = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -111,6 +111,13 @@ def setKmhV3Params(args, system):
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
+            # SC table ablation config for gcc15 slice CI.
+            cpu.branchPred.mgsc.enableBwTable = False
+            cpu.branchPred.mgsc.enableLTable = False
+            cpu.branchPred.mgsc.enableITable = False
+            cpu.branchPred.mgsc.enableGTable = False
+            cpu.branchPred.mgsc.enablePTable = False
+            cpu.branchPred.mgsc.enableBiasTable = False
             cpu.branchPred.ras.enabled = True
 
         # l1 cache per core

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -112,9 +112,9 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
             # SC table ablation config for gcc15 slice CI.
-            cpu.branchPred.mgsc.enableBwTable = False
+            cpu.branchPred.mgsc.enableBwTable = True
             cpu.branchPred.mgsc.enableLTable = False
-            cpu.branchPred.mgsc.enableITable = True
+            cpu.branchPred.mgsc.enableITable = False
             cpu.branchPred.mgsc.enableGTable = False
             cpu.branchPred.mgsc.enablePTable = False
             cpu.branchPred.mgsc.enableBiasTable = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -116,8 +116,8 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mgsc.enableLTable = False
             cpu.branchPred.mgsc.enableITable = False
             cpu.branchPred.mgsc.enableGTable = False
-            cpu.branchPred.mgsc.enablePTable = True
-            cpu.branchPred.mgsc.enableBiasTable = False
+            cpu.branchPred.mgsc.enablePTable = False
+            cpu.branchPred.mgsc.enableBiasTable = True
             cpu.branchPred.ras.enabled = True
 
         # l1 cache per core

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -111,6 +111,12 @@ def setKmhV3Params(args, system):
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
+            cpu.branchPred.mgsc.enableBwTable = False
+            cpu.branchPred.mgsc.enableLTable = False
+            cpu.branchPred.mgsc.enableITable = False
+            cpu.branchPred.mgsc.enableGTable = True
+            cpu.branchPred.mgsc.enablePTable = False
+            cpu.branchPred.mgsc.enableBiasTable = False
             cpu.branchPred.mgsc.enablePCThreshold = True
             cpu.branchPred.ras.enabled = True
 

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -112,11 +112,11 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
             # SC table ablation config for gcc15 slice CI.
-            cpu.branchPred.mgsc.enableBwTable = True
+            cpu.branchPred.mgsc.enableBwTable = False
             cpu.branchPred.mgsc.enableLTable = False
             cpu.branchPred.mgsc.enableITable = False
             cpu.branchPred.mgsc.enableGTable = False
-            cpu.branchPred.mgsc.enablePTable = False
+            cpu.branchPred.mgsc.enablePTable = True
             cpu.branchPred.mgsc.enableBiasTable = False
             cpu.branchPred.ras.enabled = True
 

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -115,7 +115,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mgsc.enableBwTable = False
             cpu.branchPred.mgsc.enableLTable = False
             cpu.branchPred.mgsc.enableITable = False
-            cpu.branchPred.mgsc.enableGTable = False
+            cpu.branchPred.mgsc.enableGTable = True
             cpu.branchPred.mgsc.enablePTable = False
             cpu.branchPred.mgsc.enableBiasTable = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -113,9 +113,9 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mgsc.enabled = True
             # SC table ablation config for gcc15 slice CI.
             cpu.branchPred.mgsc.enableBwTable = False
-            cpu.branchPred.mgsc.enableLTable = False
+            cpu.branchPred.mgsc.enableLTable = True
             cpu.branchPred.mgsc.enableITable = False
-            cpu.branchPred.mgsc.enableGTable = True
+            cpu.branchPred.mgsc.enableGTable = False
             cpu.branchPred.mgsc.enablePTable = False
             cpu.branchPred.mgsc.enableBiasTable = False
             cpu.branchPred.ras.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -111,13 +111,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
             cpu.branchPred.mgsc.enabled = True
-            # SC table ablation config for gcc15 slice CI.
-            cpu.branchPred.mgsc.enableBwTable = False
-            cpu.branchPred.mgsc.enableLTable = False
-            cpu.branchPred.mgsc.enableITable = False
-            cpu.branchPred.mgsc.enableGTable = False
-            cpu.branchPred.mgsc.enablePTable = False
-            cpu.branchPred.mgsc.enableBiasTable = True
+            cpu.branchPred.mgsc.enablePCThreshold = True
             cpu.branchPred.ras.enabled = True
 
         # l1 cache per core

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -432,15 +432,15 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     bool use_sc_pred = forceUseSC;  // Force use SC if configured
     if (!use_sc_pred) {
         if (tage_info.tage_pred_conf_high) {
-            if (abs(total_sum) > total_thres / 2) {
+            if (abs(total_sum) > total_thres) {
                 use_sc_pred = true;
             }
         } else if (tage_info.tage_pred_conf_mid) {
-            if (abs(total_sum) > total_thres / 4) {
+            if (abs(total_sum) > total_thres / 2) {
                 use_sc_pred = true;
             }
         } else if (tage_info.tage_pred_conf_low) {
-            if (abs(total_sum) > total_thres / 8) {
+            if (abs(total_sum) > total_thres / 4) {
                 use_sc_pred = true;
             }
         }
@@ -792,8 +792,8 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
 #ifndef UNIT_TEST
     // Write trace record
     if (enableDB && (focusBranchPC == 0 || entry.pc == focusBranchPC)) {
-        auto effective_gate = pred.tage_conf_high ? (total_thres / 2)
-            : (pred.tage_conf_mid ? (total_thres / 4) : (total_thres / 8));
+        auto effective_gate = pred.tage_conf_high ? total_thres
+            : (pred.tage_conf_mid ? (total_thres / 2) : (total_thres / 4));
         auto margin = std::abs(total_sum) - effective_gate;
         auto foldIndexSig = [](const std::vector<unsigned> &indices) -> uint64_t {
             uint64_t sig = 0xcbf29ce484222325ULL;


### PR DESCRIPTION
test enable each SC table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example configuration exposes an additional branch-predictor toggle allowing users to enable PC-threshold gating.

* **Chores**
  * Made branch-prediction override gating more conservative by raising confidence thresholds; this alters when an alternative predictor can override the primary predictor, which may affect prediction behavior and performance trade-offs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->