### PR TITLE
mem: reduce bank conflict causing by refill data read

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -396,7 +396,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     storeBuffer.setData(store_buffer_entries);
 
     bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
-    pendingDcacheRefill.resize(dcacheSetDivNum, false);
+    pendingDcacheRefill.resize(dcacheSetDivNum);
     dcacheRefillDataRead.resize(dcacheSetDivNum, 0);
     dcacheRefillDataWrite.resize(dcacheSetDivNum, 0);
     dcacheRefillTagWrite.resize(dcacheSetDivNum, 0);
@@ -535,20 +535,21 @@ LSQ::clearAddresses()
         bool currentCycleBusy =
             (dcacheRefillDataRead[div] | dcacheRefillDataWrite[div]) & 0x1;
 
-        if (pendingDcacheRefill[div]) {
+        auto &pendingRefill = pendingDcacheRefill[div];
+        if (pendingRefill.valid) {
             // If current cycle is busy, we stall the new request (keep pending).
             // If free, we issue the new request.
             if (!currentCycleBusy) {
-                pendingDcacheRefill[div] = false;
-                // Data Read at current cycle (Bit 0)
-                dcacheRefillDataRead[div] |= 0x1;
+                // Clean victims don't need the extra data-read occupancy.
+                if (pendingRefill.needDataRead) {
+                    // Data Read at 1 cycle later (Bit 1)
+                    dcacheRefillDataRead[div] |= (1 << 1);
+                }
+                pendingRefill = {};
                 // Tag Write at 3 cycles later (Bit 3)
                 dcacheRefillTagWrite[div] |= (1 << 3);
                 // Data Write at 4 cycles later (Bit 4)
                 dcacheRefillDataWrite[div] |= (1 << 4);
-
-                // We just occupied the current cycle.
-                currentCycleBusy = true;
             }
         }
 
@@ -609,9 +610,12 @@ LSQ::loadBankConflictedCheck(Addr vaddr)
 }
 
 void
-LSQ::notifyDcacheRefill(Addr addr)
+LSQ::notifyDcacheRefill(Addr addr, bool need_data_read)
 {
-    pendingDcacheRefill.at(getDcacheDiv(addr)) = true;
+    const unsigned div = getDcacheDiv(addr);
+    auto &pendingRefill = pendingDcacheRefill.at(div);
+    pendingRefill.valid = true;
+    pendingRefill.needDataRead |= need_data_read;
 }
 
 unsigned

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -396,10 +396,6 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     storeBuffer.setData(store_buffer_entries);
 
     bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
-    pendingDcacheRefill.resize(dcacheSetDivNum);
-    dcacheRefillDataRead.resize(dcacheSetDivNum, 0);
-    dcacheRefillDataWrite.resize(dcacheSetDivNum, 0);
-    dcacheRefillTagWrite.resize(dcacheSetDivNum, 0);
 }
 
 
