### PR TITLE
cpu: Refactor BTB history replay interfaces

### DIFF
--- a/docs/Gem5_Docs/frontend/AI_unitTest.md
+++ b/docs/Gem5_Docs/frontend/AI_unitTest.md
@@ -79,8 +79,8 @@ boost::dynamic_bitset<> history(64, 0);
 // Make prediction to generate meta data
 tage->putPCHistory(startPC, history, stagePreds);
 
-// update (folded) histories for tage
-tage->specUpdateHist(s0History, finalPred);
+// update folded histories for tage
+tage->specUpdateGHist(s0History, finalPred, finalPred.getGHistUpdate());
 tage->getPredictionMeta();
 
 // shift history

--- a/docs/Gem5_Docs/frontend/tage_upper_bound_design_20260310.md
+++ b/docs/Gem5_Docs/frontend/tage_upper_bound_design_20260310.md
@@ -54,7 +54,7 @@
 但要明确：
 
 - **继承 `BTBTAGE` 不等于自动继承了 UB-S(outcome) 需要的 history 生命周期**
-- 当前生产代码真正维护的是 path-history folding；`specUpdateHist/recoverHist` 这部分对 `UB-S(outcome)` 不能直接沿用
+- 当前生产代码真正维护的是 path-history folding；`specUpdateGHist/recoverHist` 这部分对 `UB-S(outcome)` 不能直接沿用
 
 ## 4. 核心设计决策
 
@@ -146,7 +146,7 @@ ubTable[i] : unordered_map<UBKey_i, UBEntry>
 
 所以子类必须自己实现：
 
-- `specUpdateHist`
+- `specUpdateGHist`
 - `recoverHist`
 
 并在自己的 `meta` 中保存与 exact outcome history 对应的 snapshot。
@@ -161,7 +161,7 @@ ubTable[i] : unordered_map<UBKey_i, UBEntry>
 规则：
 
 1. prediction 时按当前 exact history 构造各表 key
-2. `specUpdateHist` 用最终预测方向推测更新 exact history
+2. `specUpdateGHist` 用最终预测方向推测更新 exact history
 3. squash 时 `recoverHist` 先恢复 snapshot，再按真实结果重放
 
 是否继续调用基类的 `specUpdatePHist/recoverPHist`：
@@ -284,7 +284,7 @@ ubTable[i] : unordered_map<UBKey_i, UBEntry>
 
 1. 定义 `UBKey` / `UBEntry` / custom hash
 2. 搭 `BTBTAGEUpperBound : public BTBTAGE`
-3. 实现 exact outcome history 的 `specUpdateHist/recoverHist`
+3. 实现 exact outcome history 的 `specUpdateGHist/recoverHist`
 4. 实现 provider/alt 查找
 5. 实现 update + 统计
 6. 跑两个 gobmk slice

--- a/docs/design-docs/frontend/phr_design.md
+++ b/docs/design-docs/frontend/phr_design.md
@@ -65,19 +65,19 @@ thread.s0BwHistory.resize(historyBits, 0);
 
 顶层并不会对 block 内所有分支都更新 PHR。它只对“当前 block 最终选中的那次 taken 控制流”更新一次。
 
-决定更新来源的逻辑在 `FullBTBPrediction::getPHistReplay()`：
+决定更新来源的逻辑在 `FullBTBPrediction::getPHistUpdate()`：
 
 ```cpp
-PathHistoryReplay getPHistReplay()
+PathHistoryUpdate getPHistUpdate()
 {
-    PathHistoryReplay replay;
+    PathHistoryUpdate update;
     const auto &entry = getTakenEntry();
     if (entry.valid) {
-        replay.taken = true;
-        replay.pc = entry.pc;
-        replay.target = getEntryTarget(entry);
+        update.taken = true;
+        update.pc = entry.pc;
+        update.target = getEntryTarget(entry);
     }
-    return replay;
+    return update;
 }
 ```
 

--- a/docs/design-docs/frontend/phr_design.md
+++ b/docs/design-docs/frontend/phr_design.md
@@ -65,33 +65,19 @@ thread.s0BwHistory.resize(historyBits, 0);
 
 顶层并不会对 block 内所有分支都更新 PHR。它只对“当前 block 最终选中的那次 taken 控制流”更新一次。
 
-决定更新来源的逻辑在 `FullBTBPrediction::getPHistInfo()`：
+决定更新来源的逻辑在 `FullBTBPrediction::getPHistReplay()`：
 
 ```cpp
-std::tuple<Addr, Addr, bool> getPHistInfo()
+PathHistoryReplay getPHistReplay()
 {
-    bool taken = false;
-    Addr pc = 0;
-    Addr target = 0;
-    for (auto &entry : btbEntries) {
-        if (entry.valid) {
-            if (entry.isCond) {
-                auto it = CondTakens_find(condTakens, entry.pc);
-                if (it != condTakens.end() && it->second) {
-                    taken = true;
-                    pc = entry.pc;
-                    target = entry.target;
-                    break;
-                }
-            } else {
-                taken = true;
-                pc = entry.pc;
-                target = entry.target;
-                break;
-            }
-        }
+    PathHistoryReplay replay;
+    const auto &entry = getTakenEntry();
+    if (entry.valid) {
+        replay.taken = true;
+        replay.pc = entry.pc;
+        replay.target = getEntryTarget(entry);
     }
-    return std::make_tuple(pc, target, taken);
+    return replay;
 }
 ```
 

