### PR TITLE
[codex] cpu-o3: Fix split-request LSQ violator selection

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -956,25 +956,34 @@ Fault
 LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
         const DynInstPtr& inst)
 {
-    auto saved_it = loadIt;
-    for (auto req0 : inst->savedRequest->_reqs) {
-        Addr inst_eff_addr1 = req0->getPaddr() >> depCheckShift;
-        Addr inst_eff_addr2 = (req0->getPaddr() + req0->getSize() - 1) >> depCheckShift;
+    /** @todo in theory you only need to check an instruction that has executed
+     * however, there isn't a good way in the pipeline at the moment to check
+     * all instructions that will execute before the store writes back. Thus,
+     * like the implementation that came before it, we're overly conservative.
+     */
+    while (loadIt != loadQueue.end()) {
+        DynInstPtr ld_inst = loadIt->instruction();
+        if (!ld_inst->effAddrValid() || ld_inst->strictlyOrdered()) {
+            ++loadIt;
+            continue;
+        }
 
-        /** @todo in theory you only need to check an instruction that has executed
-            * however, there isn't a good way in the pipeline at the moment to check
-            * all instructions that will execute before the store writes back. Thus,
-            * like the implementation that came before it, we're overly conservative.
-            */
-        DPRINTF(LSQUnit, "Checking for violations for [sn:%lli], addr: %#lx\n",
-                inst->seqNum, req0->getPaddr());
-        loadIt = saved_it;
-        while (loadIt != loadQueue.end()) {
-            DynInstPtr ld_inst = loadIt->instruction();
-            if (!ld_inst->effAddrValid() || ld_inst->strictlyOrdered()) {
-                ++loadIt;
-                continue;
-            }
+        // The LQ is ordered oldest to youngest. Once the remaining loads are
+        // newer than an already-recorded violator, they cannot improve the
+        // squash point for this check.
+        if (!inst->isLoad() && memDepViolator &&
+                ld_inst->seqNum > memDepViolator->seqNum) {
+            return NoFault;
+        }
+
+        bool done_checking_load = false;
+        for (auto req0 : inst->savedRequest->_reqs) {
+            Addr inst_eff_addr1 = req0->getPaddr() >> depCheckShift;
+            Addr inst_eff_addr2 =
+                (req0->getPaddr() + req0->getSize() - 1) >> depCheckShift;
+
+            DPRINTF(LSQUnit, "Checking for violations for [sn:%lli], addr: %#lx\n",
+                    inst->seqNum, req0->getPaddr());
 
             for (auto req1 : loadIt->request()->_reqs) {
                 Addr ld_eff_addr1 = req1->getPaddr() >> depCheckShift;
@@ -1011,6 +1020,7 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                         DPRINTF(LSQUnit, "Found possible load violation at addr: %#x"
                                 " between instructions [sn:%lli] and [sn:%lli]\n",
                                 inst_eff_addr1, inst->seqNum, ld_inst->seqNum);
+                        done_checking_load = true;
                         break;
                     } else {
                         // A load/store incorrectly passed this store.
@@ -1024,6 +1034,7 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                         // So next time this load replaying to pipeline will forward from store correctly
                         // And no RAW violation happens
                         if (ld_inst->needNukeReplay()) {
+                            done_checking_load = true;
                             break;
                         }
 
@@ -1031,6 +1042,7 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                         // should occur since the load can forward data from store later
                         if (ld_inst->skipRawCheck()) {
                             ++stats.skipRawWhenLoadAtS0;
+                            done_checking_load = true;
                             break;
                         }
 
@@ -1057,8 +1069,11 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                     }
                 }
             }
-            ++loadIt;
+            if (done_checking_load) {
+                break;
+            }
         }
+        ++loadIt;
     }
     return NoFault;
 }


### PR DESCRIPTION
## Motivation

`LSQUnit::checkViolations()` currently handles split requests by iterating over the current memory instruction's sub-requests first, then scanning younger loads for each sub-request. For a split store this can select the first matching load for `store.req0` even when an older younger-load only conflicts with `store.req1`.

That violates the LSQ invariant that `memDepViolator` should be the oldest load that has a memory-ordering violation. If the selected violator is too young, the subsequent memory-order squash can leave an older incorrectly executed load in the pipeline.

Example shape:

```text
store S:
  req0 overlaps load_new
  req1 overlaps load_old

LQ order:
  load_old
  load_new
```

The old loop can report `load_new` before it ever checks `S.req1` against `load_old`.

## Approach

Reorder the scan so the load queue remains the outer ordering:

```text
for each younger load, oldest to youngest:
  for each current/store sub-request:
    for each load sub-request:
      check overlap
```

This preserves behavior for the common scalar single-request case, while making split-request handling choose the oldest violating load before returning.

## Scope and Impact

This is a narrow LSQ ordering fix in `src/cpu/o3/lsq_unit.cc`.

Normal aligned scalar accesses usually have a single request, so the scan result should remain equivalent. The affected cases are split-request accesses, especially the current vector/wide-memory path that reuses scalar LSQ request handling.

## Validation

- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`

A focused unit test was not added in this PR. A reliable regression requires constructing a split store, two younger loads, and a specific out-of-order execution window inside LSQ state; there is no lightweight LSQ harness currently available for that without substantial test scaffolding.

Pushing branch `lsq-split-violator-align` should also trigger `gem5 Align BTB Performance Test(0.3c)` with `configs/example/kmhv3.py` and `gcc15-spec06-0.3c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of load-store ordering violations in out-of-order CPU simulation with refined detection logic.

* **Refactor**
  * Optimized violation scanning algorithm to terminate early when violations are detected, reducing simulation overhead and enhancing accuracy of memory operation ordering checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->