### PR TITLE
[codex] misc: Fix Python runtime detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,22 +193,17 @@ If you have problem generating SPECCPU checkpoints, following links might help y
 
 Install dependencies as [official GEM5 tutorial](https://www.gem5.org/documentation/general_docs/building) says:
 
-### Setup on Ubuntu 22.04
-If compiling gem5 on Ubuntu 22.04, or related Linux distributions, you may install all these dependencies using APT:
+### Setup on Ubuntu 24.04
+
+Ubuntu 24.04 is the recommended environment for building and running this
+repository. The default system Python 3.12 works with the build flow; no
+separate Python environment is required.
 
 ``` shell
+sudo apt update
 sudo apt install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev libboost-all-dev pkg-config libsqlite3-dev zstd libzstd-dev
-```
-
-### Setup on Ubuntu 20.04
-If compiling gem5 on Ubuntu 20.04, or related Linux distributions, you may install all these dependencies using APT:
-
-``` shell
-sudo apt install build-essential git m4 scons zlib1g zlib1g-dev \
-    libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
-    python3-dev python-is-python3 libboost-all-dev pkg-config libsqlite3-dev zstd libzstd-dev
 ```
 
 ### Setup using [Nix](https://github.com/NixOS/nix)
@@ -430,59 +425,11 @@ export GCBV_REF_SO=`realpath difftest/build/riscv64-spike-so`
 ```
 # FAQ
 
-## Python problems
-
-If your machine has a Python with very high version, you may need to install a lower version of Python
-to avoid some compatibility issues. We recommend to use miniconda to install Python 3.8.
-
-Installation command, copied from official [miniconda website](https://docs.conda.io/projects/miniconda/en/latest/)
-
-``` shell
-mkdir -p ~/miniconda3
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-rm -rf ~/miniconda3/miniconda.sh
-```
-
-Then add conda to path in `~/.bashrc` or `~/.zshrc`. Note this will hide the system Python.
-
-``` shell
-# for bash
-~/miniconda3/bin/conda init bash
-# for zsh
-~/miniconda3/bin/conda init zsh
-```
-Restart your terminal, and you should be able to use conda. Then create a Python 3.8 env:
-
-``` shell
-# create env
-conda create --name py38 --file $gem5_home/ext/xs_env/gem5-py38.txt
-
-# This is mudatory to avoid conda auto activate base env
-conda config --set auto_activate_base false
-```
-
-Each time login, you need to activate the conda env before building GEM5:
-
-``` shell
-conda activate py38
-```
-
-In case that you don't like this or it causes problem, to completely remove Python and conda from your PATH, run:
-
-``` shell
-# for bash
-conda init bash --reverse
-# for zsh
-conda init zsh --reverse
-```
-
-
-
 ## It complains `Python not found`
 
-This is often not Python missing, but other problems.
-Because the build scripts (and scons) uses a strange way to find Python, see `site_scons/gem5_scons/configure.py` for more detail.
+This is often not Python missing, but another configure-time problem.
+Check `build/RISCV/gem5.build/scons_config.log` for the real compiler, linker,
+or runtime loader error.
 For example, when building with clang10, I encountered this problem:
 
 ```
@@ -493,15 +440,15 @@ Error: Check failed for Python.h header.
        CC = clang
 ```
 
-This is not becaues of Python, but because GCC and clang have different warning suppression flags.
+This is not because of Python, but because GCC and clang have different warning suppression flags.
 To fix it, I apply this path:
 
 ``` shell
 git apply ext/xs_env/clang-warning-suppress.patch
 ```
 
-But Python complaints are also possible caused by other problems,
-For similar errors, check `build/RISCV/gem5.build/scons_config.log` to get the real error message.
+Python complaints can also be caused by other problems. For similar errors,
+check `build/RISCV/gem5.build/scons_config.log` to get the real error message.
 
 
 # Original README

--- a/SConstruct
+++ b/SConstruct
@@ -78,6 +78,7 @@
 # Global Python imports
 import atexit
 import os
+import shlex
 import sys
 
 from os import mkdir, remove, environ
@@ -337,11 +338,21 @@ def config_embedded_python(env):
         # Since this function does not use the `unique` param, one should not
         # pass any value to this param.
         assert(unique==True)
-        flags = cmd_output.split()
+        flags = shlex.split(cmd_output)
         prefixes = ('-l', '-L', '-I')
         is_useful = lambda x: any(x.startswith(prefix) for prefix in prefixes)
         useful_flags = list(filter(is_useful, flags))
         env.MergeFlags(' '.join(useful_flags))
+
+        lib_paths = [
+            flag[2:] for flag in flags
+            if flag.startswith('-L') and len(flag) > 2
+        ]
+        for path in lib_paths:
+            if os.path.isabs(path):
+                # The configure test runs the embedded interpreter, so a
+                # non-system libpython path must be visible at run time too.
+                env.AppendUnique(RPATH=[path])
 
     env.ParseConfig(cmd, flag_filter)
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,54 +2,16 @@
 
 ## 安装环境
 
-### Ubuntu 22.04 依赖安装
+### Ubuntu 24.04 依赖安装
 
 ```bash
+sudo apt update
 sudo apt install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev libboost-all-dev pkg-config libsqlite3-dev zstd libzstd-dev
 ```
 
-**Note:** 目前建议在ubuntu 22.04上进行编译，ubuntu 20.04可能存在兼容性问题。
-
-### Python环境配置
-
-如果您的机器Python版本过高，可能需要安装较低版本以避免兼容性问题。推荐使用miniconda安装Python 3.8：
-
-```bash
-mkdir -p ~/miniconda3
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-rm -rf ~/miniconda3/miniconda.sh
-
-# for bash
-~/miniconda3/bin/conda init bash
-# for zsh
-~/miniconda3/bin/conda init zsh
-```
-
-重启终端后，创建Python 3.8环境：
-
-```bash
-# 创建环境
-conda create --name py38 --file $gem5_home/ext/xs_env/gem5-py38.txt
-# 避免conda自动激活base环境
-conda config --set auto_activate_base false
-# 每次登录需要激活conda环境
-conda activate py38
-```
-
-也可以使用pyenv安装Python 3.8：
-
-```bash
-pyenv install 3.8.13
-pyenv local 3.8.13
-```
-激活环境：
-
-```bash
-pyenv activate py38
-```
+**Note:** 目前建议在 Ubuntu 24.04 上编译和运行。默认的系统 Python 3.12 可以正常使用，不需要额外安装 miniconda 或降级到旧版本 Python。
 
 ## 克隆与构建
 
@@ -205,11 +167,7 @@ bash ../parallel_sim.sh `realpath ../kmh_v3_btb.sh` $workloads_lst /top/dir/of/c
 
 为了能够在没有root访问权限的服务器上运行，我们提供了一个简单的docker脚本来运行xs-gem5。更多细节请参阅关于在docker中运行的README。
 
-也可以使用我们提供的docker镜像，基于ubuntu22.04，镜像中已经安装了所有依赖。
-```bash
-docker pull zhangqianlong/ubuntu22_gem5:v1
-docker run -it zhangqianlong/ubuntu22_gem5:v1
-```
+如需使用 Docker 环境，请参考关于在 Docker 中运行的 README。当前本地编译和运行优先推荐 Ubuntu 24.04。
 
 
 ## Arch DB使用
@@ -220,7 +178,7 @@ Arch DB是一个使用SQLite存储程序微架构跟踪的数据库。您可以�
 
 ### Python问题
 
-如果出现"Python not found"错误，这通常不是Python缺失，而是其他问题。检查`build/RISCV/gem5.build/scons_config.log`获取真正的错误信息。
+Ubuntu 24.04 默认的系统 Python 3.12 可以正常使用。如果出现"Python not found"错误，这通常不是Python缺失，而是其他 configure 阶段问题。检查`build/RISCV/gem5.build/scons_config.log`获取真正的错误信息。
 
 对于使用clang10时遇到的问题，可以应用以下补丁：
 ```bash


### PR DESCRIPTION
## Motivation

Some builds can fail during SCons configure with `Checking Python version... no` even after `Python.h` is found. This is not necessarily a Python version problem: the configure probe links an embedded Python test and then runs it, so non-system Python installations such as conda also need their `libpython` directory to be visible to the runtime loader.

The README and quick-start docs also still recommended installing a Python 3.8 conda environment for high Python versions, which is misleading now that Ubuntu 24.04's default Python 3.12 works.

## Approach

- Parse `python*-config` output with `shlex.split()`.
- Reuse absolute `-L` paths from `python*-config` as runtime library paths for embedded Python configure probes and resulting binaries.
- Remove the old Python 3.8/miniconda guidance from README and quick start.
- Update the documented recommended environment to Ubuntu 24.04 with system Python 3.12.

## Validation

- `python3 -m py_compile SConstruct`
- Forced SCons configure reached and passed `Checking Python version... 3.12.3`; the bounded build command later timed out during generated-header work, not during Python detection.
- The generated Python configure probe includes RUNPATH entries derived from `python3-config` `-L` paths and runs successfully, printing `3.12.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build/setup instructions to target Ubuntu 24.04 and recommend the default system Python 3.12
  * Improved troubleshooting guidance for configuration-stage errors with clearer diagnostics
  * Removed legacy alternative Python-version setup instructions for a simpler environment

* **Improvements**
  * Better handling of embedded-Python library locations so runtime dependencies are found more reliably

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->