--- a/docs/design-docs/frontend/phr_design.md
+++ b/docs/design-docs/frontend/phr_design.md
@@ -161,8 +161,8 @@ DecoupledBPUWithBTB::pHistShiftIn(
 关键顺序在 `updateHistoryForPrediction()`：
 
 ```cpp
-components[i]->specUpdateHist(s0History, finalPred);
-components[i]->specUpdatePHist(s0PHistory, finalPred);
+components[i]->specUpdateGHist(s0History, finalPred, ghist_update);
+components[i]->specUpdatePHist(s0PHistory, finalPred, phist_update);
 ...
 histShiftIn(shamt, taken, s0History);
 pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1124,8 +1124,6 @@ class BTBMGSC(TimedBaseBTBPredictor):
     cxx_class = 'gem5::branch_prediction::btb_pred::BTBMGSC'
     cxx_header = "cpu/pred/btb/btb_mgsc.hh"
 
-    needMoreHistories = Param.Bool(True, "MGSC needs auxiliary histories")
-
     bwTableNum = Param.Unsigned(2, "Num global backward branch GEHL tables")
     bwHistLen = VectorParam.Int([4, 8], "Global backward branch GEHL history lengths")
     bwTableIdxWidth = Param.Unsigned(11,

--- a/src/cpu/pred/README.md
+++ b/src/cpu/pred/README.md
@@ -34,8 +34,10 @@ DecoupledBPUWithBTB 是一个解耦的分支预测器设计，主要包含以下
 
 - putPCHistry: 根据 startAddr 作为起始预测地址，记录在 stagePreds 中作为预测结果
 - getPredictionMeta：获取预测元数据，相当于 checkpoints, 存储预测时候的状态，预测错误时候回滚，指令提交时候验证
-- specUpdateHist：推测更新历史，只有 uRAS 实现！其他预测器不会推测更新！
-- recoverHist：squash（分支预测错误）后恢复历史，tage/RAS 实现，并更新 s0history
+- specUpdateGHist/specUpdatePHist：推测更新 TAGE/ITTAGE/MGSC 等预测器的 folded history
+- recoverHist/recoverPHist：squash（分支预测错误）后恢复 folded history，并用实际结果重放
+- RAS 的 `specUpdateState`/`recoverState`：只更新返回栈内部状态，不属于 folded history 接口
+- ABTB 的 `recoverState`：squash 后清理 ahead pipeline，不属于 folded history 接口
 - update：用 commit stream 更新预测器内容，是准确更新
 - commitBranch: 当前 FetchBlock 这条分支提交时候，统计数据
 

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -376,13 +376,10 @@ AheadBTB::getPredictionMeta(ThreadID tid)
 }
 
 void
-AheadBTB::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
-
-void
-AheadBTB::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+AheadBTB::recoverState(const FetchTarget &entry)
 {
     auto &state = threadState(entry.tid);
-    // clear ahead pipeline first
+    // Clear ahead pipeline after squash.
     while (!state.aheadReadBtbEntries.empty()) {
         state.aheadReadBtbEntries.pop();
     }

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -153,11 +153,7 @@ class AheadBTB : public TimedBaseBTBPredictor
      */
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    // not used
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
-
-    void recoverHist(const boost::dynamic_bitset<> &history,
-        const FetchTarget &entry, int shamt, bool cond_taken) override;
+    void recoverState(const FetchTarget &entry);
 
 #ifndef UNIT_TEST
     /** Creates a BTB with the given number of entries, number of bits per

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -577,8 +577,8 @@ BTBITTAGE::tageHit()
 void
 BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    auto [pc, target, taken] = pred.getPHistInfo();
-    doUpdateHist(history, taken, pc, target, pred.tid);
+    const auto replay = pred.getPHistReplay();
+    doUpdateHist(history, replay.taken, replay.pc, replay.target, pred.tid);
 }
 
 /**
@@ -595,7 +595,9 @@ BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredic
  * @param cond_taken The actual branch outcome
  */
 void
-BTBITTAGE::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+BTBITTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
+                        const FetchTarget &entry,
+                        const PathHistoryReplay &replay)
 {
     auto &state = historyState(entry.tid);
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
@@ -604,8 +606,7 @@ BTBITTAGE::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarge
         state.altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
         state.indexFoldedHist[i].recover(predMeta->indexFoldedHist[i]);
     }
-    doUpdateHist(history, cond_taken, entry.getControlPC(),
-                 entry.getTakenTarget(), entry.tid);
+    doUpdateHist(history, replay.taken, replay.pc, replay.target, entry.tid);
 }
 
 void

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -563,23 +563,8 @@ BTBITTAGE::tageHit()
 }
 
 /**
- * @brief Updates branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates path folded histories.
  */
-void
-BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdatePHist(history, pred, pred.getPHistUpdate());
-}
-
 void
 BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history,
                            FullBTBPrediction &pred,

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -577,8 +577,8 @@ BTBITTAGE::tageHit()
 void
 BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    const auto replay = pred.getPHistReplay();
-    doUpdateHist(history, replay.taken, replay.pc, replay.target, pred.tid);
+    const auto update = pred.getPHistUpdate();
+    doUpdateHist(history, update.taken, update.pc, update.target, pred.tid);
 }
 
 /**
@@ -597,7 +597,7 @@ BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredic
 void
 BTBITTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
                         const FetchTarget &entry,
-                        const PathHistoryReplay &replay)
+                        const PathHistoryUpdate &update)
 {
     auto &state = historyState(entry.tid);
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
@@ -606,7 +606,7 @@ BTBITTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
         state.altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
         state.indexFoldedHist[i].recover(predMeta->indexFoldedHist[i]);
     }
-    doUpdateHist(history, replay.taken, replay.pc, replay.target, entry.tid);
+    doUpdateHist(history, update.taken, update.pc, update.target, entry.tid);
 }
 
 void

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -577,7 +577,14 @@ BTBITTAGE::tageHit()
 void
 BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    const auto update = pred.getPHistUpdate();
+    specUpdatePHist(history, pred, pred.getPHistUpdate());
+}
+
+void
+BTBITTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                           FullBTBPrediction &pred,
+                           const PathHistoryUpdate &update)
+{
     doUpdateHist(history, update.taken, update.pc, update.target, pred.tid);
 }
 

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -104,15 +104,12 @@ class BTBITTAGE : public TimedBaseBTBPredictor
 
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    // speculative update 3 folded history, according history and pred.taken
-    // the other specUpdateHist methods are left blank
-    void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    // Speculatively update path folded histories.
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
                          const PathHistoryUpdate &update) override;
 
-    // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
-    // the other recoverHist methods are left blank
+    // Recover path folded histories after a misprediction.
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
                       const PathHistoryUpdate &update) override;

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -107,6 +107,9 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // speculative update 3 folded history, according history and pred.taken
     // the other specUpdateHist methods are left blank
     void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update) override;
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -111,7 +111,8 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
     void recoverPHist(const boost::dynamic_bitset<> &history,
-                        const FetchTarget &entry,int shamt, bool cond_taken) override;
+                      const FetchTarget &entry,
+                      const PathHistoryReplay &replay) override;
 
     void update(const FetchTarget &entry) override;
 

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -112,7 +112,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     // the other recoverHist methods are left blank
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      const PathHistoryReplay &replay) override;
+                      const PathHistoryUpdate &update) override;
 
     void update(const FetchTarget &entry) override;
 

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -184,10 +184,6 @@ BTBMGSC::BTBMGSC()
       mgscStats()
 {
     // Test-only small config: keep tables tiny and deterministic for fast unit tests.
-    // MGSC uses multiple histories (GHR/PHR/BWHR/LHR). Keep it enabled in unit tests so we can
-    // build training-loop style tests that exercise each table.
-    needMoreHistories = true;
-
     initStorage();
     updateThreshold = 35 * 8;
 }
@@ -232,7 +228,6 @@ BTBMGSC::BTBMGSC(const Params &p)
       mgscStats(this)
 {
     DPRINTF(MGSC, "BTBMGSC constructor\n");
-    this->needMoreHistories = p.needMoreHistories;
     initStorage();
     updateThreshold = 35 * 8;
 
@@ -1154,25 +1149,10 @@ BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool ta
 
 
 /**
- * @brief Updates branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates global folded histories.
  */
 void
-BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdateHist(history, pred, pred.getHistUpdate());
-}
-
-void
-BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history,
+BTBMGSC::specUpdateGHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred,
                         const DirectionHistoryUpdate &update)
 {
@@ -1182,23 +1162,8 @@ BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history,
 }
 
 /**
- * @brief Updates branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates path folded histories.
  */
-void
-BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdatePHist(history, pred, pred.getPHistUpdate());
-}
-
 void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
@@ -1211,23 +1176,8 @@ BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history,
 
 
 /**
- * @brief Updates global backward branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current global backward branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates global backward folded histories.
  */
-void
-BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdateBwHist(history, pred, pred.getBwHistUpdate());
-}
-
 void
 BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history,
                           FullBTBPrediction &pred,
@@ -1238,23 +1188,8 @@ BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history,
 }
 
 /**
- * @brief Updates IMLI branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- * Note: IMLI only uses counter, not history bits.
- *
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates IMLI folded histories.
  */
-void
-BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
-{
-    specUpdateIHist(pred, pred.getBwHistUpdate());
-}
-
 void
 BTBMGSC::specUpdateIHist(FullBTBPrediction &pred,
                          const DirectionHistoryUpdate &update)
@@ -1266,23 +1201,8 @@ BTBMGSC::specUpdateIHist(FullBTBPrediction &pred,
 }
 
 /**
- * @brief Updates local branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current local branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates local folded histories.
  */
-void
-BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred)
-{
-    specUpdateLHist(history, pred, pred.getHistUpdate());
-}
-
 void
 BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history,
                          FullBTBPrediction &pred,

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -1168,8 +1168,15 @@ BTBMGSC::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt, bool ta
 void
 BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
+    specUpdateHist(history, pred, pred.getHistUpdate());
+}
+
+void
+BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history,
+                        FullBTBPrediction &pred,
+                        const DirectionHistoryUpdate &update)
+{
     auto &state = historyState(pred.tid);
-    const auto update = pred.getHistUpdate();
     doUpdateHist(history, update.shamt, update.taken,
                  state.indexGFoldedHist);  // use global history to update G folded history
 }
@@ -1189,8 +1196,15 @@ BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPredictio
 void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
+    specUpdatePHist(history, pred, pred.getPHistUpdate());
+}
+
+void
+BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update)
+{
     auto &state = historyState(pred.tid);
-    const auto update = pred.getPHistUpdate();
     doUpdateHist(history, update.shamt, update.taken, state.indexPFoldedHist,
                  update.pc, update.target);  // only path history needs pc!
 }
@@ -1211,8 +1225,15 @@ BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredicti
 void
 BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
+    specUpdateBwHist(history, pred, pred.getBwHistUpdate());
+}
+
+void
+BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history,
+                          FullBTBPrediction &pred,
+                          const DirectionHistoryUpdate &update)
+{
     auto &state = historyState(pred.tid);
-    const auto update = pred.getBwHistUpdate();
     doUpdateHist(history, update.shamt, update.taken, state.indexBwFoldedHist);
 }
 
@@ -1231,8 +1252,14 @@ BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPredict
 void
 BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
 {
+    specUpdateIHist(pred, pred.getBwHistUpdate());
+}
+
+void
+BTBMGSC::specUpdateIHist(FullBTBPrediction &pred,
+                         const DirectionHistoryUpdate &update)
+{
     auto &state = historyState(pred.tid);
-    const auto update = pred.getBwHistUpdate();
     // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
     boost::dynamic_bitset<> dummy;
     doUpdateHist(dummy, update.shamt, update.taken, state.indexIFoldedHist);
@@ -1253,8 +1280,15 @@ BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
 void
 BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred)
 {
+    specUpdateLHist(history, pred, pred.getHistUpdate());
+}
+
+void
+BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history,
+                         FullBTBPrediction &pred,
+                         const DirectionHistoryUpdate &update)
+{
     auto &state = historyState(pred.tid);
-    const auto update = pred.getHistUpdate();
     const Addr localHistoryIndex =
         getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories), pred.asidHash);
     doUpdateHist(history[localHistoryIndex], update.shamt, update.taken,

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -1169,10 +1169,9 @@ void
 BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getHistInfo();
-    doUpdateHist(history, shamt, cond_taken, state.indexGFoldedHist);  // use global history to update G folded history
+    const auto replay = pred.getHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken,
+                 state.indexGFoldedHist);  // use global history to update G folded history
 }
 
 /**
@@ -1191,8 +1190,9 @@ void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    auto [pc, target, taken] = pred.getPHistInfo();
-    doUpdateHist(history, 2, taken, state.indexPFoldedHist, pc, target);  // only path history needs pc!
+    const auto replay = pred.getPHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken, state.indexPFoldedHist,
+                 replay.pc, replay.target);  // only path history needs pc!
 }
 
 
@@ -1212,10 +1212,8 @@ void
 BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getBwHistInfo();
-    doUpdateHist(history, shamt, cond_taken, state.indexBwFoldedHist);
+    const auto replay = pred.getBwHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken, state.indexBwFoldedHist);
 }
 
 /**
@@ -1234,12 +1232,10 @@ void
 BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getBwHistInfo();
+    const auto replay = pred.getBwHistReplay();
     // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
     boost::dynamic_bitset<> dummy;
-    doUpdateHist(dummy, shamt, cond_taken, state.indexIFoldedHist);
+    doUpdateHist(dummy, replay.shamt, replay.taken, state.indexIFoldedHist);
 }
 
 /**
@@ -1258,12 +1254,10 @@ void
 BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getHistInfo();
+    const auto replay = pred.getHistReplay();
     const Addr localHistoryIndex =
         getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories), pred.asidHash);
-    doUpdateHist(history[localHistoryIndex], shamt, cond_taken,
+    doUpdateHist(history[localHistoryIndex], replay.shamt, replay.taken,
                  state.indexLFoldedHist[localHistoryIndex]);
 }
 
@@ -1308,7 +1302,9 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &
  * @param cond_taken The actual branch outcome
  */
 void
-BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
+                      const FetchTarget &entry,
+                      const PathHistoryReplay &replay)
 {
     if (!isEnabled()) {
         return;  // No recover when disabled
@@ -1318,8 +1314,8 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget 
     for (int i = 0; i < pTableNum; i++) {
         state.indexPFoldedHist[i].recover(predMeta->indexPFoldedHist[i]);
     }
-    doUpdateHist(history, 2, cond_taken, state.indexPFoldedHist,
-                 entry.getControlPC(), entry.getTakenTarget());
+    doUpdateHist(history, replay.shamt, replay.taken, state.indexPFoldedHist,
+                 replay.pc, replay.target);
 }
 
 /**

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -1169,8 +1169,8 @@ void
 BTBMGSC::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    const auto replay = pred.getHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken,
+    const auto update = pred.getHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken,
                  state.indexGFoldedHist);  // use global history to update G folded history
 }
 
@@ -1190,9 +1190,9 @@ void
 BTBMGSC::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    const auto replay = pred.getPHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken, state.indexPFoldedHist,
-                 replay.pc, replay.target);  // only path history needs pc!
+    const auto update = pred.getPHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken, state.indexPFoldedHist,
+                 update.pc, update.target);  // only path history needs pc!
 }
 
 
@@ -1212,8 +1212,8 @@ void
 BTBMGSC::specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    const auto replay = pred.getBwHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken, state.indexBwFoldedHist);
+    const auto update = pred.getBwHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken, state.indexBwFoldedHist);
 }
 
 /**
@@ -1232,10 +1232,10 @@ void
 BTBMGSC::specUpdateIHist(FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    const auto replay = pred.getBwHistReplay();
+    const auto update = pred.getBwHistUpdate();
     // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
     boost::dynamic_bitset<> dummy;
-    doUpdateHist(dummy, replay.shamt, replay.taken, state.indexIFoldedHist);
+    doUpdateHist(dummy, update.shamt, update.taken, state.indexIFoldedHist);
 }
 
 /**
@@ -1254,10 +1254,10 @@ void
 BTBMGSC::specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred)
 {
     auto &state = historyState(pred.tid);
-    const auto replay = pred.getHistReplay();
+    const auto update = pred.getHistUpdate();
     const Addr localHistoryIndex =
         getPcIndex(pred.bbStart, log2(numEntriesFirstLocalHistories), pred.asidHash);
-    doUpdateHist(history[localHistoryIndex], replay.shamt, replay.taken,
+    doUpdateHist(history[localHistoryIndex], update.shamt, update.taken,
                  state.indexLFoldedHist[localHistoryIndex]);
 }
 
@@ -1304,7 +1304,7 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &
 void
 BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      const PathHistoryReplay &replay)
+                      const PathHistoryUpdate &update)
 {
     if (!isEnabled()) {
         return;  // No recover when disabled
@@ -1314,8 +1314,8 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
     for (int i = 0; i < pTableNum; i++) {
         state.indexPFoldedHist[i].recover(predMeta->indexPFoldedHist[i]);
     }
-    doUpdateHist(history, replay.shamt, replay.taken, state.indexPFoldedHist,
-                 replay.pc, replay.target);
+    doUpdateHist(history, update.shamt, update.taken, state.indexPFoldedHist,
+                 update.pc, update.target);
 }
 
 /**

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -172,8 +172,8 @@ class BTBMGSC : public TimedBaseBTBPredictor
     // pred.taken
     void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
                      bool cond_taken) override;
-    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                      bool cond_taken) override;
+    void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
+                      const PathHistoryReplay &replay) override;
     void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
                        bool cond_taken) override;
     void recoverIHist(const FetchTarget &entry, int shamt,

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -173,7 +173,7 @@ class BTBMGSC : public TimedBaseBTBPredictor
     void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
-                      const PathHistoryReplay &replay) override;
+                      const PathHistoryUpdate &update) override;
     void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
                        bool cond_taken) override;
     void recoverIHist(const FetchTarget &entry, int shamt,

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -161,39 +161,33 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    // speculative update all folded history, according history and pred.taken
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
-    void specUpdateHist(const boost::dynamic_bitset<> &history,
+    // Speculatively update all folded histories.
+    void specUpdateGHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred,
                         const DirectionHistoryUpdate &update) override;
-    void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
                          const PathHistoryUpdate &update) override;
-    void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
     void specUpdateBwHist(const boost::dynamic_bitset<> &history,
                           FullBTBPrediction &pred,
-                          const DirectionHistoryUpdate &update) override;
-    void specUpdateIHist(FullBTBPrediction &pred) override;
+                          const DirectionHistoryUpdate &update);
     void specUpdateIHist(FullBTBPrediction &pred,
-                         const DirectionHistoryUpdate &update) override;
-    void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) override;
+                         const DirectionHistoryUpdate &update);
     void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history,
                          FullBTBPrediction &pred,
-                         const DirectionHistoryUpdate &update) override;
+                         const DirectionHistoryUpdate &update);
 
-    // Recover all folded history after a misprediction, then update all folded history according to history and
-    // pred.taken
+    // Recover all folded histories after a misprediction.
     void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
                       const PathHistoryUpdate &update) override;
     void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt,
-                       bool cond_taken) override;
+                       bool cond_taken);
     void recoverIHist(const FetchTarget &entry, int shamt,
-                      bool cond_taken) override;
+                      bool cond_taken);
     void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt,
-                      bool cond_taken) override;
+                      bool cond_taken);
 
     // Update predictor state based on actual branch outcomes
     void update(const FetchTarget &entry) override;

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -163,10 +163,24 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
     // speculative update all folded history, according history and pred.taken
     void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdateHist(const boost::dynamic_bitset<> &history,
+                        FullBTBPrediction &pred,
+                        const DirectionHistoryUpdate &update) override;
     void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update) override;
     void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdateBwHist(const boost::dynamic_bitset<> &history,
+                          FullBTBPrediction &pred,
+                          const DirectionHistoryUpdate &update) override;
     void specUpdateIHist(FullBTBPrediction &pred) override;
+    void specUpdateIHist(FullBTBPrediction &pred,
+                         const DirectionHistoryUpdate &update) override;
     void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) override;
+    void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history,
+                         FullBTBPrediction &pred,
+                         const DirectionHistoryUpdate &update) override;
 
     // Recover all folded history after a misprediction, then update all folded history according to history and
     // pred.taken

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -1222,8 +1222,8 @@ BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
         return;
     }
 
-    auto [shamt, taken] = pred.getHistInfo();
-    doUpdateHist(history, shamt, taken, 0, 0, pred.tid);
+    const auto replay = pred.getHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken, 0, 0, pred.tid);
 }
 
 void
@@ -1233,8 +1233,9 @@ BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredicti
         return;
     }
 
-    auto [pc, target, taken] = pred.getPHistInfo();
-    doUpdateHist(history, 2, taken, pc, target, pred.tid);
+    const auto replay = pred.getPHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken, replay.pc,
+                 replay.target, pred.tid);
 }
 
 void
@@ -1276,15 +1277,15 @@ BTBTAGE::recoverHist(const boost::dynamic_bitset<> &history,
 
 void
 BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchTarget &entry, int shamt, bool cond_taken)
+    const FetchTarget &entry, const PathHistoryReplay &replay)
 {
     if (!usePathHistory) {
         return;
     }
 
     recoverFoldedHist(entry);
-    doUpdateHist(history, 2, cond_taken, entry.getControlPC(),
-                 entry.getTakenTarget(), entry.tid);
+    doUpdateHist(history, replay.shamt, replay.taken, replay.pc,
+                 replay.target, entry.tid);
 }
 
 // Check folded history after speculative update and recovery

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -1218,22 +1218,36 @@ void
 BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred)
 {
+    specUpdateHist(history, pred, pred.getHistUpdate());
+}
+
+void
+BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
+                        FullBTBPrediction &pred,
+                        const DirectionHistoryUpdate &update)
+{
     if (usePathHistory) {
         return;
     }
 
-    const auto update = pred.getHistUpdate();
     doUpdateHist(history, update.shamt, update.taken, 0, 0, pred.tid);
 }
 
 void
 BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
+    specUpdatePHist(history, pred, pred.getPHistUpdate());
+}
+
+void
+BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update)
+{
     if (!usePathHistory) {
         return;
     }
 
-    const auto update = pred.getPHistUpdate();
     doUpdateHist(history, update.shamt, update.taken, update.pc,
                  update.target, pred.tid);
 }

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -1222,8 +1222,8 @@ BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
         return;
     }
 
-    const auto replay = pred.getHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken, 0, 0, pred.tid);
+    const auto update = pred.getHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken, 0, 0, pred.tid);
 }
 
 void
@@ -1233,9 +1233,9 @@ BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredicti
         return;
     }
 
-    const auto replay = pred.getPHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken, replay.pc,
-                 replay.target, pred.tid);
+    const auto update = pred.getPHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken, update.pc,
+                 update.target, pred.tid);
 }
 
 void
@@ -1277,15 +1277,15 @@ BTBTAGE::recoverHist(const boost::dynamic_bitset<> &history,
 
 void
 BTBTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchTarget &entry, const PathHistoryReplay &replay)
+    const FetchTarget &entry, const PathHistoryUpdate &update)
 {
     if (!usePathHistory) {
         return;
     }
 
     recoverFoldedHist(entry);
-    doUpdateHist(history, replay.shamt, replay.taken, replay.pc,
-                 replay.target, entry.tid);
+    doUpdateHist(history, update.shamt, update.taken, update.pc,
+                 update.target, entry.tid);
 }
 
 // Check folded history after speculative update and recovery

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -1203,26 +1203,10 @@ BTBTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, int shamt,
 }
 
 /**
- * @brief Updates branch history for speculative execution
- * 
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- * 
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- * 
- * @param history The current branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates direction folded histories.
  */
 void
-BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
-                        FullBTBPrediction &pred)
-{
-    specUpdateHist(history, pred, pred.getHistUpdate());
-}
-
-void
-BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
+BTBTAGE::specUpdateGHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred,
                         const DirectionHistoryUpdate &update)
 {
@@ -1231,12 +1215,6 @@ BTBTAGE::specUpdateHist(const boost::dynamic_bitset<> &history,
     }
 
     doUpdateHist(history, update.shamt, update.taken, 0, 0, pred.tid);
-}
-
-void
-BTBTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdatePHist(history, pred, pred.getPHistUpdate());
 }
 
 void

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -148,8 +148,14 @@ class BTBTAGE : public TimedBaseBTBPredictor
     // Update folded history from GHR when configured in direction-history mode.
     void specUpdateHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred) override;
+    void specUpdateHist(const boost::dynamic_bitset<> &history,
+                        FullBTBPrediction &pred,
+                        const DirectionHistoryUpdate &update) override;
     // Update folded history from PHR when configured in path-history mode.
     void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update) override;
 
     void recoverHist(const boost::dynamic_bitset<> &history,
                      const FetchTarget &entry, int shamt,

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -156,7 +156,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      const PathHistoryReplay &replay) override;
+                      const PathHistoryUpdate &update) override;
 
     // Update predictor state based on actual branch outcomes
     void update(const FetchTarget &entry) override;

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -146,13 +146,10 @@ class BTBTAGE : public TimedBaseBTBPredictor
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
     // Update folded history from GHR when configured in direction-history mode.
-    void specUpdateHist(const boost::dynamic_bitset<> &history,
-                        FullBTBPrediction &pred) override;
-    void specUpdateHist(const boost::dynamic_bitset<> &history,
+    void specUpdateGHist(const boost::dynamic_bitset<> &history,
                         FullBTBPrediction &pred,
                         const DirectionHistoryUpdate &update) override;
     // Update folded history from PHR when configured in path-history mode.
-    void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
                          const PathHistoryUpdate &update) override;

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -155,7 +155,8 @@ class BTBTAGE : public TimedBaseBTBPredictor
                      const FetchTarget &entry, int shamt,
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history,
-                        const FetchTarget &entry,int shamt, bool cond_taken) override;
+                      const FetchTarget &entry,
+                      const PathHistoryReplay &replay) override;
 
     // Update predictor state based on actual branch outcomes
     void update(const FetchTarget &entry) override;

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -340,12 +340,21 @@ void
 BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
                                    FullBTBPrediction &pred)
 {
+    specUpdatePHist(history, pred, pred.getPHistUpdate());
+}
+
+void
+BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                                   FullBTBPrediction &pred,
+                                   const PathHistoryUpdate &update)
+{
+    (void)pred;
+
     if (historySource != HistorySource::PathHash) {
         return;
     }
 
     exactPathHistory = history;
-    const auto update = pred.getPHistUpdate();
     updatePathHistory(exactPathHistory, update.taken, update.pc,
                       update.target);
 }

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -329,21 +329,6 @@ BTBTAGEUpperBound::getPredictionMeta(ThreadID tid)
 }
 
 void
-BTBTAGEUpperBound::specUpdateHist(const boost::dynamic_bitset<> &history,
-                                  FullBTBPrediction &pred)
-{
-    (void)history;
-    (void)pred;
-}
-
-void
-BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
-                                   FullBTBPrediction &pred)
-{
-    specUpdatePHist(history, pred, pred.getPHistUpdate());
-}
-
-void
 BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
                                    FullBTBPrediction &pred,
                                    const PathHistoryUpdate &update)

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -345,9 +345,9 @@ BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
     }
 
     exactPathHistory = history;
-    const auto replay = pred.getPHistReplay();
-    updatePathHistory(exactPathHistory, replay.taken, replay.pc,
-                      replay.target);
+    const auto update = pred.getPHistUpdate();
+    updatePathHistory(exactPathHistory, update.taken, update.pc,
+                      update.target);
 }
 
 void
@@ -364,7 +364,7 @@ BTBTAGEUpperBound::recoverHist(const boost::dynamic_bitset<> &history,
 void
 BTBTAGEUpperBound::recoverPHist(const boost::dynamic_bitset<> &history,
                                 const FetchTarget &entry,
-                                const PathHistoryReplay &replay)
+                                const PathHistoryUpdate &update)
 {
     (void)entry;
 
@@ -373,8 +373,8 @@ BTBTAGEUpperBound::recoverPHist(const boost::dynamic_bitset<> &history,
     }
 
     exactPathHistory = history;
-    updatePathHistory(exactPathHistory, replay.taken, replay.pc,
-                      replay.target);
+    updatePathHistory(exactPathHistory, update.taken, update.pc,
+                      update.target);
 }
 
 bool

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -345,8 +345,9 @@ BTBTAGEUpperBound::specUpdatePHist(const boost::dynamic_bitset<> &history,
     }
 
     exactPathHistory = history;
-    auto [pc, target, taken] = pred.getPHistInfo();
-    updatePathHistory(exactPathHistory, taken, pc, target);
+    const auto replay = pred.getPHistReplay();
+    updatePathHistory(exactPathHistory, replay.taken, replay.pc,
+                      replay.target);
 }
 
 void
@@ -362,18 +363,18 @@ BTBTAGEUpperBound::recoverHist(const boost::dynamic_bitset<> &history,
 
 void
 BTBTAGEUpperBound::recoverPHist(const boost::dynamic_bitset<> &history,
-                                const FetchTarget &entry, int shamt,
-                                bool cond_taken)
+                                const FetchTarget &entry,
+                                const PathHistoryReplay &replay)
 {
-    (void)shamt;
+    (void)entry;
 
     if (historySource != HistorySource::PathHash) {
         return;
     }
 
     exactPathHistory = history;
-    updatePathHistory(exactPathHistory, cond_taken,
-                      entry.getControlPC(), entry.getTakenTarget());
+    updatePathHistory(exactPathHistory, replay.taken, replay.pc,
+                      replay.target);
 }
 
 bool

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -101,6 +101,9 @@ class BTBTAGEUpperBound : public BTBTAGE
                         FullBTBPrediction &pred) override;
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update) override;
     void recoverHist(const boost::dynamic_bitset<> &history,
                      const FetchTarget &entry,
                      int shamt,

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -97,10 +97,6 @@ class BTBTAGEUpperBound : public BTBTAGE
 
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    void specUpdateHist(const boost::dynamic_bitset<> &history,
-                        FullBTBPrediction &pred) override;
-    void specUpdatePHist(const boost::dynamic_bitset<> &history,
-                         FullBTBPrediction &pred) override;
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
                          const PathHistoryUpdate &update) override;

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -107,7 +107,7 @@ class BTBTAGEUpperBound : public BTBTAGE
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      const PathHistoryReplay &replay) override;
+                      const PathHistoryUpdate &update) override;
     void update(const FetchTarget &entry) override;
     void checkFoldedHist(const bitset &history, const char *when) override;
 

--- a/src/cpu/pred/btb/btb_tage_ub.hh
+++ b/src/cpu/pred/btb/btb_tage_ub.hh
@@ -107,8 +107,7 @@ class BTBTAGEUpperBound : public BTBTAGE
                      bool cond_taken) override;
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      int shamt,
-                      bool cond_taken) override;
+                      const PathHistoryReplay &replay) override;
     void update(const FetchTarget &entry) override;
     void checkFoldedHist(const bitset &history, const char *when) override;
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -146,10 +146,6 @@ class UBTB : public TimedBaseBTBPredictor
         return meta;
     }
 
-    // the following methods are not used
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override {}
-    void recoverHist(const boost::dynamic_bitset<> &history,
-        const FetchTarget &entry, int shamt, bool cond_taken) override{};
     void reset();
     void setTrace() override;
     TraceManager *ubtbTrace;

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -435,7 +435,7 @@ struct FetchTarget
         return startPC;
     }
 
-    DirectionHistoryUpdate getHistUpdateDuringSquash(
+    DirectionHistoryUpdate getGHistUpdateDuringSquash(
         Addr squash_pc, bool is_cond, bool actually_taken) const
     {
         DirectionHistoryUpdate update;
@@ -661,7 +661,7 @@ struct FullBTBPrediction
         }
     }
 
-    DirectionHistoryUpdate getHistUpdate()  //global or local
+    DirectionHistoryUpdate getGHistUpdate()  //global or local
     {
         DirectionHistoryUpdate update; // shamt is the number of bits to shift in history update
         for (auto &entry : btbEntries) {

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -308,13 +308,13 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
 #define FillStageLoop(x) for (int x = getDelay(); x < stagePreds.size(); ++x)
 
-struct DirectionHistoryReplay
+struct DirectionHistoryUpdate
 {
     int shamt = 0;
     bool taken = false;
 };
 
-struct PathHistoryReplay
+struct PathHistoryUpdate
 {
     static constexpr int NumShift = 2;
 
@@ -435,48 +435,48 @@ struct FetchTarget
         return startPC;
     }
 
-    DirectionHistoryReplay getHistReplayDuringSquash(
+    DirectionHistoryUpdate getHistUpdateDuringSquash(
         Addr squash_pc, bool is_cond, bool actually_taken) const
     {
-        DirectionHistoryReplay replay;
+        DirectionHistoryUpdate update;
         for (auto &entry : predBTBEntries) {
             if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
-                replay.shamt++;
+                update.shamt++;
             }
         }
         if (is_cond) {
-            replay.shamt++;
-            replay.taken = actually_taken;
+            update.shamt++;
+            update.taken = actually_taken;
         }
-        return replay;
+        return update;
     }
 
-    DirectionHistoryReplay getBwHistReplayDuringSquash(
+    DirectionHistoryUpdate getBwHistUpdateDuringSquash(
         Addr squash_pc, bool is_cond, bool actually_taken, Addr target) const
     {
-        DirectionHistoryReplay replay;
+        DirectionHistoryUpdate update;
         for (auto &entry : predBTBEntries) {
             if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
-                replay.shamt++;
+                update.shamt++;
             }
         }
         if (is_cond) {
-            replay.shamt++;
-            replay.taken = actually_taken && (squash_pc > target);
+            update.shamt++;
+            update.taken = actually_taken && (squash_pc > target);
         }
-        return replay;
+        return update;
     }
 
-    PathHistoryReplay getPHistReplayDuringSquash(
+    PathHistoryUpdate getPHistUpdateDuringSquash(
         Addr squash_pc, bool actually_taken, Addr target) const
     {
-        PathHistoryReplay replay;
-        replay.taken = actually_taken && getControlPC() == squash_pc;
-        if (replay.taken) {
-            replay.pc = squash_pc;
-            replay.target = target;
+        PathHistoryUpdate update;
+        update.taken = actually_taken && getControlPC() == squash_pc;
+        if (update.taken) {
+            update.pc = squash_pc;
+            update.target = target;
         }
-        return replay;
+        return update;
     }
 
     // should be called before components update
@@ -661,18 +661,18 @@ struct FullBTBPrediction
         }
     }
 
-    DirectionHistoryReplay getHistReplay()  //global or local
+    DirectionHistoryUpdate getHistUpdate()  //global or local
     {
-        DirectionHistoryReplay replay; // shamt is the number of bits to shift in history update
+        DirectionHistoryUpdate update; // shamt is the number of bits to shift in history update
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) { // if found a cond branch, shamt++
-                    replay.shamt++;
+                    update.shamt++;
                     auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) { // if the cond branch is taken, taken = true
-                            replay.taken = true;
+                            update.taken = true;
                             break;
                         }
                     }
@@ -684,21 +684,21 @@ struct FullBTBPrediction
         }
         // For example, return (3, true) means 3 bits to shift in history update,
         // and the third branch is taken, new hist = xxx001
-        return replay;
+        return update;
     }
 
-    DirectionHistoryReplay getBwHistReplay() //global backward or imli
+    DirectionHistoryUpdate getBwHistUpdate() //global backward or imli
     {
-        DirectionHistoryReplay replay;
+        DirectionHistoryUpdate update;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) {
-                    replay.shamt++;
+                    update.shamt++;
                     auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
-                            replay.taken = (entry.target < entry.pc); // branch is backward if target < pc
+                            update.taken = (entry.target < entry.pc); // branch is backward if target < pc
                             break;
                         }
                     }
@@ -708,19 +708,19 @@ struct FullBTBPrediction
                 }
             }
         }
-        return replay;
+        return update;
     }
 
-    PathHistoryReplay getPHistReplay() //path
+    PathHistoryUpdate getPHistUpdate() //path
     {
-        PathHistoryReplay replay;
+        PathHistoryUpdate update;
         const auto &entry = getTakenEntry();
         if (entry.valid) {
-            replay.taken = true;
-            replay.pc = entry.pc;
-            replay.target = getEntryTarget(entry);
+            update.taken = true;
+            update.pc = entry.pc;
+            update.target = getEntryTarget(entry);
         }
-        return replay;
+        return update;
     }
 
 };

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -324,6 +324,13 @@ struct PathHistoryUpdate
     Addr target = 0;
 };
 
+struct BTBHistoryUpdate
+{
+    DirectionHistoryUpdate ghist;
+    DirectionHistoryUpdate bwhist;
+    PathHistoryUpdate phist;
+};
+
 /**
  * @brief Fetch Stream representing a sequence of instructions with prediction info
  *
@@ -476,6 +483,19 @@ struct FetchTarget
             update.pc = squash_pc;
             update.target = target;
         }
+        return update;
+    }
+
+    BTBHistoryUpdate getHistoryUpdateDuringSquash(
+        Addr squash_pc, bool is_cond, bool actually_taken, Addr target) const
+    {
+        BTBHistoryUpdate update;
+        update.ghist = getHistUpdateDuringSquash(
+            squash_pc, is_cond, actually_taken);
+        update.bwhist = getBwHistUpdateDuringSquash(
+            squash_pc, is_cond, actually_taken, target);
+        update.phist = getPHistUpdateDuringSquash(
+            squash_pc, actually_taken, target);
         return update;
     }
 
@@ -720,6 +740,15 @@ struct FullBTBPrediction
             update.pc = entry.pc;
             update.target = getEntryTarget(entry);
         }
+        return update;
+    }
+
+    BTBHistoryUpdate getHistoryUpdate()
+    {
+        BTBHistoryUpdate update;
+        update.ghist = getHistUpdate();
+        update.bwhist = getBwHistUpdate();
+        update.phist = getPHistUpdate();
         return update;
     }
 

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -324,13 +324,6 @@ struct PathHistoryUpdate
     Addr target = 0;
 };
 
-struct BTBHistoryUpdate
-{
-    DirectionHistoryUpdate ghist;
-    DirectionHistoryUpdate bwhist;
-    PathHistoryUpdate phist;
-};
-
 /**
  * @brief Fetch Stream representing a sequence of instructions with prediction info
  *
@@ -483,19 +476,6 @@ struct FetchTarget
             update.pc = squash_pc;
             update.target = target;
         }
-        return update;
-    }
-
-    BTBHistoryUpdate getHistoryUpdateDuringSquash(
-        Addr squash_pc, bool is_cond, bool actually_taken, Addr target) const
-    {
-        BTBHistoryUpdate update;
-        update.ghist = getHistUpdateDuringSquash(
-            squash_pc, is_cond, actually_taken);
-        update.bwhist = getBwHistUpdateDuringSquash(
-            squash_pc, is_cond, actually_taken, target);
-        update.phist = getPHistUpdateDuringSquash(
-            squash_pc, actually_taken, target);
         return update;
     }
 
@@ -740,15 +720,6 @@ struct FullBTBPrediction
             update.pc = entry.pc;
             update.target = getEntryTarget(entry);
         }
-        return update;
-    }
-
-    BTBHistoryUpdate getHistoryUpdate()
-    {
-        BTBHistoryUpdate update;
-        update.ghist = getHistUpdate();
-        update.bwhist = getBwHistUpdate();
-        update.phist = getPHistUpdate();
         return update;
     }
 

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -308,6 +308,22 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
 #define FillStageLoop(x) for (int x = getDelay(); x < stagePreds.size(); ++x)
 
+struct DirectionHistoryReplay
+{
+    int shamt = 0;
+    bool taken = false;
+};
+
+struct PathHistoryReplay
+{
+    static constexpr int NumShift = 2;
+
+    int shamt = NumShift;
+    bool taken = false;
+    Addr pc = 0;
+    Addr target = 0;
+};
+
 /**
  * @brief Fetch Stream representing a sequence of instructions with prediction info
  *
@@ -419,42 +435,48 @@ struct FetchTarget
         return startPC;
     }
 
-    std::pair<int, bool> getHistInfoDuringSquash(Addr squash_pc, bool is_cond, bool actually_taken)
+    DirectionHistoryReplay getHistReplayDuringSquash(
+        Addr squash_pc, bool is_cond, bool actually_taken) const
     {
-        int shamt = 0;
-        bool cond_taken = false;
+        DirectionHistoryReplay replay;
         for (auto &entry : predBTBEntries) {
             if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
-                shamt++;
+                replay.shamt++;
             }
         }
         if (is_cond) {
-            shamt++;
-            cond_taken = actually_taken;
+            replay.shamt++;
+            replay.taken = actually_taken;
         }
-        return std::make_pair(shamt, cond_taken);
+        return replay;
     }
 
-    std::pair<int, bool> getBwHistInfoDuringSquash(Addr squash_pc, bool is_cond, bool actually_taken, Addr target)
+    DirectionHistoryReplay getBwHistReplayDuringSquash(
+        Addr squash_pc, bool is_cond, bool actually_taken, Addr target) const
     {
-        int shamt = 0;
-        bool cond_taken = false;
+        DirectionHistoryReplay replay;
         for (auto &entry : predBTBEntries) {
             if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
-                shamt++;
+                replay.shamt++;
             }
         }
         if (is_cond) {
-            shamt++;
-            cond_taken = actually_taken && (squash_pc > target);
+            replay.shamt++;
+            replay.taken = actually_taken && (squash_pc > target);
         }
-        return std::make_pair(shamt, cond_taken);
+        return replay;
     }
 
-    bool getPHistTakenDuringSquash(Addr squash_pc, bool actually_taken) const
+    PathHistoryReplay getPHistReplayDuringSquash(
+        Addr squash_pc, bool actually_taken, Addr target) const
     {
-        auto ctrl_pc = getControlPC();
-        return actually_taken && ctrl_pc == squash_pc;
+        PathHistoryReplay replay;
+        replay.taken = actually_taken && getControlPC() == squash_pc;
+        if (replay.taken) {
+            replay.pc = squash_pc;
+            replay.target = target;
+        }
+        return replay;
     }
 
     // should be called before components update
@@ -639,19 +661,18 @@ struct FullBTBPrediction
         }
     }
 
-    std::pair<int, bool> getHistInfo()  //global or local
+    DirectionHistoryReplay getHistReplay()  //global or local
     {
-        int shamt = 0; // shamt is the number of bits to shift in history update
-        bool taken = false;
+        DirectionHistoryReplay replay; // shamt is the number of bits to shift in history update
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) { // if found a cond branch, shamt++
-                    shamt++;
+                    replay.shamt++;
                     auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) { // if the cond branch is taken, taken = true
-                            taken = true;
+                            replay.taken = true;
                             break;
                         }
                     }
@@ -663,22 +684,21 @@ struct FullBTBPrediction
         }
         // For example, return (3, true) means 3 bits to shift in history update,
         // and the third branch is taken, new hist = xxx001
-        return std::make_pair(shamt, taken);
+        return replay;
     }
 
-    std::pair<int, bool> getBwHistInfo() //global backward or imli
+    DirectionHistoryReplay getBwHistReplay() //global backward or imli
     {
-        int shamt = 0;
-        bool taken = false;
+        DirectionHistoryReplay replay;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
                 if (entry.isCond) {
-                    shamt++;
+                    replay.shamt++;
                     auto& pc = entry.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
-                            taken = (entry.target < entry.pc); // branch is backward if target < pc
+                            replay.taken = (entry.target < entry.pc); // branch is backward if target < pc
                             break;
                         }
                     }
@@ -688,16 +708,19 @@ struct FullBTBPrediction
                 }
             }
         }
-        return std::make_pair(shamt, taken);
+        return replay;
     }
 
-    std::tuple<Addr, Addr, bool> getPHistInfo() //path
+    PathHistoryReplay getPHistReplay() //path
     {
+        PathHistoryReplay replay;
         const auto &entry = getTakenEntry();
         if (entry.valid) {
-            return std::make_tuple(entry.pc, getEntryTarget(entry), true);
+            replay.taken = true;
+            replay.pc = entry.pc;
+            replay.target = getEntryTarget(entry);
         }
-        return std::make_tuple(0, 0, false);
+        return replay;
     }
 
 };

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1057,37 +1057,33 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     }
 
     // Get prediction information for history updates
-    int shamt;
-    bool taken;
-    std::tie(shamt, taken) = finalPred.getHistInfo();
+    auto ghist = finalPred.getHistReplay();
 
     // Update global history
-    histShiftIn(shamt, taken, s0History);
+    histShiftIn(ghist.shamt, ghist.taken, s0History);
 
     // Update history manager and verify TAGE folded history
     historyManagers[tid].addSpeculativeHist(
-        entry.startPC, shamt, taken, entry.predBranchInfo, ftq.backId(tid) + 1);
+        entry.startPC, ghist.shamt, ghist.taken,
+        entry.predBranchInfo, ftq.backId(tid) + 1);
 
     // Get prediction information for global backward history updates
-    int bw_shamt;
-    bool bw_taken;
-    std::tie(bw_shamt, bw_taken) = finalPred.getBwHistInfo();
-
-    // Get prediction information for path history updates
-    auto [p_pc, p_target, p_taken]= finalPred.getPHistInfo(); // p_taken = taken
+    auto bwhist = finalPred.getBwHistReplay();
+    auto phist = finalPred.getPHistReplay();
 
     // Update global backward history
-    histShiftIn(bw_shamt, bw_taken, s0BwHistory);
+    histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
 
     // Update path history
-    pHistShiftIn(2, p_taken, s0PHistory, p_pc, p_target);
+    pHistShiftIn(phist.shamt, phist.taken, s0PHistory,
+                 phist.pc, phist.target);
 
     // Update local history
     const Addr localHistoryIndex =
         mgsc->getPcIndex(finalPred.bbStart,
                          log2(mgsc->getNumEntriesFirstLocalHistories()),
                          finalPred.asidHash);
-    histShiftIn(shamt, taken,
+    histShiftIn(ghist.shamt, ghist.taken,
         s0LHistory[localHistoryIndex]);
 
 #ifndef NDEBUG
@@ -1142,54 +1138,51 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0BwHistory = target.bwhistory;
     s0LHistory = target.lhistory;
 
-    // Get actual history shift information
-    int real_shamt;
-    bool real_taken;
-    std::tie(real_shamt, real_taken) = target.getHistInfoDuringSquash(
+    // Get actual history replay information.
+    auto ghist = target.getHistReplayDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken);
-
-    // Get actual history shift information
-    int real_bw_shamt;
-    bool real_bw_taken;
-    std::tie(real_bw_shamt, real_bw_taken) = target.getBwHistInfoDuringSquash(
-    squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
-    bool real_p_taken = target.getPHistTakenDuringSquash(
-        squash_pc.instAddr(), actually_taken);
+    auto bwhist = target.getBwHistReplayDuringSquash(
+        squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
+    auto phist = target.getPHistReplayDuringSquash(
+        squash_pc.instAddr(), actually_taken, redirect_pc);
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {
-        components[i]->recoverHist(s0History, target, real_shamt, real_taken);
-        components[i]->recoverPHist(s0PHistory, target, 2, real_p_taken);
+        components[i]->recoverHist(s0History, target, ghist.shamt, ghist.taken);
+        components[i]->recoverPHist(s0PHistory, target, phist);
         if (components[i]->needMoreHistories) {
-            components[i]->recoverBwHist(s0BwHistory, target, real_bw_shamt, real_bw_taken);
-            components[i]->recoverIHist(target, real_bw_shamt, real_bw_taken);
-            components[i]->recoverLHist(s0LHistory, target, real_shamt, real_taken);
+            components[i]->recoverBwHist(s0BwHistory, target,
+                                         bwhist.shamt, bwhist.taken);
+            components[i]->recoverIHist(target, bwhist.shamt, bwhist.taken);
+            components[i]->recoverLHist(s0LHistory, target,
+                                        ghist.shamt, ghist.taken);
         }
     }
 
     // Update global history with actual outcome
-    histShiftIn(real_shamt, real_taken, s0History);
+    histShiftIn(ghist.shamt, ghist.taken, s0History);
 
     // Update path history with actual outcome
-    pHistShiftIn(2, real_p_taken, s0PHistory, squash_pc.instAddr(), redirect_pc);
+    pHistShiftIn(phist.shamt, phist.taken, s0PHistory,
+                 phist.pc, phist.target);
 
     // Update global backward history with actual outcome
-    histShiftIn(real_bw_shamt, real_bw_taken, s0BwHistory);
+    histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
 
     // Update local history with actual outcome
     const Addr localHistoryIndex =
         mgsc->getPcIndex(target.startPC,
                          log2(mgsc->getNumEntriesFirstLocalHistories()),
                          target.asidHash);
-    histShiftIn(real_shamt, real_taken,
+    histShiftIn(ghist.shamt, ghist.taken,
                 s0LHistory[localHistoryIndex]);
 
     // Update history manager with appropriate branch info
     if (squash_type == SQUASH_CTRL) {
-        historyManagers[tid].squash(target_id, real_shamt, real_taken,
+        historyManagers[tid].squash(target_id, ghist.shamt, ghist.taken,
                                     target.exeBranchInfo);
     } else {
-        historyManagers[tid].squash(target_id, real_shamt, real_taken,
+        historyManagers[tid].squash(target_id, ghist.shamt, ghist.taken,
                                     BranchInfo());
     }
 

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1043,10 +1043,9 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     auto& s0LHistory = threads[tid].s0LHistory;
     auto& finalPred = threads[tid].finalPred;
 
-    const auto history_update = finalPred.getHistoryUpdate();
-    const auto &ghist = history_update.ghist;
-    const auto &bwhist = history_update.bwhist;
-    const auto &phist = history_update.phist;
+    const auto ghist = finalPred.getHistUpdate();
+    const auto bwhist = finalPred.getBwHistUpdate();
+    const auto phist = finalPred.getPHistUpdate();
 
     // Update component-specific history, for TAGE/ITTAGE/MGSC
     for (int i = 0; i < numComponents; i++) {
@@ -1136,11 +1135,12 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0LHistory = target.lhistory;
 
     // Get actual history update information.
-    const auto history_update = target.getHistoryUpdateDuringSquash(
+    const auto ghist = target.getHistUpdateDuringSquash(
+        squash_pc.instAddr(), is_conditional, actually_taken);
+    const auto bwhist = target.getBwHistUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
-    const auto &ghist = history_update.ghist;
-    const auto &bwhist = history_update.bwhist;
-    const auto &phist = history_update.phist;
+    const auto phist = target.getPHistUpdateDuringSquash(
+        squash_pc.instAddr(), actually_taken, redirect_pc);
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1057,7 +1057,7 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     }
 
     // Get prediction information for history updates
-    auto ghist = finalPred.getHistReplay();
+    auto ghist = finalPred.getHistUpdate();
 
     // Update global history
     histShiftIn(ghist.shamt, ghist.taken, s0History);
@@ -1068,8 +1068,8 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
         entry.predBranchInfo, ftq.backId(tid) + 1);
 
     // Get prediction information for global backward history updates
-    auto bwhist = finalPred.getBwHistReplay();
-    auto phist = finalPred.getPHistReplay();
+    auto bwhist = finalPred.getBwHistUpdate();
+    auto phist = finalPred.getPHistUpdate();
 
     // Update global backward history
     histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
@@ -1138,12 +1138,12 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0BwHistory = target.bwhistory;
     s0LHistory = target.lhistory;
 
-    // Get actual history replay information.
-    auto ghist = target.getHistReplayDuringSquash(
+    // Get actual history update information.
+    auto ghist = target.getHistUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken);
-    auto bwhist = target.getBwHistReplayDuringSquash(
+    auto bwhist = target.getBwHistUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
-    auto phist = target.getPHistReplayDuringSquash(
+    auto phist = target.getPHistUpdateDuringSquash(
         squash_pc.instAddr(), actually_taken, redirect_pc);
 
     // Recover component-specific history

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1043,43 +1043,48 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     auto& s0LHistory = threads[tid].s0LHistory;
     auto& finalPred = threads[tid].finalPred;
 
-    const auto ghist = finalPred.getHistUpdate();
-    const auto bwhist = finalPred.getBwHistUpdate();
-    const auto phist = finalPred.getPHistUpdate();
+    const auto ghist_update = finalPred.getGHistUpdate();
+    const auto bwhist_update = finalPred.getBwHistUpdate();
+    const auto phist_update = finalPred.getPHistUpdate();
 
-    // Update component-specific history, for TAGE/ITTAGE/MGSC
+    // RAS updates its speculative stack, not folded history.
+    if (ras->isEnabled()) {
+        ras->specUpdateState(finalPred);
+    }
+
+    // Update component-local folded histories.
     for (int i = 0; i < numComponents; i++) {
-        // use old s0History to update folded history, then use finalPred to update folded history
-        components[i]->specUpdateHist(s0History, finalPred, ghist);
-        components[i]->specUpdatePHist(s0PHistory, finalPred, phist);
-        if (components[i]->needMoreHistories) {
-            components[i]->specUpdateBwHist(s0BwHistory, finalPred, bwhist);
-            components[i]->specUpdateIHist(finalPred, bwhist);
-            components[i]->specUpdateLHist(s0LHistory, finalPred, ghist);
-        }
+        // use old histories to update predictor-local folded histories
+        components[i]->specUpdateGHist(s0History, finalPred, ghist_update);
+        components[i]->specUpdatePHist(s0PHistory, finalPred, phist_update);
+    }
+    if (mgsc->isEnabled()) {
+        mgsc->specUpdateBwHist(s0BwHistory, finalPred, bwhist_update);
+        mgsc->specUpdateIHist(finalPred, bwhist_update);
+        mgsc->specUpdateLHist(s0LHistory, finalPred, ghist_update);
     }
 
     // Update global history
-    histShiftIn(ghist.shamt, ghist.taken, s0History);
+    histShiftIn(ghist_update.shamt, ghist_update.taken, s0History);
 
     // Update history manager and verify TAGE folded history
     historyManagers[tid].addSpeculativeHist(
-        entry.startPC, ghist.shamt, ghist.taken,
+        entry.startPC, ghist_update.shamt, ghist_update.taken,
         entry.predBranchInfo, ftq.backId(tid) + 1);
 
     // Update global backward history
-    histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
+    histShiftIn(bwhist_update.shamt, bwhist_update.taken, s0BwHistory);
 
     // Update path history
-    pHistShiftIn(phist.shamt, phist.taken, s0PHistory,
-                 phist.pc, phist.target);
+    pHistShiftIn(phist_update.shamt, phist_update.taken, s0PHistory,
+                 phist_update.pc, phist_update.target);
 
     // Update local history
     const Addr localHistoryIndex =
         mgsc->getPcIndex(finalPred.bbStart,
                          log2(mgsc->getNumEntriesFirstLocalHistories()),
                          finalPred.asidHash);
-    histShiftIn(ghist.shamt, ghist.taken,
+    histShiftIn(ghist_update.shamt, ghist_update.taken,
         s0LHistory[localHistoryIndex]);
 
 #ifndef NDEBUG
@@ -1135,51 +1140,61 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0LHistory = target.lhistory;
 
     // Get actual history update information.
-    const auto ghist = target.getHistUpdateDuringSquash(
+    const auto ghist_update = target.getGHistUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken);
-    const auto bwhist = target.getBwHistUpdateDuringSquash(
+    const auto bwhist_update = target.getBwHistUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
-    const auto phist = target.getPHistUpdateDuringSquash(
+    const auto phist_update = target.getPHistUpdateDuringSquash(
         squash_pc.instAddr(), actually_taken, redirect_pc);
 
-    // Recover component-specific history
+    // RAS recovers its speculative stack, not folded history.
+    if (ras->isEnabled()) {
+        ras->recoverState(target);
+    }
+    if (abtb->isEnabled()) {
+        abtb->recoverState(target);
+    }
+
+    // Recover component-local folded histories.
     for (int i = 0; i < numComponents; ++i) {
-        components[i]->recoverHist(s0History, target, ghist.shamt, ghist.taken);
-        components[i]->recoverPHist(s0PHistory, target, phist);
-        if (components[i]->needMoreHistories) {
-            components[i]->recoverBwHist(s0BwHistory, target,
-                                         bwhist.shamt, bwhist.taken);
-            components[i]->recoverIHist(target, bwhist.shamt, bwhist.taken);
-            components[i]->recoverLHist(s0LHistory, target,
-                                        ghist.shamt, ghist.taken);
-        }
+        components[i]->recoverHist(s0History, target, ghist_update.shamt,
+                                   ghist_update.taken);
+        components[i]->recoverPHist(s0PHistory, target, phist_update);
+    }
+    if (mgsc->isEnabled()) {
+        mgsc->recoverBwHist(s0BwHistory, target, bwhist_update.shamt,
+                            bwhist_update.taken);
+        mgsc->recoverIHist(target, bwhist_update.shamt,
+                           bwhist_update.taken);
+        mgsc->recoverLHist(s0LHistory, target, ghist_update.shamt,
+                           ghist_update.taken);
     }
 
     // Update global history with actual outcome
-    histShiftIn(ghist.shamt, ghist.taken, s0History);
+    histShiftIn(ghist_update.shamt, ghist_update.taken, s0History);
 
     // Update path history with actual outcome
-    pHistShiftIn(phist.shamt, phist.taken, s0PHistory,
-                 phist.pc, phist.target);
+    pHistShiftIn(phist_update.shamt, phist_update.taken, s0PHistory,
+                 phist_update.pc, phist_update.target);
 
     // Update global backward history with actual outcome
-    histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
+    histShiftIn(bwhist_update.shamt, bwhist_update.taken, s0BwHistory);
 
     // Update local history with actual outcome
     const Addr localHistoryIndex =
         mgsc->getPcIndex(target.startPC,
                          log2(mgsc->getNumEntriesFirstLocalHistories()),
                          target.asidHash);
-    histShiftIn(ghist.shamt, ghist.taken,
+    histShiftIn(ghist_update.shamt, ghist_update.taken,
                 s0LHistory[localHistoryIndex]);
 
     // Update history manager with appropriate branch info
     if (squash_type == SQUASH_CTRL) {
-        historyManagers[tid].squash(target_id, ghist.shamt, ghist.taken,
-                                    target.exeBranchInfo);
+        historyManagers[tid].squash(target_id, ghist_update.shamt,
+                                    ghist_update.taken, target.exeBranchInfo);
     } else {
-        historyManagers[tid].squash(target_id, ghist.shamt, ghist.taken,
-                                    BranchInfo());
+        historyManagers[tid].squash(target_id, ghist_update.shamt,
+                                    ghist_update.taken, BranchInfo());
     }
 
     // Perform history consistency checks when not a fast build variant

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -1043,21 +1043,22 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     auto& s0LHistory = threads[tid].s0LHistory;
     auto& finalPred = threads[tid].finalPred;
 
+    const auto history_update = finalPred.getHistoryUpdate();
+    const auto &ghist = history_update.ghist;
+    const auto &bwhist = history_update.bwhist;
+    const auto &phist = history_update.phist;
 
     // Update component-specific history, for TAGE/ITTAGE/MGSC
     for (int i = 0; i < numComponents; i++) {
         // use old s0History to update folded history, then use finalPred to update folded history
-        components[i]->specUpdateHist(s0History, finalPred);
-        components[i]->specUpdatePHist(s0PHistory, finalPred);
+        components[i]->specUpdateHist(s0History, finalPred, ghist);
+        components[i]->specUpdatePHist(s0PHistory, finalPred, phist);
         if (components[i]->needMoreHistories) {
-            components[i]->specUpdateBwHist(s0BwHistory, finalPred);
-            components[i]->specUpdateIHist(finalPred);
-            components[i]->specUpdateLHist(s0LHistory, finalPred);
+            components[i]->specUpdateBwHist(s0BwHistory, finalPred, bwhist);
+            components[i]->specUpdateIHist(finalPred, bwhist);
+            components[i]->specUpdateLHist(s0LHistory, finalPred, ghist);
         }
     }
-
-    // Get prediction information for history updates
-    auto ghist = finalPred.getHistUpdate();
 
     // Update global history
     histShiftIn(ghist.shamt, ghist.taken, s0History);
@@ -1066,10 +1067,6 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     historyManagers[tid].addSpeculativeHist(
         entry.startPC, ghist.shamt, ghist.taken,
         entry.predBranchInfo, ftq.backId(tid) + 1);
-
-    // Get prediction information for global backward history updates
-    auto bwhist = finalPred.getBwHistUpdate();
-    auto phist = finalPred.getPHistUpdate();
 
     // Update global backward history
     histShiftIn(bwhist.shamt, bwhist.taken, s0BwHistory);
@@ -1139,12 +1136,11 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     s0LHistory = target.lhistory;
 
     // Get actual history update information.
-    auto ghist = target.getHistUpdateDuringSquash(
-        squash_pc.instAddr(), is_conditional, actually_taken);
-    auto bwhist = target.getBwHistUpdateDuringSquash(
+    const auto history_update = target.getHistoryUpdateDuringSquash(
         squash_pc.instAddr(), is_conditional, actually_taken, redirect_pc);
-    auto phist = target.getPHistUpdateDuringSquash(
-        squash_pc.instAddr(), actually_taken, redirect_pc);
+    const auto &ghist = history_update.ghist;
+    const auto &bwhist = history_update.bwhist;
+    const auto &phist = history_update.phist;
 
     // Recover component-specific history
     for (int i = 0; i < numComponents; ++i) {

--- a/src/cpu/pred/btb/docs/RAS.md
+++ b/src/cpu/pred/btb/docs/RAS.md
@@ -93,10 +93,10 @@ void putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
 - Fills prediction stages with current top-of-stack address
 - Prepares for potential speculative updates
 
-### 2. Speculative Update (`specUpdateHist`)
+### 2. Speculative Update (`specUpdateState`)
 
 ```cpp
-void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
+void specUpdateState(FullBTBPrediction &pred)
 ```
 
 - **For Call Instructions**: Executes `push(retAddr)`
@@ -108,11 +108,10 @@ void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &p
   - Removes top entry from inflight queue or committed stack
   - Updates pointers and counters accordingly
 
-### 3. Recovery Phase (`recoverHist`)
+### 3. Recovery Phase (`recoverState`)
 
 ```cpp
-void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, 
-                 int shamt, bool cond_taken)
+void recoverState(const FetchTarget &entry)
 ```
 
 - Restores RAS state to a previous checkpoint using stored metadata

--- a/src/cpu/pred/btb/docs/btb_tage.md
+++ b/src/cpu/pred/btb/docs/btb_tage.md
@@ -188,7 +188,7 @@ The predictor maintains three types of folded histories:
 These histories are updated speculatively and recovered on mispredictions.
 
 ```cpp
