### PR TITLE
[codex] Drop GCB_RESTORER requirement

### DIFF
--- a/.codex/skills/tage-trace-workflow/SKILL.md
+++ b/.codex/skills/tage-trace-workflow/SKILL.md
@@ -65,7 +65,6 @@ rg -n "CondTrace_0_write|BpuPredictionTrace_write|microTageTrace_write" build/ch
 
 ```bash
 export GCBV_REF_SO=/nfs/home/yanyue/tools/gem5-tools/ref-h/riscv64-nemu-interpreter-so
-export GCB_RESTORER=""
 ```
 
 示例：

--- a/.github/workflows/autotest/gem5-h.cfg
+++ b/.github/workflows/autotest/gem5-h.cfg
@@ -15,8 +15,7 @@ log_root = ./log_root_h
 compile_thread = 70
 
 set_var = export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so" && \
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so" && \
-          export GCB_RESTORER=""
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
 
 #checkpoints 搜索路径
 #格式: <path1 level> ; <path2 level>

--- a/.github/workflows/autotest/gem5-vec.cfg
+++ b/.github/workflows/autotest/gem5-vec.cfg
@@ -10,8 +10,7 @@
 debug_mode = true
 #指定log的输出路径
 log_root = ./log_root_v
-set_env=export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so" && \
-	export GCB_RESTORER=""
+set_env=export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-so"
 
 [iteration]
 working_mode=single

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -195,7 +195,6 @@ jobs:
         # ${{ steps.config.outputs.comment }}
         env:
           GCBV_REF_SO: "/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
-          GCB_RESTORER: ""
           GEM5_HOME: ${{ github.workspace }}
           GEM5_BUILD_TYPE: fast
           PERF_ARCHIVE_DIR: ${{ steps.archive.outputs.target_dir }}

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -51,23 +51,6 @@ jobs:
           bash util/memory_check/run-xs-with-valgrind.sh
           cd $GEM5_HOME
 
-  new_sim_script_test_gcb:
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test new simulation script on RV64GCB
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GCB_RESTORER="/nfs/home/share/gem5_ci/tools/normal-gcb-restorer.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test
-          cd $GEM5_HOME/util/xs_scripts/test
-          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/gcb_test.zstd
 
   new_sim_script_test_gcbv:
     runs-on: [self-hosted, open]
@@ -118,7 +101,6 @@ jobs:
       - name: XS-GEM5 - Test xiangshan.py simulation scripts
         run: |
           export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GCB_RESTORER=""
           export GEM5_HOME=$(pwd)
           mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
           cd $GEM5_HOME/util/xs_scripts/test_l2tlb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,11 @@ This repository is primarily developed on shared Linux servers.
 - For full-system, checkpoint, and difftest-related tasks, prefer assuming `GCBV_REF_SO` is available.
 - The default CI-style reference path is:
   `GCBV_REF_SO=/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so`
-- The default explicit setting for `GCB_RESTORER` is:
-  `GCB_RESTORER=""`
-- Whether `GCB_RESTORER` and `AM_HOME` are needed depends on the task:
-  - restore-related workflows may require checking `GCB_RESTORER`
+- Normal single-core GCB checkpoint slices are expected to carry their own restorer.
+  Do not require `GCB_RESTORER`; pass `--gcpt-restorer` only when intentionally
+  overriding the embedded restorer for legacy checkpoints.
+- Whether an external restorer and `AM_HOME` are needed depends on the task:
+  - legacy restore override workflows may require checking the relevant restorer variable
   - some frontend micro-tests and bare-metal test flows may require checking `AM_HOME`
 - Before running environment-dependent tasks, check the relevant variables instead of assuming local defaults are correct.
 

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -349,12 +349,8 @@ def config_xiangshan_inputs(args: argparse.Namespace, sys):
             else:
                 fatal("Plz set $GCBH_RESTORER when running RVH checkpoints")
         else:
-            if "GCB_RESTORER" in os.environ:
-                gcpt_restorer = os.environ["GCB_RESTORER"]
-                print("Obtained gcpt_restorer from GCB_RESTORER: ", gcpt_restorer)
-            else:
-                fatal("Plz set $GCB_RESTORER or pass it through --gcpt-restorer"
-                      " when running non-RVV checkpoints")
+            gcpt_restorer = ""
+            print("Using restorer embedded in checkpoint")
     else:
         print("Obtained gcpt_restorer from args.gcpt_restorer: ", args.gcpt_restorer)
         gcpt_restorer = args.gcpt_restorer

