### PR TITLE
configs: Disable MGSC for SC benefit ablation

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -110,7 +110,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True
-            cpu.branchPred.mgsc.enabled = True
+            cpu.branchPred.mgsc.enabled = False
             cpu.branchPred.ras.enabled = True
 
         # l1 cache per core


### PR DESCRIPTION
## Summary
- Disable the whole MGSC predictor in the KMHV3 DecoupledBPUWithBTB config.
- Keep individual SC table settings untouched; this PR only measures whole-SC contribution on current xs-dev.

## Motivation
PR #852 previously showed about a 0.3 Int-score drop when SC was effectively removed. Since current mainline includes the recent PHR recovery fix, rerun the simplest SC-off ablation first before deciding whether table-level ablations are worth repeating.

## Validation
- python3 -m py_compile configs/example/kmhv3.py
- git diff --check

Expected follow-up: compare the perf robot score against current xs-dev.