@@ -529,45 +525,137 @@ LSQ::tick()
 void
 LSQ::clearAddresses()
 {
-    for (unsigned div = 0; div < dcacheSetDivNum; div++) {
-        // Check if the current cycle is already occupied by previous operations
-        // (e.g. delayed writeback).
-        bool currentCycleBusy =
-            (dcacheRefillDataRead[div] | dcacheRefillDataWrite[div]) & 0x1;
-
-        auto &pendingRefill = pendingDcacheRefill[div];
-        if (pendingRefill.valid) {
-            // If current cycle is busy, we stall the new request (keep pending).
-            // If free, we issue the new request.
-            if (!currentCycleBusy) {
-                // Clean victims don't need the extra data-read occupancy.
-                if (pendingRefill.needDataRead) {
-                    // Data Read at 1 cycle later (Bit 1)
-                    dcacheRefillDataRead[div] |= (1 << 1);
-                }
-                pendingRefill = {};
-                // Tag Write at 3 cycles later (Bit 3)
-                dcacheRefillTagWrite[div] |= (1 << 3);
-                // Data Write at 4 cycles later (Bit 4)
-                dcacheRefillDataWrite[div] |= (1 << 4);
-            }
-        }
-
-        // Advance the pipeline for the next cycle.
-        dcacheRefillDataRead[div] >>= 1;
-        dcacheRefillTagWrite[div] >>= 1;
-        dcacheRefillDataWrite[div] >>= 1;
-
-        std::fill(bankOccupied[div].begin(), bankOccupied[div].end(),
-                  currentCycleBusy);
-    }
+    advanceDcacheRefillPipe();
     recentlyloadAddr.clear();
+}
+
+void
+LSQ::advanceDcacheRefillPipe()
+{
+    DcacheRefillBufferedPipe next_pipe = {};
+    std::vector<bool> current_cycle_busy_divs(dcacheSetDivNum, false);
+
+    markDcacheRefillBusyDivs(current_cycle_busy_divs);
+
+    const auto &s1_data_read = dcacheRefillStage(DcacheRefillStage::S1DataRead);
+    const auto &s2_data_resp = dcacheRefillStage(DcacheRefillStage::S2DataResp);
+    const auto &s3_tag_write = dcacheRefillStage(DcacheRefillStage::S3TagWrite);
+    const auto &s4_data_write =
+        dcacheRefillStage(DcacheRefillStage::S4DataWrite);
+
+    auto &next_s1_data_read =
+        next_pipe.at(dcacheRefillPipeIndex(DcacheRefillStage::S1DataRead));
+    auto &next_s2_data_resp =
+        next_pipe.at(dcacheRefillPipeIndex(DcacheRefillStage::S2DataResp));
+    auto &next_s3_tag_write =
+        next_pipe.at(dcacheRefillPipeIndex(DcacheRefillStage::S3TagWrite));
+    auto &next_s4_data_write =
+        next_pipe.at(dcacheRefillPipeIndex(DcacheRefillStage::S4DataWrite));
+
+    // Advance s3 to s4
+    if (s3_tag_write.valid) {
+        next_s4_data_write = s3_tag_write;
+    }
+    // Advance s2 to s3
+    if (s2_data_resp.valid) {
+        next_s3_tag_write = s2_data_resp;
+    }
+    // Advance s1 to s2 or block at s1
+    if (hasDcacheRefillDataArrayConflict()) {
+        // A same-div S4 data write blocks the younger S1 data read and
+        // backpressures the S0 TagReadEntry admission path for one cycle.
+        next_s1_data_read = s1_data_read;
+    } else if (s1_data_read.valid) {
+        next_s2_data_resp = s1_data_read;
+    }
+
+    if (!dcacheRefillInputQ.empty()) {
+        const auto &queued_refill = dcacheRefillInputQ.front();
+        if (canEnterDcacheRefillPipe(queued_refill, next_pipe)) {
+            // S0 TagReadEntry is consumed at admission time. Once admitted, the
+            // request is recorded in the buffered S1 slot for later cycles.
+            next_s1_data_read.valid = true;
+            next_s1_data_read.refill = queued_refill;
+            dcacheRefillInputQ.pop();
+        }
+    }
+
+    dcacheRefillPipe = next_pipe;
+
+    for (unsigned div = 0; div < dcacheSetDivNum; div++) {
+        std::fill(bankOccupied[div].begin(), bankOccupied[div].end(),
+                  current_cycle_busy_divs[div]);
+    }
+}
+
+LSQ::DcacheRefillPipeSlot &
+LSQ::dcacheRefillStage(DcacheRefillStage stage)
+{
+    return dcacheRefillPipe.at(dcacheRefillPipeIndex(stage));
+}
+
+const LSQ::DcacheRefillPipeSlot &
+LSQ::dcacheRefillStage(DcacheRefillStage stage) const
+{
+    return dcacheRefillPipe.at(dcacheRefillPipeIndex(stage));
+}
+
+void
+LSQ::markDcacheRefillBusyDivs(std::vector<bool> &busy_divs) const
+{
+    const auto &s1_data_read = dcacheRefillStage(DcacheRefillStage::S1DataRead);
+    const auto &s4_data_write =
+        dcacheRefillStage(DcacheRefillStage::S4DataWrite);
+
+    if (s1_data_read.valid && s1_data_read.refill.needDataRead) {
+        busy_divs.at(s1_data_read.refill.div) = true;
+    }
+    if (s4_data_write.valid) {
+        busy_divs.at(s4_data_write.refill.div) = true;
+    }
+}
+
+bool
+LSQ::hasDcacheRefillDataArrayConflict() const
+{
+    const auto &s1_data_read = dcacheRefillStage(DcacheRefillStage::S1DataRead);
+    const auto &s4_data_write =
+        dcacheRefillStage(DcacheRefillStage::S4DataWrite);
+
+    return s1_data_read.valid &&
+        s1_data_read.refill.needDataRead &&
+        s4_data_write.valid &&
+        s1_data_read.refill.div == s4_data_write.refill.div;
+}
+
+bool
+LSQ::canEnterDcacheRefillPipe(const DcacheRefillRequest &request,
+                              const DcacheRefillBufferedPipe &next_pipe) const
+{
+    // Check if blocked by tag read
+    const bool s0_tag_read_blocked =
+        dcacheRefillStage(DcacheRefillStage::S3TagWrite).valid;
+    // Check if s1 is blocked
+    const bool s1_backpressured =
+        next_pipe.at(dcacheRefillPipeIndex(DcacheRefillStage::S1DataRead)).valid;
+
+    if (s0_tag_read_blocked || s1_backpressured) {
+        return false;
+    }
+    // Check if blocked by set conflict
+    return !isDcacheRefillSetBlocked(request.setKey);
 }
 
 unsigned
 LSQ::getDcacheDiv(Addr vaddr) const
 {
     return (vaddr >> dcacheLineBits) & (dcacheSetDivNum - 1);
+}
+
+uint64_t
+LSQ::getDcacheSetKey(Addr vaddr) const
+{
+    return (vaddr >> dcacheLineBits) & ((1ULL << dcacheSetBits) - 1);
 }
 
 uint64_t
