### PR TITLE
cpu: Fix BTB PHR recovery after control squash

### DIFF
--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -403,6 +403,12 @@ struct FetchTarget
         return std::make_pair(shamt, cond_taken);
     }
 
+    bool getPHistTakenDuringSquash(Addr squash_pc, bool actually_taken) const
+    {
+        auto ctrl_pc = getControlPC();
+        return actually_taken && ctrl_pc == squash_pc;
+    }
+
     // should be called before components update
     void setUpdateInstEndPC(unsigned predictWidth)
     {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -998,11 +998,13 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     bool real_bw_taken;
     std::tie(real_bw_shamt, real_bw_taken) = target.getBwHistInfoDuringSquash(
     squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
+    bool real_p_taken = target.getPHistTakenDuringSquash(
+        squash_pc.instAddr(), actually_taken);
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {
         components[i]->recoverHist(s0History, target, real_shamt, real_taken);
-        components[i]->recoverPHist(s0PHistory, target, real_shamt, real_taken);
+        components[i]->recoverPHist(s0PHistory, target, 2, real_p_taken);
         if (components[i]->needMoreHistories) {
             components[i]->recoverBwHist(s0BwHistory, target, real_bw_shamt, real_bw_taken);
             components[i]->recoverIHist(target, real_bw_shamt, real_bw_taken);
@@ -1014,7 +1016,7 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     histShiftIn(real_shamt, real_taken, s0History);
 
     // Update path history with actual outcome
-    pHistShiftIn(2, real_taken, s0PHistory, squash_pc.instAddr(), redirect_pc);
+    pHistShiftIn(2, real_p_taken, s0PHistory, squash_pc.instAddr(), redirect_pc);
 
     // Update global backward history with actual outcome
     histShiftIn(real_bw_shamt, real_bw_taken, s0BwHistory);

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -303,7 +303,8 @@ struct MgscHarness
             recover_stream.exeTaken = actual_taken;
 
             mgsc.recoverHist(ghr, recover_stream, shamt, actual_taken);
-            mgsc.recoverPHist(phr, recover_stream, 2, actual_taken);
+            bool actual_p_taken = actual_taken;
+            mgsc.recoverPHist(phr, recover_stream, 2, actual_p_taken);
 
             bool actual_bw_taken = actual_taken && (entry.target < entry.pc);
             mgsc.recoverBwHist(bwhr, recover_stream, bw_shamt, actual_bw_taken);

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -113,12 +113,12 @@ void specUpdateSelectedHistory(BTBTAGE* tage,
 void recoverSelectedHistory(BTBTAGE* tage,
                             const boost::dynamic_bitset<>& history,
                             const FetchTarget& stream, int shamt,
-                            bool cond_taken)
+                            bool path_taken)
 {
     if (tage->usesPathHistory()) {
-        tage->recoverPHist(history, stream, shamt, cond_taken);
+        tage->recoverPHist(history, stream, shamt, path_taken);
     } else {
-        tage->recoverHist(history, stream, shamt, cond_taken);
+        tage->recoverHist(history, stream, shamt, path_taken);
     }
 }
 
@@ -146,6 +146,11 @@ void applyActualHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
     } else {
         applyOutcomeHistory(history, shamt, taken);
     }
+}
+
+bool getActualPathTaken(const FetchTarget& stream)
+{
+    return stream.exeTaken && stream.exeBranchInfo.pc == stream.squashPC;
 }
 
 /**
@@ -251,7 +256,8 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
             history = pre_spec_history;
         }
         // Recover from misprediction
-        recoverSelectedHistory(tage, history, stream, 1, actual_taken);
+        recoverSelectedHistory(tage, history, stream, 1,
+                               getActualPathTaken(stream));
         applyActualHistory(tage, history, stream.exeBranchInfo, 1, actual_taken);
         tage->checkFoldedHist(history, "recover");
     }
@@ -1308,6 +1314,31 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesReturnOverridePathHashSnapsh
     bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
 
     EXPECT_TRUE(predicted);
+}
+
+TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
+    BTBEntry entry = createBTBEntry(0x1000, false, true, true, -1, 0x2040);
+    boost::dynamic_bitset<> pathHistoryBefore(128, 0);
+    boost::dynamic_bitset<> pathHistoryAfter(128, 0);
+    applyPathHistoryTaken(pathHistoryAfter, entry.pc, entry.target);
+
+    FullBTBPrediction pred;
+    pred.btbEntries.push_back(entry);
+    tage->putPCHistory(0x1000, pathHistoryBefore, stagePreds);
+    auto meta = tage->getPredictionMeta();
+
+    FetchTarget stream = createStream(0x1000, entry, true, meta);
+    stream = setMispredStream(stream);
+
+    auto [ghr_shamt, ghr_taken] =
+        stream.getHistInfoDuringSquash(entry.pc, false, true);
+    EXPECT_EQ(ghr_shamt, 0);
+    EXPECT_FALSE(ghr_taken);
+    EXPECT_TRUE(stream.getPHistTakenDuringSquash(entry.pc, true));
+
+    tage->recoverPHist(pathHistoryBefore, stream, 2,
+                       stream.getPHistTakenDuringSquash(entry.pc, true));
+    tage->checkFoldedHist(pathHistoryAfter, "recover taken control path");
 }
 
 


### PR DESCRIPTION
## Summary

This PR fixes BTB path-history recovery after a control squash. It intentionally keeps the existing 15-bit PHR hash/footprint unchanged; the V2-style 10-bit footprint should be evaluated in a separate PR.

Changes:
- recover PHR with the actual taken control path during squash, instead of reusing the GHR conditional-taken bit
- keep GHR/BWHR recovery semantics unchanged
- add a TAGE regression that shows GHR does not update for a taken unconditional squash while PHR must still recover the taken control path
- clarify the TAGE/MGSC test-side naming around PHR `path_taken`

## Root Cause

Prediction-time PHR update uses the taken control edge: `(taken_pc, target)`. That edge can be a taken conditional branch, direct jump, indirect jump, or return.

The previous squash-recovery path reused `real_taken` from `getHistInfoDuringSquash()`. That value has GHR semantics: it is only true for an actually taken conditional branch. For taken non-conditional control squashes, GHR should not shift in a taken outcome, but PHR must recover the actual taken edge. As a result, the old path skipped PHR repair after taken unconditional/indirect/return squashes and left later predictions using a stale PHR context.

## Exploration Notes

While analyzing the V2-style PHR experiment, I split the change into three variants on `sjeng_22213` with the same `20M warmup + 20M running` setup:

| variant | total MPKI | cond MPKI | total miss |
|---|---:|---:|---:|
| current new PHR: new hash + fixed recover | 6.222 | 5.429 | 124444 |
| old hash + fixed recover | 6.209 | 5.428 | 124183 |
| new hash + old recover | 6.681 | 5.840 | 133617 |
| archived old baseline | 6.728 | 5.880 | 134556 |

This points to the squash-recovery fix as the main source of the observed gain on that slice, rather than the hash/footprint change.

## Validation

- `scons build/RISCV/cpu/pred/btb/test/tage.test.debug build/RISCV/cpu/pred/btb/test/mgsc.test.debug --unit-test -j32`
- `./build/RISCV/cpu/pred/btb/test/tage.test.debug`
- `./build/RISCV/cpu/pred/btb/test/mgsc.test.debug`
- `scons build/RISCV/gem5.opt --gold-linker -j32`

## Follow-up

This area still deserves cleanup. PHR has accumulated several bugs because the API shape was inherited from GHR-style recovery. A follow-up should split history replay into explicit GHR/BWHR/PHR replay records, remove misleading `cond_taken` naming from PHR APIs, and add table-driven tests for conditional, unconditional, indirect, return, and non-control squash cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined branch prediction history recovery mechanisms in CPU simulator for enhanced squash condition handling
  * Extended test coverage for predictor validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->