--- a/docs/Gem5_Docs/top/gem5_tutorial.md
+++ b/docs/Gem5_Docs/top/gem5_tutorial.md
@@ -28,8 +28,6 @@ scons build/RISCV/gem5.debug --gold-linker -j48
 ```shell
 # 设置 diff 的 nemu
 export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-# 设置 GCB_RESTORE 为空
-export GCB_RESTORER=""
 # 跑一个 bin (非 ckpt)
 ./build/RISCV/gem5.opt configs/example/kmhv3.py --generic-rv-cpt /nfs/home/share/gem5_ci/checkpoints/coremark-riscv64-xs.bin --raw-cpt
 # 跑一个 ckpt
@@ -45,7 +43,6 @@ export CHECKPOINT_ROOT="/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_archive/sp
 # 或者使用大机房 ckpt 路径
 # export CHECKPOINT_ROOT="/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc"
 export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-export GCB_RESTORER=""
 export GEM5_HOME=$(pwd)
 mkdir -p $GEM5_HOME/util/xs_scripts/test
 cd $GEM5_HOME/util/xs_scripts/test
@@ -119,10 +116,6 @@ bash example-scripts/gem5-score-ci.sh \
             {
                 "name": "GCBV_REF_SO",
                 "value": "/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-            },
-            {
-                "name": "GCB_RESTORER",
-                "value": ""
             },
             {
                 "name": "GEM5_HOME",

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -126,17 +126,16 @@ export GCBV_REF_SO=`realpath difftest/build/riscv64-spike-so`
 
 ## 构建GCPT恢复器
 
-**Note:** 目前新版本切片或者裸机程序，都不需要使用GCPT恢复器了，所以可以跳过这一步。同时设置GCPT恢复器环境变量为空
-```bash
-export GCB_RESTORER=
-```
+**Note:** 目前新版本切片或者裸机程序，都不需要外部GCPT恢复器了，所以可以跳过这一步。
+只有需要覆盖旧切片内置恢复代码时，才需要传入 `--gcpt-restorer`。
 
 如果需要使用GCPT恢复器，请参考以下步骤：
 ```bash
 git clone https://github.com/OpenXiangShan/NEMU.git
 cd NEMU/resource/gcpt_restore
 make
-export GCB_RESTORER=`realpath build/gcpt.bin`
+# 在GEM5仓库运行旧切片时显式传入外部恢复器
+./build/RISCV/gem5.opt ./configs/example/kmhv3.py --generic-rv-cpt=<checkpoint> --gcpt-restorer=/path/to/NEMU/resource/gcpt_restore/build/gcpt.bin
 
 # 构建RVV版本
 git clone https://github.com/OpenXiangShan/NEMU.git -b gcpt_new_mem_layout

--- a/util/xs_scripts/ecore_4wide.sh
+++ b/util/xs_scripts/ecore_4wide.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCB_REF_SO GCB_RESTORER gem5_home; do
+for var in GCB_REF_SO gem5_home; do
     checkForVariable $var
 done
 

--- a/util/xs_scripts/kmh_6wide.sh
+++ b/util/xs_scripts/kmh_6wide.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
+for var in GCBV_REF_SO gem5_home; do
     checkForVariable $var
 done
 

--- a/util/xs_scripts/kmh_6wide_btb.sh
+++ b/util/xs_scripts/kmh_6wide_btb.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
+for var in GCBV_REF_SO gem5_home; do
     checkForVariable $var
 done
 

--- a/util/xs_scripts/kmh_6wide_ideal_l2.sh
+++ b/util/xs_scripts/kmh_6wide_ideal_l2.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCB_REF_SO GCB_RESTORER gem5_home; do
+for var in GCB_REF_SO gem5_home; do
     checkForVariable $var
 done
 

--- a/util/xs_scripts/kmh_v3_btb.sh
+++ b/util/xs_scripts/kmh_v3_btb.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
+for var in GCBV_REF_SO gem5_home; do
     checkForVariable $var
 done
 

--- a/util/xs_scripts/kmh_v3_ideal.sh
+++ b/util/xs_scripts/kmh_v3_ideal.sh
@@ -3,7 +3,7 @@
 script_dir=$(dirname -- "$( readlink -f -- "$0"; )")
 source $script_dir/common.sh
 
-for var in GCBV_REF_SO GCB_RESTORER gem5_home; do
+for var in GCBV_REF_SO gem5_home; do
     checkForVariable $var
 done
 


### PR DESCRIPTION
## Summary

- stop requiring `GCB_RESTORER` for normal single-core GCB checkpoint restores
- remove empty `GCB_RESTORER` exports from CI, common wrapper scripts, and local docs
- drop the old RV64GCB simulation-script CI job that depended on the external restorer path

## Motivation

Modern checkpoint slices carry their own restorer code. Requiring `GCB_RESTORER=""` kept an old compatibility path alive and made local and CI difftest setup more confusing than necessary. Legacy checkpoints can still use an explicit `--gcpt-restorer` override.

## Validation

- `python3 -m py_compile configs/common/xiangshan.py`
- `env -u GCB_RESTORER GCBV_REF_SO=/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so ./build/RISCV/gem5.opt --outdir /tmp/gem5-no-gcb-restorer-direct ./configs/example/kmhv3.py --generic-rv-cpt=/nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd --warmup-insts-no-switch=1 --maxinsts=1`
- `env -u GCB_RESTORER GCBV_REF_SO=/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so GEM5_BUILD_TYPE=opt bash /nfs/home/yanyue/workspace/GEM5_review/util/xs_scripts/kmh_v3_btb.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd` reached checkpoint restore and simulation before the external timeout stopped the long-running wrapper path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated environment setup guidance to remove `GCB_RESTORER` requirement and reflect new restorer approach.

* **Configuration**
  * Simplified checkpoint restorer handling; embedded restorers now used by default.
  * Legacy checkpoints supported via explicit override for external restorer.
  * Updated utility scripts, CI/CD workflows, and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->