### PR TITLE
cpu: Check BTB path history replay

### DIFF
--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -957,52 +957,13 @@ DecoupledBPUWithBTB::fillAheadPipeline(FetchTarget &entry)
 }
 
 void
-DecoupledBPUWithBTB::checkHistory(const boost::dynamic_bitset<> &history,
-                                  ThreadID tid)
+DecoupledBPUWithBTB::checkHistories(const boost::dynamic_bitset<> &history,
+                                    const boost::dynamic_bitset<> &phistory,
+                                    ThreadID tid)
 {
-    // This function performs a crucial validation of branch history consistency
-    // It rebuilds the "ideal" history from HistoryManager's records and compares
-    // it with the actual history being used by the branch predictor
-
-    // Initialize counter for total history bits and a bitset for rebuilt history
-    unsigned ideal_size = 0;
-    boost::dynamic_bitset<> ideal_hash_hist(historyBits, 0);
-
-    // Iterate through all speculative history entries stored in HistoryManager
-    for (const auto entry: historyManagers[tid].getSpeculativeHist()) {
-        // Only process entries that have non-zero shift amount (actual branches)
-        if (entry.shamt != 0) {
-            // Accumulate total history bits
-            ideal_size += entry.shamt;
-            DPRINTF(DecoupleBPVerbose, "pc: %#lx, shamt: %lu, cond_taken: %d\n", entry.pc,
-                    entry.shamt, entry.cond_taken);
-
-            // Rebuild history by shifting and setting bits based on recorded outcomes
-            // This emulates how history would be built if all branches were predicted perfectly
-            ideal_hash_hist <<= entry.shamt;
-            ideal_hash_hist[0] = entry.cond_taken;
-        }
-    }
-
-    // Determine how many bits to compare (minimum of ideal size and actual history bits)
-    unsigned comparable_size = std::min(ideal_size, historyBits);
-
-    // Prepare actual history for comparison by creating a copy
-    boost::dynamic_bitset<> sized_real_hist(history);
-
-    // Resize both histories to the comparable size for accurate comparison
-    ideal_hash_hist.resize(comparable_size);
-    sized_real_hist.resize(comparable_size);
-
-    // boost::to_string(ideal_hash_hist, buf1);
-    // boost::to_string(sized_real_hist, buf2);
-    DPRINTF(DecoupleBP,
-            "Ideal size:\t%u, real history size:\t%u, comparable size:\t%u\n",
-            ideal_size, historyBits, comparable_size);
-    // DPRINTF(DecoupleBP, "Ideal history:\t%s\nreal history:\t%s\n",
-    //         buf1.c_str(), buf2.c_str());
-
-    assert(ideal_hash_hist == sized_real_hist);
+    DPRINTF(DecoupleBP, "Checking GHR/PHR speculative history replay\n");
+    assert(historyManagers[tid].checkGHist(history, historyBits));
+    assert(historyManagers[tid].checkPHist(phistory, historyBits));
 }
 
 void
@@ -1069,8 +1030,8 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
 
     // Update history manager and verify TAGE folded history
     historyManagers[tid].addSpeculativeHist(
-        entry.startPC, ghist_update.shamt, ghist_update.taken,
-        entry.predBranchInfo, ftq.backId(tid) + 1);
+        entry.startPC, entry.history, entry.phistory, ghist_update,
+        phist_update, entry.predBranchInfo, ftq.backId(tid) + 1);
 
     // Update global backward history
     histShiftIn(bwhist_update.shamt, bwhist_update.taken, s0BwHistory);
@@ -1190,16 +1151,17 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
 
     // Update history manager with appropriate branch info
     if (squash_type == SQUASH_CTRL) {
-        historyManagers[tid].squash(target_id, ghist_update.shamt,
-                                    ghist_update.taken, target.exeBranchInfo);
+        historyManagers[tid].squash(target_id, ghist_update,
+                                    phist_update,
+                                    target.exeBranchInfo);
     } else {
-        historyManagers[tid].squash(target_id, ghist_update.shamt,
-                                    ghist_update.taken, BranchInfo());
+        historyManagers[tid].squash(target_id, ghist_update,
+                                    phist_update, BranchInfo());
     }
 
     // Perform history consistency checks when not a fast build variant
 #ifndef NDEBUG