@@ -583,6 +671,21 @@ LSQ::getDcacheDivBankSetKey(Addr vaddr) const
 {
     return (static_cast<uint64_t>(getDcacheDiv(vaddr)) << dcacheSetBankBits) |
         getDcacheBankSetKey(vaddr);
+}
+
+bool
+LSQ::isDcacheRefillSetBlocked(uint64_t set_key) const
+{
+    for (unsigned stage = static_cast<unsigned>(DcacheRefillStage::S1DataRead);
+         stage <= static_cast<unsigned>(DcacheRefillStage::S3TagWrite);
+         ++stage) {
+        const auto &pipe_stage =
+            dcacheRefillStage(static_cast<DcacheRefillStage>(stage));
+        if (pipe_stage.valid && pipe_stage.refill.setKey == set_key) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool
@@ -612,10 +715,8 @@ LSQ::loadBankConflictedCheck(Addr vaddr)
 void
 LSQ::notifyDcacheRefill(Addr addr, bool need_data_read)
 {
-    const unsigned div = getDcacheDiv(addr);
-    auto &pendingRefill = pendingDcacheRefill.at(div);
-    pendingRefill.valid = true;
-    pendingRefill.needDataRead |= need_data_read;
+    dcacheRefillInputQ.push(
+        {addr, getDcacheDiv(addr), getDcacheSetKey(addr), need_data_read});
 }
 
 unsigned

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1129,13 +1129,19 @@ class LSQ
     int storeWbStage() const { return _storeWbStage; }
 
   public:
+    struct PendingDcacheRefill
+    {
+        bool valid = false;
+        bool needDataRead = false;
+    };
+
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
     std::vector<std::vector<bool>> bankOccupied;
 
-    void notifyDcacheRefill(Addr addr);
+    void notifyDcacheRefill(Addr addr, bool need_data_read);
 
-    std::vector<bool> pendingDcacheRefill;
+    std::vector<PendingDcacheRefill> pendingDcacheRefill;
     std::vector<uint32_t> dcacheRefillDataRead;
     std::vector<uint32_t> dcacheRefillDataWrite;
     std::vector<uint32_t> dcacheRefillTagWrite;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -42,6 +42,7 @@
 #ifndef __CPU_O3_LSQ_HH__
 #define __CPU_O3_LSQ_HH__
 
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <list>
@@ -1043,14 +1044,22 @@ class LSQ
 
     void clearAddresses();
 
+    void advanceDcacheRefillPipe();
+
     unsigned
     getDcacheDiv(Addr vaddr) const;
+
+    uint64_t
+    getDcacheSetKey(Addr vaddr) const;
 
     uint64_t
     getDcacheBankSetKey(Addr vaddr) const;
 
     uint64_t
     getDcacheDivBankSetKey(Addr vaddr) const;
+
+    bool
+    isDcacheRefillSetBlocked(uint64_t set_key) const;
 
     Addr bankNum(Addr a) const { return (a >> 3) & 0x7; };
 
@@ -1129,11 +1138,61 @@ class LSQ
     int storeWbStage() const { return _storeWbStage; }
 
   public:
-    struct PendingDcacheRefill
+    enum class DcacheRefillStage : unsigned
     {
-        bool valid = false;
+        S0TagReadEntry = 0,
+        S1DataRead,
+        S2DataResp,
+        S3TagWrite,
+        S4DataWrite,
+        S5Complete,
+    };
+
+    struct DcacheRefillRequest
+    {
+        Addr addr = 0;
+        unsigned div = 0;
+        uint64_t setKey = 0;
         bool needDataRead = false;
     };
+
+    struct DcacheRefillPipeSlot
+    {
+        bool valid = false;
+        DcacheRefillRequest refill;
+    };
+
+    // S0 happens at admission time. The stored array keeps the buffered
+    // pipeline slots from S1 to S4, while S5 is the pipe exit.
+    static constexpr unsigned FirstBufferedDcacheRefillStage =
+        static_cast<unsigned>(DcacheRefillStage::S1DataRead);
+    static constexpr unsigned LastBufferedDcacheRefillStage =
+        static_cast<unsigned>(DcacheRefillStage::S4DataWrite);
+    static constexpr unsigned NumBufferedDcacheRefillStages =
+        LastBufferedDcacheRefillStage - FirstBufferedDcacheRefillStage + 1;
+
+    using DcacheRefillBufferedPipe =
+        std::array<DcacheRefillPipeSlot, NumBufferedDcacheRefillStages>;
+
+    static constexpr unsigned
+    dcacheRefillPipeIndex(DcacheRefillStage stage)
+    {
+        return static_cast<unsigned>(stage) - FirstBufferedDcacheRefillStage;
+    }
+
+    DcacheRefillPipeSlot &
+    dcacheRefillStage(DcacheRefillStage stage);
+
+    const DcacheRefillPipeSlot &
+    dcacheRefillStage(DcacheRefillStage stage) const;
+
+    void markDcacheRefillBusyDivs(std::vector<bool> &busy_divs) const;
+
+    bool hasDcacheRefillDataArrayConflict() const;
+
+    bool canEnterDcacheRefillPipe(const DcacheRefillRequest &request,
+                                  const DcacheRefillBufferedPipe &next_pipe)
+        const;
 
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
@@ -1141,18 +1200,13 @@ class LSQ
 
     void notifyDcacheRefill(Addr addr, bool need_data_read);
 
-    std::vector<PendingDcacheRefill> pendingDcacheRefill;
-    std::vector<uint32_t> dcacheRefillDataRead;
-    std::vector<uint32_t> dcacheRefillDataWrite;
-    std::vector<uint32_t> dcacheRefillTagWrite;
+    std::queue<DcacheRefillRequest> dcacheRefillInputQ;
+    DcacheRefillBufferedPipe
+        dcacheRefillPipe = {};
 
     bool isDcacheRefillTagWrite() const
     {
-        for (auto stage : dcacheRefillTagWrite) {
-            if (stage & 0x1)
-                return true;
-        }
-        return false;
+        return dcacheRefillStage(DcacheRefillStage::S3TagWrite).valid;
     }
 
   protected:

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -961,16 +961,19 @@ BaseCache::recvTimingResp(PacketPtr pkt)
 
         const bool allocate = (writeAllocator && mshr->wasWholeLineWrite) ?
             writeAllocator->allocate() : mshr->allocOnFill();
+        bool refill_need_data_read = false;
+        blk = handleFill(pkt, blk, writebacks, allocate,
+                         &refill_need_data_read);
         // Optionally indicate that the Dcache received a refill request
         // to drive LSQ-side modelling.
         if (simulateDcacheRefill && cacheLevel == 1 && pkt->getLSQPtr()) {
             const Addr refill_addr =
                 pkt->req && pkt->req->hasVaddr() ? pkt->req->getVaddr() :
                 pkt->getAddr();
-            pkt->getLSQPtr()->notifyDcacheRefill(refill_addr);
+            pkt->getLSQPtr()->notifyDcacheRefill(refill_addr,
+                                                 refill_need_data_read);
             stats.DcacheRefillTimes++;
         }
-        blk = handleFill(pkt, blk, writebacks, allocate);
         assert(blk != nullptr);
         ppFill->notify(pkt);
     }
@@ -1431,9 +1434,12 @@ BaseCache::getNextQueueEntry()
 
 bool
 BaseCache::handleEvictions(std::vector<CacheBlk*> &evict_blks,
-    PacketList &writebacks)
+    PacketList &writebacks, bool *evicted_dirty)
 {
     bool replacement = false;
+    if (evicted_dirty != nullptr) {
+        *evicted_dirty = false;
+    }
     for (const auto& blk : evict_blks) {
         if (blk->isValid()) {
             replacement = true;
@@ -1475,7 +1481,7 @@ BaseCache::handleEvictions(std::vector<CacheBlk*> &evict_blks,
                         }
                     }
                 }
-                evictBlock(blk, writebacks);
+                evictBlock(blk, writebacks, evicted_dirty);
             }
         }
     }
