### PR TITLE
cpu-o3: Simplify SMT store buffer model

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -89,86 +89,16 @@ LSQ::DcachePort::DcachePort(LSQ *_lsq, CPU *_cpu) :
 
 std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;
 
-namespace
-{
-
-bool
-storeBufferEntryEligibleForLoad(const LSQ::StoreBufferEntry *entry,
-                                ThreadID load_tid, InstSeqNum load_seq,
-                                uint64_t visible_generation)
-{
-    if (!entry) {
-        return false;
-    }
-
-    if (entry->tid == load_tid) {
-        return entry->seqNum < load_seq;
-    }
-
-    return entry->generation != 0 && entry->generation <= visible_generation;
-}
-
-bool
-storeBufferByteEligibleForLoad(const LSQ::StoreBufferEntry *entry,
-                               size_t byte_idx, ThreadID load_tid,
-                               InstSeqNum load_seq,
-                               uint64_t visible_generation)
-{
-    if (!entry) {
-        return false;
-    }
-
-    if (entry->tid == load_tid) {
-        return entry->seqNum < load_seq;
-    }
-
-    if (!entry->sending) {
-        return false;
-    }
-
-    return byte_idx < entry->byteGenerations.size() &&
-           entry->byteGenerations[byte_idx] != 0 &&
-           entry->byteGenerations[byte_idx] <= visible_generation;
-}
-
-uint64_t
-storeBufferEligibleGeneration(const LSQ::StoreBufferEntry *entry,
-                              ThreadID load_tid, InstSeqNum load_seq,
-                              uint64_t visible_generation)
-{
-    if (!entry) {
-        return 0;
-    }
-
-    uint64_t best_generation = 0;
-    if (storeBufferEntryEligibleForLoad(entry, load_tid, load_seq,
-                                        visible_generation)) {
-        best_generation = entry->generation;
-    }
-    if (storeBufferEntryEligibleForLoad(entry->vice, load_tid, load_seq,
-                                        visible_generation)) {
-        best_generation = std::max(best_generation, entry->vice->generation);
-    }
-    return best_generation;
-}
-
-} // anonymous namespace
-
 void
 LSQ::StoreBufferEntry::reset(ThreadID tid, InstSeqNum seq_num,
                              uint64_t block_vaddr, uint64_t block_paddr,
                              uint64_t offset, uint8_t *datas, uint64_t size,
-                             const std::vector<bool> &mask,
-                             uint64_t generation)
+                             const std::vector<bool> &mask)
 {
     std::fill(validMask.begin(), validMask.begin() + offset, false);
-    std::fill(byteGenerations.begin(), byteGenerations.end(), 0);
 
     for (int i = 0; i < size; i++) {
         validMask[offset + i] = mask[i];
-        if (mask[i]) {
-            byteGenerations[offset + i] = generation;
-        }
     }
 
     std::fill(validMask.begin() + offset + size, validMask.end(), false);
@@ -178,7 +108,6 @@ LSQ::StoreBufferEntry::reset(ThreadID tid, InstSeqNum seq_num,
     this->seqNum = seq_num;
     this->blockVaddr = block_vaddr;
     this->blockPaddr = block_paddr;
-    this->generation = generation;
     this->sending = false;
     this->request = nullptr;
     this->vice = nullptr;
@@ -186,23 +115,20 @@ LSQ::StoreBufferEntry::reset(ThreadID tid, InstSeqNum seq_num,
 
 void
 LSQ::StoreBufferEntry::merge(uint64_t offset, uint8_t *datas, uint64_t size,
-                             const std::vector<bool> &mask,
-                             uint64_t generation)
+                             const std::vector<bool> &mask)
 {
     assert(offset + size <= validMask.size());
     for (uint64_t i = 0; i < size; ++i) {
         if (mask[i]) {
             blockDatas[offset + i] = datas[i];
             validMask[offset + i] = true;
-            byteGenerations[offset + i] = generation;
         }
     }
 }
 
 bool
 LSQ::StoreBufferEntry::recordForward(RequestPtr req, LSQRequest *lsqreq,
-                                     ThreadID load_tid, InstSeqNum load_seq,
-                                     uint64_t visible_generation)
+                                     ThreadID load_tid, InstSeqNum load_seq)
 {
     int offset = req->getPaddr() & (validMask.size() - 1);
     // the offset in the split request
@@ -211,16 +137,14 @@ LSQ::StoreBufferEntry::recordForward(RequestPtr req, LSQRequest *lsqreq,
         assert(offset == 0);
     }
     bool full_forward = true;
+    auto byteEligible = [&](StoreBufferEntry *entry, int byte_idx) {
+        return entry && entry->tid == load_tid && entry->seqNum < load_seq &&
+               entry->validMask[byte_idx];
+    };
     for (int i = 0; i < req->getSize(); i++) {
         assert(goffset + i < lsqreq->_size);
-        const bool vice_eligible =
-            vice && vice->validMask[offset + i] &&
-            storeBufferByteEligibleForLoad(vice, offset + i, load_tid,
-                                           load_seq, visible_generation);
-        const bool self_eligible =
-            validMask[offset + i] &&
-            storeBufferByteEligibleForLoad(this, offset + i, load_tid,
-                                           load_seq, visible_generation);
+        const bool vice_eligible = byteEligible(vice, offset + i);
+        const bool self_eligible = byteEligible(this, offset + i);
         if (vice_eligible) {
             // vice is newer
             assert(vice->blockVaddr == blockVaddr);
@@ -377,12 +301,6 @@ LSQ::StoreBuffer::getEvict()
     lru_index.pop_back();
     assert(data_vld[index]);
     return data_vec[index];
-}
-
-LSQ::StoreBufferEntry *
-LSQ::StoreBuffer::getEvict(const bool *eligible_tids, size_t num_threads)
-{
-    return getEvict(eligible_tids, nullptr, num_threads);
 }
 
 LSQ::StoreBufferEntry *
@@ -944,12 +862,11 @@ LSQ::processWriteback()
     // before sbuffer sendpackets
     clearAddresses();
 
-    bool storeblocked = false;
     std::list<ThreadID>::iterator threads = activeThreads->begin();
     std::list<ThreadID>::iterator end = activeThreads->end();
     while (threads != end) {
         ThreadID tid = *threads++;
-        storeblocked |= thread[tid].writebackBlockedStore(); // amo
+        thread[tid].writebackBlockedStore(); // amo
     }
 
     storeBufferWriteback();
@@ -969,14 +886,7 @@ LSQ::processWriteback()
     for (ThreadID tid : *activeThreads) {
         offload_demand[tid] = thread[tid].countStoreBufferOffloadableEntries(
             maxStoreBufferEntriesAcceptedFromSQPerCycle);
-        // During a global sbuffer flush, only threads that requested the
-        // flush may keep draining older committed stores from their SQ.
-        // If both SMT threads are flushing simultaneously, both must still be
-        // allowed to make forward progress, otherwise they can deadlock while
-        // waiting on each other's flush bit.
-        const bool conti =
-            !storeBufferFlushing() || storeBufferFlushing(tid);
-        if (conti && offload_demand[tid] != 0) {
+        if (offload_demand[tid] != 0) {
             requester_tids.push_back(tid);
         }
     }
@@ -1015,7 +925,6 @@ LSQ::processWriteback()
             }
         }
     }
-    threads = activeThreads->begin();
     bool has_thread_offloaded = false;
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         thread[(nextStoreBufferInsertTid + tid) % numThreads].offloadToStoreBuffer(offload_quota[(nextStoreBufferInsertTid + tid) % numThreads], offload_fail);
@@ -1067,37 +976,36 @@ LSQ::storeBufferWriteback()
         }
 
         std::optional<StoreBufferEvictCause> cause;
