### PR TITLE
cpu-o3: Fix vector store queue deadlock

### DIFF
--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -958,8 +958,10 @@ IEW::dispatchInsts()
         iew_info.iqCount = scheduler->getIQInsts(i);
 
         bool ldst_block = !canInsertLDSTQue(i);
-        bool block = stallSig->blockIEW[i] || ldst_block;
-        bool active = !block && !fixedbuffer[i].empty();
+        bool rename_block = stallSig->blockIEW[i] || ldst_block;
+        // LDST queue reservation gates new rename input, but the already
+        // buffered tail must still drain through per-instruction LSQ checks.
+        bool active = !stallSig->blockIEW[i] && !fixedbuffer[i].empty();
         StallReason block_reason = StallReason::NoStall;
         if (stallSig->blockIEW[i]) {
             block_reason = stallSig->iewBlockReason[i];
@@ -969,10 +971,11 @@ IEW::dispatchInsts()
                 block_reason = StallReason::OtherStall;
             }
         }
-        iew_info.blockReason = block ? block_reason : StallReason::NoStall;
+        iew_info.blockReason = rename_block ? block_reason : StallReason::NoStall;
 
-        stallSig->blockRename[i] = block;
-        stallSig->renameBlockReason[i] = block ? block_reason : StallReason::NoStall;
+        stallSig->blockRename[i] = rename_block;
+        stallSig->renameBlockReason[i] =
+            rename_block ? block_reason : StallReason::NoStall;
         if (active) {
             const auto freeze =
                 active_arbiter.observe(i, smtBorrowPriority(iew_info));

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2352,8 +2352,9 @@ LSQUnit::offloadToStoreBuffer(uint32_t max_entries, std::vector<bool>& offload_f
 {
     assert(!lsq->storeBufferBlocked());
     if (isStoreBlocked) return;
-    if (max_entries == 0) return;
 
+    // Zero-sized stores do not consume store-buffer quota, but they still need
+    // completeStore() to free SQ entries.
     uint32_t accepted_entries = 0;
     while (storesToWB > 0 &&
            storeWBIt.dereferenceable() &&


### PR DESCRIPTION
## Summary
- allow IEW to drain already-buffered instructions while LDST reservation blocks new rename input
- allow zero-sized vector stores to complete even when store-buffer offload quota is zero

## Root Cause
Vector store instructions can create zero-sized store micro-ops. These entries do not consume store-buffer quota, but they still occupy SQ entries and must call completeStore() to make progress. The old offload path returned early when quota was zero, so a run of zero-sized vector stores could keep SQ nearly full and block rename indefinitely. A related IEW gate also prevented an already-buffered store tail from draining into available SQ entries once free SQ dropped below renameWidth.

## Validation
- scons build/RISCV/gem5.opt --gold-linker -j16
- vsse8.v-0 with notama NEMU ref: m5_exit
- vsseg5e32.v-0 with notama NEMU ref: m5_exit
- vsuxei32.v-0 with notama NEMU ref: m5_exit
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU pipeline instruction dispatch logic for more accurate rename stall signal handling.
  * Fixed zero-sized store handling in the load-store queue to ensure proper memory queue entry cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenXiangShan/GEM5/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->