@@ -2091,13 +2097,17 @@ BaseCache::maintainClusivity(bool from_cache, CacheBlk *blk)
 
 CacheBlk*
 BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
-                      bool allocate)
+                      bool allocate, bool *refill_need_data_read)
 {
     assert(pkt->isResponse());
     Addr addr = pkt->getAddr();
     bool is_secure = pkt->isSecure();
     const bool has_old_data = blk && blk->isValid();
     const std::string old_state = (debug::Cache && blk) ? blk->print() : "";
+
+    if (refill_need_data_read != nullptr) {
+        *refill_need_data_read = false;
+    }
 
     // When handling a fill, we should have no writes to this line.
     assert(addr == pkt->getBlockAddr(blkSize));
@@ -2109,7 +2119,8 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
 
         // need to do a replacement if allocating, otherwise we stick
         // with the temporary storage
-        blk = allocate ? allocateBlock(pkt, writebacks) : nullptr;
+        blk = allocate ? allocateBlock(pkt, writebacks, refill_need_data_read)
+                       : nullptr;
 
         if (!blk) {
             // No replaceable block or a mostly exclusive
@@ -2207,7 +2218,8 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
 }
 
 CacheBlk*
-BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks)
+BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks,
+                         bool *evicted_dirty)
 {
     // Get address
     const Addr addr = pkt->getAddr();
@@ -2246,7 +2258,7 @@ BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks)
     DPRINTF(CacheRepl, "Replacement victim: %s\n", victim->print());
 
     // Try to evict blocks; if it fails, give up on allocation
