### PR TITLE
misc: use dependabot to track actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "misc"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
[Node.js 20 is being deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so we need to update the version of the actions used in our CI. However, manually updating them all the time is a hassle.

This PR uses GitHub Dependabot to provide a more automated way to handle updates.

Showcase in xs-env: https://github.com/OpenXiangShan/xs-env/pull/87

After this PR is merged, a maintainer with owner permissions needs to enable it on the [Insights -> Dependency graph -> Dependabot](https://github.com/OpenXiangShan/GEM5/network/updates) page

Change-Id: I8226522846afbdb2c23c7fb5cb9c686387a48cbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for GitHub Actions on a weekly schedule to help maintain security and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->