-void specUpdateHist(const boost::dynamic_bitset<> &history,
+void specUpdateGHist(const boost::dynamic_bitset<> &history,
                     FullBTBPrediction &pred,
                     const DirectionHistoryUpdate &update) {
     doUpdateHist(history, update.shamt, update.taken);
@@ -231,8 +231,8 @@ The key interactions include:
 The BTBTAGE predictor integrates with the fetch stream mechanism through:
 
 1. `putPCHistory`: Makes predictions for a stream of instructions
-2. `specUpdateHist`: Speculatively updates history based on predictions
-3. `recoverHist`: Recovers history state after mispredictions
+2. `specUpdateGHist`: Speculatively updates folded history based on explicit history updates
+3. `recoverHist`: Recovers folded history state after mispredictions
 4. `update`: Updates predictor state based on actual branch outcomes
 
 The fetch stream mechanism provides a unified interface for all branch predictors and manages the flow of predictions and updates.
@@ -304,7 +304,8 @@ tage->putPCHistory(startPC, history, stagePreds);
 auto meta = tage->getPredictionMeta();
 
 // Speculatively update history (folded histories)
-tage->specUpdateHist(history, stagePreds[1]);  // Use final prediction to update
+auto hist_update = stagePreds[1].getGHistUpdate();
+tage->specUpdateGHist(history, stagePreds[1], hist_update);
 
 // Shift actual history register
 history <<= shamt;  // Shift by amount corresponding to instructions

--- a/src/cpu/pred/btb/docs/btb_tage.md
+++ b/src/cpu/pred/btb/docs/btb_tage.md
@@ -188,8 +188,9 @@ The predictor maintains three types of folded histories:
 These histories are updated speculatively and recovered on mispredictions.
 
 ```cpp
-void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {
-    const auto update = pred.getHistUpdate();
+void specUpdateHist(const boost::dynamic_bitset<> &history,
+                    FullBTBPrediction &pred,
+                    const DirectionHistoryUpdate &update) {
     doUpdateHist(history, update.shamt, update.taken);
 }
 

--- a/src/cpu/pred/btb/docs/btb_tage.md
+++ b/src/cpu/pred/btb/docs/btb_tage.md
@@ -189,10 +189,8 @@ These histories are updated speculatively and recovered on mispredictions.
 
 ```cpp
 void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {
-    int shamt;
-    bool cond_taken;
-    std::tie(shamt, cond_taken) = pred.getHistInfo();
-    doUpdateHist(history, shamt, cond_taken);
+    const auto replay = pred.getHistReplay();
+    doUpdateHist(history, replay.shamt, replay.taken);
 }
 
 void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {

--- a/src/cpu/pred/btb/docs/btb_tage.md
+++ b/src/cpu/pred/btb/docs/btb_tage.md
@@ -189,8 +189,8 @@ These histories are updated speculatively and recovered on mispredictions.
 
 ```cpp
 void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {
-    const auto replay = pred.getHistReplay();
-    doUpdateHist(history, replay.shamt, replay.taken);
+    const auto update = pred.getHistUpdate();
+    doUpdateHist(history, update.shamt, update.taken);
 }
 
 void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -320,16 +320,6 @@ MBTB::getPredictionMeta(ThreadID tid)
     return meta;
 }
 
-void
-MBTB::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
-
-void
-MBTB::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
-{
-    // MBTB doesn't support ahead-pipelined stages, nothing to recover
-}
-
-
 /**
  * Helper function to lookup entries in a single block
  * @param block_pc The aligned PC to lookup

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -149,12 +149,6 @@ class MBTB : public TimedBaseBTBPredictor
      */
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    // not used
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
-
-    void recoverHist(const boost::dynamic_bitset<> &history,
-        const FetchTarget &entry, int shamt, bool cond_taken) override;
-
     /**
      * @brief derive new btb entry from old ones and set updateNewBTBEntry field in stream
      *        only in L1BTB will this function be called before update

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -972,8 +972,8 @@ MicroTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken,
 void
 MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    auto [pc, target, taken] = pred.getPHistInfo();
-    doUpdateHist(history, taken, pc, target, pred.tid);
+    const auto replay = pred.getPHistReplay();
+    doUpdateHist(history, replay.taken, replay.pc, replay.target, pred.tid);
 }
 
 /**
@@ -991,7 +991,7 @@ MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredic
  */
 void
 MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchTarget &entry, int shamt, bool cond_taken)
+    const FetchTarget &entry, const PathHistoryReplay &replay)
 {
     auto &state = historyState(entry.tid);
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
@@ -1019,8 +1019,8 @@ MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
              !state.aheadIndexFoldedHist.empty());
         if (queue_valid_mismatch) {
             DPRINTF(TAGEHistory,
-                    "recoverPHist: ahead queue valid mismatch after restore, cond_taken %d\n",
-                    cond_taken);
+                    "recoverPHist: ahead queue valid mismatch after restore, path_taken %d\n",
+                    replay.taken);
         }
     }
 
@@ -1028,8 +1028,7 @@ MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
         state.altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
         state.tagFoldedHist[i].recover(predMeta->tagFoldedHist[i]);
     }
-    doUpdateHist(history, cond_taken, entry.getControlPC(),
-                 entry.getTakenTarget(), entry.tid);
+    doUpdateHist(history, replay.taken, replay.pc, replay.target, entry.tid);
 }
 
 // Check folded history after speculative update and recovery

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -972,7 +972,14 @@ MicroTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken,
 void
 MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    const auto update = pred.getPHistUpdate();
+    specUpdatePHist(history, pred, pred.getPHistUpdate());
+}
+
+void
+MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history,
+                           FullBTBPrediction &pred,
+                           const PathHistoryUpdate &update)
+{
     doUpdateHist(history, update.taken, update.pc, update.target, pred.tid);
 }
 

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -958,23 +958,8 @@ MicroTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken,
 }
 
 /**
- * @brief Updates branch history for speculative execution
- *
- * This function updates the branch history for speculative execution
- * based on the provided history and prediction information.
- *
- * It first retrieves the history information from the prediction metadata
- * and then calls the doUpdateHist function to update the folded histories.
- *
- * @param history The current branch history
- * @param pred The prediction metadata containing history information
+ * @brief Speculatively updates path folded histories.
  */
-void
-MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
-{
-    specUpdatePHist(history, pred, pred.getPHistUpdate());
-}
-
 void
 MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history,
                            FullBTBPrediction &pred,

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -972,8 +972,8 @@ MicroTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken,
 void
 MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
 {
-    const auto replay = pred.getPHistReplay();
-    doUpdateHist(history, replay.taken, replay.pc, replay.target, pred.tid);
+    const auto update = pred.getPHistUpdate();
+    doUpdateHist(history, update.taken, update.pc, update.target, pred.tid);
 }
 
 /**
@@ -991,7 +991,7 @@ MicroTAGE::specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPredic
  */
 void
 MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
-    const FetchTarget &entry, const PathHistoryReplay &replay)
+    const FetchTarget &entry, const PathHistoryUpdate &update)
 {
     auto &state = historyState(entry.tid);
     std::shared_ptr<TageMeta> predMeta = std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
@@ -1020,7 +1020,7 @@ MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
         if (queue_valid_mismatch) {
             DPRINTF(TAGEHistory,
                     "recoverPHist: ahead queue valid mismatch after restore, path_taken %d\n",
-                    replay.taken);
+                    update.taken);
         }
     }
 
@@ -1028,7 +1028,7 @@ MicroTAGE::recoverPHist(const boost::dynamic_bitset<> &history,
         state.altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
         state.tagFoldedHist[i].recover(predMeta->tagFoldedHist[i]);
     }
-    doUpdateHist(history, replay.taken, replay.pc, replay.target, entry.tid);
+    doUpdateHist(history, update.taken, update.pc, update.target, entry.tid);
 }
 
 // Check folded history after speculative update and recovery

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -133,7 +133,8 @@ class MicroTAGE : public TimedBaseBTBPredictor
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank
     void recoverPHist(const boost::dynamic_bitset<> &history,
-                        const FetchTarget &entry,int shamt, bool cond_taken) override;
+                      const FetchTarget &entry,
+                      const PathHistoryReplay &replay) override;
 
 #ifdef UNIT_TEST
     // API compatibility wrappers for testing

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -134,7 +134,7 @@ class MicroTAGE : public TimedBaseBTBPredictor
     // the other recoverHist methods are left blank
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
-                      const PathHistoryReplay &replay) override;
+                      const PathHistoryUpdate &update) override;
 
 #ifdef UNIT_TEST
     // API compatibility wrappers for testing

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -126,30 +126,15 @@ class MicroTAGE : public TimedBaseBTBPredictor
 
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-    // speculative update 3 folded history, according history and pred.taken
-    // the other specUpdateHist methods are left blank
-    void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    // Speculatively update path folded histories.
     void specUpdatePHist(const boost::dynamic_bitset<> &history,
                          FullBTBPrediction &pred,
                          const PathHistoryUpdate &update) override;
 
-    // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
-    // the other recoverHist methods are left blank
+    // Recover path folded histories after a misprediction.
     void recoverPHist(const boost::dynamic_bitset<> &history,
                       const FetchTarget &entry,
                       const PathHistoryUpdate &update) override;
-
-#ifdef UNIT_TEST
-    // API compatibility wrappers for testing
-    void specUpdateHist(const boost::dynamic_bitset<> &, FullBTBPrediction &) override
-    {
-    }
-
-    void recoverHist(const boost::dynamic_bitset<> &, const FetchTarget &, int,
-                     bool) override
-    {
-    }
-#endif
 
     // Update predictor state based on actual branch outcomes
     void update(const FetchTarget &entry) override;

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -129,6 +129,9 @@ class MicroTAGE : public TimedBaseBTBPredictor
     // speculative update 3 folded history, according history and pred.taken
     // the other specUpdateHist methods are left blank
     void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+    void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                         FullBTBPrediction &pred,
+                         const PathHistoryUpdate &update) override;
 
     // Recover 3 folded history after a misprediction, then update 3 folded history according to history and pred.taken
     // the other recoverHist methods are left blank

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -126,7 +126,7 @@ BTBRAS::getPredictionMeta(ThreadID tid)
 }
 
 void
-BTBRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
+BTBRAS::specUpdateState(FullBTBPrediction &pred)
 {
     const ThreadID tid = pred.tid;
     assert(tid < numThreads);
@@ -153,12 +153,12 @@ BTBRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction
     }
     
     if (takenEntry.isCall || takenEntry.isReturn)
-        printStack("after specUpdateHist", tid);
+        printStack("after specUpdateState", tid);
     DPRINTFR(RAS, "meta TOSR %d TOSW %d\n", state.meta->TOSR, state.meta->TOSW);
 }
 
 void
-BTBRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+BTBRAS::recoverState(const FetchTarget &entry)
 {
     const ThreadID tid = entry.tid;
     assert(tid < numThreads);
@@ -166,7 +166,7 @@ BTBRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &e
     auto takenEntry = entry.exeBranchInfo;
     /*
     if (takenEntry.isCall || takenEntry.isReturn) {
-        printStack("before recoverHist", tid);
+        printStack("before recoverState", tid);
     }*/
     // recover sp and tos first
     auto meta_ptr = std::static_pointer_cast<RASMeta>(entry.predMetas[getComponentIdx()]);
@@ -197,9 +197,9 @@ BTBRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &e
             DPRINTF(RAS, "IsRet expect target %lx, preded %lx, pred taken %d pred target %lx\n",
                 takenEntry.target, meta_ptr->target, entry.predTaken, entry.predBranchInfo.target);
         }
-        printStack("after recoverHist", tid);
+        printStack("after recoverState", tid);
     }
-    
+
 }
 
 void

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -96,9 +96,9 @@ namespace btb_pred {
         
         std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-        void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+        void specUpdateState(FullBTBPrediction &pred);
 
-        void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) override;
+        void recoverState(const FetchTarget &entry);
 
         void update(const FetchTarget &entry) override;
 

--- a/src/cpu/pred/btb/test/README.md
+++ b/src/cpu/pred/btb/test/README.md
@@ -73,8 +73,8 @@ boost::dynamic_bitset<> history(64, 0);
 // Make prediction to generate meta data
 tage->putPCHistory(startPC, history, stagePreds);
 
-// update (folded) histories for tage
-tage->specUpdateHist(s0History, finalPred);
+// update folded histories for tage
+tage->specUpdateGHist(s0History, finalPred, finalPred.getGHistUpdate());
 tage->getPredictionMeta();
 
 // shift history

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -58,8 +58,7 @@ FullBTBPrediction makePrediction(Addr startPC, AheadBTB *abtb,
 void clearAheadPipeline(AheadBTB *abtb, ThreadID tid) {
     FetchTarget stream;
     stream.tid = tid;
-    boost::dynamic_bitset<> history(8, 0);
-    abtb->recoverHist(history, stream, 0, false);
+    abtb->recoverState(stream);
 }
 
 void updateBTB(FetchTarget &stream, AheadBTB *abtb, MBTB *mbtb) {

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -258,12 +258,12 @@ struct MgscHarness
             }
         }
 
-        const auto ghist = stage_preds[1].getHistUpdate();
+        const auto ghist = stage_preds[1].getGHistUpdate();
         const auto bwhist = stage_preds[1].getBwHistUpdate();
         const auto phist = stage_preds[1].getPHistUpdate();
 
         // Speculative folded-history update (use pre-update histories, like DecoupledBPUWithBTB does).
-        mgsc.specUpdateHist(ghr_before, stage_preds[1], ghist);
+        mgsc.specUpdateGHist(ghr_before, stage_preds[1], ghist);
         mgsc.specUpdatePHist(phr_before, stage_preds[1], phist);
         mgsc.specUpdateBwHist(bwhr_before, stage_preds[1], bwhist);
         mgsc.specUpdateIHist(stage_preds[1], bwhist);
@@ -867,7 +867,7 @@ TEST(BTBMGSCTest, SpecUpdatePHistUsesIndirectTargetOverride)
     boost::dynamic_bitset<> expected_phr = h.phr;
     pHistShiftIn(2, true, expected_phr, entry.pc, indirectTarget);
 
-    h.mgsc.specUpdatePHist(h.phr, pred);
+    h.mgsc.specUpdatePHist(h.phr, pred, pred.getPHistUpdate());
     h.mgsc.checkFoldedHist(h.ghr, expected_phr, h.lhr,
                            "indirect target override");
 }
@@ -892,7 +892,7 @@ TEST(BTBMGSCTest, SpecUpdatePHistUsesReturnTargetOverride)
     boost::dynamic_bitset<> expected_phr = h.phr;
     pHistShiftIn(2, true, expected_phr, entry.pc, returnTarget);
 
-    h.mgsc.specUpdatePHist(h.phr, pred);
+    h.mgsc.specUpdatePHist(h.phr, pred, pred.getPHistUpdate());
     h.mgsc.checkFoldedHist(h.ghr, expected_phr, h.lhr,
                            "return target override");
 }

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -266,22 +266,18 @@ struct MgscHarness
         mgsc.specUpdateLHist(lhr_before, stage_preds[1]);
 
         // Speculative external history update using predicted outcome.
-        int shamt;
-        bool cond_taken;
-        std::tie(shamt, cond_taken) = stage_preds[1].getHistInfo();
-        histShiftIn(shamt, cond_taken, ghr);
+        const auto ghist = stage_preds[1].getHistReplay();
+        histShiftIn(ghist.shamt, ghist.taken, ghr);
 
-        int bw_shamt;
-        bool bw_taken;
-        std::tie(bw_shamt, bw_taken) = stage_preds[1].getBwHistInfo();
-        histShiftIn(bw_shamt, bw_taken, bwhr);
+        const auto bwhist = stage_preds[1].getBwHistReplay();
+        histShiftIn(bwhist.shamt, bwhist.taken, bwhr);
 
-        auto [p_pc, p_target, p_taken] = stage_preds[1].getPHistInfo();
-        pHistShiftIn(2, p_taken, phr, p_pc, p_target);
+        const auto phist = stage_preds[1].getPHistReplay();
+        pHistShiftIn(phist.shamt, phist.taken, phr, phist.pc, phist.target);
 
         unsigned lhr_idx =
             mgsc.getPcIndex(stage_preds[1].bbStart, log2(mgsc.getNumEntriesFirstLocalHistories()));
-        histShiftIn(shamt, cond_taken, lhr[lhr_idx]);
+        histShiftIn(ghist.shamt, ghist.taken, lhr[lhr_idx]);
 
         // std::string buf;
         // boost::to_string(lhr[lhr_idx], buf);
@@ -301,21 +297,25 @@ struct MgscHarness
             recover_stream.resolved = true;
             recover_stream.exeBranchInfo = entry;
             recover_stream.exeTaken = actual_taken;
+            recover_stream.squashPC = entry.pc;
 
-            mgsc.recoverHist(ghr, recover_stream, shamt, actual_taken);
-            bool actual_p_taken = actual_taken;
-            mgsc.recoverPHist(phr, recover_stream, 2, actual_p_taken);
+            mgsc.recoverHist(ghr, recover_stream, ghist.shamt, actual_taken);
+            const auto actual_phist = recover_stream.getPHistReplayDuringSquash(
+                entry.pc, actual_taken, entry.target);
+            mgsc.recoverPHist(phr, recover_stream, actual_phist);
 
             bool actual_bw_taken = actual_taken && (entry.target < entry.pc);
-            mgsc.recoverBwHist(bwhr, recover_stream, bw_shamt, actual_bw_taken);
-            mgsc.recoverIHist(recover_stream, bw_shamt, actual_bw_taken);
-            mgsc.recoverLHist(lhr, recover_stream, shamt, actual_taken);
+            mgsc.recoverBwHist(bwhr, recover_stream,
+                               bwhist.shamt, actual_bw_taken);
+            mgsc.recoverIHist(recover_stream, bwhist.shamt, actual_bw_taken);
+            mgsc.recoverLHist(lhr, recover_stream, ghist.shamt, actual_taken);
 
             // Apply correct external history update.
-            histShiftIn(shamt, actual_taken, ghr);
-            histShiftIn(bw_shamt, actual_bw_taken, bwhr);
-            pHistShiftIn(2, actual_taken, phr, entry.pc, entry.target);
-            histShiftIn(shamt, actual_taken, lhr[lhr_idx]);
+            histShiftIn(ghist.shamt, actual_taken, ghr);
+            histShiftIn(bwhist.shamt, actual_bw_taken, bwhr);
+            pHistShiftIn(actual_phist.shamt, actual_phist.taken, phr,
+                         actual_phist.pc, actual_phist.target);
+            histShiftIn(ghist.shamt, actual_taken, lhr[lhr_idx]);
         }
 
         // Training update using prediction meta

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -258,21 +258,23 @@ struct MgscHarness
             }
         }
 
+        const auto history_update = stage_preds[1].getHistoryUpdate();
+        const auto &ghist = history_update.ghist;
+        const auto &bwhist = history_update.bwhist;
+        const auto &phist = history_update.phist;
+
         // Speculative folded-history update (use pre-update histories, like DecoupledBPUWithBTB does).
-        mgsc.specUpdateHist(ghr_before, stage_preds[1]);
-        mgsc.specUpdatePHist(phr_before, stage_preds[1]);
-        mgsc.specUpdateBwHist(bwhr_before, stage_preds[1]);
-        mgsc.specUpdateIHist(stage_preds[1]);
-        mgsc.specUpdateLHist(lhr_before, stage_preds[1]);
+        mgsc.specUpdateHist(ghr_before, stage_preds[1], ghist);
+        mgsc.specUpdatePHist(phr_before, stage_preds[1], phist);
+        mgsc.specUpdateBwHist(bwhr_before, stage_preds[1], bwhist);
+        mgsc.specUpdateIHist(stage_preds[1], bwhist);
+        mgsc.specUpdateLHist(lhr_before, stage_preds[1], ghist);
 
         // Speculative external history update using predicted outcome.
-        const auto ghist = stage_preds[1].getHistUpdate();
         histShiftIn(ghist.shamt, ghist.taken, ghr);
 
-        const auto bwhist = stage_preds[1].getBwHistUpdate();
         histShiftIn(bwhist.shamt, bwhist.taken, bwhr);
 
-        const auto phist = stage_preds[1].getPHistUpdate();
         pHistShiftIn(phist.shamt, phist.taken, phr, phist.pc, phist.target);
 
         unsigned lhr_idx =

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -266,13 +266,13 @@ struct MgscHarness
         mgsc.specUpdateLHist(lhr_before, stage_preds[1]);
 
         // Speculative external history update using predicted outcome.
-        const auto ghist = stage_preds[1].getHistReplay();
+        const auto ghist = stage_preds[1].getHistUpdate();
         histShiftIn(ghist.shamt, ghist.taken, ghr);
 
-        const auto bwhist = stage_preds[1].getBwHistReplay();
+        const auto bwhist = stage_preds[1].getBwHistUpdate();
         histShiftIn(bwhist.shamt, bwhist.taken, bwhr);
 
-        const auto phist = stage_preds[1].getPHistReplay();
+        const auto phist = stage_preds[1].getPHistUpdate();
         pHistShiftIn(phist.shamt, phist.taken, phr, phist.pc, phist.target);
 
         unsigned lhr_idx =
@@ -300,7 +300,7 @@ struct MgscHarness
             recover_stream.squashPC = entry.pc;
 
             mgsc.recoverHist(ghr, recover_stream, ghist.shamt, actual_taken);
-            const auto actual_phist = recover_stream.getPHistReplayDuringSquash(
+            const auto actual_phist = recover_stream.getPHistUpdateDuringSquash(
                 entry.pc, actual_taken, entry.target);
             mgsc.recoverPHist(phr, recover_stream, actual_phist);
 

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -258,10 +258,9 @@ struct MgscHarness
             }
         }
 
-        const auto history_update = stage_preds[1].getHistoryUpdate();
-        const auto &ghist = history_update.ghist;
-        const auto &bwhist = history_update.bwhist;
-        const auto &phist = history_update.phist;
+        const auto ghist = stage_preds[1].getHistUpdate();
+        const auto bwhist = stage_preds[1].getBwHistUpdate();
+        const auto phist = stage_preds[1].getPHistUpdate();
 
         // Speculative folded-history update (use pre-update histories, like DecoupledBPUWithBTB does).
         mgsc.specUpdateHist(ghr_before, stage_preds[1], ghist);

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -115,10 +115,10 @@ void recoverSelectedHistory(BTBTAGE* tage,
                             const boost::dynamic_bitset<>& history,
                             const FetchTarget& stream, int shamt,
                             bool cond_taken,
-                            const PathHistoryReplay& path_replay)
+                            const PathHistoryUpdate& path_update)
 {
     if (tage->usesPathHistory()) {
-        tage->recoverPHist(history, stream, path_replay);
+        tage->recoverPHist(history, stream, path_update);
     } else {
         tage->recoverHist(history, stream, shamt, cond_taken);
     }
@@ -128,13 +128,13 @@ void applyPredictedHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
                            FullBTBPrediction& pred)
 {
     if (tage->usesPathHistory()) {
-        const auto replay = pred.getPHistReplay();
-        if (replay.taken) {
-            applyPathHistoryTaken(history, replay.pc, replay.target);
+        const auto update = pred.getPHistUpdate();
+        if (update.taken) {
+            applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto replay = pred.getHistReplay();
-        applyOutcomeHistory(history, replay.shamt, replay.taken);
+        const auto update = pred.getHistUpdate();
+        applyOutcomeHistory(history, update.shamt, update.taken);
     }
 }
 
@@ -150,13 +150,13 @@ void applyActualHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
     }
 }
 
-PathHistoryReplay getActualPathReplay(const FetchTarget& stream)
+PathHistoryUpdate getActualPathUpdate(const FetchTarget& stream)
 {
-    return stream.getPHistReplayDuringSquash(
+    return stream.getPHistUpdateDuringSquash(
         stream.squashPC, stream.exeTaken, stream.exeBranchInfo.target);
 }
 
-TEST(FetchTargetHistoryReplayTest, SquashReplaySeparatesDirectionAndPath)
+TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
 {
     struct Case
     {
@@ -242,7 +242,7 @@ TEST(FetchTargetHistoryReplayTest, SquashReplaySeparatesDirectionAndPath)
             0x2040,
         },
         {
-            "path replay requires resolved control pc",
+            "path update requires resolved control pc",
             {},
             createBTBEntry(0x1010, false, true, true, -1, 0x3000),
             0x1008,
@@ -289,11 +289,11 @@ TEST(FetchTargetHistoryReplayTest, SquashReplaySeparatesDirectionAndPath)
         stream.resolved = true;
         stream.squashPC = c.squashPC;
 
-        const auto ghist = stream.getHistReplayDuringSquash(
+        const auto ghist = stream.getHistUpdateDuringSquash(
             c.squashPC, c.isCond, c.actualTaken);
-        const auto bwhist = stream.getBwHistReplayDuringSquash(
+        const auto bwhist = stream.getBwHistUpdateDuringSquash(
             c.squashPC, c.isCond, c.actualTaken, c.redirectPC);
-        const auto phist = stream.getPHistReplayDuringSquash(
+        const auto phist = stream.getPHistUpdateDuringSquash(
             c.squashPC, c.actualTaken, c.redirectPC);
 
         EXPECT_EQ(ghist.shamt, c.expectedGHistShamt);
@@ -388,15 +388,15 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
     bool history_updated = false;
     boost::dynamic_bitset<> pre_spec_history = history;
     if (tage->usesPathHistory()) {
-        const auto replay = stagePreds[1].getPHistReplay();
-        history_updated = replay.taken;
-        if (replay.taken) {
-            applyPathHistoryTaken(history, replay.pc, replay.target);
+        const auto update = stagePreds[1].getPHistUpdate();
+        history_updated = update.taken;
+        if (update.taken) {
+            applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto replay = stagePreds[1].getHistReplay();
-        history_updated = replay.shamt > 0;
-        applyOutcomeHistory(history, replay.shamt, replay.taken);
+        const auto update = stagePreds[1].getHistUpdate();
+        history_updated = update.shamt > 0;
+        applyOutcomeHistory(history, update.shamt, update.taken);
     }
     tage->checkFoldedHist(history, "speculative update");
 
@@ -411,9 +411,9 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
             history = pre_spec_history;
         }
         // Recover from misprediction
-        const auto path_replay = getActualPathReplay(stream);
+        const auto path_update = getActualPathUpdate(stream);
         recoverSelectedHistory(tage, history, stream, 1, actual_taken,
-                               path_replay);
+                               path_update);
         applyActualHistory(tage, history, stream.exeBranchInfo, 1, actual_taken);
         tage->checkFoldedHist(history, "recover");
     }
@@ -769,9 +769,9 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
 
     // Recover to pre-speculative state and update with correct outcome
     boost::dynamic_bitset<> recoveryHistory = originalHistory;
-    const auto path_replay = getActualPathReplay(stream);
+    const auto path_update = getActualPathUpdate(stream);
     recoverSelectedHistory(tage, recoveryHistory, stream, 1, !predicted_taken,
-                           path_replay);
+                           path_update);
 
     // Expected history should be original updated with the actual outcome.
     boost::dynamic_bitset<> expectedHistory = originalHistory;
@@ -1488,8 +1488,8 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
     FetchTarget stream = createStream(0x1000, entry, true, meta);
     stream = setMispredStream(stream);
 
-    const auto ghist = stream.getHistReplayDuringSquash(entry.pc, false, true);
-    const auto phist = stream.getPHistReplayDuringSquash(
+    const auto ghist = stream.getHistUpdateDuringSquash(entry.pc, false, true);
+    const auto phist = stream.getPHistUpdateDuringSquash(
         entry.pc, true, entry.target);
     EXPECT_EQ(ghist.shamt, 0);
     EXPECT_FALSE(ghist.taken);

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <vector>
 
 #include "base/types.hh"
 #include "cpu/pred/btb/btb_tage.hh"
@@ -113,12 +114,13 @@ void specUpdateSelectedHistory(BTBTAGE* tage,
 void recoverSelectedHistory(BTBTAGE* tage,
                             const boost::dynamic_bitset<>& history,
                             const FetchTarget& stream, int shamt,
-                            bool path_taken)
+                            bool cond_taken,
+                            const PathHistoryReplay& path_replay)
 {
     if (tage->usesPathHistory()) {
-        tage->recoverPHist(history, stream, shamt, path_taken);
+        tage->recoverPHist(history, stream, path_replay);
     } else {
-        tage->recoverHist(history, stream, shamt, path_taken);
+        tage->recoverHist(history, stream, shamt, cond_taken);
     }
 }
 
@@ -126,13 +128,13 @@ void applyPredictedHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
                            FullBTBPrediction& pred)
 {
     if (tage->usesPathHistory()) {
-        auto [pred_pc, pred_target, pred_taken] = pred.getPHistInfo();
-        if (pred_taken) {
-            applyPathHistoryTaken(history, pred_pc, pred_target);
+        const auto replay = pred.getPHistReplay();
+        if (replay.taken) {
+            applyPathHistoryTaken(history, replay.pc, replay.target);
         }
     } else {
-        auto [shamt, taken] = pred.getHistInfo();
-        applyOutcomeHistory(history, shamt, taken);
+        const auto replay = pred.getHistReplay();
+        applyOutcomeHistory(history, replay.shamt, replay.taken);
     }
 }
 
@@ -148,9 +150,162 @@ void applyActualHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
     }
 }
 
-bool getActualPathTaken(const FetchTarget& stream)
+PathHistoryReplay getActualPathReplay(const FetchTarget& stream)
 {
-    return stream.exeTaken && stream.exeBranchInfo.pc == stream.squashPC;
+    return stream.getPHistReplayDuringSquash(
+        stream.squashPC, stream.exeTaken, stream.exeBranchInfo.target);
+}
+
+TEST(FetchTargetHistoryReplayTest, SquashReplaySeparatesDirectionAndPath)
+{
+    struct Case
+    {
+        const char* name;
+        std::vector<BTBEntry> predictedBeforeSquash;
+        BTBEntry resolvedEntry;
+        Addr squashPC;
+        bool isCond;
+        bool actualTaken;
+        Addr redirectPC;
+        int expectedGHistShamt;
+        bool expectedGHistTaken;
+        int expectedBwHistShamt;
+        bool expectedBwHistTaken;
+        bool expectedPHistTaken;
+        Addr expectedPHistPC;
+        Addr expectedPHistTarget;
+    };
+
+    const std::vector<Case> cases = {
+        {
+            "conditional not taken",
+            {},
+            createBTBEntry(0x1008, true, true, false, -1, 0x2000),
+            0x1008,
+            true,
+            false,
+            0x2000,
+            1,
+            false,
+            1,
+            false,
+            false,
+            0,
+            0,
+        },
+        {
+            "conditional taken forward",
+            {},
+            createBTBEntry(0x1008, true, true, false, -1, 0x2000),
+            0x1008,
+            true,
+            true,
+            0x2000,
+            1,
+            true,
+            1,
+            false,
+            true,
+            0x1008,
+            0x2000,
+        },
+        {
+            "conditional taken backward",
+            {},
+            createBTBEntry(0x1008, true, true, false, -1, 0x0ff0),
+            0x1008,
+            true,
+            true,
+            0x0ff0,
+            1,
+            true,
+            1,
+            true,
+            true,
+            0x1008,
+            0x0ff0,
+        },
+        {
+            "unconditional taken",
+            {},
+            createBTBEntry(0x1008, false, true, true, -1, 0x2040),
+            0x1008,
+            false,
+            true,
+            0x2040,
+            0,
+            false,
+            0,
+            false,
+            true,
+            0x1008,
+            0x2040,
+        },
+        {
+            "path replay requires resolved control pc",
+            {},
+            createBTBEntry(0x1010, false, true, true, -1, 0x3000),
+            0x1008,
+            true,
+            true,
+            0x2000,
+            1,
+            true,
+            1,
+            false,
+            false,
+            0,
+            0,
+        },
+        {
+            "branches before squash contribute direction slots",
+            {
+                createBTBEntry(0x1000, true, true, false, -1, 0x1800),
+                createBTBEntry(0x1004, true, true, false, -1, 0x1804),
+            },
+            createBTBEntry(0x1008, true, true, false, -1, 0x2000),
+            0x1008,
+            true,
+            true,
+            0x2000,
+            3,
+            true,
+            3,
+            false,
+            true,
+            0x1008,
+            0x2000,
+        },
+    };
+
+    for (const auto& c : cases) {
+        SCOPED_TRACE(c.name);
+
+        FetchTarget stream;
+        stream.startPC = 0x1000;
+        stream.predBTBEntries = c.predictedBeforeSquash;
+        stream.exeBranchInfo = c.resolvedEntry;
+        stream.exeTaken = c.actualTaken;
+        stream.resolved = true;
+        stream.squashPC = c.squashPC;
+
+        const auto ghist = stream.getHistReplayDuringSquash(
+            c.squashPC, c.isCond, c.actualTaken);
+        const auto bwhist = stream.getBwHistReplayDuringSquash(
+            c.squashPC, c.isCond, c.actualTaken, c.redirectPC);
+        const auto phist = stream.getPHistReplayDuringSquash(
+            c.squashPC, c.actualTaken, c.redirectPC);
+
+        EXPECT_EQ(ghist.shamt, c.expectedGHistShamt);
+        EXPECT_EQ(ghist.taken, c.expectedGHistTaken);
+        EXPECT_EQ(bwhist.shamt, c.expectedBwHistShamt);
+        EXPECT_EQ(bwhist.taken, c.expectedBwHistTaken);
+        EXPECT_EQ(phist.taken, c.expectedPHistTaken);
+        if (c.expectedPHistTaken) {
+            EXPECT_EQ(phist.pc, c.expectedPHistPC);
+            EXPECT_EQ(phist.target, c.expectedPHistTarget);
+        }
+    }
 }
 
 /**
@@ -233,15 +388,15 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
     bool history_updated = false;
     boost::dynamic_bitset<> pre_spec_history = history;
     if (tage->usesPathHistory()) {
-        auto [pred_pc, pred_target, pred_taken] = stagePreds[1].getPHistInfo();
-        history_updated = pred_taken;
-        if (pred_taken) {
-            applyPathHistoryTaken(history, pred_pc, pred_target);
+        const auto replay = stagePreds[1].getPHistReplay();
+        history_updated = replay.taken;
+        if (replay.taken) {
+            applyPathHistoryTaken(history, replay.pc, replay.target);
         }
     } else {
-        auto [shamt, taken] = stagePreds[1].getHistInfo();
-        history_updated = shamt > 0;
-        applyOutcomeHistory(history, shamt, taken);
+        const auto replay = stagePreds[1].getHistReplay();
+        history_updated = replay.shamt > 0;
+        applyOutcomeHistory(history, replay.shamt, replay.taken);
     }
     tage->checkFoldedHist(history, "speculative update");
 
@@ -256,8 +411,9 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
             history = pre_spec_history;
         }
         // Recover from misprediction
-        recoverSelectedHistory(tage, history, stream, 1,
-                               getActualPathTaken(stream));
+        const auto path_replay = getActualPathReplay(stream);
+        recoverSelectedHistory(tage, history, stream, 1, actual_taken,
+                               path_replay);
         applyActualHistory(tage, history, stream.exeBranchInfo, 1, actual_taken);
         tage->checkFoldedHist(history, "recover");
     }
@@ -613,7 +769,9 @@ TEST_F(BTBTAGETest, HistoryRecoveryCorrectness) {
 
     // Recover to pre-speculative state and update with correct outcome
     boost::dynamic_bitset<> recoveryHistory = originalHistory;
-    recoverSelectedHistory(tage, recoveryHistory, stream, 1, !predicted_taken);
+    const auto path_replay = getActualPathReplay(stream);
+    recoverSelectedHistory(tage, recoveryHistory, stream, 1, !predicted_taken,
+                           path_replay);
 
     // Expected history should be original updated with the actual outcome.
     boost::dynamic_bitset<> expectedHistory = originalHistory;
@@ -1330,14 +1488,16 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
     FetchTarget stream = createStream(0x1000, entry, true, meta);
     stream = setMispredStream(stream);
 
-    auto [ghr_shamt, ghr_taken] =
-        stream.getHistInfoDuringSquash(entry.pc, false, true);
-    EXPECT_EQ(ghr_shamt, 0);
-    EXPECT_FALSE(ghr_taken);
-    EXPECT_TRUE(stream.getPHistTakenDuringSquash(entry.pc, true));
+    const auto ghist = stream.getHistReplayDuringSquash(entry.pc, false, true);
+    const auto phist = stream.getPHistReplayDuringSquash(
+        entry.pc, true, entry.target);
+    EXPECT_EQ(ghist.shamt, 0);
+    EXPECT_FALSE(ghist.taken);
+    EXPECT_TRUE(phist.taken);
+    EXPECT_EQ(phist.pc, entry.pc);
+    EXPECT_EQ(phist.target, entry.target);
 
-    tage->recoverPHist(pathHistoryBefore, stream, 2,
-                       stream.getPHistTakenDuringSquash(entry.pc, true));
+    tage->recoverPHist(pathHistoryBefore, stream, phist);
     tage->checkFoldedHist(pathHistoryAfter, "recover taken control path");
 }
 

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -107,7 +107,7 @@ void specUpdateSelectedHistory(BTBTAGE* tage,
     if (tage->usesPathHistory()) {
         tage->specUpdatePHist(history, pred, pred.getPHistUpdate());
     } else {
-        tage->specUpdateHist(history, pred, pred.getHistUpdate());
+        tage->specUpdateGHist(history, pred, pred.getGHistUpdate());
     }
 }
 
@@ -133,7 +133,7 @@ void applyPredictedHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
             applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto update = pred.getHistUpdate();
+        const auto update = pred.getGHistUpdate();
         applyOutcomeHistory(history, update.shamt, update.taken);
     }
 }
@@ -289,7 +289,7 @@ TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
         stream.resolved = true;
         stream.squashPC = c.squashPC;
 
-        const auto ghist = stream.getHistUpdateDuringSquash(
+        const auto ghist = stream.getGHistUpdateDuringSquash(
             c.squashPC, c.isCond, c.actualTaken);
         const auto bwhist = stream.getBwHistUpdateDuringSquash(
             c.squashPC, c.isCond, c.actualTaken, c.redirectPC);
@@ -394,7 +394,7 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
             applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto update = stagePreds[1].getHistUpdate();
+        const auto update = stagePreds[1].getGHistUpdate();
         history_updated = update.shamt > 0;
         applyOutcomeHistory(history, update.shamt, update.taken);
     }
@@ -1414,7 +1414,7 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesPathHashHistorySnapshot) {
     FullBTBPrediction pred;
     pred.btbEntries.push_back(entry);
     pred.condTakens.push_back({entry.pc, true});
-    tage->specUpdatePHist(pathHistoryA, pred);
+    tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
 
     bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
 
@@ -1439,7 +1439,7 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesIndirectOverridePathHashSnap
     pred.condTakens.push_back({entry.pc, true});
     pred.indirectTargets.push_back({entry.pc, indirectTarget});
 
-    tage->specUpdatePHist(pathHistoryA, pred);
+    tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
     tage->checkFoldedHist(pathHistoryB, "indirect target override");
 
     bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
@@ -1466,7 +1466,7 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesReturnOverridePathHashSnapsh
     pred.condTakens.push_back({entry.pc, true});
     pred.returnTarget = returnTarget;
 
-    tage->specUpdatePHist(pathHistoryA, pred);
+    tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
     tage->checkFoldedHist(pathHistoryB, "return target override");
 
     bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
@@ -1488,7 +1488,7 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
     FetchTarget stream = createStream(0x1000, entry, true, meta);
     stream = setMispredStream(stream);
 
-    const auto ghist = stream.getHistUpdateDuringSquash(entry.pc, false, true);
+    const auto ghist = stream.getGHistUpdateDuringSquash(entry.pc, false, true);
     const auto phist = stream.getPHistUpdateDuringSquash(
         entry.pc, true, entry.target);
     EXPECT_EQ(ghist.shamt, 0);

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -104,11 +104,10 @@ void specUpdateSelectedHistory(BTBTAGE* tage,
                                const boost::dynamic_bitset<>& history,
                                FullBTBPrediction& pred)
 {
-    const auto update = pred.getHistoryUpdate();
     if (tage->usesPathHistory()) {
-        tage->specUpdatePHist(history, pred, update.phist);
+        tage->specUpdatePHist(history, pred, pred.getPHistUpdate());
     } else {
-        tage->specUpdateHist(history, pred, update.ghist);
+        tage->specUpdateHist(history, pred, pred.getHistUpdate());
     }
 }
 
@@ -128,14 +127,13 @@ void recoverSelectedHistory(BTBTAGE* tage,
 void applyPredictedHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
                            FullBTBPrediction& pred)
 {
-    const auto history_update = pred.getHistoryUpdate();
     if (tage->usesPathHistory()) {
-        const auto &update = history_update.phist;
+        const auto update = pred.getPHistUpdate();
         if (update.taken) {
             applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto &update = history_update.ghist;
+        const auto update = pred.getHistUpdate();
         applyOutcomeHistory(history, update.shamt, update.taken);
     }
 }

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -104,10 +104,11 @@ void specUpdateSelectedHistory(BTBTAGE* tage,
                                const boost::dynamic_bitset<>& history,
                                FullBTBPrediction& pred)
 {
+    const auto update = pred.getHistoryUpdate();
     if (tage->usesPathHistory()) {
-        tage->specUpdatePHist(history, pred);
+        tage->specUpdatePHist(history, pred, update.phist);
     } else {
-        tage->specUpdateHist(history, pred);
+        tage->specUpdateHist(history, pred, update.ghist);
     }
 }
 
@@ -127,13 +128,14 @@ void recoverSelectedHistory(BTBTAGE* tage,
 void applyPredictedHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
                            FullBTBPrediction& pred)
 {
+    const auto history_update = pred.getHistoryUpdate();
     if (tage->usesPathHistory()) {
-        const auto update = pred.getPHistUpdate();
+        const auto &update = history_update.phist;
         if (update.taken) {
             applyPathHistoryTaken(history, update.pc, update.target);
         }
     } else {
-        const auto update = pred.getHistUpdate();
+        const auto &update = history_update.ghist;
         applyOutcomeHistory(history, update.shamt, update.taken);
     }
 }

--- a/src/cpu/pred/btb/test/ras_test.cc
+++ b/src/cpu/pred/btb/test/ras_test.cc
@@ -123,7 +123,7 @@ protected:
         boost::dynamic_bitset<> history(8, 0);
         auto meta = ras->getPredictionMeta();
         auto callPred = createCallPrediction(callPC, callPC, target, size);
-        ras->specUpdateHist(history, callPred);
+        ras->specUpdateState(callPred);
         return meta;
     }
 
@@ -144,7 +144,7 @@ TEST_F(RASTest, BasicConstruction) {
     checkReturnTarget(0x1000, 0x80000000L);
 }
 
-// Test basic push and pop operations through specUpdateHist
+// Test basic push and pop operations through specUpdateState
 TEST_F(RASTest, BasicPushPop) {
     boost::dynamic_bitset<> history(8, 0);
 
@@ -155,7 +155,7 @@ TEST_F(RASTest, BasicPushPop) {
     auto callPred = createCallPrediction(0x1000, 0x1000, 0x2000);
 
     // Execute speculative update (this should push return address)
-    ras->specUpdateHist(history, callPred);
+    ras->specUpdateState(callPred);
 
     // Check new state - should have return address (pc + size)
     checkReturnTarget(0x2000, 0x1004);
@@ -164,7 +164,7 @@ TEST_F(RASTest, BasicPushPop) {
     auto retPred = createReturnPrediction(0x2000, 0x2000, 0x1004);
 
     // Execute return speculative update (this should pop)
-    ras->specUpdateHist(history, retPred);
+    ras->specUpdateState(retPred);
 
     // Check final state - should be back to initial state
     checkReturnTarget(0x1004, 0x80000000L);
@@ -176,11 +176,11 @@ TEST_F(RASTest, MultiplePushes) {
 
     // Push first call
     auto callPred1 = createCallPrediction(0x1000, 0x1000, 0x2000);
-    ras->specUpdateHist(history, callPred1);
+    ras->specUpdateState(callPred1);
 
     // Push second call
     auto callPred2 = createCallPrediction(0x2000, 0x2000, 0x3000);
-    ras->specUpdateHist(history, callPred2);
+    ras->specUpdateState(callPred2);
 
     // Check current state (should be second call's return address)
     checkReturnTarget(0x3000, 0x2004);
@@ -195,7 +195,7 @@ TEST_F(RASTest, SameAddressCounter) {
     // Push same return address multiple times
     for (int i = 0; i < 3; i++) {
         auto callPred = createCallPrediction(0x1000, 0x1000, 0x2000);
-        ras->specUpdateHist(history, callPred);
+        ras->specUpdateState(callPred);
     }
 
     // Check that we still get the same return address
@@ -203,7 +203,7 @@ TEST_F(RASTest, SameAddressCounter) {
 
     // Pop once - should still get the same address due to counter
     auto retPred = createReturnPrediction(0x2000, 0x2000, retAddr);
-    ras->specUpdateHist(history, retPred);
+    ras->specUpdateState(retPred);
 
     // Should still be the same address due to counter > 0
     checkReturnTarget(0x1004, retAddr);
@@ -219,7 +219,7 @@ TEST_F(RASTest, BasicRecovery) {
 
     // Do some speculative operations
     auto callPred = createCallPrediction(0x1000, 0x1000, 0x2000);
-    ras->specUpdateHist(history, callPred);
+    ras->specUpdateState(callPred);
 
     // Create recovery stream
     FetchTarget recoverStream;
@@ -228,7 +228,7 @@ TEST_F(RASTest, BasicRecovery) {
     recoverStream.predMetas[0] = initialMeta;
 
     // Recover to initial state
-    ras->recoverHist(history, recoverStream, 0, false);
+    ras->recoverState(recoverStream);
 
     // Check that we're back to initial state
     checkReturnTarget(0x1000, 0x80000000L);
@@ -247,7 +247,7 @@ TEST_F(RASTest, SpeculativeStackOverflow) {
         Addr callPC = 0x1000 + i * 0x100;
         Addr target = 0x2000 + i * 0x100;
         auto callPred = createCallPrediction(callPC, callPC, target);
-        ras->specUpdateHist(history, callPred);
+        ras->specUpdateState(callPred);
     }
 
     // The top of stack should be the last pushed return address
@@ -265,7 +265,7 @@ TEST_F(RASTest, SpeculativeStackOverflow) {
 
         // Create return prediction to pop
         auto retPred = createReturnPrediction(currentPC, currentPC, expectedRetAddr);
-        ras->specUpdateHist(history, retPred);
+        ras->specUpdateState(retPred);
     }
 
     // After popping 8 entries, we should be back to the committed stack
@@ -282,7 +282,7 @@ TEST_F(RASTest, SpeculativeStackWraparound) {
         Addr callPC = 0x1000 + i * 0x10;
         Addr target = 0x2000 + i * 0x10;
         auto callPred = createCallPrediction(callPC, callPC, target);
-        ras->specUpdateHist(history, callPred);
+        ras->specUpdateState(callPred);
     }
 
     // Verify the top entry
@@ -290,14 +290,14 @@ TEST_F(RASTest, SpeculativeStackWraparound) {
 
     // Now push one more - this should wrap around and overwrite the first entry
     auto overflowCall = createCallPrediction(0x1080, 0x1080, 0x2080);
-    ras->specUpdateHist(history, overflowCall);
+    ras->specUpdateState(overflowCall);
 
     // Top should now be the overflow entry
     checkReturnTarget(0x2080, 0x1084);
 
     // Pop once - should get the overflow entry
     auto retPred = createReturnPrediction(0x2080, 0x2080, 0x1084);
-    ras->specUpdateHist(history, retPred);
+    ras->specUpdateState(retPred);
 
     // Now we should have entries 7,6,5,4,3,2,1 available (entry 0 was overwritten)
     // So the top should be entry 7: 0x1070 -> 0x1074
@@ -336,14 +336,14 @@ TEST_F(RASTest, EmptyStackPop) {
 
     // Try to pop from empty stack
     auto retPred = createReturnPrediction(0x1000, 0x1000, 0x1004);
-    ras->specUpdateHist(history, retPred);
+    ras->specUpdateState(retPred);
 
     // Should still return default value when popping from empty stack
     checkReturnTarget(0x1004, 0x80000000L);
 
     // Pop again to test multiple pops on empty stack
     auto retPred2 = createReturnPrediction(0x1004, 0x1004, 0x1008);
-    ras->specUpdateHist(history, retPred2);
+    ras->specUpdateState(retPred2);
 
     // Should gracefully handle multiple pops without crashing
     checkReturnTarget(0x1008, 0x80000000L);
@@ -361,7 +361,7 @@ TEST_F(RASTest, CounterOverflow) {
     // Push the same return address 5 times (more than maxCtr=3)
     for (int i = 0; i < 5; i++) {
         auto callPred = createCallPrediction(callPC, callPC, target);
-        ras->specUpdateHist(history, callPred);
+        ras->specUpdateState(callPred);
 
         // Should always get the same return address
         checkReturnTarget(target, retAddr);
@@ -371,7 +371,7 @@ TEST_F(RASTest, CounterOverflow) {
     // (due to counter), then move to next entry on 4th pop
     for (int i = 0; i < 3; i++) {
         auto retPred = createReturnPrediction(target, target, retAddr);
-        ras->specUpdateHist(history, retPred);
+        ras->specUpdateState(retPred);
 
         // Should still be the same address due to counter
         checkReturnTarget(0x3000, retAddr);
@@ -379,7 +379,7 @@ TEST_F(RASTest, CounterOverflow) {
 
     // One more pop should move to next entry (default in this case)
     auto retPred = createReturnPrediction(target, target, retAddr);
-    ras->specUpdateHist(history, retPred);
+    ras->specUpdateState(retPred);
     checkReturnTarget(0x3000, 0x80000000L);
 }
 
@@ -392,14 +392,14 @@ TEST_F(RASTest, ComplexRecovery) {
     auto call2 = createCallPrediction(0x2000, 0x2000, 0x3000);
     auto call3 = createCallPrediction(0x3000, 0x3000, 0x4000);
 
-    ras->specUpdateHist(history, call1);
+    ras->specUpdateState(call1);
 
     // Save state after first call
     checkReturnTarget(0x2000, 0x1004);
     auto meta1 = ras->getPredictionMeta();
 
-    ras->specUpdateHist(history, call2);
-    ras->specUpdateHist(history, call3);
+    ras->specUpdateState(call2);
+    ras->specUpdateState(call3);
 
     // Now we should have 3 entries on the stack
     checkReturnTarget(0x4000, 0x3004);
@@ -413,14 +413,14 @@ TEST_F(RASTest, ComplexRecovery) {
     recoverStream.exeBranchInfo.size = 4;
     recoverStream.predMetas[0] = meta1;
 
-    ras->recoverHist(history, recoverStream, 0, true);
+    ras->recoverState(recoverStream);
 
     // Should be back to state with just one call
     checkReturnTarget(0x2000, 0x1004);
 
     // Now do a different speculation path
     auto call2_alt = createCallPrediction(0x2000, 0x2000, 0x5000);
-    ras->specUpdateHist(history, call2_alt);
+    ras->specUpdateState(call2_alt);
 
     // Should have the new call's return address on top
     checkReturnTarget(0x5000, 0x2004);
@@ -447,7 +447,7 @@ TEST_F(RASTest, CommitFlow) {
     // Test recovery - should now use committed stack
     boost::dynamic_bitset<> history(8, 0);
     auto recoverStream = createCallCommitStream(0x1000, 0x1000, 4, initialMeta, false);
-    ras->recoverHist(history, recoverStream, 0, false);
+    ras->recoverState(recoverStream);
 
     // After recovery, committed stack should be available
     checkReturnTarget(0x2000, 0x1004);
@@ -473,7 +473,7 @@ TEST_F(RASTest, MixedOperations) {
 
     // Step 3: Simulate misprediction and recovery
     auto recoverStream = createCallCommitStream(0x1000, 0x1000, 4, meta0, true);
-    ras->recoverHist(history, recoverStream, 0, true);
+    ras->recoverState(recoverStream);
 
     // Should have committed call1, but lose speculative call2 and call3
     checkReturnTarget(0x2000, 0x1004);
@@ -484,11 +484,11 @@ TEST_F(RASTest, MixedOperations) {
 
     // Step 5: Pop operations
     auto ret1 = createReturnPrediction(0x5000, 0x5000, 0x2004);
-    ras->specUpdateHist(history, ret1);
+    ras->specUpdateState(ret1);
     checkReturnTarget(0x2004, 0x1004);
 
     auto ret2 = createReturnPrediction(0x2004, 0x2004, 0x1004);
-    ras->specUpdateHist(history, ret2);
+    ras->specUpdateState(ret2);
     checkReturnTarget(0x1004, 0x80000000L);
 }
 
@@ -527,7 +527,7 @@ TEST_F(RASTest, PointerWraparound) {
     // Pop all speculative entries - should eventually reach committed stack
     for (int i = 0; i < 10; i++) {
         auto retPred = createReturnPrediction(0x5000, 0x5000, 0x5004);
-        ras->specUpdateHist(history, retPred);
+        ras->specUpdateState(retPred);
     }
 
     // Should be back to committed stack top

--- a/src/cpu/pred/btb/test/uras_test.cc
+++ b/src/cpu/pred/btb/test/uras_test.cc
@@ -75,7 +75,7 @@ public:
         meta.tos = stack[sp];
     }
 
-    void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
+    void specUpdateState(FullBTBPrediction &pred)
     {
         auto &stack = specStack;
         auto &sp = specSp;
@@ -93,14 +93,14 @@ public:
         }
     }
 
-    // recover hist, from entry.predMetas[0] to recover sp and tos
+    // recover state, from entry.predMetas[0] to recover sp and tos
     // then if exeTaken, do push & pops on control squash
     // input: only entry is used.
     // used when branch prediction error
     // two steps:
     // 1. recover sp and tos from entry.predMetas[0]
     // 2. do push & pops on control squash based on the actual branch type (call/return)
-    void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+    void recoverState(const FetchTarget &entry)
     {
         auto &stack = specStack;
         auto &sp = specSp;
@@ -278,8 +278,8 @@ TEST_F(URASTest, PutPCHistoryBasic) {
     EXPECT_EQ(meta->tos.ctr, 0);
 }
 
-// test specUpdateHist for call
-TEST_F(URASTest, SpecUpdateHistCall) {
+// test specUpdateState for call
+TEST_F(URASTest, SpecUpdateStateCall) {
     boost::dynamic_bitset<> history(8, 0);
     FullBTBPrediction pred;
     pred.bbStart = 0x1000;
@@ -299,9 +299,9 @@ TEST_F(URASTest, SpecUpdateHistCall) {
     EXPECT_EQ(sp, 0);
     EXPECT_EQ(stack[sp].retAddr, 0x80000000L);
     
-    // 执行specUpdateHist
-    uras->specUpdateHist(history, pred);
-    
+    // 执行 specUpdateState
+    uras->specUpdateState(pred);
+
     // 验证：
     // 1. 返回地址应该是call指令的下一条指令地址
     EXPECT_EQ(stack[sp].retAddr, 0x1004);  // pc + size
@@ -309,7 +309,7 @@ TEST_F(URASTest, SpecUpdateHistCall) {
     EXPECT_EQ(sp, 1);
 }
 
-TEST_F(URASTest, SpecUpdateHistReturn) {
+TEST_F(URASTest, SpecUpdateStateReturn) {
     boost::dynamic_bitset<> history(8, 0);
     FullBTBPrediction pred;
     pred.bbStart = 0x1000;
@@ -327,9 +327,9 @@ TEST_F(URASTest, SpecUpdateHistReturn) {
     retEntry.target = 0x2000;
     pred.btbEntries.push_back(retEntry);
     
-    // 执行specUpdateHist
-    uras->specUpdateHist(history, pred);
-    
+    // 执行 specUpdateState
+    uras->specUpdateState(pred);
+
     // 验证：
     // 1. returnTarget应该是栈顶的地址
     EXPECT_EQ(pred.returnTarget, 0x2000);
@@ -337,7 +337,7 @@ TEST_F(URASTest, SpecUpdateHistReturn) {
     EXPECT_EQ(sp, 0);
 }
 
-TEST_F(URASTest, SpecUpdateHistCallReturn) {
+TEST_F(URASTest, SpecUpdateStateCallReturn) {
     boost::dynamic_bitset<> history(8, 0);
     
     // First prediction with call
@@ -352,9 +352,9 @@ TEST_F(URASTest, SpecUpdateHistCallReturn) {
     callEntry.target = 0x2000;
     pred1.btbEntries.push_back(callEntry);
     
-    // 执行call的specUpdateHist
-    uras->specUpdateHist(history, pred1);
-    
+    // 执行 call 的 specUpdateState
+    uras->specUpdateState(pred1);
+
     // Second prediction with return
     FullBTBPrediction pred2;
     pred2.bbStart = 0x2000;
@@ -366,9 +366,9 @@ TEST_F(URASTest, SpecUpdateHistCallReturn) {
     retEntry.target = 0x1004;  // 返回到call的下一条指令
     pred2.btbEntries.push_back(retEntry);
     
-    // 执行return的specUpdateHist
-    uras->specUpdateHist(history, pred2);
-    
+    // 执行 return 的 specUpdateState
+    uras->specUpdateState(pred2);
+
     // 验证：
     auto& stack = uras->getSpecStack();
     auto& sp = uras->getSpecSp();
@@ -379,7 +379,7 @@ TEST_F(URASTest, SpecUpdateHistCallReturn) {
 }
 
 // Test basic recovery functionality
-TEST_F(URASTest, RecoverHistBasic) {
+TEST_F(URASTest, RecoverStateBasic) {
     boost::dynamic_bitset<> history(8, 0);
     FetchTarget entry;
 
@@ -395,15 +395,15 @@ TEST_F(URASTest, RecoverHistBasic) {
     entry.predMetas[0] = std::make_shared<uRASMeta>(meta);
     
     // recover
-    uras->recoverHist(history, entry, 0, false);
-    
+    uras->recoverState(entry);
+
     // verify recovery result
     EXPECT_EQ(sp, 0);  // sp should be restored
     EXPECT_EQ(stack[sp].retAddr, 0x2000);  // tos should be restored
 }
 
 // Test recovery with return instruction
-TEST_F(URASTest, RecoverHistReturn) {
+TEST_F(URASTest, RecoverStateReturn) {
     boost::dynamic_bitset<> history(8, 0);
     FetchTarget entry;
 
@@ -424,15 +424,15 @@ TEST_F(URASTest, RecoverHistReturn) {
     entry.exeBranchInfo.pc = 0x2000;
     
     // 执行恢复
-    uras->recoverHist(history, entry, 0, false);
-    
+    uras->recoverState(entry);
+
     // 验证：应该先恢复sp和tos，然后执行pop
     EXPECT_EQ(sp, 0);  // 1(恢复) -> 0(pop)
     EXPECT_EQ(stack[sp].retAddr, 0x80000000L);  // 初始值
 }
 
 // Test recovery with call instruction
-TEST_F(URASTest, RecoverHistCall) {
+TEST_F(URASTest, RecoverStateCall) {
     boost::dynamic_bitset<> history(8, 0);
     FetchTarget entry;
 
@@ -453,15 +453,15 @@ TEST_F(URASTest, RecoverHistCall) {
     entry.exeBranchInfo.size = 4;
     
     // 执行恢复
-    uras->recoverHist(history, entry, 0, false);
-    
+    uras->recoverState(entry);
+
     // 验证：应该先恢复sp和tos，然后执行push
     EXPECT_EQ(sp, 1);  // 0(恢复) -> 1(push)
     EXPECT_EQ(stack[sp].retAddr, 0x1004);  // pc + size
 }
 
 // Test recovery with call-return sequence
-TEST_F(URASTest, RecoverHistCallReturn) {
+TEST_F(URASTest, RecoverStateCallReturn) {
     boost::dynamic_bitset<> history(8, 0);
     FetchTarget entry1, entry2;
 
@@ -479,8 +479,8 @@ TEST_F(URASTest, RecoverHistCallReturn) {
     entry1.exeBranchInfo.pc = 0x1000;
     entry1.exeBranchInfo.size = 4;
     
-    uras->recoverHist(history, entry1, 0, false);
-    
+    uras->recoverState(entry1);
+
     // 验证call的结果
     EXPECT_EQ(sp, 1);
     EXPECT_EQ(stack[sp].retAddr, 0x1004);
@@ -495,8 +495,8 @@ TEST_F(URASTest, RecoverHistCallReturn) {
     entry2.exeBranchInfo.isReturn = true;
     entry2.exeBranchInfo.pc = 0x2000;
     
-    uras->recoverHist(history, entry2, 0, false);
-    
+    uras->recoverState(entry2);
+
     // 验证return的结果
     EXPECT_EQ(sp, 0);
     EXPECT_EQ(stack[sp].retAddr, 0x80000000L);

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -72,8 +72,11 @@ class TimedBaseBTBPredictor: public SimObject
     virtual void specUpdateIHist(FullBTBPrediction &pred) {}
     virtual void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) {}
     virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
+    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
+                              const PathHistoryReplay &replay) {}
+    virtual void recoverBwHist(const boost::dynamic_bitset<> &history,
+                               const FetchTarget &entry, int shamt,
+                               bool cond_taken) {}
     virtual void recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void update(const FetchTarget &entry) {}

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -66,58 +66,18 @@ class TimedBaseBTBPredictor: public SimObject
         return nullptr;
     }
 
-    virtual void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
-    virtual void specUpdateHist(const boost::dynamic_bitset<> &history,
+    virtual void specUpdateGHist(const boost::dynamic_bitset<> &history,
                                 FullBTBPrediction &pred,
-                                const DirectionHistoryUpdate &update)
-    {
-        (void)update;
-        specUpdateHist(history, pred);
-    }
-    virtual void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
+                                const DirectionHistoryUpdate &update) {}
     virtual void specUpdatePHist(const boost::dynamic_bitset<> &history,
                                  FullBTBPrediction &pred,
-                                 const PathHistoryUpdate &update)
-    {
-        (void)update;
-        specUpdatePHist(history, pred);
-    }
-    virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
-    virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history,
-                                  FullBTBPrediction &pred,
-                                  const DirectionHistoryUpdate &update)
-    {
-        (void)update;
-        specUpdateBwHist(history, pred);
-    }
-    virtual void specUpdateIHist(FullBTBPrediction &pred) {}
-    virtual void specUpdateIHist(FullBTBPrediction &pred,
-                                 const DirectionHistoryUpdate &update)
-    {
-        (void)update;
-        specUpdateIHist(pred);
-    }
-    virtual void specUpdateLHist(
-        const std::vector<boost::dynamic_bitset<>> &history,
-        FullBTBPrediction &pred) {}
-    virtual void specUpdateLHist(
-        const std::vector<boost::dynamic_bitset<>> &history,
-        FullBTBPrediction &pred, const DirectionHistoryUpdate &update)
-    {
-        (void)update;
-        specUpdateLHist(history, pred);
-    }
+                                 const PathHistoryUpdate &update) {}
     virtual void recoverHist(const boost::dynamic_bitset<> &history,
                              const FetchTarget &entry, int shamt,
                              bool cond_taken) {}
     virtual void recoverPHist(const boost::dynamic_bitset<> &history,
                               const FetchTarget &entry,
                               const PathHistoryUpdate &update) {}
-    virtual void recoverBwHist(const boost::dynamic_bitset<> &history,
-                               const FetchTarget &entry, int shamt,
-                               bool cond_taken) {}
-    virtual void recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void update(const FetchTarget &entry) {}
     virtual unsigned getDelay() {return numDelay;}
     virtual bool getResolvedUpdate() {return resolvedUpdate;}
@@ -131,7 +91,6 @@ class TimedBaseBTBPredictor: public SimObject
 
     int componentIdx{0};
     unsigned aheadPipelinedStages{0};
-    bool needMoreHistories{false};
     int getComponentIdx() { return componentIdx; }
     void setComponentIdx(int idx) { componentIdx = idx; }
 

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -67,12 +67,51 @@ class TimedBaseBTBPredictor: public SimObject
     }
 
     virtual void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
+    virtual void specUpdateHist(const boost::dynamic_bitset<> &history,
+                                FullBTBPrediction &pred,
+                                const DirectionHistoryUpdate &update)
+    {
+        (void)update;
+        specUpdateHist(history, pred);
+    }
     virtual void specUpdatePHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
+    virtual void specUpdatePHist(const boost::dynamic_bitset<> &history,
+                                 FullBTBPrediction &pred,
+                                 const PathHistoryUpdate &update)
+    {
+        (void)update;
+        specUpdatePHist(history, pred);
+    }
     virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) {}
+    virtual void specUpdateBwHist(const boost::dynamic_bitset<> &history,
+                                  FullBTBPrediction &pred,
+                                  const DirectionHistoryUpdate &update)
+    {
+        (void)update;
+        specUpdateBwHist(history, pred);
+    }
     virtual void specUpdateIHist(FullBTBPrediction &pred) {}
-    virtual void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) {}
-    virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
-    virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
+    virtual void specUpdateIHist(FullBTBPrediction &pred,
+                                 const DirectionHistoryUpdate &update)
+    {
+        (void)update;
+        specUpdateIHist(pred);
+    }
+    virtual void specUpdateLHist(
+        const std::vector<boost::dynamic_bitset<>> &history,
+        FullBTBPrediction &pred) {}
+    virtual void specUpdateLHist(
+        const std::vector<boost::dynamic_bitset<>> &history,
+        FullBTBPrediction &pred, const DirectionHistoryUpdate &update)
+    {
+        (void)update;
+        specUpdateLHist(history, pred);
+    }
+    virtual void recoverHist(const boost::dynamic_bitset<> &history,
+                             const FetchTarget &entry, int shamt,
+                             bool cond_taken) {}
+    virtual void recoverPHist(const boost::dynamic_bitset<> &history,
+                              const FetchTarget &entry,
                               const PathHistoryUpdate &update) {}
     virtual void recoverBwHist(const boost::dynamic_bitset<> &history,
                                const FetchTarget &entry, int shamt,

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -73,7 +73,7 @@ class TimedBaseBTBPredictor: public SimObject
     virtual void specUpdateLHist(const std::vector<boost::dynamic_bitset<>> &history, FullBTBPrediction &pred) {}
     virtual void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) {}
     virtual void recoverPHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry,
-                              const PathHistoryReplay &replay) {}
+                              const PathHistoryUpdate &update) {}
     virtual void recoverBwHist(const boost::dynamic_bitset<> &history,
                                const FetchTarget &entry, int shamt,
                                bool cond_taken) {}

--- a/src/cpu/pred/btb/uras.cc
+++ b/src/cpu/pred/btb/uras.cc
@@ -93,7 +93,7 @@ BTBuRAS::getPredictionMeta(ThreadID tid)
 }
 
 void
-BTBuRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred)
+BTBuRAS::specUpdateState(FullBTBPrediction &pred)
 {
     auto &stack = specStack;
     auto &sp = specSp;
@@ -121,15 +121,15 @@ BTBuRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPredictio
         DPRINTF(URAS, "spec stack pop at pc 0x%llx target %llx\n", pred.bbStart, retAddr);
         pop(stack, sp);
     }
-    printStack("after specUpdateHist", stack, sp);
+    printStack("after specUpdateState", stack, sp);
 }
 
 void
-BTBuRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken)
+BTBuRAS::recoverState(const FetchTarget &entry)
 {
     auto &stack = specStack;
     auto &sp = specSp;
-    printStack("before recoverHist", stack, sp);
+    printStack("before recoverState", stack, sp);
     // recover sp and tos first
     auto meta_ptr = std::static_pointer_cast<uRASMeta>(entry.predMetas[getComponentIdx()]);
     auto takenSlot = entry.exeBranchInfo;
@@ -160,7 +160,7 @@ BTBuRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &
             push(retAddr, stack, sp);
         }
     }
-    printStack("after recoverHist", stack, sp);
+    printStack("after recoverState", stack, sp);
 }
 
 void

--- a/src/cpu/pred/btb/uras.hh
+++ b/src/cpu/pred/btb/uras.hh
@@ -45,11 +45,11 @@ class BTBuRAS : public TimedBaseBTBPredictor
         
         std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
-        void specUpdateHist(const boost::dynamic_bitset<> &history, FullBTBPrediction &pred) override;
+        void specUpdateState(FullBTBPrediction &pred);
 
         unsigned getDelay() override {return 0;}
 
-        void recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &entry, int shamt, bool cond_taken) override;
+        void recoverState(const FetchTarget &entry);
 
         void update(const FetchTarget &entry) override;
 


### PR DESCRIPTION
## Summary

- make BTB history replay explicit with separate direction and path update records
- use the path update record for PHR speculative update and squash recovery, so PHR no longer looks like a GHR-style shamt/taken replay
- remove shallow aggregate helpers that only wrapped short getGHist/getBwHist/getPHist calls
- rename the shared folded-history interface from specUpdateHist to specUpdateGHist and keep specUpdatePHist as the path-history counterpart
- split RAS/uRAS and ABTB speculative state recovery out of the folded-history interface
- keep MGSC-only Bw/IMLI/local folded histories inside MGSC instead of exposing them through TimedBaseBTBPredictor
- refresh related docs and tests to match the narrower interfaces

## Motivation

This is a follow-up cleanup for #876. The PHR squash fix depends on a semantic distinction that was easy to miss in the old interface: GHR/BWHR replay is based on direction history, while PHR replay records the actual taken control edge and target. This PR keeps that distinction visible at the call sites and removes pass-through helpers that made the code look more abstract without reducing what readers had to understand.

The latest cleanup is intentionally biased toward deletion. RAS/uRAS update return-stack state rather than folded history, ABTB only needs to clear its ahead pipeline on squash, and only MGSC consumes Bw/IMLI/local histories. Keeping those cases out of the base predictor interface makes the remaining common seam smaller and more accurate.

## Scope and impact

The intended behavior is unchanged from the PHR recovery fix. This PR mainly changes names, call structure, and interface ownership around speculative history update and squash recovery. Predictor algorithms, table indexing, and path hash semantics are not intended to change.

## Validation

- `util/style.py -m`
- `git diff --check`
- `scons build/RISCV/cpu/pred/btb/test/tage.test.debug build/RISCV/cpu/pred/btb/test/mgsc.test.debug build/RISCV/cpu/pred/btb/test/uras.test.debug build/RISCV/cpu/pred/btb/test/abtb.test.debug build/RISCV/cpu/pred/btb/test/btb.test.debug --unit-test -j32`
- `./build/RISCV/cpu/pred/btb/test/tage.test.debug` (28/28 passed)
- `./build/RISCV/cpu/pred/btb/test/mgsc.test.debug` (13/13 passed)
- `./build/RISCV/cpu/pred/btb/test/uras.test.debug` (12/12 passed)
- `./build/RISCV/cpu/pred/btb/test/abtb.test.debug` (3/3 passed)
- `./build/RISCV/cpu/pred/btb/test/btb.test.debug` (19/19 passed)
- `scons build/RISCV/gem5.opt --gold-linker -j16`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation for branch prediction components to clarify history update mechanisms and lifecycle requirements.

* **Refactor**
  * Refactored branch prediction history update and recovery interfaces to use structured update objects instead of raw parameters, improving API clarity and consistency across predictor components.
  * Simplified state-recovery methods for certain predictor components to reduce parameter dependencies.

* **Tests**
  * Updated unit tests to align with refactored history update APIs and structured parameter passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->