-    if (!handleEvictions(evict_blks, writebacks)) {
+    if (!handleEvictions(evict_blks, writebacks, evicted_dirty)) {
         return nullptr;
     }
 
@@ -2291,7 +2303,8 @@ BaseCache::invalidateBlock(CacheBlk *blk)
 }
 
 void
-BaseCache::evictBlock(CacheBlk *blk, PacketList &writebacks)
+BaseCache::evictBlock(CacheBlk *blk, PacketList &writebacks,
+                      bool *evicted_dirty)
 {
     if (archDBer) {
         Addr paddr = regenerateBlkAddr(blk);
@@ -2300,6 +2313,10 @@ BaseCache::evictBlock(CacheBlk *blk, PacketList &writebacks)
     }
 
     DPRINTF(CacheTrace, "Evicting block %#llx\n", regenerateBlkAddr(blk));
+
+    if (evicted_dirty != nullptr && blk->isSet(CacheBlk::DirtyBit)) {
+        *evicted_dirty = true;
+    }
 
     PacketPtr pkt = evictBlock(blk);
 

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -881,7 +881,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @return False if any of the evicted blocks is in transient state.
      */
     bool handleEvictions(std::vector<CacheBlk*> &evict_blks,
-        PacketList &writebacks);
+        PacketList &writebacks, bool *evicted_dirty = nullptr);
 
     /**
      * Handle a fill operation caused by a received packet.
@@ -902,7 +902,8 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @return Pointer to the new cache block.
      */
     CacheBlk *handleFill(PacketPtr pkt, CacheBlk *blk,
-                         PacketList &writebacks, bool allocate);
+                         PacketList &writebacks, bool allocate,
+                         bool *refill_need_data_read = nullptr);
 
     /**
      * Allocate a new block and perform any necessary writebacks
@@ -916,7 +917,8 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @param writebacks A list of writeback packets for the evicted blocks
      * @return the allocated block
      */
-    CacheBlk *allocateBlock(const PacketPtr pkt, PacketList &writebacks);
+    CacheBlk *allocateBlock(const PacketPtr pkt, PacketList &writebacks,
+                            bool *evicted_dirty = nullptr);
     /**
      * Evict a cache block.
      *
@@ -935,7 +937,8 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @param blk Block to invalidate
      * @param writebacks Return a list of packets with writebacks
      */
-    void evictBlock(CacheBlk *blk, PacketList &writebacks);
+    void evictBlock(CacheBlk *blk, PacketList &writebacks,
+                    bool *evicted_dirty = nullptr);
 
     /**
      * Invalidate a cache block.

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -1033,7 +1033,8 @@ class Packet : public Printable
            headerDelay(pkt->headerDelay),
            snoopDelay(0),
            payloadDelay(pkt->payloadDelay),
-           senderState(pkt->senderState)
+           senderState(pkt->senderState),
+           lsqPtr(pkt->lsqPtr)
     {
         if (!clear_flags)
             flags.set(pkt->flags & COPY_FLAGS);


### PR DESCRIPTION
when dcache refill request replaces a clean block, no need to read data of it.

Change-Id: If5fd34ce9fd150f0fd883dbe5c1b7c8b554c0592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate cache refill timing by tracking when refills need data-read, reducing stalls and improving memory timing fidelity.
  * Improved detection of dirty evictions to better account for writebacks during refills.
  * Refined refill scheduling and pipeline behavior for more consistent memory-system performance and reduced contention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->