### PR TITLE
mem-cache: Align cache hint wakeup ordering with responses

### DIFF
--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -103,7 +103,7 @@ BaseCache::SendTimingRespEvent::description() const
 }
 
 BaseCache::SendCustomEvent::SendCustomEvent(BaseCache* cache, PacketPtr pkt, int sig, bool deletePkt)
-    : Event(Stat_Event_Pri, AutoDelete),
+    : Event(Minimum_Pri, AutoDelete),
       cache(cache),
       pkt(pkt),
       sig(sig),

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -1020,11 +1020,7 @@ Cache::sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt)
     const int initial_offset = initial_tgt->pkt->getOffset(blkSize);
 
     MSHR::TargetList targets = mshr->copyServiceableTargets(pkt);
-    // ResponseQueue is a forceOrder Queue, so if first tgt is delayed,
-    // all tgt will be delayed to the same time as the first tgt,
-    // for more details, see PacketQueue::schedSendTiming
-    bool firstTgt = true;
-    bool firstTgtDelayed = false;
+    std::vector<std::pair<Packet *, Tick>> scheduled_hints;
     for (auto &target: targets) {
         Packet *tgt_pkt = target.pkt;
         if (target.source == MSHR::Target::FromCPU) {
@@ -1034,10 +1030,19 @@ Cache::sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt)
             if (transfer_offset < 0) {
                 transfer_offset += blkSize;
             }
-            if (firstTgt) {
-                firstTgtDelayed = transfer_offset != 0 && pkt->payloadDelay != 0;
+
+            Tick sendHintTime = curTick() +
+                (transfer_offset ? pkt->payloadDelay : 0);
+
+            // Match the response queue's force-order behavior: a later target
+            // with the same packet address must not overtake an earlier one.
+            for (const auto& scheduled_hint : scheduled_hints) {
+                if (scheduled_hint.first->matchAddr(tgt_pkt) &&
+                    scheduled_hint.second > sendHintTime) {
+                    sendHintTime = scheduled_hint.second;
+                }
             }
-            Tick sendHintTime = curTick() + ((transfer_offset || firstTgtDelayed) ? pkt->payloadDelay : 0);
+
             DPRINTF(Cache, "sendHintViaMSHRTargets: pkt: %#lx, sendHintTime: %ld", tgt_pkt->getAddr(), sendHintTime);
             if (sendHintTime == curTick()) {
                 BaseCache::cpuSidePort.sendCustomSignal(tgt_pkt, DcacheRespType::Hint);
@@ -1046,7 +1051,7 @@ Cache::sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt)
                 SendCustomEvent* hintEvent = new SendCustomEvent(this, tgt_pkt, DcacheRespType::Hint, false);
                 schedule(hintEvent, sendHintTime);
             }
-            firstTgt = false;
+            scheduled_hints.emplace_back(tgt_pkt, sendHintTime);
         }
     }
 }


### PR DESCRIPTION
Make cache-generated hint wakeups follow the same ordering assumptions as the response path.

Cache::sendHintViaMSHRTargets() used to treat a delayed first target as a reason to delay every later target in the MSHR. That does not match RespPacketQueue::forceOrder, which only preserves order for targets with the same packet address. Compute each hint's base send time from its own critical-word offset and only inherit a later send time from previous hints that matchAddr().

Also schedule BaseCache::SendCustomEvent at Minimum_Pri so a hint event scheduled for the same tick can fire before CPU tick work. This keeps the wakeup signal ahead of the matching timing response in the same cycle instead of letting it slip behind CPU-side processing.

Change-Id: I87a79eccf7ee08f90e7b604808ac04ff96cc6880
Tested: scons build/RISCV/gem5.opt --gold-linker -j64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event priority handling and hint scheduling logic to maintain proper ordering in cache response operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->