### PR TITLE
cpu: Add BTB unit-test stats shim

### DIFF
--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -111,6 +111,7 @@ BTBTAGE::BTBTAGE(unsigned numPredictors, unsigned numWaysPerTable,
     maxHistLen = histLengths[numPredictors-1];
     numTablesToAlloc = 1;
     enableSC = false;
+    tageStats.init(numPredictors, numBanks);
 #else
 // Constructor: Initialize TAGE predictor with given parameters
 BTBTAGE::BTBTAGE(const Params& p):
@@ -476,10 +477,8 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
     lastPredBankId = getBankId(startPC);
     predBankValid = true;
 
-#ifndef UNIT_TEST
     // Record prediction access per bank
     tageStats.predAccessPerBank[lastPredBankId]++;
-#endif
 
     DPRINTF(TAGE, "putPCHistory startAddr: %#lx, bank: %u\n",
             startPC, lastPredBankId);
@@ -579,7 +578,6 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     tageStats.resolveBranchHasAlt += alt_info.found;
     tageStats.resolveBranchUseAltTable += use_alt_table;
     tageStats.resolveBranchUseBaseTable += use_base_table;
-#ifndef UNIT_TEST
     if (main_info.found) {
         tageStats.resolveProviderTable[main_info.table]++;
     }
@@ -592,7 +590,6 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     if (use_alt_table) {
         tageStats.resolveUseAltTable[alt_info.table]++;
     }
-#endif
 
     // Update use_alt_on_na when provider is weak (0 or -1)
     if (main_info.found) {
@@ -662,22 +659,18 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
         tageStats.mispredictBranchHasAlt += alt_info.found;
         tageStats.mispredictBranchUseAltTable += use_alt_table;
         tageStats.mispredictBranchUseBaseTable += use_base_table;
-#ifndef UNIT_TEST
         if (use_provider) {
             tageStats.mispredictUseProviderTable[main_info.table]++;
         }
         if (use_alt_table) {
             tageStats.mispredictUseAltTable[alt_info.table]++;
         }
-#endif
     }
     if (getDelay() == 2){
         if (this_fb_mispred) {
             tageStats.updateMispred++;
             if (!used_alt && main_info.found) {
-#ifndef UNIT_TEST
                 tageStats.updateTableMispreds[main_info.table]++;
-#endif
             }
         }
     }
@@ -830,17 +823,13 @@ BTBTAGE::canResolveUpdate(const FetchTarget &stream) {
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
-#ifndef UNIT_TEST
     // Record attempted update access per bank (even if it conflicts)
     tageStats.updateAccessPerBank[updateBank]++;
-#endif
 
     if (enableBankConflict && predBankValid && updateBank == lastPredBankId) {
         tageStats.updateBankConflict++;
         tageStats.updateDeferredDueToConflict++;
-#ifndef UNIT_TEST
         tageStats.updateBankConflictPerBank[updateBank]++;
-#endif
         DPRINTF(TAGE, "Bank conflict detected: update bank %u conflicts with prediction bank %u, "
                       "deferring this update (will retry after blocking prediction)\n",
                       updateBank, lastPredBankId);
@@ -906,7 +895,6 @@ BTBTAGE::update(const FetchTarget &stream) {
                     btb_entry.pc);
         }
 
-#ifndef UNIT_TEST
         if (has_original_pred && original_pred.finalProviderTable >= 0) {
             if (original_pred.taken == actual_taken) {
                 tageStats.updateFinalSourceTableCorrect[original_pred.finalProviderTable]++;
@@ -918,7 +906,6 @@ BTBTAGE::update(const FetchTarget &stream) {
         } else if (has_original_pred) {
             tageStats.updateFinalSourceBaseWrong++;
         }
-#endif
 
         TagePrediction recomputed;
         if (updateOnRead || !has_original_pred) {
@@ -1394,8 +1381,19 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     ADD_STAT(predHit, statistics::units::Count::get(), "number of conditional branch predictions that hit"),
     ADD_STAT(predMiss, statistics::units::Count::get(), "number of conditional branch predictions that miss")
 {
-    predTableHits.init(0, numPredictors-1, 1);
-    updateTableHits.init(0, numPredictors-1, 1);
+    init(numPredictors, numBanks);
+}
+#endif
+
+void
+BTBTAGE::TageStats::init(int predictors, int banks)
+{
+    numPredictors = predictors;
+    numBanks = banks;
+    bankIdx = 0;
+
+    predTableHits.init(0, numPredictors - 1, 1);
+    updateTableHits.init(0, numPredictors - 1, 1);
     updateTableMispreds.init(numPredictors);
     predFinalSourceTable.init(numPredictors);
     updateFinalSourceTableCorrect.init(numPredictors);
@@ -1407,12 +1405,10 @@ BTBTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, int 
     mispredictUseProviderTable.init(numPredictors);
     mispredictUseAltTable.init(numPredictors);
 
-    // Initialize per-bank statistics vectors
     updateBankConflictPerBank.init(numBanks);
     updateAccessPerBank.init(numBanks);
     predAccessPerBank.init(numBanks);
 }
-#endif
 
 // Update statistics based on TAGE prediction
 void
@@ -1423,27 +1419,21 @@ BTBTAGE::TageStats::updateStatsWithTagePrediction(const TagePrediction &pred, bo
     bool useAlt = pred.useAlt;
     if (when_pred) {
         if (hit) {
-#ifndef UNIT_TEST
             predTableHits.sample(hit_table, 1);
-#endif
         } else {
             predNoHitUseBim++;
         }
         if (!hit || useAlt) {
             predUseAlt++;
         }
-#ifndef UNIT_TEST
         if (pred.finalProviderTable >= 0) {
             predFinalSourceTable[pred.finalProviderTable]++;
         } else {
             predFinalSourceBase++;
         }
-#endif
     } else {
         if (hit) {
-#ifndef UNIT_TEST
             updateTableHits.sample(hit_table, 1);
-#endif
         } else {
             updateNoHitUseBim++;
         }

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -14,6 +14,7 @@
 #include "cpu/o3/limits.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/folded_hist.hh"
+#include "cpu/pred/btb/test_stats.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
 
 // Conditional includes based on build mode
@@ -324,11 +325,9 @@ class BTBTAGE : public TimedBaseBTBPredictor
     unsigned lastPredBankId;         // Bank ID of last prediction
     bool predBankValid;              // Whether lastPredBankId is valid
 
-#ifdef UNIT_TEST
-    typedef uint64_t Scalar;
-#else
-    typedef statistics::Scalar Scalar;
-#endif
+    using Scalar = test_stats::Scalar;
+    using Vector = test_stats::Vector;
+    using Distribution = test_stats::Distribution;
 
     // Statistics for TAGE predictor
 #ifdef UNIT_TEST
@@ -378,27 +377,25 @@ class BTBTAGE : public TimedBaseBTBPredictor
         Scalar updateBankConflict;           // Number of bank conflicts detected
         Scalar updateDeferredDueToConflict;  // Number of updates deferred due to bank conflict (retried later)
 
-#ifndef UNIT_TEST
         // Fine-grained per-bank statistics
-        statistics::Vector updateBankConflictPerBank;  // Conflicts per bank
-        statistics::Vector updateAccessPerBank;        // Update accesses per bank
-        statistics::Vector predAccessPerBank;          // Prediction accesses per bank
+        Vector updateBankConflictPerBank;  // Conflicts per bank
+        Vector updateAccessPerBank;        // Update accesses per bank
+        Vector predAccessPerBank;          // Prediction accesses per bank
 
-        statistics::Vector resolveProviderTable;
-        statistics::Vector resolveAltTable;
-        statistics::Vector resolveUseProviderTable;
-        statistics::Vector resolveUseAltTable;
-        statistics::Vector mispredictUseProviderTable;
-        statistics::Vector mispredictUseAltTable;
+        Vector resolveProviderTable;
+        Vector resolveAltTable;
+        Vector resolveUseProviderTable;
+        Vector resolveUseAltTable;
+        Vector mispredictUseProviderTable;
+        Vector mispredictUseAltTable;
 
-        statistics::Distribution predTableHits;
-        statistics::Distribution updateTableHits;
+        Distribution predTableHits;
+        Distribution updateTableHits;
 
-        statistics::Vector updateTableMispreds;
-        statistics::Vector predFinalSourceTable;
-        statistics::Vector updateFinalSourceTableCorrect;
-        statistics::Vector updateFinalSourceTableWrong;
-#endif
+        Vector updateTableMispreds;
+        Vector predFinalSourceTable;
+        Vector updateFinalSourceTableCorrect;
+        Vector updateFinalSourceTableWrong;
 
         Scalar condPredwrong;
         Scalar condMissTakens;
@@ -416,6 +413,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 #ifndef UNIT_TEST
         TageStats(statistics::Group* parent, int numPredictors, int numBanks);
 #endif
+        void init(int numPredictors, int numBanks);
         void updateStatsWithTagePrediction(const TagePrediction &pred, bool when_pred);
     } ;
 

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -73,6 +73,7 @@ MBTB::MBTB(unsigned numEntries, unsigned tagBits, unsigned numWays, unsigned num
       tagBits(tagBits)
 {
     setNumDelay(numDelay);
+    btbStats.init(numWays);
 #else
 // Production constructor
 MBTB::MBTB(const Params &p)
@@ -217,9 +218,7 @@ MBTB::processEntries(const std::vector<TickedBTBEntry>& entries, Addr startAddr)
         DPRINTF(BTB, "BTB: lookup hit, dumping hit entry\n");
         btbStats.predHit++;
         btbStats.predHitNum += hitNum;
-#ifndef UNIT_TEST
         btbStats.predHitCount.sample(hitNum);
-#endif
         for (auto &entry: processed_entries) {
             printTickedBTBEntry(entry);
         }
@@ -952,9 +951,15 @@ MBTB::BTBStats::BTBStats(statistics::Group* parent, int numWays) :
     ADD_STAT(victimCacheHit, statistics::units::Count::get(), "victim cache hits")
 
 {
-    predHitCount.init(0, numWays * 2, 1);   // max 4ways * 2(halfAligned) + VC
+    init(numWays);
 }
 #endif
+
+void
+MBTB::BTBStats::init(int numWays)
+{
+    predHitCount.init(0, numWays * 2, 1);
+}
 
 // Close conditional namespace wrapper for testing
 #ifdef UNIT_TEST

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -44,6 +44,7 @@
 
 #include "base/types.hh"
 #include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/test_stats.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
 
 // Conditional includes based on build mode
@@ -408,11 +409,8 @@ class MBTB : public TimedBaseBTBPredictor
         READ, WRITE, EVICT
     };
 
-#ifdef UNIT_TEST
-    typedef uint64_t Scalar;
-#else
-    typedef statistics::Scalar Scalar;
-#endif
+    using Scalar = test_stats::Scalar;
+    using Distribution = test_stats::Distribution;
 
 #ifdef UNIT_TEST
 public:
@@ -470,10 +468,11 @@ public:
         // Victim cache statistics
         Scalar victimCacheHit;
 
+        Distribution predHitCount;
 #ifndef UNIT_TEST
-        statistics::Distribution predHitCount;
         BTBStats(statistics::Group* parent, int numWays);
 #endif
+        void init(int numWays);
     } btbStats;
 
 };

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -342,8 +342,6 @@ class BTBTAGETest : public ::testing::Test
 protected:
     void SetUp() override {
         tage = new BTBTAGE();
-        // memset tageStats to 0
-        memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
         history.resize(64, false);  // 64-bit history initialized to 0
         stagePreds.resize(2);  // 2 stages
     }
@@ -910,7 +908,6 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
 TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
     // Start with a fresh predictor
     tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
-    memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
     history.resize(64, false);
     stagePreds.resize(2);
 
@@ -1004,7 +1001,6 @@ TEST_F(BTBTAGETest, AllocationBehaviorWithMultipleWays) {
 
 TEST_F(BTBTAGETest, AllocationReplacesStrongNotUsefulEntry) {
     tage = new BTBTAGE(1, 2, 10); // only 1 predictor table, 2 ways
-    memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
     history.resize(64, false);
     stagePreds.resize(2);
 
@@ -1141,7 +1137,6 @@ class BTBTAGEUpperBoundTest : public ::testing::Test
   protected:
     void SetUp() override {
         tage = new BTBTAGEUpperBound();
-        memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
         history.resize(128, false);
         stagePreds.resize(2);
     }
@@ -1157,7 +1152,6 @@ class BTBTAGEUpperBoundPathHashTest : public ::testing::Test
     void SetUp() override {
         tage = new BTBTAGEUpperBound(4, 1024, 4,
             BTBTAGEUpperBound::HistorySource::PathHash);
-        memset(&tage->tageStats, 0, sizeof(BTBTAGE::TageStats));
         outcomeHistory.resize(128, false);
         pathHistory.resize(128, false);
         stagePreds.resize(2);

--- a/src/cpu/pred/btb/test_stats.hh
+++ b/src/cpu/pred/btb/test_stats.hh
@@ -1,0 +1,149 @@
+/*
+ * Lightweight statistics shims for BTB predictor unit tests.
+ *
+ * Production builds use gem5's statistics classes directly.  Unit-test builds
+ * only need the tiny counter/vector/distribution API used by predictor logic,
+ * so this header provides drop-in stand-ins without pulling in the stats
+ * runtime.
+ */
+
+#ifndef __CPU_PRED_BTB_TEST_STATS_HH__
+#define __CPU_PRED_BTB_TEST_STATS_HH__
+
+#ifdef UNIT_TEST
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace gem5
+{
+namespace branch_prediction
+{
+namespace btb_pred
+{
+namespace test_stats
+{
+
+class Scalar
+{
+  private:
+    uint64_t value = 0;
+
+  public:
+    Scalar() = default;
+
+    Scalar &
+    operator++()
+    {
+        ++value;
+        return *this;
+    }
+
+    uint64_t
+    operator++(int)
+    {
+        uint64_t old = value;
+        ++value;
+        return old;
+    }
+
+    template <typename T>
+    Scalar &
+    operator+=(T delta)
+    {
+        value += static_cast<uint64_t>(delta);
+        return *this;
+    }
+
+    template <typename T>
+    Scalar &
+    operator=(T next)
+    {
+        value = static_cast<uint64_t>(next);
+        return *this;
+    }
+
+    operator uint64_t() const { return value; }
+};
+
+class Vector
+{
+  private:
+    std::vector<uint64_t> values;
+
+  public:
+    Vector() = default;
+
+    void init(std::size_t size) { values.assign(size, 0); }
+
+    uint64_t &operator[](std::size_t idx)
+    {
+        assert(idx < values.size());
+        return values[idx];
+    }
+
+    uint64_t operator[](std::size_t idx) const
+    {
+        assert(idx < values.size());
+        return values[idx];
+    }
+};
+
+class Distribution
+{
+  private:
+    int64_t min = 0;
+    int64_t max = 0;
+    int64_t bucket = 1;
+    std::vector<uint64_t> buckets;
+
+  public:
+    Distribution() = default;
+
+    void
+    init(int64_t min_value, int64_t max_value, int64_t bucket_size)
+    {
+        assert(bucket_size > 0);
+        min = min_value;
+        max = max_value;
+        bucket = bucket_size;
+        buckets.assign((max - min) / bucket + 1, 0);
+    }
+
+    void
+    sample(int64_t value, uint64_t count = 1)
+    {
+        if (value < min || value > max) {
+            return;
+        }
+        std::size_t idx = static_cast<std::size_t>((value - min) / bucket);
+        assert(idx < buckets.size());
+        buckets[idx] += count;
+    }
+};
+
+} // namespace test_stats
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5
+
+#else
+
+#include "base/statistics.hh"
+
+namespace gem5
+{
+namespace branch_prediction
+{
+namespace btb_pred
+{
+namespace test_stats = statistics;
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5
+
+#endif // UNIT_TEST
+
+#endif // __CPU_PRED_BTB_TEST_STATS_HH__


### PR DESCRIPTION
## Motivation

This PR is a small refactor for the BTB unit-test path. Some predictor tests need to exercise stats updates, but the previous code had to avoid or manually reset parts of gem5's production statistics objects in `UNIT_TEST` builds. That made the test path harder to read and easy to accidentally diverge from the production update logic.

## Approach

Introduce a lightweight `test_stats` shim for BTB unit tests, covering the small subset of `Scalar`, `Vector`, and `Distribution` APIs used by the predictor logic.

With this shim:

- MBTB and BTBTAGE can keep their stats update code closer to the production path.
- Unit tests no longer need to `memset` predictor stats manually.
- Several `#ifndef UNIT_TEST` guards around stats updates can be removed.
- Production builds still use gem5's normal statistics classes.

This is intended as a readability and testability refactor only. It does not change predictor algorithms, timing behavior, allocation policy, or production stats semantics.

## Scope

The change is scoped to the existing BTB/TAGE unit-test paths that currently need non-scalar stats support. ABTB already has a simple scalar-only `UNIT_TEST` stats path, and UBTB does not currently have a standalone unit-test build path, so they are left unchanged in this PR.

## Performance Impact

No performance change is expected. The production code continues to use gem5 statistics objects, and the shim is only active under `UNIT_TEST`.

## Validation

- Built/runs the affected BTB/TAGE unit-test target:
  - `scons build/RISCV/cpu/pred/btb/test/tage.test.debug --unit-test`
  - `./build/RISCV/cpu/pred/btb/test/tage.test.debug`