### PR TITLE
cpu-o3: Limit decode FIFO backpressure to SMT

### DIFF
--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -493,7 +493,11 @@ Decode::tick()
         toFetch->decodeInfo[tid].blockReason =
             stallSig->fetchBlockReason[tid];
     };
+    // Single-thread mode already uses blockDecode feedback for real backend
+    // stalls; this extra FIFO guard is only needed when SMT arbitration can
+    // leave a non-selected thread's fetch groups queued behind another thread.
     const bool fifoBackpressured =
+        numThreads > 1 &&
         !stallBuffer.empty() &&
         eachstallSize.size() + fetchToDecodeDelay >=
             eachstallSize.capacity();


### PR DESCRIPTION
Change-Id: Icacb54645b65e74a9ca3890036f258bb45293cea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced CPU simulator accuracy by refining multi-threaded backpressure logic to selectively apply arbitration handling only during simultaneous multi-threading execution. This improves simulation fidelity for multi-threaded workloads while preserving single-threaded behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->