### PR TITLE
configs: Align ideal KMHv3 memory config with RTL

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -112,9 +112,9 @@ def setKmhV3IdealParams(args, system):
                     # Configure XSDRRIP replacement policy (DRRIP mode)
                     # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
                     l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
-            system.tol2bus_list[i].forward_latency = 0  # 3->0
-            system.tol2bus_list[i].response_latency = 0  # 3->0
-            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0
+            system.tol2bus_list[i].forward_latency = 3  # 0->3
+            system.tol2bus_list[i].response_latency = 3  # 0->3
+            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 0->1
 
             # Enable dual-port for DCache → L2 communication
             # ReqLayer[0]: ICache+DCache+ITB+DTB → L2, allow 2 requests per cycle
@@ -141,7 +141,7 @@ if __name__ == '__m5_main__':
     args.l2_size = '2MB'
     args.l3_size = '32MB'
     # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = False
+    args.enable_pf_buffer = True
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 


### PR DESCRIPTION
## Motivation

This PR updates the ideal KMHv3 configuration to match the current RTL-aligned memory hierarchy assumptions.

The previous config used zero-cycle L2 bus forward/response latency and disabled prefetch buffers. That no longer matches the intended RTL-aligned setup for this configuration.

## Approach

- Restore `tol2bus.forward_latency` to 3 cycles.
- Restore `tol2bus.response_latency` to 3 cycles.
- Set `tol2bus.hint_wakeup_ahead_cycles` to 1 cycle.
- Enable prefetch buffers for hardware prefetchers in `idealkmhv3.py`.

## Scope of Impact

This change only affects `configs/example/idealkmhv3.py`.

## Validation

- Built with `scons build/RISCV/gem5.opt --gold-linker -j64`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated L2 cache bus timing parameters for improved memory subsystem performance
  * Enabled hardware prefetcher buffers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->