+        StoreBufferEntry *entry = nullptr;
         if (storeBufferFlushing()) {
-            cause = StoreBufferEvictCause::Flush;
-            DPRINTF(StoreBuffer, "sbuffer flushing\n");
-        } else if (storeBuffer.unsentSize() > getSbufferEvictThreshold()) {
+            entry = storeBuffer.getEvict(
+                _storeBufferFlushing, _storeBufferFlushBeforeSeq, numThreads);
+            if (entry) {
+                cause = StoreBufferEvictCause::Flush;
+                DPRINTF(StoreBuffer, "sbuffer flushing\n");
+            }
+        }
+        if (!entry && storeBuffer.unsentSize() > getSbufferEvictThreshold()) {
             cause = StoreBufferEvictCause::Full;
             DPRINTF(StoreBuffer, "sbuffer has reached threshold\n");
-        } else if (any_sq_will_full) {
+        } else if (!entry && any_sq_will_full) {
             cause = StoreBufferEvictCause::SQFull;
             DPRINTF(StoreBuffer, "sbuffer has reached SQ threshold\n");
-        } else if (getStoreBufferInactiveCycles() >
+        } else if (!entry && getStoreBufferInactiveCycles() >
                    getStoreBufferInactiveThreshold()) {
             cause = StoreBufferEvictCause::Timeout;
             DPRINTF(StoreBuffer, "sbuffer has reached timeout\n");
-        } else {
+        } else if (!entry) {
             incStoreBufferInactiveCycles();
         }
 
         if (cause) {
-            StoreBufferEntry *entry = nullptr;
-            if (*cause == StoreBufferEvictCause::Flush) {
-                entry = storeBuffer.getEvict(
-                    _storeBufferFlushing, _storeBufferFlushBeforeSeq,
-                    numThreads);
-            } else {
+            if (!entry) {
                 entry = storeBuffer.getEvict();
             }
             if (!entry) {
-                /* Disabled with the broad sbuffer watchdog above. */
                 return;
             }
-            /* Disabled with the broad sbuffer watchdog above. */
             auto &owner_unit = thread[entry->tid];
             recordStoreBufferEviction(*cause);
             DPRINTF(StoreBuffer, "Evicting sbuffer entry[%#x]\n",
@@ -1191,20 +1099,10 @@ void
 LSQ::completeSbufferEvict(PacketPtr pkt)
 {
     auto request = dynamic_cast<SbufferRequest *>(pkt->senderState);
-    const Addr block_paddr = request->sbuffer_entry->blockPaddr;
-    invalidateOtherThreadStoreBufferBytes(request->sbuffer_entry->tid,
-                                          request->mainReq()->getPaddr(),
-                                          request->mainReq()->getByteEnable(),
-                                          request->sbuffer_entry->generation);
-    markStoreBufferBlockVisible(block_paddr,
-                                request->sbuffer_entry->generation);
-    const bool replay_executed_loads =
-        cpu->consumeSyncVisibleStoreReplay(request->sbuffer_entry->tid);
+    cpu->consumeSyncVisibleStoreReplay(request->sbuffer_entry->tid);
     notifyOtherThreadsStoreVisible(request->sbuffer_entry->tid,
                                    request->mainReq()->getPaddr(),
-                                   request->mainReq()->getByteEnable(),
-                                   request->sbuffer_entry->seqNum,
-                                   replay_executed_loads);
+                                   request->mainReq()->getByteEnable());
     if (cpu->goldenMemManager() &&
         cpu->goldenMemManager()->inPmem(request->mainReq()->getPaddr())) {
         Addr paddr = request->mainReq()->getPaddr();
@@ -1216,7 +1114,6 @@ LSQ::completeSbufferEvict(PacketPtr pkt)
     }
 
     storeBuffer.release(request->sbuffer_entry);
-    reclaimStoreBufferBlockMetadata(block_paddr);
     DPRINTF(StoreBuffer,
             "finish entry[%#x] evict to cache, sbuffer size: %d, "
             "unsentsize: %d\n",
@@ -2017,179 +1914,26 @@ LSQ::flushStores(ThreadID tid, InstSeqNum seq_num)
     return false;
 }
 
-void
-LSQ::requestGlobalStoreBufferFlush()
-{
-    for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        _storeBufferFlushing[tid] = true;
-        _storeBufferFlushBeforeSeq[tid] = static_cast<InstSeqNum>(-1);
-    }
-}
-
-bool
-LSQ::storeBufferHasConflict(ThreadID tid, Addr block_paddr) const
-{
-    for (ThreadID other_tid = 0; other_tid < numThreads; ++other_tid) {
-        if (other_tid == tid) {
-            continue;
-        }
-
-        if (storeBuffer.get(other_tid, block_paddr)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-uint64_t
-LSQ::bumpStoreBufferBlockVersion(Addr block_paddr)
-{
-    auto &version = storeBufferBlockVersion[block_paddr];
-    ++version;
-    if (version == 0) {
-        version = 1;
-    }
-    return version;
-}
-
-uint64_t
-LSQ::currentStoreBufferBlockVersion(Addr block_paddr) const
-{
-    auto it = storeBufferBlockVersion.find(block_paddr);
-    return it == storeBufferBlockVersion.end() ? 0 : it->second;
-}
-
-void
-LSQ::markStoreBufferBlockVisible(Addr block_paddr, uint64_t generation)
-{
-    auto &visible = storeBufferVisibleVersion[block_paddr];
-    visible = std::max(visible, generation);
-    reclaimStoreBufferBlockMetadata(block_paddr);
-}
-
-uint64_t
-LSQ::currentStoreBufferVisibleVersion(Addr block_paddr) const
-{
-    auto it = storeBufferVisibleVersion.find(block_paddr);
-    return it == storeBufferVisibleVersion.end() ? 0 : it->second;
-}
-
 LSQ::StoreBufferEntry *
 LSQ::findForwardingStoreBufferEntry(Addr block_paddr, ThreadID load_tid,
                                     InstSeqNum load_seq) const
 {
-    StoreBufferEntry *best_entry = nullptr;
-    uint64_t best_generation = 0;
-    const auto visible_generation =
-        currentStoreBufferVisibleVersion(block_paddr);
-
-    for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        auto entry = storeBuffer.get(tid, block_paddr);
-        if (!entry) {
-            continue;
-        }
-
-        const uint64_t entry_generation =
-            storeBufferEligibleGeneration(entry, load_tid, load_seq,
-                                          visible_generation);
-        if (entry_generation == 0) {
-            continue;
-        }
-
-        if (!best_entry || entry_generation > best_generation) {
-            best_entry = entry;
-            best_generation = entry_generation;
-        }
+    auto entry = storeBuffer.get(load_tid, block_paddr);
+    if (!entry) {
+        return nullptr;
     }
 
-    return best_entry;
-}
-
-bool
-LSQ::hasLiveStoreBufferBlock(Addr block_paddr) const
-{
-    for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        if (storeBuffer.get(tid, block_paddr)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-void
-LSQ::reclaimStoreBufferBlockMetadata(Addr block_paddr)
-{
-    if (hasLiveStoreBufferBlock(block_paddr)) {
-        return;
+    if (entry->seqNum < load_seq ||
+        (entry->vice && entry->vice->seqNum < load_seq)) {
+        return entry;
     }
 
-    auto version_it = storeBufferBlockVersion.find(block_paddr);
-    if (version_it == storeBufferBlockVersion.end()) {
-        storeBufferVisibleVersion.erase(block_paddr);
-        return;
-    }
-
-    auto visible_it = storeBufferVisibleVersion.find(block_paddr);
-    const uint64_t visible_generation =
-        visible_it == storeBufferVisibleVersion.end() ? 0 : visible_it->second;
-    if (visible_generation < version_it->second) {
-        return;
-    }
-
-    storeBufferBlockVersion.erase(version_it);
-    if (visible_it != storeBufferVisibleVersion.end()) {
-        storeBufferVisibleVersion.erase(visible_it);
-    }
-}
-
-void
-LSQ::invalidateOtherThreadStoreBufferBytes(
-    ThreadID tid, Addr paddr, const std::vector<bool> &mask,
-    uint64_t generation)
-{
-    const Addr cache_block_mask =
-        ~((static_cast<Addr>(cpu->cacheLineSize())) - 1);
-    const Addr block_paddr = paddr & cache_block_mask;
-    const Addr offset = paddr & ~cache_block_mask;
-    auto invalidate_entry = [&](StoreBufferEntry *entry) {
-        if (!entry || offset + mask.size() > entry->validMask.size()) {
-            return;
-        }
-
-        if (!entry->sending) {
-            return;
-        }
-
-        for (size_t i = 0; i < mask.size(); ++i) {
-            if (mask[i] &&
-                entry->byteGenerations[offset + i] != 0 &&
-                entry->byteGenerations[offset + i] <= generation) {
-                entry->validMask[offset + i] = false;
-            }
-        }
-    };
-
-    for (ThreadID other_tid = 0; other_tid < numThreads; ++other_tid) {
-        if (other_tid == tid) {
-            continue;
-        }
-
-        auto entry = storeBuffer.get(other_tid, block_paddr);
-        if (!entry) {
-            continue;
-        }
-
-        invalidate_entry(entry);
-        invalidate_entry(entry->vice);
-    }
+    return nullptr;
 }
 
 void
 LSQ::notifyOtherThreadsStoreVisible(ThreadID tid, Addr store_paddr,
-                                    const std::vector<bool> &byte_enable,
-                                    InstSeqNum store_seq,
-                                    bool replay_executed_loads)
+                                    const std::vector<bool> &byte_enable)
 {
     if (numThreads <= 1) {
         return;
@@ -2215,9 +1959,7 @@ LSQ::notifyOtherThreadsStoreVisible(ThreadID tid, Addr store_paddr,
         if (other_tid == tid) {
             continue;
         }
-        thread[other_tid].checkLocalStoreVisible(store_paddr, byte_enable,
-                                                 store_seq,
-                                                 replay_executed_loads);
+        thread[other_tid].checkLocalStoreVisible(store_paddr, byte_enable);
     }
 }
 
@@ -2306,14 +2048,13 @@ LSQ::dumpStoreBuffer(ThreadID tid) const
             continue;
         }
 
-        cprintf("  idx:%d seq:%llu paddr:%#lx vaddr:%#lx sending=%d vice=%d generation=%llu request=%p\n",
+        cprintf("  idx:%d seq:%llu paddr:%#lx vaddr:%#lx sending=%d vice=%d request=%p\n",
                 entry->index,
                 static_cast<unsigned long long>(entry->seqNum),
                 entry->blockPaddr,
                 entry->blockVaddr,
                 entry->sending,
                 entry->vice != nullptr,
-                static_cast<unsigned long long>(entry->generation),
                 entry->request);
     }
 }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -153,8 +153,6 @@ class LSQ
         Addr blockPaddr;
         std::vector<uint8_t> blockDatas;
         std::vector<bool> validMask;
-        std::vector<uint64_t> byteGenerations;
-        uint64_t generation = 0;
         bool sending;
         // the another same addr entry when sending
         // another cannot sending until self sending finished
@@ -166,20 +164,17 @@ class LSQ
         {
             blockDatas.resize(size, 0);
             validMask.resize(size, false);
-            byteGenerations.resize(size, 0);
         }
 
         void reset(ThreadID tid, InstSeqNum seq_num, uint64_t block_vaddr,
                    uint64_t block_paddr, uint64_t offset, uint8_t *datas,
-                   uint64_t size, const std::vector<bool> &mask,
-                   uint64_t generation);
+                   uint64_t size, const std::vector<bool> &mask);
 
         void merge(uint64_t offset, uint8_t *datas, uint64_t size,
-                   const std::vector<bool> &mask, uint64_t generation);
+                   const std::vector<bool> &mask);
 
         bool recordForward(RequestPtr req, LSQRequest *lsqreq,
-                           ThreadID load_tid, InstSeqNum load_seq,
-                           uint64_t visible_generation);
+                           ThreadID load_tid, InstSeqNum load_seq);
     };
 
     class StoreBuffer
@@ -187,7 +182,7 @@ class LSQ
         using mapIter =
             typename std::unordered_map<uint64_t, StoreBufferEntry *>::iterator;
 
-        // key = (paddr & cacheblockmask)
+        // key = (paddr & cacheblockmask) plus tid
         uint64_t _size = 0;
         int max_size = 0;
         int max_thread = 0;
@@ -221,8 +216,6 @@ class LSQ
         StoreBufferEntry *get(ThreadID tid, uint64_t addr) const;
         void update(int index);
         StoreBufferEntry *getEvict();
-        StoreBufferEntry *getEvict(const bool *eligible_tids,
-                                   size_t num_threads);
         StoreBufferEntry *getEvict(const bool *eligible_tids,
                                    const InstSeqNum *eligible_seq,
                                    size_t num_threads);
@@ -374,7 +367,6 @@ class LSQ
         bool _hasStaleTranslation;
         bool _sbufferBypass;
         bool _goldenSnapshotCaptured = false;
-        uint64_t _storeBufferGeneration = 0;
 
         struct FWDPacket
         {
@@ -1038,24 +1030,11 @@ class LSQ
     // true if all stores are flushed
     bool flushStores(ThreadID tid);
     bool flushStores(ThreadID tid, InstSeqNum seq_num);
-    void requestGlobalStoreBufferFlush();
-    bool storeBufferHasConflict(ThreadID tid, Addr block_paddr) const;
-    uint64_t bumpStoreBufferBlockVersion(Addr block_paddr);
-    uint64_t currentStoreBufferBlockVersion(Addr block_paddr) const;
-    void markStoreBufferBlockVisible(Addr block_paddr, uint64_t generation);
-    uint64_t currentStoreBufferVisibleVersion(Addr block_paddr) const;
     StoreBufferEntry *findForwardingStoreBufferEntry(Addr block_paddr,
                                                      ThreadID load_tid,
                                                      InstSeqNum load_seq) const;
-    bool hasLiveStoreBufferBlock(Addr block_paddr) const;
-    void reclaimStoreBufferBlockMetadata(Addr block_paddr);
-    void invalidateOtherThreadStoreBufferBytes(
-        ThreadID tid, Addr paddr, const std::vector<bool> &mask,
-        uint64_t generation);
     void notifyOtherThreadsStoreVisible(ThreadID tid, Addr store_paddr,
-                                        const std::vector<bool> &byte_enable,
-                                        InstSeqNum store_seq,
-                                        bool replay_executed_loads);
+                                        const std::vector<bool> &byte_enable);
 
     /** Returns the number of stores a specific thread has to write back. */
     int numStoresToSbuffer(ThreadID tid);
@@ -1290,8 +1269,6 @@ class LSQ
     const uint64_t storeBufferInactiveThreshold;
     const uint32_t maxStoreBufferEntriesAcceptedFromSQPerCycle = 2;
     StoreBuffer storeBuffer;
-    std::unordered_map<Addr, uint64_t> storeBufferBlockVersion;
-    std::unordered_map<Addr, uint64_t> storeBufferVisibleVersion;
     bool _storeBufferFlushing[MaxThreads] = {false};
     InstSeqNum _storeBufferFlushBeforeSeq[MaxThreads] = {
         static_cast<InstSeqNum>(-1)

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1069,13 +1069,8 @@ overlapsVisibleStore(const o3::LSQ::LSQRequest *load_req, Addr store_paddr,
 
 void
 LSQUnit::checkLocalStoreVisible(Addr store_paddr,
-                                const std::vector<bool> &store_byte_enable,
-                                InstSeqNum store_seq,
-                                bool replay_executed_loads)
+                                const std::vector<bool> &store_byte_enable)
 {
-    [[maybe_unused]] const InstSeqNum visible_store_seq = store_seq;
-    [[maybe_unused]] const bool replay_visible_loads = replay_executed_loads;
-
     if (loadQueue.empty()) {
         return;
     }
@@ -2270,13 +2265,6 @@ LSQUnit::directStoreToCache()
     }
 
     if (request->mainReq()->hasPaddr()) {
-        if (request->_storeBufferGeneration == 0) {
-            const Addr block_paddr =
-                request->mainReq()->getPaddr() & cacheBlockMask;
-            request->_storeBufferGeneration =
-                lsq->bumpStoreBufferBlockVersion(block_paddr);
-        }
-
         if (system->multiContextDifftest() && inst->isAtomic() &&
             cpu->goldenMemManager() &&
             cpu->goldenMemManager()->inPmem(request->mainReq()->getPaddr())) {
@@ -2387,14 +2375,6 @@ LSQUnit::offloadToStoreBuffer(uint32_t max_entries, std::vector<bool>& offload_f
             if (!(storeWBIt.idx() == storeQueue.head())) {
                 break;
             }
-            if (request->mainReq()->hasPaddr()) {
-                const Addr block_paddr =
-                    request->mainReq()->getPaddr() & cacheBlockMask;
-                if (lsq->storeBufferHasConflict(lsqID, block_paddr)) {
-                    lsq->requestGlobalStoreBufferFlush();
-                    break;
-                }
-            }
             if (!storeBufferEmpty(lsqID)) {
                 lsq->flushStores(lsqID);
                 break;
@@ -2472,7 +2452,6 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
 
     // check request is not already in the storebuffer
     auto entry = storeBuffer.get(lsqID, blockPaddr);
-    const auto generation = lsq->bumpStoreBufferBlockVersion(blockPaddr);
 
     if (entry) {
         if (entry->sending) {
@@ -2480,8 +2459,7 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
                 // merge into vice
                 stats.sbufferMerge++;
                 entry = entry->vice;
-                entry->merge(offset, datas, size, mask, generation);
-                entry->generation = generation;
+                entry->merge(offset, datas, size, mask);
                 DPRINTF(StoreBuffer, "Merging vice entry[%#x] for addr %#x\n",
                         blockPaddr, paddr);
             } else {
@@ -2495,8 +2473,7 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
                 stats.sbufferCreateVice++;
                 auto vice = storeBuffer.createVice(entry);
                 vice->reset(lsqID, store_seq, blockVaddr, blockPaddr, offset,
-                            datas, size, mask, generation);
-                vice->generation = generation;
+                            datas, size, mask);
                 DPRINTF(StoreBuffer, "Create new vice entry[%#x] for addr %#x\n",
                         blockPaddr, paddr);
             }
@@ -2504,9 +2481,8 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
             // merge into unsent
             stats.sbufferMerge++;
             storeBuffer.update(entry->index);
-            entry->merge(offset, datas, size, mask, generation);
+            entry->merge(offset, datas, size, mask);
             entry->seqNum = std::max(entry->seqNum, store_seq);
-            entry->generation = generation;
             DPRINTF(StoreBuffer, "Merging entry[%#x] for addr %#x\n",
                     blockPaddr, paddr);
         }
@@ -2522,8 +2498,7 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
         stats.sbufferNewline++;
         auto entry = storeBuffer.getEmpty();
         entry->reset(lsqID, store_seq, blockVaddr, blockPaddr, offset, datas,
-                     size, mask, generation);
-        entry->generation = generation;
+                     size, mask);
         storeBuffer.insert(entry);
         DPRINTF(StoreBuffer, "Create new entry[%#x] for addr %#x\n",
                 blockPaddr, paddr);
@@ -2888,32 +2863,12 @@ LSQUnit::completeStore(typename StoreQueue::iterator store_idx, bool from_sbuffe
     if (!from_sbuffer &&
         (!store_inst->isStoreConditional() || store_inst->lockedWriteSuccess()) &&
         has_paddr) {
-        const Addr block_paddr = request->mainReq()->getPaddr() & cacheBlockMask;
-        auto generation = request->_storeBufferGeneration;
-        const bool replay_executed_loads =
-            store_inst->isAtomic() || cpu->consumeSyncVisibleStoreReplay(lsqID);
-        if (generation == 0) {
-            generation = lsq->bumpStoreBufferBlockVersion(block_paddr);
+        if (!store_inst->isAtomic()) {
+            cpu->consumeSyncVisibleStoreReplay(lsqID);
         }
-        lsq->invalidateOtherThreadStoreBufferBytes(
-            lsqID, request->mainReq()->getPaddr(),
-            request->mainReq()->getByteEnable(), generation);
-        lsq->markStoreBufferBlockVisible(block_paddr, generation);
         lsq->notifyOtherThreadsStoreVisible(lsqID,
             request->mainReq()->getPaddr(),
-            request->mainReq()->getByteEnable(), store_inst->seqNum,
-            replay_executed_loads);
-    }
-
-    if (from_sbuffer &&
-        (!store_inst->isStoreConditional() || store_inst->lockedWriteSuccess()) &&
-        has_paddr) {
-        auto generation = request->_storeBufferGeneration;
-        if (generation == 0) {
-            generation = lsq->bumpStoreBufferBlockVersion(
-                request->mainReq()->getPaddr() & cacheBlockMask);
-            request->_storeBufferGeneration = generation;
-        }
+            request->mainReq()->getByteEnable());
     }
 
     if (!from_sbuffer &&
@@ -3056,8 +3011,7 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
                 DPRINTF(StoreBuffer, "sbuffer entry[%#x] coverage %s\n", entry->blockPaddr, pkt->print());
                 if (entry->recordForward(
                         pkt->req, request, lsqID,
-                        request->instruction()->seqNum,
-                        lsq->currentStoreBufferVisibleVersion(block_addr))) {
+                        request->instruction()->seqNum)) {
                     assert(request->isSplit()); // here must be split request
                     stats.sbufferFullForward++;
                 } else if (!request->SBforwardPackets.empty()) {
@@ -3699,9 +3653,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
             blk_addr, lsqID, load_inst->seqNum);
         if (entry) {
             if (entry->recordForward(request->mainReq(), request, lsqID,
-                                     load_inst->seqNum,
-                                     lsq->currentStoreBufferVisibleVersion(
-                                         blk_addr))) {
+                                     load_inst->seqNum)) {
                 // full forward
                 // no need to send to cache
                 stats.sbufferFullForward++;

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -331,9 +331,7 @@ class LSQUnit
      */
     void checkSnoop(PacketPtr pkt);
     void checkLocalStoreVisible(Addr store_paddr,
-                                const std::vector<bool> &store_byte_enable,
-                                InstSeqNum store_seq,
-                                bool replay_executed_loads);
+                                const std::vector<bool> &store_byte_enable);
 
     /** Iq issues a load to load pipeline. */
     void issueToLoadPipe(const DynInstPtr &inst);


### PR DESCRIPTION
Change-Id: I3f49aef4fb11ee91e80a23a8d30d9af3ce5b0695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified store-buffer forwarding logic in multi-threaded CPU simulation by removing generation-based visibility tracking.
  * Optimized store-buffer writeback path and inter-thread visibility mechanisms for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->