-    checkHistory(s0History, tid);
+    checkHistories(s0History, s0PHistory, tid);
     if (tage->isEnabled()) {
         tage->checkFoldedHist(
             tage->usesPathHistory() ? s0PHistory : s0History, tid,

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -436,7 +436,9 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void overrideStats(OverrideReason overrideReason);
 
-    void checkHistory(const boost::dynamic_bitset<> &history, ThreadID tid);
+    void checkHistories(const boost::dynamic_bitset<> &history,
+                        const boost::dynamic_bitset<> &phistory,
+                        ThreadID tid);
 
     Addr getPreservedReturnAddr(const DynInstPtr &dynInst);
 

--- a/src/cpu/pred/btb/history_manager.hh
+++ b/src/cpu/pred/btb/history_manager.hh
@@ -4,6 +4,7 @@
 #include <list>
 
 #include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/folded_hist.hh"
 
 #ifdef UNIT_TEST
 #include "cpu/pred/btb/test/test_dprintf.hh"
@@ -46,15 +47,30 @@ class HistoryManager
      */
     struct HistoryEntry
     {
-        HistoryEntry(Addr _pc, int _shamt, bool _cond_taken, bool _is_call, bool _is_return,
-            Addr _retAddr, uint64_t stream_id)
-            : pc(_pc), shamt(_shamt), cond_taken(_cond_taken), is_call(_is_call),
-                is_return(_is_return), retAddr(_retAddr), streamId(stream_id)
+        HistoryEntry(Addr _pc,
+            const boost::dynamic_bitset<> &ghist_base,
+            const boost::dynamic_bitset<> &phist_base,
+            DirectionHistoryUpdate ghist_update,
+            PathHistoryUpdate phist_update, bool _is_call,
+            bool _is_return, Addr _retAddr, uint64_t stream_id)
+            : pc(_pc),
+              ghistBase(ghist_base),
+              phistBase(phist_base),
+              shamt(ghist_update.shamt),
+              cond_taken(ghist_update.taken),
+              phistUpdate(phist_update),
+              is_call(_is_call),
+              is_return(_is_return),
+              retAddr(_retAddr),
+              streamId(stream_id)
         {
         }
       Addr pc;           ///< Program counter of the branch
-      Addr shamt;        ///< Shift amount for history update
+      boost::dynamic_bitset<> ghistBase; ///< GHR before this speculative update
+      boost::dynamic_bitset<> phistBase; ///< PHR before this speculative update
+      int shamt;         ///< Shift amount for direction history update
       bool cond_taken;   ///< Whether conditional branch was taken
+      PathHistoryUpdate phistUpdate; ///< Path history update
       bool is_call;      ///< Whether branch is a call instruction
       bool is_return;    ///< Whether branch is a return instruction
       Addr retAddr;      ///< Return address (for call instructions)
@@ -93,13 +109,17 @@ class HistoryManager
      * This is called when a new branch prediction is made.
      *
      * @param addr Address of the branch
-     * @param shamt Shift amount for history update
-     * @param cond_taken Whether the branch was predicted taken
+     * @param ghist_update Direction-history update
+     * @param phist_update Path-history update
      * @param bi Branch information structure
      * @param stream_id ID of the fetch stream containing this branch
      */
-    void addSpeculativeHist(const Addr addr, const int shamt,
-                            bool cond_taken, BranchInfo &bi,
+    void addSpeculativeHist(const Addr addr,
+                            const boost::dynamic_bitset<> &ghist_base,
+                            const boost::dynamic_bitset<> &phist_base,
+                            const DirectionHistoryUpdate &ghist_update,
+                            const PathHistoryUpdate &phist_update,
+                            BranchInfo &bi,
                             const uint64_t stream_id)
     {
         // Extract branch type information from BranchInfo
@@ -108,8 +128,9 @@ class HistoryManager
         Addr retAddr = bi.getEnd();
 
         // Add new entry to the end of speculative history list
-        speculativeHists.emplace_back(addr, shamt, cond_taken, is_call,
-            is_return, retAddr, stream_id);
+        speculativeHists.emplace_back(addr, ghist_base, phist_base,
+            ghist_update, phist_update,
+            is_call, is_return, retAddr, stream_id);
 
         // Debug print the newly added entry
         const auto &it = speculativeHists.back();
@@ -163,12 +184,14 @@ class HistoryManager
      * and removes all subsequent speculative history entries.
      *
      * @param stream_id ID of the stream being squashed
-     * @param shamt Actual shift amount
-     * @param cond_taken Actual branch outcome (taken/not-taken)
+     * @param ghist_update Actual direction-history update
+     * @param phist_update Path-history update
      * @param bi Branch information structure with actual results
      */
-    void squash(const uint64_t stream_id, const int shamt,
-                const bool cond_taken, BranchInfo bi)
+    void squash(const uint64_t stream_id,
+                const DirectionHistoryUpdate &ghist_update,
+                const PathHistoryUpdate &phist_update,
+                BranchInfo bi)
     {
         // Debug dump before squash operations
         dump("before squash");
@@ -178,8 +201,9 @@ class HistoryManager
         while (it != speculativeHists.end()) {
             if (it->streamId == stream_id) {
                 // Found the squashed stream - update with correct information
-                it->cond_taken = cond_taken;
-                it->shamt = shamt;
+                it->cond_taken = ghist_update.taken;
+                it->shamt = ghist_update.shamt;
+                it->phistUpdate = phist_update;
 
                 // Update branch type information
                 it->is_call = bi.isCall;
@@ -207,6 +231,74 @@ class HistoryManager
 
         // Verify history integrity after squash
         checkSanity();
+    }
+
+    boost::dynamic_bitset<> replayGHist(unsigned history_bits) const
+    {
+        if (speculativeHists.empty()) {
+            return boost::dynamic_bitset<>(history_bits, 0);
+        }
+
+        // The first surviving entry stores the GHR snapshot before its own
+        // speculative update. Replaying all recorded direction updates from
+        // that base should reproduce DecoupledBPUWithBTB's current GHR after
+        // commit/squash bookkeeping.
+        boost::dynamic_bitset<> ideal_hist = speculativeHists.front().ghistBase;
+        ideal_hist.resize(history_bits);
+        for (const auto &entry : speculativeHists) {
+            if (entry.shamt <= 0) {
+                continue;
+            }
+            ideal_hist <<= entry.shamt;
+            ideal_hist[0] = entry.cond_taken;
+        }
+        return ideal_hist;
+    }
+
+    boost::dynamic_bitset<> replayPHist(unsigned history_bits) const
+    {
+        if (speculativeHists.empty()) {
+            return boost::dynamic_bitset<>(history_bits, 0);
+        }
+
+        // PHR uses the same ledger invariant as GHR, but replays the recorded
+        // PathHistoryUpdate instead of re-deriving path-update semantics here.
+        // This keeps HistoryManager a consistency checker for raw PHR state,
+        // while FetchTarget tests cover whether each descriptor is correct.
+        boost::dynamic_bitset<> ideal_hist = speculativeHists.front().phistBase;
+        ideal_hist.resize(history_bits);
+        for (const auto &entry : speculativeHists) {
+            const auto &update = entry.phistUpdate;
+            if (update.shamt <= 0 || !update.taken) {
+                continue;
+            }
+            ideal_hist <<= update.shamt;
+            uint64_t hash = pathHash(update.pc, update.target);
+            for (std::size_t i = 0;
+                 i < pathHashLength && i < ideal_hist.size(); ++i) {
+                ideal_hist[i] = (hash & 1) ^ ideal_hist[i];
+                hash >>= 1;
+            }
+        }
+        return ideal_hist;
+    }
+
+    bool checkGHist(const boost::dynamic_bitset<> &history,
+                    unsigned history_bits) const
+    {
+        if (speculativeHists.empty()) {
+            return true;
+        }
+        return compareHistory(replayGHist(history_bits), history, history_bits);
+    }
+
+    bool checkPHist(const boost::dynamic_bitset<> &history,
+                    unsigned history_bits) const
+    {
+        if (speculativeHists.empty()) {
+            return true;
+        }
+        return compareHistory(replayPHist(history_bits), history, history_bits);
     }
 
     /**
@@ -265,9 +357,26 @@ class HistoryManager
     {
         DPRINTF(DecoupleBPVerbose,
                 "%s stream: %lu, pc %#lx, shamt %ld, cond_taken %d, "
-                "is_call %d, is_ret %d, retAddr %#lx\n",
+                "phist_shamt %d, phist_taken %d, phist_pc %#lx, "
+                "phist_target %#lx, is_call %d, is_ret %d, retAddr %#lx\n",
                 when, entry.streamId, entry.pc, entry.shamt, entry.cond_taken,
+                entry.phistUpdate.shamt,
+                entry.phistUpdate.taken,
+                entry.phistUpdate.pc,
+                entry.phistUpdate.target,
                 entry.is_call, entry.is_return, entry.retAddr);
+    }
+
+  private:
+    static bool compareHistory(const boost::dynamic_bitset<> &ideal,
+                               const boost::dynamic_bitset<> &actual,
+                               unsigned history_bits)
+    {
+        boost::dynamic_bitset<> sized_ideal(ideal);
+        boost::dynamic_bitset<> sized_actual(actual);
+        sized_ideal.resize(history_bits);
+        sized_actual.resize(history_bits);
+        return sized_ideal == sized_actual;
     }
 };
 

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -41,6 +41,10 @@ GTest('folded_hist.test',
     '../folded_hist.cc',
 )
 
+GTest('history_manager.test',
+    'history_manager.test.cc',
+)
+
 # add --unit-test to enable unit test mode for RAS
 # TODO: Fix RAS test
 # GTest('ras.test',
@@ -55,6 +59,7 @@ env.Append(UNITTESTS=['uras.test',
         'tage.test',
         'mgsc.test',
         'folded_hist.test',
+        'history_manager.test',
         'jump_ahead.test',
         'fetch_target_queue.test',
         'decoupled_bpred.test'])

--- a/src/cpu/pred/btb/test/history_manager.test.cc
+++ b/src/cpu/pred/btb/test/history_manager.test.cc
@@ -1,0 +1,169 @@
+#include <gtest/gtest.h>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "cpu/pred/btb/history_manager.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+namespace test
+{
+
+namespace
+{
+
+void
+applyPathHistoryUpdate(boost::dynamic_bitset<> &history,
+                       const PathHistoryUpdate &update)
+{
+    if (!update.taken || update.shamt <= 0) {
+        return;
+    }
+
+    history <<= update.shamt;
+    uint64_t hash = pathHash(update.pc, update.target);
+    for (std::size_t i = 0; i < pathHashLength && i < history.size(); ++i) {
+        history[i] = (hash & 1) ^ history[i];
+        hash >>= 1;
+    }
+}
+
+void
+applyDirectionHistoryUpdate(boost::dynamic_bitset<> &history,
+                            const DirectionHistoryUpdate &update)
+{
+    if (update.shamt <= 0) {
+        return;
+    }
+
+    history <<= update.shamt;
+    history[0] = update.taken;
+}
+
+BranchInfo
+makeBranchInfo(Addr pc, Addr target, bool is_cond)
+{
+    BranchInfo info;
+    info.pc = pc;
+    info.target = target;
+    info.isCond = is_cond;
+    info.size = 4;
+    return info;
+}
+
+} // namespace
+
+TEST(HistoryManagerTest, PathReplayChecksRecordedSquashPathUpdate)
+{
+    constexpr unsigned history_bits = 128;
+    HistoryManager manager(16);
+
+    boost::dynamic_bitset<> base_ghr(history_bits, 0);
+    boost::dynamic_bitset<> base_phr(history_bits, 0);
+    base_ghr[3] = true;
+    base_phr[5] = true;
+
+    auto branch = makeBranchInfo(0x1008, 0x2040, false);
+
+    DirectionHistoryUpdate predicted_ghr;
+    PathHistoryUpdate predicted_phr;
+    predicted_phr.taken = false;
+    manager.addSpeculativeHist(0x1000, base_ghr, base_phr,
+                               predicted_ghr, predicted_phr, branch, 1);
+
+    DirectionHistoryUpdate actual_ghr;
+    actual_ghr.shamt = 0;
+    actual_ghr.taken = false;
+
+    PathHistoryUpdate actual_phr;
+    actual_phr.taken = true;
+    actual_phr.pc = branch.pc;
+    actual_phr.target = branch.target;
+    EXPECT_TRUE(actual_phr.taken);
+    EXPECT_EQ(actual_phr.pc, branch.pc);
+    EXPECT_EQ(actual_phr.target, branch.target);
+
+    manager.squash(1, actual_ghr, actual_phr, branch);
+
+    auto correct_ghr = base_ghr;
+    auto correct_phr = base_phr;
+    applyDirectionHistoryUpdate(correct_ghr, actual_ghr);
+    applyPathHistoryUpdate(correct_phr, actual_phr);
+
+    auto missing_path_update_phr = base_phr;
+
+    EXPECT_TRUE(manager.checkGHist(correct_ghr, history_bits));
+    EXPECT_TRUE(manager.checkPHist(correct_phr, history_bits));
+    EXPECT_FALSE(manager.checkPHist(missing_path_update_phr, history_bits));
+}
+
+TEST(HistoryManagerTest, SquashDropsYoungerPathUpdates)
+{
+    constexpr unsigned history_bits = 128;
+    HistoryManager manager(16);
+
+    boost::dynamic_bitset<> base_ghr(history_bits, 0);
+    boost::dynamic_bitset<> base_phr(history_bits, 0);
+
+    auto first = makeBranchInfo(0x1008, 0x2040, false);
+    auto younger = makeBranchInfo(0x1010, 0x3000, true);
+
+    DirectionHistoryUpdate first_ghr;
+    PathHistoryUpdate first_phr;
+    first_phr.taken = true;
+    first_phr.pc = first.pc;
+    first_phr.target = first.target;
+
+    manager.addSpeculativeHist(0x1000, base_ghr, base_phr,
+                               first_ghr, first_phr, first, 1);
+
+    auto after_first_ghr = base_ghr;
+    auto after_first_phr = base_phr;
+    applyDirectionHistoryUpdate(after_first_ghr, first_ghr);
+    applyPathHistoryUpdate(after_first_phr, first_phr);
+
+    DirectionHistoryUpdate younger_ghr;
+    younger_ghr.shamt = 1;
+    younger_ghr.taken = true;
+    PathHistoryUpdate younger_phr;
+    younger_phr.taken = true;
+    younger_phr.pc = younger.pc;
+    younger_phr.target = younger.target;
+
+    manager.addSpeculativeHist(0x1000, after_first_ghr, after_first_phr,
+                               younger_ghr, younger_phr, younger, 2);
+
+    DirectionHistoryUpdate actual_ghr;
+    actual_ghr.shamt = 0;
+    actual_ghr.taken = false;
+    PathHistoryUpdate actual_phr;
+    actual_phr.taken = true;
+    actual_phr.pc = first.pc;
+    actual_phr.target = first.target;
+
+    manager.squash(1, actual_ghr, actual_phr, first);
+
+    auto expected_phr = base_phr;
+    applyPathHistoryUpdate(expected_phr, actual_phr);
+
+    auto with_younger_phr = after_first_phr;
+    applyPathHistoryUpdate(with_younger_phr, younger_phr);
+
+    EXPECT_TRUE(manager.checkPHist(expected_phr, history_bits));
+    EXPECT_FALSE(manager.checkPHist(with_younger_phr, history_bits));
+}
+
+} // namespace test
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5


### PR DESCRIPTION
## Motivation

HistoryManager already replays speculative GHR state after squash, but raw PHR was not checked against the same speculative ledger. That made it easier for PHR bookkeeping drift to survive until a folded-history assert or a later predictor symptom.

## Approach

- Store the GHR and PHR base snapshots for each speculative history entry.
- Record the real DirectionHistoryUpdate and PathHistoryUpdate descriptors used by the BPU top level.
- Replay both GHR and PHR from the oldest surviving entry and check them against DecoupledBPUWithBTB's current histories after squash.
- Add focused HistoryManager unit tests for resolved path-history replay and dropping younger path updates.

This check intentionally does not create an independent oracle for PathHistoryUpdate descriptor generation. Descriptor semantics remain covered by FetchTarget/TAGE path-history tests.

## Validation

- scons build/RISCV/cpu/pred/btb/test/history_manager.test.debug build/RISCV/cpu/pred/btb/test/tage.test.debug --unit-test -j16
- ./build/RISCV/cpu/pred/btb/test/history_manager.test.debug
- ./build/RISCV/cpu/pred/btb/test/tage.test.debug --gtest_filter=BTBTAGEUpperBoundPathHashTest.RecoverPHistUsesTakenControlPath:FetchTargetHistoryUpdateTest.SquashUpdateSeparatesDirectionAndPath
- git diff --check
- scons build/RISCV/gem5.opt --gold-linker -j1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal branch history validation mechanisms to use direct consistency checks with both global and path history components.
  * Enhanced history tracking data structures to capture richer metadata during speculative execution and recovery operations.

* **Tests**
  * Added unit tests for branch history management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->