### PR TITLE
configs: Align ideal kmhv3 timing with RTL

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -115,9 +115,9 @@ def setKmhV3IdealParams(args, system):
                     # Configure XSDRRIP replacement policy (DRRIP mode)
                     # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
                     l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
-            system.tol2bus_list[i].forward_latency = 0  # 3->0
-            system.tol2bus_list[i].response_latency = 0  # 3->0
-            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0
+            system.tol2bus_list[i].forward_latency = 3  # 3->0
+            system.tol2bus_list[i].response_latency = 3  # 3->0
+            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 2->0
 
             # Enable dual-port for DCache → L2 communication
             # ReqLayer[0]: ICache+DCache+ITB+DTB → L2, allow 2 requests per cycle
@@ -144,7 +144,7 @@ if __name__ == '__m5_main__':
     args.l2_size = '2MB'
     args.l3_size = '32MB'
     # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = False
+    args.enable_pf_buffer = True
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 


### PR DESCRIPTION
## Summary

- Restore the ideal KmhV3 ToL2 bus forward and response latencies to 3 cycles.
- Set the ToL2 hint wakeup ahead cycles to 1.
- Enable prefetch buffers by default for the ideal KmhV3 configuration.

## Motivation

These defaults better align the ideal KmhV3 configuration with the RTL implementation and reduce configuration-level differences when comparing gem5 behavior against RTL.

## Validation

- Not run. Configuration-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration parameters for L2-to-core bus timing behavior to improve latency handling.
  * Enabled prefetch buffer optimization for enhanced performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->