### PR TITLE
Revert "cpu-o3: tage back to 16k"

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -86,6 +86,9 @@ def setKmhV3IdealParams(args, system):
         if args.bp_type == 'DecoupledBPUWithBTB':
             cpu.branchPred.ftq_size = 64
             cpu.branchPred.fsq_size = 64
+            # TAGE table sizes and numWays tunning
+            cpu.branchPred.tage.tableSizes = [2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048]
+            cpu.branchPred.tage.numWays = [2, 2, 4, 2, 2, 2, 2, 2]
             # cpu.branchPred.microtage.enabled = False
 
         # l1 cache per core


### PR DESCRIPTION
Reverts OpenXiangShan/GEM5#865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch predictor configuration parameters to enhance system tuning capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->