### PR TITLE
[codex] Refactor BTB branch and prediction payloads

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -858,22 +858,24 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
     const auto &stream = dbpbtb->ftqFetchingTarget(tid);
 
     const Addr curr_pc = next_pc.instAddr();
-    assert(stream.startPC <= curr_pc && curr_pc < stream.predEndPC);
+    assert(stream.startPC <= curr_pc &&
+           curr_pc < stream.prediction.fallThrough);
 
     bool run_out = false;
 
     // Taken when the current PC matches the predicted control PC.
-    predict_taken = stream.predTaken && (curr_pc == stream.predBranchInfo.pc);
+    predict_taken = stream.prediction.taken &&
+                    (curr_pc == stream.prediction.branchSlot.pc);
     if (predict_taken) {
         auto &rpc = next_pc.as<GenericISA::PCStateWithNext>();
-        rpc.pc(stream.predBranchInfo.target);
-        rpc.npc(stream.predBranchInfo.target + 4);
+        rpc.pc(stream.prediction.branchSlot.target);
+        rpc.npc(stream.prediction.branchSlot.target + 4);
         rpc.uReset();
         run_out = true;
     } else if (inst->staticInst->isMicroop()) {
         // Microops must advance uPC explicitly; they do not rely on decoder NPC.
         inst->staticInst->advancePC(next_pc);
-        run_out = next_pc.instAddr() >= stream.predEndPC;
+        run_out = next_pc.instAddr() >= stream.prediction.fallThrough;
     } else {
         // Sequential fetch: decoder already computed npc with correct inst size.
         auto &rpc = next_pc.as<RiscvISA::PCState>();
@@ -882,7 +884,7 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
         // Placeholder; decoder will overwrite npc on the next decode.
         rpc.npc(fall_thru + 4);
         rpc.uReset();
-        run_out = fall_thru >= stream.predEndPC;
+        run_out = fall_thru >= stream.prediction.fallThrough;
     }
 
     // Track how many dynamic instructions were fetched for this (legacy) FTQ/FSQ entry.
@@ -2205,7 +2207,7 @@ Fetch::sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state) {
     threads[tid].startPC = start_pc;
 
     if (current_pc < stream.startPC ||
-        current_pc >= stream.predEndPC) {
+        current_pc >= stream.prediction.fallThrough) {
         auto &reset_pc = threads[tid].fetchpc->as<RiscvISA::PCState>();
         reset_pc.pc(stream.startPC);
         reset_pc.npc(stream.startPC + 4);
@@ -2214,12 +2216,12 @@ Fetch::sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state) {
                 "[tid:%i] Resetting fetch PC to new FTQ stream start %s "
                 "(previous PC %#lx outside [%#lx, %#lx))\n",
                 tid, *threads[tid].fetchpc, current_pc,
-                stream.startPC, stream.predEndPC);
+                stream.startPC, stream.prediction.fallThrough);
     }
 
     DPRINTF(Fetch, "[tid:%i] Issuing a pipelined I-cache access for new FSQ entry, "
                   "starting at PC %#x (endPC %#x; original PC %s)\n",
-            tid, start_pc, stream.predEndPC, pc_state);
+            tid, start_pc, stream.prediction.fallThrough, pc_state);
     fetchCacheLine(start_pc, tid, pc_state.instAddr());
 }
 

--- a/src/cpu/o3/trace/TraceFetch.cc
+++ b/src/cpu/o3/trace/TraceFetch.cc
@@ -538,9 +538,9 @@ TraceFetch::chooseWrongPathNopSize(ThreadID tid, Addr pc)
         assert(fetch.dbpbtb);
         if (fetch.dbpbtb->ftqHasFetching(tid)) {
             const auto &stream = fetch.dbpbtb->ftqFetchingTarget(tid);
-            block_end = stream.predEndPC;
-            taken_pc = stream.predBranchInfo.pc;
-            taken = stream.predTaken;
+            block_end = stream.prediction.fallThrough;
+            taken_pc = stream.prediction.branchSlot.pc;
+            taken = stream.prediction.taken;
         }
     }
     // If the current PC matches predicted takenPC (assume 4B branches), use a 4B NOP.

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -301,15 +301,15 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
     // Set predictions for each branch
     for (auto &e : mixed_entries) {
         assert(e.valid);
-        if (e.isCond()) {
+        if (e.slot.isCond()) {
             FillStageLoop(s) stagePreds[s].condTakens.push_back({e.slot.pc, e.alwaysTaken || (e.ctr >= 0)});
-        } else if (e.isIndirect()) {
+        } else if (e.slot.isIndirect()) {
             // Set predicted target for indirect branches
             DPRINTF(ABTB, "setting indirect target for pc %#lx to %#lx\n", e.slot.pc, e.slot.target);
 
             FillStageLoop(s) stagePreds[s].indirectTargets.push_back({e.slot.pc, e.slot.target});
 
-            if (e.isReturn()) {
+            if (e.slot.isReturn()) {
                 FillStageLoop(s) stagePreds[s].returnTarget = e.slot.target;
             }
             break;
@@ -496,7 +496,7 @@ AheadBTB::checkPredictionHit(const FetchTarget &stream, const BTBMeta* meta)
 {
     bool pred_branch_hit = false;
     for (auto &e : meta->hit_entries) {
-        if (stream.exeBranchInfo == e) {
+        if (stream.exeBranchInfo == e.slot) {
             pred_branch_hit = true;
             break;
         }
@@ -563,11 +563,11 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
     }
     // if cond entry in btb now, use the one in btb, since we need the up-to-date counter
     // else use the recorded entry
-    auto entry_to_write = entry.isCond() && found ? BTBEntry(*it) : entry;
+    auto entry_to_write = entry.slot.isCond() && found ? BTBEntry(*it) : entry;
     entry_to_write.slot.resolved = false; // reset resolved bit on update
     entry_to_write.tag = btb_tag;   // update tag after found it!
     // update saturating counter if necessary
-    if (entry_to_write.isCond()) {
+    if (entry_to_write.slot.isCond()) {
         bool this_cond_taken = isTaken && takenbranchinfo.pc == entry_to_write.slot.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
@@ -577,7 +577,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
         }
     }
     // update indirect target if necessary
-    if (entry_to_write.isIndirect() && isTaken && takenbranchinfo.pc == entry_to_write.slot.pc) {
+    if (entry_to_write.slot.isIndirect() && isTaken &&
+        takenbranchinfo.pc == entry_to_write.slot.pc) {
         entry_to_write.slot.target = takenbranchinfo.target;
     }
     auto ticked_entry = TickedBTBEntry(entry_to_write, curTick());
@@ -587,7 +588,7 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(ticked_entry.slot.pc, ticked_entry.getType(),
+            rec.set(ticked_entry.slot.pc, ticked_entry.slot.getType(),
                 ticked_entry.slot.target, btb_idx, Mode::WRITE, 1);
             btbTrace->write_record(rec);
         }
@@ -603,7 +604,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+            rec.set(entry_in_btb_now->slot.pc,
+                entry_in_btb_now->slot.getType(),
                     entry_in_btb_now->slot.target, btb_idx, Mode::EVICT, 0);
                 btbTrace->write_record(rec);
         }
@@ -620,7 +622,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+            rec.set(entry_in_btb_now->slot.pc,
+                entry_in_btb_now->slot.getType(),
                 entry_in_btb_now->slot.target, btb_idx, Mode::WRITE, 0);
             btbTrace->write_record(rec);
         }
@@ -639,8 +642,9 @@ AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
         return;
     }
 
-    Addr end_inst_pc = s3Pred.isTaken() ? s3Pred.getTakenEntry().slot.pc :
-                            (s3Pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
+    auto taken_result = s3Pred.getTakenSlotResult(predictWidth);
+    Addr end_inst_pc = taken_result.taken() ? taken_result.controlPC() :
+                       taken_result.fallThrough;
 
     // AheadBTB use S3 prediction for update
     auto &state = threadState(s3Pred.tid);
@@ -656,12 +660,14 @@ AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
             return;
         }
         Addr btb_idx = getIndex(previousPC, s3Pred.asidHash);  // use last pc to get idx
-        BranchInfo takenbranchinfo;
-        takenbranchinfo.pc = s3Pred.getTakenEntry().slot.pc;
-        takenbranchinfo.target = s3Pred.getTakenEntry().slot.target;
+        BranchSlot takenbranchinfo;
+        if (taken_result.taken()) {
+            takenbranchinfo = taken_result.resolvedSlot();
+        }
         entry.source = getComponentIdx(); // mark the entry source as AheadBTB
 
-        updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo, s3Pred.isTaken());
+        updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo,
+                       taken_result.taken());
     }
 }
 std::vector<BTBEntry>
@@ -670,20 +676,21 @@ AheadBTB::collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entr
 {
     auto all_entries = old_entries;
     BTBEntry new_entry = BTBEntry();
+    auto taken_entry = s3Pred.getTakenEntry();
     // which causes its counter to update twice unintentionally
     // we need to check if the new entry already exists in uBTB
     bool pred_branch_hit = false;
     for (auto &e: old_entries) {
-        if (s3Pred.getTakenEntry() == e) {
+        if (taken_entry == e) {
             pred_branch_hit = true;
             break;
         }
     }
-    if (!pred_branch_hit&& s3Pred.isTaken()) {
-        new_entry = s3Pred.getTakenEntry();
+    if (!pred_branch_hit && taken_entry.valid) {
+        new_entry = taken_entry;
         new_entry.valid = true;
 
-        if (new_entry.isCond()) {
+        if (new_entry.slot.isCond()) {
             new_entry.alwaysTaken = true;
             new_entry.ctr = 0;
         }

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -471,7 +471,7 @@ AheadBTB::processOldEntries(const std::vector<BTBEntry>& hit_entries,
 {
     // auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
     // // hit entries whose corresponding insts are acutally executed
-    // Addr end_inst_pc = stream.updateEndInstPC;
+    // Addr end_inst_pc = stream.update.endInstPC;
     DPRINTF(ABTB, "end_inst_pc: %#lx\n", end_inst_pc);
     // remove not executed btb entries, pc > end_inst_pc
     auto old_entries = hit_entries;
@@ -496,13 +496,13 @@ AheadBTB::checkPredictionHit(const FetchTarget &stream, const BTBMeta* meta)
 {
     bool pred_branch_hit = false;
     for (auto &e : meta->hit_entries) {
-        if (stream.exeBranchInfo == e.slot) {
+        if (stream.resolve.branchSlot == e.slot) {
             pred_branch_hit = true;
             break;
         }
     }
-    if (!pred_branch_hit && stream.exeTaken) {
-        DPRINTF(ABTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
+    if (!pred_branch_hit && stream.resolve.taken) {
+        DPRINTF(ABTB, "update miss detected, pc %#lx, predTick %lu\n", stream.resolve.branchSlot.pc, stream.predTick);
         btbStats.updateMiss++;
     }
 
@@ -525,13 +525,13 @@ AheadBTB::collectEntriesToUpdate(const std::vector<BTBEntry>& old_entries,
     // we need to check if the new entry already exists in uBTB
     bool pred_branch_hit = false;
     for (auto &e: all_entries) {
-        if (stream.updateNewBTBEntry == e) {
+        if (stream.update.newBTBEntry == e) {
             pred_branch_hit = true;
             break;
         }
     }
     if (!pred_branch_hit) {
-        all_entries.push_back(stream.updateNewBTBEntry);
+        all_entries.push_back(stream.update.newBTBEntry);
     }
 
     DPRINTF(ABTB, "all_entries_to_update.size(): %lu\n", all_entries.size());
@@ -718,7 +718,7 @@ AheadBTB::update(const FetchTarget &stream)
         return;
     }
     auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]).get();
-    Addr end_inst_pc = stream.updateEndInstPC;
+    Addr end_inst_pc = stream.update.endInstPC;
 
     // 1. Process old entries
     auto old_entries = processOldEntries(meta->hit_entries, end_inst_pc);
@@ -743,7 +743,7 @@ AheadBTB::update(const FetchTarget &stream)
         }
         Addr btb_idx = getIndex(previousPC, stream.asidHash);  // use last pc to get idx
         entry.source = getComponentIdx(); // mark the entry source as AheadBTB
-        updateBTBEntry(btb_idx, btb_tag, entry, stream.exeBranchInfo, stream.exeTaken);
+        updateBTBEntry(btb_idx, btb_tag, entry, stream.resolve.branchSlot, stream.resolve.taken);
     }
 }
 
@@ -794,7 +794,7 @@ AheadBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     }
     // bool this_branch_miss = !this_branch_hit;
     bool cond_not_taken = inst->isCondCtrl() && !inst->branching();
-    bool this_branch_taken = stream.exeTaken && stream.getControlPC() == pc; // all uncond should be taken
+    bool this_branch_taken = stream.resolve.taken && stream.getControlPC() == pc; // all uncond should be taken
     Addr this_branch_target = npc;
     if (this_branch_hit) {
         btbStats.allBranchHits++;

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -199,12 +199,12 @@ AheadBTB::processEntries(const std::vector<TickedBTBEntry>& entries, Addr startA
     // Sort by instruction order
     std::sort(processed_entries.begin(), processed_entries.end(), 
              [](const BTBEntry &a, const BTBEntry &b) {
-                 return a.pc < b.pc;
+                 return a.slot.pc < b.slot.pc;
              });
 
     auto it = std::remove_if(processed_entries.begin(), processed_entries.end(),
                            [startAddr](const BTBEntry &e) {
-                               return e.pc < startAddr;
+                               return e.slot.pc < startAddr;
                            });
     processed_entries.erase(it, processed_entries.end());
 
@@ -212,7 +212,7 @@ AheadBTB::processEntries(const std::vector<TickedBTBEntry>& entries, Addr startA
                     ~mask(floorLog2(predictWidth) - 1);
     it = std::remove_if(processed_entries.begin(), processed_entries.end(),
                         [abtb_end](const BTBEntry &e) {
-                            return e.pc >= abtb_end;
+                            return e.slot.pc >= abtb_end;
                         });
     processed_entries.erase(it, processed_entries.end());
 
@@ -256,7 +256,7 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
         assert(ubtb_pred_entry.valid);
         mixed_entries = entries;
         for (auto &entry : mixed_entries) {
-            if (entry.pc == ubtb_pred_entry.pc) {
+            if (entry.slot.pc == ubtb_pred_entry.slot.pc) {
                 entry.valid = false; // invalidate duplicated entry from aBTB (only use for align counter)
                 break;
             }
@@ -265,7 +265,7 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
         // Deduplicate entries by pc (order can change)
         std::sort(mixed_entries.begin(), mixed_entries.end(),
               [](const TickedBTBEntry& a, const TickedBTBEntry& b) {
-                  return a.pc < b.pc;
+                  return a.slot.pc < b.slot.pc;
               });
         // Drop entries invalidated during deduplication above
         mixed_entries.erase(std::remove_if(mixed_entries.begin(), mixed_entries.end(),
@@ -301,16 +301,16 @@ AheadBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
     // Set predictions for each branch
     for (auto &e : mixed_entries) {
         assert(e.valid);
-        if (e.isCond) {
-            FillStageLoop(s) stagePreds[s].condTakens.push_back({e.pc, e.alwaysTaken || (e.ctr >= 0)});
-        } else if (e.isIndirect) {
+        if (e.isCond()) {
+            FillStageLoop(s) stagePreds[s].condTakens.push_back({e.slot.pc, e.alwaysTaken || (e.ctr >= 0)});
+        } else if (e.isIndirect()) {
             // Set predicted target for indirect branches
-            DPRINTF(ABTB, "setting indirect target for pc %#lx to %#lx\n", e.pc, e.target);
+            DPRINTF(ABTB, "setting indirect target for pc %#lx to %#lx\n", e.slot.pc, e.slot.target);
 
-            FillStageLoop(s) stagePreds[s].indirectTargets.push_back({e.pc, e.target});
+            FillStageLoop(s) stagePreds[s].indirectTargets.push_back({e.slot.pc, e.slot.target});
 
-            if (e.isReturn) {
-                FillStageLoop(s) stagePreds[s].returnTarget = e.target;
+            if (e.isReturn()) {
+                FillStageLoop(s) stagePreds[s].returnTarget = e.slot.target;
             }
             break;
         }
@@ -478,7 +478,7 @@ AheadBTB::processOldEntries(const std::vector<BTBEntry>& hit_entries,
     DPRINTF(ABTB, "old_entries.size(): %lu\n", old_entries.size());
     //dumpBTBEntries(old_entries);
     auto remove_it = std::remove_if(old_entries.begin(), old_entries.end(),
-        [end_inst_pc](const BTBEntry &e) { return e.pc > end_inst_pc; });
+        [end_inst_pc](const BTBEntry &e) { return e.slot.pc > end_inst_pc; });
     old_entries.erase(remove_it, old_entries.end());
     DPRINTF(ABTB, "after removing not executed insts, old_entries.size(): %lu\n", old_entries.size());
     //dumpBTBEntries(old_entries);
@@ -563,12 +563,12 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
     }
     // if cond entry in btb now, use the one in btb, since we need the up-to-date counter
     // else use the recorded entry
-    auto entry_to_write = entry.isCond && found ? BTBEntry(*it) : entry;
-    entry_to_write.resolved = false; // reset resolved bit on update
+    auto entry_to_write = entry.isCond() && found ? BTBEntry(*it) : entry;
+    entry_to_write.slot.resolved = false; // reset resolved bit on update
     entry_to_write.tag = btb_tag;   // update tag after found it!
     // update saturating counter if necessary
-    if (entry_to_write.isCond) {
-        bool this_cond_taken = isTaken && takenbranchinfo.pc == entry_to_write.pc;
+    if (entry_to_write.isCond()) {
+        bool this_cond_taken = isTaken && takenbranchinfo.pc == entry_to_write.slot.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
         }
@@ -577,8 +577,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
         }
     }
     // update indirect target if necessary
-    if (entry_to_write.isIndirect && isTaken && takenbranchinfo.pc == entry_to_write.pc) {
-        entry_to_write.target = takenbranchinfo.target;
+    if (entry_to_write.isIndirect() && isTaken && takenbranchinfo.pc == entry_to_write.slot.pc) {
+        entry_to_write.slot.target = takenbranchinfo.target;
     }
     auto ticked_entry = TickedBTBEntry(entry_to_write, curTick());
     if (found) {
@@ -587,8 +587,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(ticked_entry.pc, ticked_entry.getType(),
-                ticked_entry.target, btb_idx, Mode::WRITE, 1);
+            rec.set(ticked_entry.slot.pc, ticked_entry.getType(),
+                ticked_entry.slot.target, btb_idx, Mode::WRITE, 1);
             btbTrace->write_record(rec);
         }
 #endif
@@ -603,8 +603,8 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                    entry_in_btb_now->target, btb_idx, Mode::EVICT, 0);
+            rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+                    entry_in_btb_now->slot.target, btb_idx, Mode::EVICT, 0);
                 btbTrace->write_record(rec);
         }
 #endif
@@ -615,13 +615,13 @@ AheadBTB::updateBTBEntry(Addr btb_idx, Addr btb_tag, const BTBEntry& entry,
         }
         btbStats.updateReplace++;
         DPRINTF(ABTB, "BTB: Replacing entry with tag %#lx, pc %#lx in set %#lx\n",
-                entry_in_btb_now->tag, entry_in_btb_now->pc, btb_idx);
+                entry_in_btb_now->tag, entry_in_btb_now->slot.pc, btb_idx);
         *entry_in_btb_now = ticked_entry;
 #ifndef UNIT_TEST
         if (enableDB) {
             BTBTrace rec;
-            rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                entry_in_btb_now->target, btb_idx, Mode::WRITE, 0);
+            rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+                entry_in_btb_now->slot.target, btb_idx, Mode::WRITE, 0);
             btbTrace->write_record(rec);
         }
 #endif
@@ -639,7 +639,7 @@ AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
         return;
     }
 
-    Addr end_inst_pc = s3Pred.isTaken() ? s3Pred.getTakenEntry().pc :
+    Addr end_inst_pc = s3Pred.isTaken() ? s3Pred.getTakenEntry().slot.pc :
                             (s3Pred.bbStart + predictWidth) & ~mask(floorLog2(predictWidth)-1);
 
     // AheadBTB use S3 prediction for update
@@ -657,8 +657,8 @@ AheadBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred, const Addr previousPC)
         }
         Addr btb_idx = getIndex(previousPC, s3Pred.asidHash);  // use last pc to get idx
         BranchInfo takenbranchinfo;
-        takenbranchinfo.pc = s3Pred.getTakenEntry().pc;
-        takenbranchinfo.target = s3Pred.getTakenEntry().target;
+        takenbranchinfo.pc = s3Pred.getTakenEntry().slot.pc;
+        takenbranchinfo.target = s3Pred.getTakenEntry().slot.target;
         entry.source = getComponentIdx(); // mark the entry source as AheadBTB
 
         updateBTBEntry(btb_idx, btb_tag, entry, takenbranchinfo, s3Pred.isTaken());
@@ -683,7 +683,7 @@ AheadBTB::collectEntriesToUpdateFromS3Pred(const std::vector<BTBEntry>& old_entr
         new_entry = s3Pred.getTakenEntry();
         new_entry.valid = true;
 
-        if (new_entry.isCond) {
+        if (new_entry.isCond()) {
             new_entry.alwaysTaken = true;
             new_entry.ctr = 0;
         }
@@ -779,7 +779,7 @@ AheadBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     bool this_branch_hit = false;
     auto entry = BTBEntry();
     for (auto e : hit_entries) {
-        if (e.pc == pc) {
+        if (e.slot.pc == pc) {
             this_branch_hit = true;
             entry = e;
             break;
@@ -817,7 +817,7 @@ AheadBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         if (!inst->isNonSpeculative()) {
             if (inst->isIndirectCtrl()) {
                 btbStats.indirectHits++;
-                Addr pred_target = entry.target;
+                Addr pred_target = entry.slot.target;
                 if (pred_target == this_branch_target) {
                     btbStats.indirectPredCorrect++;
                 } else {

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -180,7 +180,9 @@ class AheadBTB : public TimedBaseBTBPredictor
     void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
+            e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
+            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.alwaysTaken, tick);
     }
 
     std::vector<BTBEntry> collectEntriesToUpdateFromS3Pred(
@@ -368,11 +370,11 @@ class AheadBTB : public TimedBaseBTBPredictor
         Addr last = 0;
         bool misorder = false;
         for (auto &entry : es) {
-            if (entry.pc <= last) {
+            if (entry.slot.pc <= last) {
                 misorder = true;
                 break;
             }
-            last = entry.pc;
+            last = entry.slot.pc;
         }
         if (misorder) {
             panic("BTB entries are not in ascending order");

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -181,7 +181,8 @@ class AheadBTB : public TimedBaseBTBPredictor
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
             e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
-            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.slot.isCond(), e.slot.isIndirect(), e.slot.isCall(),
+            e.slot.isReturn(),
             e.alwaysTaken, tick);
     }
 

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -108,7 +108,8 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
     DPRINTF(ITTAGE, "lookupHelper startAddr: %#lx\n", startAddr);
     std::vector<TagePrediction> preds;
     for (auto &btb_entry : btbEntries) {
-        if (btb_entry.isIndirect() && !btb_entry.isReturn() && btb_entry.valid) {
+        if (btb_entry.slot.isIndirect() && !btb_entry.slot.isReturn() &&
+            btb_entry.valid) {
             DPRINTF(ITTAGE, "lookupHelper btbEntry: %#lx, always taken %d\n",
                     btb_entry.slot.pc, btb_entry.alwaysTaken);
             bool provided = false;
@@ -271,11 +272,17 @@ BTBITTAGE::update(const FetchTarget &stream)
     if (getResolvedUpdate()) {
         auto remove_it =
             std::remove_if(all_entries_to_update.begin(), all_entries_to_update.end(),
-                           [](const BTBEntry &e) { return !(e.isIndirect() && !e.isReturn() && e.slot.resolved); });
+                           [](const BTBEntry &e) {
+                               return !(e.slot.isIndirect() &&
+                                        !e.slot.isReturn() && e.slot.resolved);
+                           });
         all_entries_to_update.erase(remove_it, all_entries_to_update.end());
     } else {
         auto remove_it = std::remove_if(all_entries_to_update.begin(), all_entries_to_update.end(),
-                                        [](const BTBEntry &e) { return !(e.isIndirect() && !e.isReturn()); });
+                                        [](const BTBEntry &e) {
+                                            return !(e.slot.isIndirect() &&
+                                                     !e.slot.isReturn());
+                                        });
         all_entries_to_update.erase(remove_it, all_entries_to_update.end());
     }
 
@@ -289,7 +296,8 @@ BTBITTAGE::update(const FetchTarget &stream)
     
     // update each branch
     for (auto &btb_entry : all_entries_to_update) {
-        bool this_indirect_actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
+        bool this_indirect_actual_taken = stream.exeTaken &&
+            stream.exeBranchInfo == btb_entry.slot;
         auto pred_it = preds.find(btb_entry.slot.pc);
         TagePrediction pred;
         if (pred_it != preds.end()) {

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -261,11 +261,11 @@ BTBITTAGE::update(const FetchTarget &stream)
     Addr startAddr = stream.getRealStartPC();
     DPRINTF(ITTAGE, "update startAddr: %#lx\n", startAddr);
     // update at the basis of btb entries
-    auto all_entries_to_update = stream.updateBTBEntries;
+    auto all_entries_to_update = stream.update.btbEntries;
 
     // add new entry if it's a btb miss during prediction
-    if (!stream.updateIsOldEntry) {
-        all_entries_to_update.push_back(stream.updateNewBTBEntry);
+    if (!stream.update.isOldEntry) {
+        all_entries_to_update.push_back(stream.update.newBTBEntry);
     }
 
     // // only update indirect branches that are not returns
@@ -296,16 +296,16 @@ BTBITTAGE::update(const FetchTarget &stream)
     
     // update each branch
     for (auto &btb_entry : all_entries_to_update) {
-        bool this_indirect_actual_taken = stream.exeTaken &&
-            stream.exeBranchInfo == btb_entry.slot;
+        bool this_indirect_actual_taken = stream.resolve.taken &&
+            stream.resolve.branchSlot == btb_entry.slot;
         auto pred_it = preds.find(btb_entry.slot.pc);
         TagePrediction pred;
         if (pred_it != preds.end()) {
             pred = pred_it->second;
         }
-        bool mispred = stream.squashType == SQUASH_CTRL &&
-            stream.squashPC == btb_entry.slot.pc;
-        Addr exe_target = stream.exeBranchInfo.target;
+        bool mispred = stream.resolve.squashType == SQUASH_CTRL &&
+            stream.resolve.squashPC == btb_entry.slot.pc;
+        Addr exe_target = stream.resolve.branchSlot.target;
         auto &main_info = pred.mainInfo;
 
         // Update misprediction statistics

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -108,8 +108,9 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
     DPRINTF(ITTAGE, "lookupHelper startAddr: %#lx\n", startAddr);
     std::vector<TagePrediction> preds;
     for (auto &btb_entry : btbEntries) {
-        if (btb_entry.isIndirect && !btb_entry.isReturn && btb_entry.valid) {
-            DPRINTF(ITTAGE, "lookupHelper btbEntry: %#lx, always taken %d\n", btb_entry.pc, btb_entry.alwaysTaken);
+        if (btb_entry.isIndirect() && !btb_entry.isReturn() && btb_entry.valid) {
+            DPRINTF(ITTAGE, "lookupHelper btbEntry: %#lx, always taken %d\n",
+                    btb_entry.slot.pc, btb_entry.alwaysTaken);
             bool provided = false;
             bool alt_provided = false;
 
@@ -118,9 +119,12 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
             for (int i = numPredictors - 1; i >= 0; --i) {
                 auto &way = lookupEntries[i];
                 // TODO: count alias hit (offset match but pc differs)
-                bool match = way.valid && lookupTags[i] == way.tag && btb_entry.pc == way.pc;
-                DPRINTF(ITTAGE, "hit %d, table %d, index %d, lookup tag %d, tag %d, useful %d, btb_pc %#lx, entry_pc %#lx\n",
-                    match, i, lookupIndices[i], lookupTags[i], way.tag, way.useful, btb_entry.pc, way.pc);
+                bool match = way.valid && lookupTags[i] == way.tag &&
+                    btb_entry.slot.pc == way.pc;
+                DPRINTF(ITTAGE, "hit %d, table %d, index %d, lookup tag %d, "
+                    "tag %d, useful %d, btb_pc %#lx, entry_pc %#lx\n",
+                    match, i, lookupIndices[i], lookupTags[i], way.tag,
+                    way.useful, btb_entry.slot.pc, way.pc);
 
                 if (match) {
                     if (!provided) {
@@ -137,7 +141,7 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
             Addr main_target = main_info.entry.target;
             Addr alt_target = alt_info.entry.target;
 
-            Addr base_target = btb_entry.target;
+            Addr base_target = btb_entry.slot.target;
             bool base_as_alt = false;
 
 
@@ -164,9 +168,10 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
                 warn("no target found\n");
             }
             if (taken) {
-                results.push_back({btb_entry.pc, target});
+                results.push_back({btb_entry.slot.pc, target});
             }
-            DPRINTF(ITTAGE, "tage predict %#lx target %#lx\n", btb_entry.pc, target);
+            DPRINTF(ITTAGE, "tage predict %#lx target %#lx\n",
+                    btb_entry.slot.pc, target);
 
             // Update prediction statistics
             if (!provided) {
@@ -179,8 +184,9 @@ BTBITTAGE::lookupHelper(Addr startAddr, const std::vector<BTBEntry> &btbEntries,
                 ittageStats.predTableHits.sample(main_info.table, 1);
             }
             // Note: predTargetHit will be updated in the update phase when we know the actual target
-            TagePrediction pred(btb_entry.pc, main_info, alt_info, use_alt, main_target);
-            threadMeta[tid]->preds[btb_entry.pc] = pred;
+            TagePrediction pred(btb_entry.slot.pc, main_info, alt_info,
+                                use_alt, main_target);
+            threadMeta[tid]->preds[btb_entry.slot.pc] = pred;
         }
     }
 }
@@ -265,11 +271,11 @@ BTBITTAGE::update(const FetchTarget &stream)
     if (getResolvedUpdate()) {
         auto remove_it =
             std::remove_if(all_entries_to_update.begin(), all_entries_to_update.end(),
-                           [](const BTBEntry &e) { return !(e.isIndirect && !e.isReturn && e.resolved); });
+                           [](const BTBEntry &e) { return !(e.isIndirect() && !e.isReturn() && e.slot.resolved); });
         all_entries_to_update.erase(remove_it, all_entries_to_update.end());
     } else {
         auto remove_it = std::remove_if(all_entries_to_update.begin(), all_entries_to_update.end(),
-                                        [](const BTBEntry &e) { return !(e.isIndirect && !e.isReturn); });
+                                        [](const BTBEntry &e) { return !(e.isIndirect() && !e.isReturn()); });
         all_entries_to_update.erase(remove_it, all_entries_to_update.end());
     }
 
@@ -284,12 +290,13 @@ BTBITTAGE::update(const FetchTarget &stream)
     // update each branch
     for (auto &btb_entry : all_entries_to_update) {
         bool this_indirect_actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
-        auto pred_it = preds.find(btb_entry.pc);
+        auto pred_it = preds.find(btb_entry.slot.pc);
         TagePrediction pred;
         if (pred_it != preds.end()) {
             pred = pred_it->second;
         }
-        bool mispred = stream.squashType == SQUASH_CTRL && stream.squashPC == btb_entry.pc;
+        bool mispred = stream.squashType == SQUASH_CTRL &&
+            stream.squashPC == btb_entry.slot.pc;
         Addr exe_target = stream.exeBranchInfo.target;
         auto &main_info = pred.mainInfo;
 
@@ -414,7 +421,8 @@ BTBITTAGE::update(const FetchTarget &stream)
                     if (allocate[ti - startTable]) {
                         DPRINTF(ITTAGE, "found allocatable entry, table %d, index %d, tag %d, counter %d\n",
                             ti, newIndex, newTag, 2);
-                        newEntry = TageEntry(newTag, exe_target, 2, btb_entry.pc);
+                        newEntry = TageEntry(newTag, exe_target, 2,
+                                             btb_entry.slot.pc);
                         ittageStats.updateAllocSuccess++;
                         break; // allocate only 1 entry
                     }

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -622,7 +622,7 @@ BTBMGSC::getPredictionMeta(ThreadID tid)
 std::vector<BTBEntry>
 BTBMGSC::prepareUpdateEntries(const FetchTarget &stream)
 {
-    auto all_entries = stream.updateBTBEntries;
+    auto all_entries = stream.update.btbEntries;
 
     // Filter out non-conditional and always-taken branches
     auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
@@ -632,8 +632,8 @@ BTBMGSC::prepareUpdateEntries(const FetchTarget &stream)
     all_entries.erase(remove_it, all_entries.end());
 
     // Handle potential new BTB entry
-    auto &potential_new_entry = stream.updateNewBTBEntry;
-    if (!stream.updateIsOldEntry && potential_new_entry.slot.isCond() &&
+    auto &potential_new_entry = stream.update.newBTBEntry;
+    if (!stream.update.isOldEntry && potential_new_entry.slot.isCond() &&
         !potential_new_entry.alwaysTaken) {
         all_entries.push_back(potential_new_entry);
     }
@@ -962,8 +962,8 @@ BTBMGSC::update(const FetchTarget &stream)
 
     // Process each BTB entry
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken &&
-            stream.exeBranchInfo == btb_entry.slot;
+        bool actual_taken = stream.resolve.taken &&
+            stream.resolve.branchSlot == btb_entry.slot;
         auto pred_it = preds.find(btb_entry.slot.pc);
 
         if (pred_it == preds.end()) {
@@ -1448,7 +1448,7 @@ BTBMGSC::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         tage_taken = pred_it->second.taken_before_sc;
         pred_hit = true;
     }
-    auto actual_taken = stream.exeTaken && stream.exeBranchInfo.pc == pc;
+    auto actual_taken = stream.resolve.taken && stream.resolve.branchSlot.pc == pc;
     if (pred_hit) {
         mgscStats.predHit++;
         if (sc_taken == actual_taken) {

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -541,7 +541,7 @@ BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond() && btb_entry.valid) {
+        if (btb_entry.slot.isCond() && btb_entry.valid) {
             const Addr branch_pc = btb_entry.slot.pc;
             auto tage_info = tageInfoForMgscs.find(branch_pc);
             if (tage_info != tageInfoForMgscs.end()) {
@@ -626,12 +626,15 @@ BTBMGSC::prepareUpdateEntries(const FetchTarget &stream)
 
     // Filter out non-conditional and always-taken branches
     auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-                                    [](const BTBEntry &e) { return !e.isCond() && !e.alwaysTaken; });
+                                    [](const BTBEntry &e) {
+                                        return !e.slot.isCond() && !e.alwaysTaken;
+                                    });
     all_entries.erase(remove_it, all_entries.end());
 
     // Handle potential new BTB entry
     auto &potential_new_entry = stream.updateNewBTBEntry;
-    if (!stream.updateIsOldEntry && potential_new_entry.isCond() && !potential_new_entry.alwaysTaken) {
+    if (!stream.updateIsOldEntry && potential_new_entry.slot.isCond() &&
+        !potential_new_entry.alwaysTaken) {
         all_entries.push_back(potential_new_entry);
     }
 
@@ -959,7 +962,8 @@ BTBMGSC::update(const FetchTarget &stream)
 
     // Process each BTB entry
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
+        bool actual_taken = stream.exeTaken &&
+            stream.exeBranchInfo == btb_entry.slot;
         auto pred_it = preds.find(btb_entry.slot.pc);
 
         if (pred_it == preds.end()) {

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -404,7 +404,8 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
                                   const TageInfoForMGSC &tage_info,
                                   ThreadID tid, uint8_t asidHash)
 {
-    DPRINTF(MGSC, "generateSinglePrediction for btbEntry: %#lx, always taken %d\n", btb_entry.pc,
+    const Addr branch_pc = btb_entry.slot.pc;
+    DPRINTF(MGSC, "generateSinglePrediction for btbEntry: %#lx, always taken %d\n", branch_pc,
             btb_entry.alwaysTaken);
     const auto &state = historyState(tid);
 
@@ -445,28 +446,28 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
                                     tage_info.tage_pred_conf_low, asidHash);
     }
 
-    int bw_percsum = enableBwTable ? calculatePercsum(bwTable, bwIndex, bwTableNum, btb_entry.pc) : 0;
-    int bw_weight = findWeight(bwWeightTable, btb_entry.pc, asidHash);
+    int bw_percsum = enableBwTable ? calculatePercsum(bwTable, bwIndex, bwTableNum, branch_pc) : 0;
+    int bw_weight = findWeight(bwWeightTable, branch_pc, asidHash);
     int bw_scaled_percsum = calculateScaledPercsum(bw_weight, bw_percsum);
 
-    int l_percsum = enableLTable ? calculatePercsum(lTable, lIndex, lTableNum, btb_entry.pc) : 0;
-    int l_weight = findWeight(lWeightTable, btb_entry.pc, asidHash);
+    int l_percsum = enableLTable ? calculatePercsum(lTable, lIndex, lTableNum, branch_pc) : 0;
+    int l_weight = findWeight(lWeightTable, branch_pc, asidHash);
     int l_scaled_percsum = calculateScaledPercsum(l_weight, l_percsum);
 
-    int i_percsum = enableITable ? calculatePercsum(iTable, iIndex, iTableNum, btb_entry.pc) : 0;
-    int i_weight = findWeight(iWeightTable, btb_entry.pc, asidHash);
+    int i_percsum = enableITable ? calculatePercsum(iTable, iIndex, iTableNum, branch_pc) : 0;
+    int i_weight = findWeight(iWeightTable, branch_pc, asidHash);
     int i_scaled_percsum = calculateScaledPercsum(i_weight, i_percsum);
 
-    int g_percsum = enableGTable ? calculatePercsum(gTable, gIndex, gTableNum, btb_entry.pc) : 0;
-    int g_weight = findWeight(gWeightTable, btb_entry.pc, asidHash);
+    int g_percsum = enableGTable ? calculatePercsum(gTable, gIndex, gTableNum, branch_pc) : 0;
+    int g_weight = findWeight(gWeightTable, branch_pc, asidHash);
     int g_scaled_percsum = calculateScaledPercsum(g_weight, g_percsum);
 
-    int p_percsum = enablePTable ? calculatePercsum(pTable, pIndex, pTableNum, btb_entry.pc) : 0;
-    int p_weight = findWeight(pWeightTable, btb_entry.pc, asidHash);
+    int p_percsum = enablePTable ? calculatePercsum(pTable, pIndex, pTableNum, branch_pc) : 0;
+    int p_weight = findWeight(pWeightTable, branch_pc, asidHash);
     int p_scaled_percsum = calculateScaledPercsum(p_weight, p_percsum);
 
-    int bias_percsum = enableBiasTable ? calculatePercsum(biasTable, biasIndex, biasTableNum, btb_entry.pc) : 0;
-    int bias_weight = findWeight(biasWeightTable, btb_entry.pc, asidHash);
+    int bias_percsum = enableBiasTable ? calculatePercsum(biasTable, biasIndex, biasTableNum, branch_pc) : 0;
+    int bias_weight = findWeight(biasWeightTable, branch_pc, asidHash);
     int bias_scaled_percsum = calculateScaledPercsum(bias_weight, bias_percsum);
 
     // Calculate total sum of all weighted percsums
@@ -476,7 +477,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     // Find thresholds
     // pc-indexed threshold table (only if enabled)
     int p_update_thres =
-        enablePCThreshold ? findThreshold(pUpdateThreshold, btb_entry.pc, asidHash) : 0;
+        enablePCThreshold ? findThreshold(pUpdateThreshold, branch_pc, asidHash) : 0;
 
     int total_thres = (updateThreshold / 8) + p_update_thres;
     // Threshold is used as a confidence gate; avoid negative values which
@@ -514,9 +515,9 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     bool p_weight_scale_diff = calculateWeightScaleDiff(total_sum, p_scaled_percsum, p_percsum);
     bool bias_weight_scale_diff = calculateWeightScaleDiff(total_sum, bias_scaled_percsum, bias_percsum);
 
-    DPRINTF(MGSC, "sc predict %#lx taken %d\n", btb_entry.pc, taken);
+    DPRINTF(MGSC, "sc predict %#lx taken %d\n", branch_pc, taken);
 
-    return MgscPrediction(btb_entry.pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken,
+    return MgscPrediction(branch_pc, total_sum, use_sc_pred, taken, tage_info.tage_pred_taken,
                           tage_info.tage_pred_conf_high, tage_info.tage_pred_conf_mid, tage_info.tage_pred_conf_low,
                           total_thres, bwIndex, lIndex, iIndex, gIndex, pIndex, biasIndex, bw_weight_scale_diff,
                           l_weight_scale_diff, i_weight_scale_diff, g_weight_scale_diff, p_weight_scale_diff,
@@ -540,14 +541,15 @@ BTBMGSC::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond && btb_entry.valid) {
-            auto tage_info = tageInfoForMgscs.find(btb_entry.pc);
+        if (btb_entry.isCond() && btb_entry.valid) {
+            const Addr branch_pc = btb_entry.slot.pc;
+            auto tage_info = tageInfoForMgscs.find(branch_pc);
             if (tage_info != tageInfoForMgscs.end()) {
                 auto pred = generateSinglePrediction(btb_entry, startPC,
                                                      tage_info->second, tid,
                                                      asidHash);
-                threadMeta[tid]->preds[btb_entry.pc] = pred;
-                results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
+                threadMeta[tid]->preds[branch_pc] = pred;
+                results.push_back({branch_pc, pred.taken || btb_entry.alwaysTaken});
             } else {
                 assert(false);
             }
@@ -624,12 +626,12 @@ BTBMGSC::prepareUpdateEntries(const FetchTarget &stream)
 
     // Filter out non-conditional and always-taken branches
     auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-                                    [](const BTBEntry &e) { return !e.isCond && !e.alwaysTaken; });
+                                    [](const BTBEntry &e) { return !e.isCond() && !e.alwaysTaken; });
     all_entries.erase(remove_it, all_entries.end());
 
     // Handle potential new BTB entry
     auto &potential_new_entry = stream.updateNewBTBEntry;
-    if (!stream.updateIsOldEntry && potential_new_entry.isCond && !potential_new_entry.alwaysTaken) {
+    if (!stream.updateIsOldEntry && potential_new_entry.isCond() && !potential_new_entry.alwaysTaken) {
         all_entries.push_back(potential_new_entry);
     }
 
@@ -846,6 +848,7 @@ void
 BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const MgscPrediction &pred,
                                const FetchTarget &stream)
 {
+    const Addr branch_pc = entry.slot.pc;
     // Extract prediction information
     auto total_sum = pred.total_sum;
     auto use_mgsc = pred.use_mgsc;
@@ -857,7 +860,7 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
 
 #ifndef UNIT_TEST
     // Write trace record
-    if (enableDB && (focusBranchPC == 0 || entry.pc == focusBranchPC)) {
+    if (enableDB && (focusBranchPC == 0 || branch_pc == focusBranchPC)) {
         auto effective_gate = pred.tage_conf_high ? (total_thres / 2)
             : (pred.tage_conf_mid ? (total_thres / 4) : (total_thres / 8));
         auto margin = std::abs(total_sum) - effective_gate;
@@ -869,8 +872,8 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
             return sig;
         };
         MgscTrace t;
-        t.set(entry.pc,
-            stream.startPC, getOffset(entry.pc),
+        t.set(branch_pc,
+            stream.startPC, getOffset(branch_pc),
             tage_pred_taken, pred.tage_conf_high, pred.tage_conf_mid, pred.tage_conf_low,
             pred.bw_percsum, pred.l_percsum, pred.i_percsum,
             pred.g_percsum, pred.p_percsum, pred.bias_percsum,
@@ -898,43 +901,43 @@ BTBMGSC::updateSinglePredictor(const BTBEntry &entry, bool actual_taken, const M
         }
 
         // Update BW tables
-        updatePredTable(bwTable, pred.bwIndex, bwTableNum, entry.pc, actual_taken);
-        updateWeightTable(bwWeightTable, weightTableIdx, entry.pc, pred.bw_weight_scale_diff,
+        updatePredTable(bwTable, pred.bwIndex, bwTableNum, branch_pc, actual_taken);
+        updateWeightTable(bwWeightTable, weightTableIdx, branch_pc, pred.bw_weight_scale_diff,
                           (pred.bw_percsum >= 0) == actual_taken);
 
         // Update L tables
-        updatePredTable(lTable, pred.lIndex, lTableNum, entry.pc, actual_taken);
-        updateWeightTable(lWeightTable, weightTableIdx, entry.pc, pred.l_weight_scale_diff,
+        updatePredTable(lTable, pred.lIndex, lTableNum, branch_pc, actual_taken);
+        updateWeightTable(lWeightTable, weightTableIdx, branch_pc, pred.l_weight_scale_diff,
                           (pred.l_percsum >= 0) == actual_taken);
 
         // Update I tables
-        updatePredTable(iTable, pred.iIndex, iTableNum, entry.pc, actual_taken);
-        updateWeightTable(iWeightTable, weightTableIdx, entry.pc, pred.i_weight_scale_diff,
+        updatePredTable(iTable, pred.iIndex, iTableNum, branch_pc, actual_taken);
+        updateWeightTable(iWeightTable, weightTableIdx, branch_pc, pred.i_weight_scale_diff,
                           (pred.i_percsum >= 0) == actual_taken);
 
         // Update G tables
-        updatePredTable(gTable, pred.gIndex, gTableNum, entry.pc, actual_taken);
-        updateWeightTable(gWeightTable, weightTableIdx, entry.pc, pred.g_weight_scale_diff,
+        updatePredTable(gTable, pred.gIndex, gTableNum, branch_pc, actual_taken);
+        updateWeightTable(gWeightTable, weightTableIdx, branch_pc, pred.g_weight_scale_diff,
                           (pred.g_percsum >= 0) == actual_taken);
 
         // Update P tables
-        updatePredTable(pTable, pred.pIndex, pTableNum, entry.pc, actual_taken);
-        updateWeightTable(pWeightTable, weightTableIdx, entry.pc, pred.p_weight_scale_diff,
+        updatePredTable(pTable, pred.pIndex, pTableNum, branch_pc, actual_taken);
+        updateWeightTable(pWeightTable, weightTableIdx, branch_pc, pred.p_weight_scale_diff,
                           (pred.p_percsum >= 0) == actual_taken);
 
         // Update bias tables
-        updatePredTable(biasTable, pred.biasIndex, biasTableNum, entry.pc, actual_taken);
-        updateWeightTable(biasWeightTable, weightTableIdx, entry.pc, pred.bias_weight_scale_diff,
+        updatePredTable(biasTable, pred.biasIndex, biasTableNum, branch_pc, actual_taken);
+        updateWeightTable(biasWeightTable, weightTableIdx, branch_pc, pred.bias_weight_scale_diff,
                           (pred.bias_percsum >= 0) == actual_taken);
 
         // Update PC-indexed threshold table (only if enabled)
         if (enablePCThreshold) {
-            updatePCThresholdTable(entry.pc, stream.asidHash,
+            updatePCThresholdTable(branch_pc, stream.asidHash,
                                    sc_pred_taken != actual_taken);
         }
 
         // Update global threshold table
-        updateGlobalThreshold(entry.pc, sc_pred_taken != actual_taken);
+        updateGlobalThreshold(branch_pc, sc_pred_taken != actual_taken);
     }
 }
 
@@ -957,7 +960,7 @@ BTBMGSC::update(const FetchTarget &stream)
     // Process each BTB entry
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
-        auto pred_it = preds.find(btb_entry.pc);
+        auto pred_it = preds.find(btb_entry.slot.pc);
 
         if (pred_it == preds.end()) {
             continue;

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -426,7 +426,7 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond() && btb_entry.valid) {
+        if (btb_entry.slot.isCond() && btb_entry.valid) {
             auto pred = generateSinglePrediction(btb_entry, startPC, nullptr, tid, asidHash);
             threadMeta[tid]->preds[btb_entry.slot.pc] = pred;
             tageStats.updateStatsWithTagePrediction(pred, true);
@@ -536,11 +536,15 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken && e.slot.resolved); });
+            [](const BTBEntry &e) {
+                return !(e.slot.isCond() && !e.alwaysTaken && e.slot.resolved);
+            });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken); });
+            [](const BTBEntry &e) {
+                return !(e.slot.isCond() && !e.alwaysTaken);
+            });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -880,7 +884,8 @@ BTBTAGE::update(const FetchTarget &stream) {
     bool hasRecomputedVsActualDiff = false;
     bool hasRecomputedVsOriginalDiff = false;
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
+        bool actual_taken = stream.exeTaken &&
+            stream.exeBranchInfo == btb_entry.slot;
         const bool is_new_entry = !stream.updateIsOldEntry &&btb_entry.slot.pc == stream.updateNewBTBEntry.slot.pc;
         auto orig_it = predMeta->preds.find(btb_entry.slot.pc);
         const bool has_original_pred = orig_it != predMeta->preds.end();

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -300,7 +300,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
                                  std::shared_ptr<TageMeta> predMeta,
                                  ThreadID tid,
                                  uint8_t asidHash) {
-    DPRINTF(TAGE, "generateSinglePrediction for btbEntry: %#lx\n", btb_entry.pc);
+    DPRINTF(TAGE, "generateSinglePrediction for btbEntry: %#lx\n", btb_entry.slot.pc);
     const auto &state = historyState(tid);
 
     // Find main and alternative predictions
@@ -311,7 +311,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
 
     // Search from highest to lowest table for matches
     // Calculate branch position within the block (like RTL's cfiPosition)
-    unsigned position = getBranchIndexInBlock(btb_entry.pc, startPC);
+    unsigned position = getBranchIndexInBlock(btb_entry.slot.pc, startPC);
 
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
@@ -341,7 +341,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
                 // Do not use LRU; keep logic simple and align with CBP-style replacement
 
                 DPRINTF(TAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n",
-                    i, index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
+                    i, index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.slot.pc, position);
                 break;  // only one way can be matched, aviod multi hit, TODO: RTL how to do this?
             }
         }
@@ -362,7 +362,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
             }
         } else {
             DPRINTF(TAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n",
-                i, index, tag, position, btb_entry.pc);
+                i, index, tag, position, btb_entry.slot.pc);
         }
     }
 
@@ -373,7 +373,7 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     bool base_taken = btb_entry.ctr >= 0;
     //bool base_taken = btb_entry.ctr >= 0;
     bool alt_pred = alt_provided ? alt_taken : base_taken; // if alt provided, use alt prediction, otherwise use base
-    Addr use_alt_idx = getUseAltIdx(btb_entry.pc);
+    Addr use_alt_idx = getUseAltIdx(btb_entry.slot.pc);
     short use_alt_ctr = useAlt[use_alt_idx];
 
     // use_alt_on_na gating: when provider weak, consult per-PC counter
@@ -398,13 +398,13 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
         final_provider_is_alt = true;
     }
 
-    DPRINTF(TAGE, "tage predict %#lx taken %d\n", btb_entry.pc, taken);
+    DPRINTF(TAGE, "tage predict %#lx taken %d\n", btb_entry.slot.pc, taken);
     DPRINTF(TAGE, "tage use_alt %d ? (alt_provided %d ? alt_taken %d : base_taken %d) : main_taken %d\n",
         use_alt, alt_provided, alt_taken, base_taken, main_taken);
     DPRINTF(TAGE, "tage final source %#lx table %d alt %d\n",
-        btb_entry.pc, final_provider_table, final_provider_is_alt);
+        btb_entry.slot.pc, final_provider_table, final_provider_is_alt);
 
-    return TagePrediction(btb_entry.pc, main_info, alt_info, use_alt, taken,
+    return TagePrediction(btb_entry.slot.pc, main_info, alt_info, use_alt, taken,
         alt_pred, final_provider_table, final_provider_is_alt, use_alt_idx,
         use_alt_ctr, hit_table_mask);
 }
@@ -426,22 +426,23 @@ BTBTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEntri
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond && btb_entry.valid) {
+        if (btb_entry.isCond() && btb_entry.valid) {
             auto pred = generateSinglePrediction(btb_entry, startPC, nullptr, tid, asidHash);
-            threadMeta[tid]->preds[btb_entry.pc] = pred;
+            threadMeta[tid]->preds[btb_entry.slot.pc] = pred;
             tageStats.updateStatsWithTagePrediction(pred, true);
-            results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
-            tageInfoForMgscs[btb_entry.pc].tage_pred_taken = pred.taken;
-            tageInfoForMgscs[btb_entry.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_high = pred.mainInfo.found &&
+            results.push_back({btb_entry.slot.pc, pred.taken || btb_entry.alwaysTaken});
+            tageInfoForMgscs[btb_entry.slot.pc].tage_pred_taken = pred.taken;
+            tageInfoForMgscs[btb_entry.slot.pc].tage_main_taken = pred.mainInfo.found ? pred.mainInfo.taken() : false;
+            tageInfoForMgscs[btb_entry.slot.pc].tage_pred_conf_high = pred.mainInfo.found &&
                                          abs(pred.mainInfo.entry.counter*2 + 1) == 7; // counter saturated, -4 or 3
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_mid = pred.mainInfo.found &&
+            tageInfoForMgscs[btb_entry.slot.pc].tage_pred_conf_mid = pred.mainInfo.found &&
                                          (abs(pred.mainInfo.entry.counter*2 + 1) < 7 &&
                                          abs(pred.mainInfo.entry.counter*2 + 1) > 1); // counter not saturated, -3, -2, 1, 2
-            tageInfoForMgscs[btb_entry.pc].tage_pred_conf_low = !pred.mainInfo.found ||
+            tageInfoForMgscs[btb_entry.slot.pc].tage_pred_conf_low = !pred.mainInfo.found ||
                                          (abs(pred.mainInfo.entry.counter*2 + 1) <= 1); // counter initialized, -1 or 0
             // main predict is different from alt predict/base predict
-            tageInfoForMgscs[btb_entry.pc].tage_pred_alt_diff = pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
+            tageInfoForMgscs[btb_entry.slot.pc].tage_pred_alt_diff =
+                pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
         }
     }
 }
@@ -525,7 +526,7 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Add potential new BTB entry if it's a btb miss during prediction
     if (!stream.updateIsOldEntry) {
         BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken && stream.getControlPC() == potential_new_entry.pc;
+        bool new_entry_taken = stream.exeTaken && stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
         }
@@ -535,11 +536,11 @@ BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
+            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken && e.slot.resolved); });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
+            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken); });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -596,7 +597,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
         bool main_weak = (main_info.entry.counter == 0 || main_info.entry.counter == -1);
         if (main_weak) {
             tageStats.updateProviderNa++;
-            Addr uidx = getUseAltIdx(entry.pc);
+            Addr uidx = getUseAltIdx(entry.slot.pc);
             bool alt_correct = (alt_taken == actual_taken);
             updateCounter(alt_correct, useAltOnNaWidth, useAlt[uidx]);
             tageStats.updateUseAltOnNaUpdated++;
@@ -652,7 +653,7 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
 
     // Check if misprediction occurred
     bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
-                               stream.squashPC == entry.pc;
+                               stream.squashPC == entry.slot.pc;
     if (this_fb_mispred) {
         tageStats.mispredictBranchHasProvider += main_info.found;
         tageStats.mispredictBranchUseProvider += use_provider;
@@ -733,7 +734,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
     // 3) any not-useful way
 
     // Calculate branch position within the block (like RTL's cfiPosition)
-    unsigned position = getBranchIndexInBlock(entry.pc, startPC);
+    unsigned position = getBranchIndexInBlock(entry.slot.pc, startPC);
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
         Addr newIndex = getTageIndex(startPC, ti, meta->indexFoldedHist[ti].get(), asidHash);
@@ -776,7 +777,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
             short newCounter = actual_taken ? 0 : -1;
             auto &victim = set[selected_way];
             DPRINTF(TAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
-                    ti, newIndex, selected_way, newTag, position, newCounter, entry.pc);
+                    ti, newIndex, selected_way, newTag, position, newCounter, entry.slot.pc);
             allocInfo.success = true;
             allocInfo.table = ti;
             allocInfo.index = newIndex;
@@ -787,7 +788,7 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
             allocInfo.victimCounter = victim.counter;
             allocInfo.victimUseful = victim.useful;
             allocInfo.victimPC = victim.pc;
-            set[selected_way] = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+            set[selected_way] = TageEntry(newTag, newCounter, entry.slot.pc); // u = 0 default
             tageStats.updateAllocSuccess++;
             usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
             return true;
@@ -880,19 +881,19 @@ BTBTAGE::update(const FetchTarget &stream) {
     bool hasRecomputedVsOriginalDiff = false;
     for (auto &btb_entry : entries_to_update) {
         bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
-        const bool is_new_entry = !stream.updateIsOldEntry &&btb_entry.pc == stream.updateNewBTBEntry.pc;
-        auto orig_it = predMeta->preds.find(btb_entry.pc);
+        const bool is_new_entry = !stream.updateIsOldEntry &&btb_entry.slot.pc == stream.updateNewBTBEntry.slot.pc;
+        auto orig_it = predMeta->preds.find(btb_entry.slot.pc);
         const bool has_original_pred = orig_it != predMeta->preds.end();
         TagePrediction original_pred;
         if (has_original_pred) {
             original_pred = orig_it->second;
         } else if (!is_new_entry) {
             DPRINTF(TAGE, "update: missing original prediction for old entry pc %#lx, skip\n",
-                    btb_entry.pc);
+                    btb_entry.slot.pc);
             continue;
         } else {
             DPRINTF(TAGE, "update: reconstruct prediction for new entry pc %#lx from snapshot\n",
-                    btb_entry.pc);
+                    btb_entry.slot.pc);
         }
 
         if (has_original_pred && original_pred.finalProviderTable >= 0) {
@@ -913,7 +914,7 @@ BTBTAGE::update(const FetchTarget &stream) {
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta,
                                                  stream.tid, stream.asidHash);
             // Track differences for statistics
-            auto it = predMeta->preds.find(btb_entry.pc);
+            auto it = predMeta->preds.find(btb_entry.slot.pc);
             if (has_original_pred && it != predMeta->preds.end() && recomputed.taken != original_pred.taken) {
                 hasRecomputedVsOriginalDiff = true;
             }
@@ -957,7 +958,7 @@ BTBTAGE::update(const FetchTarget &stream) {
             }
             boost::to_string(history_low50, history_str);
             boost::to_string(phistory_low50, phistory_str);
-            TagePrediction trace_pred = predMeta->preds[btb_entry.pc];
+            TagePrediction trace_pred = predMeta->preds[btb_entry.slot.pc];
             auto main_info = trace_pred.mainInfo;
             auto alt_info = trace_pred.altInfo;
             const uint64_t history_hash = hashBitset(predMeta->history);
@@ -968,7 +969,7 @@ BTBTAGE::update(const FetchTarget &stream) {
                 hashFoldedHistVec(predMeta->tagFoldedHist);
             const uint64_t alt_tag_folded_hist_hash =
                 hashFoldedHistVec(predMeta->altTagFoldedHist);
-            t.set(startAddr, btb_entry.pc, main_info.way,
+            t.set(startAddr, btb_entry.slot.pc, main_info.way,
                 main_info.found, main_info.entry.counter, main_info.entry.useful,
                 main_info.table, main_info.index, main_info.entry.tag,
                 alt_info.found, alt_info.entry.counter, alt_info.entry.useful,

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -521,12 +521,12 @@ BTBTAGE::getPredictionMeta(ThreadID tid) {
  */
 std::vector<BTBEntry>
 BTBTAGE::prepareUpdateEntries(const FetchTarget &stream) {
-    auto all_entries = stream.updateBTBEntries;
+    auto all_entries = stream.update.btbEntries;
 
     // Add potential new BTB entry if it's a btb miss during prediction
-    if (!stream.updateIsOldEntry) {
-        BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken && stream.getControlPC() == potential_new_entry.slot.pc;
+    if (!stream.update.isOldEntry) {
+        BTBEntry potential_new_entry = stream.update.newBTBEntry;
+        bool new_entry_taken = stream.resolve.taken && stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
         }
@@ -656,8 +656,8 @@ BTBTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     }
 
     // Check if misprediction occurred
-    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
-                               stream.squashPC == entry.slot.pc;
+    bool this_fb_mispred = stream.resolve.squashType == SquashType::SQUASH_CTRL &&
+                               stream.resolve.squashPC == entry.slot.pc;
     if (this_fb_mispred) {
         tageStats.mispredictBranchHasProvider += main_info.found;
         tageStats.mispredictBranchUseProvider += use_provider;
@@ -884,9 +884,9 @@ BTBTAGE::update(const FetchTarget &stream) {
     bool hasRecomputedVsActualDiff = false;
     bool hasRecomputedVsOriginalDiff = false;
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken &&
-            stream.exeBranchInfo == btb_entry.slot;
-        const bool is_new_entry = !stream.updateIsOldEntry &&btb_entry.slot.pc == stream.updateNewBTBEntry.slot.pc;
+        bool actual_taken = stream.resolve.taken &&
+            stream.resolve.branchSlot == btb_entry.slot;
+        const bool is_new_entry = !stream.update.isOldEntry &&btb_entry.slot.pc == stream.update.newBTBEntry.slot.pc;
         auto orig_it = predMeta->preds.find(btb_entry.slot.pc);
         const bool has_original_pred = orig_it != predMeta->preds.end();
         TagePrediction original_pred;
@@ -1030,9 +1030,9 @@ BTBTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
             break;
         }
     }
-    bool fallthrough_mispred = (first_taken_pc == 0 && stream.exeTaken) ||
-                                (first_taken_pc != 0 && !stream.exeTaken);
-    bool branch_mispred = stream.exeTaken && first_taken_pc != stream.exeBranchInfo.pc;
+    bool fallthrough_mispred = (first_taken_pc == 0 && stream.resolve.taken) ||
+                                (first_taken_pc != 0 && !stream.resolve.taken);
+    bool branch_mispred = stream.resolve.taken && first_taken_pc != stream.resolve.branchSlot.pc;
     if (fallthrough_mispred || branch_mispred) {
         tageStats.updateMispred++;
     }
@@ -1503,7 +1503,7 @@ BTBTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         pred_taken = it->second.taken;
         pred_hit = true;
     }
-    bool this_cond_taken = stream.exeTaken && stream.exeBranchInfo.pc == pc;
+    bool this_cond_taken = stream.resolve.taken && stream.resolve.branchSlot.pc == pc;
     bool predcorrect = (pred_taken == this_cond_taken);
     if (!predcorrect) {
         tageStats.condPredwrong++;

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -201,7 +201,7 @@ BTBTAGEUpperBound::lookupExactPrediction(
     uint64_t hitTableMask = 0;
 
     for (int i = numPredictors - 1; i >= 0; --i) {
-        auto key = buildKey(btbEntry.pc, historyWords, histLengths[i]);
+        auto key = buildKey(btbEntry.slot.pc, historyWords, histLengths[i]);
         auto it = exactTables[i].find(key);
         if (it == exactTables[i].end()) {
             continue;
@@ -230,7 +230,7 @@ BTBTAGEUpperBound::lookupExactPrediction(
     const bool altTaken = altInfo.taken();
     const bool baseTaken = btbEntry.ctr >= 0;
     const bool altPred = altProvided ? altTaken : baseTaken;
-    Addr useAltIdx = getUseAltIdx(btbEntry.pc);
+    Addr useAltIdx = getUseAltIdx(btbEntry.slot.pc);
     short useAltCtr = useAlt[useAltIdx];
 
     bool useAltPred = false;
@@ -254,7 +254,7 @@ BTBTAGEUpperBound::lookupExactPrediction(
         finalProviderIsAlt = true;
     }
 
-    return TagePrediction(btbEntry.pc, mainInfo, altInfo, useAltPred, taken,
+    return TagePrediction(btbEntry.slot.pc, mainInfo, altInfo, useAltPred, taken,
                           altPred, finalProviderTable, finalProviderIsAlt,
                           useAltIdx, useAltCtr, hitTableMask);
 }
@@ -266,20 +266,20 @@ BTBTAGEUpperBound::notePredictionResult(
     std::unordered_map<Addr, TageInfoForMGSC> &tageInfoForMgscs,
     CondTakens &results) const
 {
-    results.push_back({btbEntry.pc, pred.taken || btbEntry.alwaysTaken});
-    tageInfoForMgscs[btbEntry.pc].tage_pred_taken = pred.taken;
-    tageInfoForMgscs[btbEntry.pc].tage_main_taken =
+    results.push_back({btbEntry.slot.pc, pred.taken || btbEntry.alwaysTaken});
+    tageInfoForMgscs[btbEntry.slot.pc].tage_pred_taken = pred.taken;
+    tageInfoForMgscs[btbEntry.slot.pc].tage_main_taken =
         pred.mainInfo.found ? pred.mainInfo.taken() : false;
-    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_high =
+    tageInfoForMgscs[btbEntry.slot.pc].tage_pred_conf_high =
         pred.mainInfo.found && abs(pred.mainInfo.entry.counter * 2 + 1) == 7;
-    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_mid =
+    tageInfoForMgscs[btbEntry.slot.pc].tage_pred_conf_mid =
         pred.mainInfo.found &&
         (abs(pred.mainInfo.entry.counter * 2 + 1) < 7 &&
          abs(pred.mainInfo.entry.counter * 2 + 1) > 1);
-    tageInfoForMgscs[btbEntry.pc].tage_pred_conf_low =
+    tageInfoForMgscs[btbEntry.slot.pc].tage_pred_conf_low =
         !pred.mainInfo.found ||
         (abs(pred.mainInfo.entry.counter * 2 + 1) <= 1);
-    tageInfoForMgscs[btbEntry.pc].tage_pred_alt_diff =
+    tageInfoForMgscs[btbEntry.slot.pc].tage_pred_alt_diff =
         pred.mainInfo.found && pred.mainInfo.taken() != pred.altPred;
 }
 
@@ -305,15 +305,15 @@ BTBTAGEUpperBound::putPCHistory(Addr startAddr, const bitset &history,
         stagePred.tageInfoForMgscs.clear();
 
         for (auto &btbEntry : stagePred.btbEntries) {
-            if (!(btbEntry.isCond && btbEntry.valid)) {
+            if (!(btbEntry.isCond() && btbEntry.valid)) {
                 continue;
             }
 
             BranchPredictionMeta branchMeta;
             auto pred = lookupExactPrediction(
                 btbEntry, ubMeta->historyWords, &branchMeta);
-            ubMeta->preds[btbEntry.pc] = pred;
-            ubMeta->branchMeta[btbEntry.pc] = branchMeta;
+            ubMeta->preds[btbEntry.slot.pc] = pred;
+            ubMeta->branchMeta[btbEntry.slot.pc] = branchMeta;
             tageStats.updateStatsWithTagePrediction(pred, true);
             notePredictionResult(btbEntry, pred, stagePred.tageInfoForMgscs,
                                  stagePred.condTakens);
@@ -389,7 +389,7 @@ BTBTAGEUpperBound::updatePredictorStateAndCheckAllocation(
             (mainInfo.entry.counter == 0 || mainInfo.entry.counter == -1);
         if (mainWeak) {
             tageStats.updateProviderNa++;
-            Addr uidx = getUseAltIdx(entry.pc);
+            Addr uidx = getUseAltIdx(entry.slot.pc);
             bool altCorrect = (altTaken == actualTaken);
             updateCounter(altCorrect, useAltOnNaWidth, useAlt[uidx]);
             tageStats.updateUseAltOnNaUpdated++;
@@ -444,7 +444,7 @@ BTBTAGEUpperBound::updatePredictorStateAndCheckAllocation(
 
     const bool thisFbMispred =
         stream.squashType == SquashType::SQUASH_CTRL &&
-        stream.squashPC == entry.pc;
+        stream.squashPC == entry.slot.pc;
     if (getDelay() == 2 && thisFbMispred) {
         tageStats.updateMispred++;
         if (!usedAlt && mainInfo.found) {
@@ -472,9 +472,9 @@ BTBTAGEUpperBound::allocateExactEntry(
     uint64_t &allocatedTable)
 {
     for (unsigned ti = startTable; ti < numPredictors; ++ti) {
-        auto key = buildKey(entry.pc, historyWords, histLengths[ti]);
+        auto key = buildKey(entry.slot.pc, historyWords, histLengths[ti]);
         auto [it, inserted] = exactTables[ti].emplace(
-            key, TageEntry(0, actualTaken ? 0 : -1, entry.pc));
+            key, TageEntry(0, actualTaken ? 0 : -1, entry.slot.pc));
         if (!inserted) {
             continue;
         }
@@ -499,7 +499,7 @@ BTBTAGEUpperBound::prepareUpperBoundUpdateEntries(const FetchTarget &stream)
     if (!stream.updateIsOldEntry) {
         BTBEntry potentialNewEntry = stream.updateNewBTBEntry;
         bool newEntryTaken =
-            stream.exeTaken && stream.getControlPC() == potentialNewEntry.pc;
+            stream.exeTaken && stream.getControlPC() == potentialNewEntry.slot.pc;
         if (!newEntryTaken) {
             potentialNewEntry.alwaysTaken = false;
         }
@@ -510,14 +510,14 @@ BTBTAGEUpperBound::prepareUpperBoundUpdateEntries(const FetchTarget &stream)
         auto removeIt = std::remove_if(
             allEntries.begin(), allEntries.end(),
             [](const BTBEntry &e) {
-                return !(e.isCond && !e.alwaysTaken && e.resolved);
+                return !(e.isCond() && !e.alwaysTaken && e.slot.resolved);
             });
         allEntries.erase(removeIt, allEntries.end());
     } else {
         auto removeIt = std::remove_if(
             allEntries.begin(), allEntries.end(),
             [](const BTBEntry &e) {
-                return !(e.isCond && !e.alwaysTaken);
+                return !(e.isCond() && !e.alwaysTaken);
             });
         allEntries.erase(removeIt, allEntries.end());
     }
@@ -543,8 +543,8 @@ BTBTAGEUpperBound::update(const FetchTarget &stream)
 
     bool hasStoredVsActualDiff = false;
     for (auto &btbEntry : entriesToUpdate) {
-        auto predIt = predMeta->preds.find(btbEntry.pc);
-        auto metaIt = predMeta->branchMeta.find(btbEntry.pc);
+        auto predIt = predMeta->preds.find(btbEntry.slot.pc);
+        auto metaIt = predMeta->branchMeta.find(btbEntry.slot.pc);
         const bool actualTaken =
             stream.exeTaken && stream.exeBranchInfo == btbEntry;
         TagePrediction storedPred;

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -305,7 +305,7 @@ BTBTAGEUpperBound::putPCHistory(Addr startAddr, const bitset &history,
         stagePred.tageInfoForMgscs.clear();
 
         for (auto &btbEntry : stagePred.btbEntries) {
-            if (!(btbEntry.isCond() && btbEntry.valid)) {
+            if (!(btbEntry.slot.isCond() && btbEntry.valid)) {
                 continue;
             }
 
@@ -510,14 +510,14 @@ BTBTAGEUpperBound::prepareUpperBoundUpdateEntries(const FetchTarget &stream)
         auto removeIt = std::remove_if(
             allEntries.begin(), allEntries.end(),
             [](const BTBEntry &e) {
-                return !(e.isCond() && !e.alwaysTaken && e.slot.resolved);
+                return !(e.slot.isCond() && !e.alwaysTaken && e.slot.resolved);
             });
         allEntries.erase(removeIt, allEntries.end());
     } else {
         auto removeIt = std::remove_if(
             allEntries.begin(), allEntries.end(),
             [](const BTBEntry &e) {
-                return !(e.isCond() && !e.alwaysTaken);
+                return !(e.slot.isCond() && !e.alwaysTaken);
             });
         allEntries.erase(removeIt, allEntries.end());
     }
@@ -546,7 +546,7 @@ BTBTAGEUpperBound::update(const FetchTarget &stream)
         auto predIt = predMeta->preds.find(btbEntry.slot.pc);
         auto metaIt = predMeta->branchMeta.find(btbEntry.slot.pc);
         const bool actualTaken =
-            stream.exeTaken && stream.exeBranchInfo == btbEntry;
+            stream.exeTaken && stream.exeBranchInfo == btbEntry.slot;
         TagePrediction storedPred;
         BranchPredictionMeta storedMeta;
         if (predIt != predMeta->preds.end() &&

--- a/src/cpu/pred/btb/btb_tage_ub.cc
+++ b/src/cpu/pred/btb/btb_tage_ub.cc
@@ -443,8 +443,8 @@ BTBTAGEUpperBound::updatePredictorStateAndCheckAllocation(
     }
 
     const bool thisFbMispred =
-        stream.squashType == SquashType::SQUASH_CTRL &&
-        stream.squashPC == entry.slot.pc;
+        stream.resolve.squashType == SquashType::SQUASH_CTRL &&
+        stream.resolve.squashPC == entry.slot.pc;
     if (getDelay() == 2 && thisFbMispred) {
         tageStats.updateMispred++;
         if (!usedAlt && mainInfo.found) {
@@ -494,12 +494,12 @@ BTBTAGEUpperBound::allocateExactEntry(
 std::vector<BTBEntry>
 BTBTAGEUpperBound::prepareUpperBoundUpdateEntries(const FetchTarget &stream)
 {
-    auto allEntries = stream.updateBTBEntries;
+    auto allEntries = stream.update.btbEntries;
 
-    if (!stream.updateIsOldEntry) {
-        BTBEntry potentialNewEntry = stream.updateNewBTBEntry;
+    if (!stream.update.isOldEntry) {
+        BTBEntry potentialNewEntry = stream.update.newBTBEntry;
         bool newEntryTaken =
-            stream.exeTaken && stream.getControlPC() == potentialNewEntry.slot.pc;
+            stream.resolve.taken && stream.getControlPC() == potentialNewEntry.slot.pc;
         if (!newEntryTaken) {
             potentialNewEntry.alwaysTaken = false;
         }
@@ -546,7 +546,7 @@ BTBTAGEUpperBound::update(const FetchTarget &stream)
         auto predIt = predMeta->preds.find(btbEntry.slot.pc);
         auto metaIt = predMeta->branchMeta.find(btbEntry.slot.pc);
         const bool actualTaken =
-            stream.exeTaken && stream.exeBranchInfo == btbEntry.slot;
+            stream.resolve.taken && stream.resolve.branchSlot == btbEntry.slot;
         TagePrediction storedPred;
         BranchPredictionMeta storedMeta;
         if (predIt != predMeta->preds.end() &&

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -91,7 +91,7 @@ UBTB::PredStatistics(const TickedUBTBEntry entry, Addr startAddr)
 {
     if (entry.valid) {
         Addr mbtb_end = (startAddr + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
-        assert(entry.pc >= startAddr && entry.pc < mbtb_end);
+        assert(entry.slot.pc >= startAddr && entry.slot.pc < mbtb_end);
         DPRINTF(UBTB, "UBTB: lookup hit: \n");
         ubtbStats.predHit += 1;
         printTickedUBTBEntry(entry);
@@ -118,16 +118,20 @@ UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPred
 
     if (entry.valid) {
         FillStageLoop(s) stagePreds[s].btbEntries.push_back(BTBEntry(entry));
-        if (entry.isCond) {
+        if (entry.isCond()) {
             // the always taken field of BTBEntry is ignored in uBTB
             // uBTB always assumes present entries to be taken
-            FillStageLoop(s) stagePreds[s].condTakens.push_back({entry.pc, true});
-        } else if (entry.isIndirect) {
+            FillStageLoop(s) stagePreds[s].condTakens.push_back(
+                {entry.slot.pc, true});
+        } else if (entry.isIndirect()) {
             // Set predicted target for indirect branches
-            DPRINTF(UBTB, "setting indirect target for pc %#lx to %#lx\n", entry.pc, entry.target);
-            FillStageLoop(s) stagePreds[s].indirectTargets.push_back({entry.pc, entry.target});
-            if (entry.isReturn) {
-                FillStageLoop(s) stagePreds[s].returnTarget = entry.target;
+            DPRINTF(UBTB, "setting indirect target for pc %#lx to %#lx\n",
+                    entry.slot.pc, entry.slot.target);
+            FillStageLoop(s) stagePreds[s].indirectTargets.push_back(
+                {entry.slot.pc, entry.slot.target});
+            if (entry.isReturn()) {
+                FillStageLoop(s) stagePreds[s].returnTarget =
+                    entry.slot.target;
             }
         }
     }
@@ -166,7 +170,8 @@ UBTB::lookup(Addr startAddr, uint8_t asidHash)
     auto it = std::find_if(ubtb.begin(), ubtb.end(),
                            [current_tag, startAddr, block_end](const TickedUBTBEntry &way) {
                                return way.valid && way.tag == current_tag &&
-                                      way.pc >= startAddr && way.pc < block_end;
+                                      way.slot.pc >= startAddr &&
+                                      way.slot.pc < block_end;
                            });
 
     if (it != ubtb.end()) {
@@ -174,7 +179,7 @@ UBTB::lookup(Addr startAddr, uint8_t asidHash)
         auto duplicate = std::find_if(std::next(it), ubtb.end(),
                                       [current_tag, startAddr, block_end](const TickedUBTBEntry &way) {
             return way.valid && way.tag == current_tag &&
-                   way.pc >= startAddr && way.pc < block_end;
+                   way.slot.pc >= startAddr && way.slot.pc < block_end;
         });
         if (duplicate != ubtb.end()) {
             DPRINTF(UBTB, "UBTB: Multiple hits found in uBTB for the same tag %#lx\n", current_tag);
@@ -197,7 +202,7 @@ UBTB::replaceOldEntry(UBTBIter oldEntryIter, const BTBEntry &newTakenEntry,
     assert(newTakenEntry.valid);
     TickedUBTBEntry newEntry = TickedUBTBEntry(newTakenEntry, curTick());
     // important! this is so that target set by RAS or ITTAGE is used
-    newEntry.target = newTakenEntry.target;
+    newEntry.slot.target = newTakenEntry.slot.target;
     newEntry.ctr = 0; // have a bug here:ubtb will accept ctr from mbtb, reset it to 0 at here
     // important: update tag (mbtb and ubtb have different tags, even diffferent tag length)
     newEntry.tag = getTag(startAddr, asidHash);
@@ -273,7 +278,8 @@ void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry,
         } else if (oldEntryIter != ubtb.end() && takenEntry.valid) {
             ubtbStats.s1Hits3Taken++;
             // both S0 and S3 predict taken
-            if (oldEntryIter->pc != takenEntry.pc || oldEntryIter->target != takenEntry.target) {
+            if (oldEntryIter->slot.pc != takenEntry.slot.pc ||
+                oldEntryIter->slot.target != takenEntry.slot.target) {
                 // S0 and S3 predict different branch instruction
                 updateUCtr(oldEntryIter->uctr, false);
                 if (oldEntryIter->uctr == 0) {
@@ -311,7 +317,7 @@ UBTB::update(const FetchTarget &stream)
     oldEntryIter = meta->hit_entry.valid ?
                     std::find_if(ubtb.begin(), ubtb.end(), [oldtag, startAddr, block_end](const TickedUBTBEntry &e) {
                         return e.valid && e.tag == oldtag &&
-                               e.pc >= startAddr && e.pc < block_end;
+                               e.slot.pc >= startAddr && e.slot.pc < block_end;
                     }) : ubtb.end();
 
     if (stream.exeTaken) {
@@ -337,7 +343,7 @@ UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     auto &hit_entry = meta->hit_entry;
     auto pc = inst->getPC();
     auto npc = inst->getNPC();
-    bool this_branch_hit = hit_entry.pc == pc;
+    bool this_branch_hit = hit_entry.slot.pc == pc;
 
     bool cond_not_taken = inst->isCondCtrl() && !inst->branching();
     bool this_branch_taken = stream.exeTaken && stream.getControlPC() == pc;  // all uncond should be taken
@@ -371,7 +377,7 @@ UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         if (!inst->isNonSpeculative()) {
             if (inst->isIndirectCtrl()) {
                 ubtbStats.indirectHits++;
-                Addr pred_target = hit_entry.target;
+                Addr pred_target = hit_entry.slot.target;
                 if (pred_target == this_branch_target) {
                     ubtbStats.indirectPredCorrect++;
                 } else {

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -302,12 +302,12 @@ UBTB::update(const FetchTarget &stream)
 {
     auto meta = std::static_pointer_cast<UBTBMeta>(stream.predMetas[getComponentIdx()]);
     // hit entries whose corresponding insts are acutally executed
-    Addr end_inst_pc = stream.updateEndInstPC;
+    Addr end_inst_pc = stream.update.endInstPC;
 
     auto pred_hit_entry = meta->hit_entry;
     // Find the iterator in ubtb that matches pred_hit_entry (by tag and pc)
      // Use BTBEntry instead of BranchInfo; make it invalid when not taken
-    BTBEntry takenEntry = stream.exeTaken ? BTBEntry(stream.exeBranchInfo) : BTBEntry();
+    BTBEntry takenEntry = stream.resolve.taken ? BTBEntry(stream.resolve.branchSlot) : BTBEntry();
     auto startAddr = stream.getRealStartPC();
     Addr oldtag = getTag(startAddr, stream.asidHash);
     Addr block_end = (startAddr + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
@@ -320,10 +320,12 @@ UBTB::update(const FetchTarget &stream)
                                e.slot.pc >= startAddr && e.slot.pc < block_end;
                     }) : ubtb.end();
 
-    if (stream.exeTaken) {
+    if (stream.resolve.taken) {
         if (!pred_hit_entry.valid ||
-            pred_hit_entry.slot != stream.exeBranchInfo) {
-            DPRINTF(UBTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
+            pred_hit_entry.slot != stream.resolve.branchSlot) {
+            DPRINTF(UBTB, "update miss detected, pc %#lx, "
+                    "predTick %lu\n",
+                    stream.resolve.branchSlot.pc, stream.predTick);
             ubtbStats.updateMiss++;
         }else {
             ubtbStats.updateHit++;
@@ -347,7 +349,7 @@ UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     bool this_branch_hit = hit_entry.slot.pc == pc;
 
     bool cond_not_taken = inst->isCondCtrl() && !inst->branching();
-    bool this_branch_taken = stream.exeTaken && stream.getControlPC() == pc;  // all uncond should be taken
+    bool this_branch_taken = stream.resolve.taken && stream.getControlPC() == pc;  // all uncond should be taken
     Addr this_branch_target = npc;
     if (this_branch_hit) {
         ubtbStats.allBranchHits++;

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -118,18 +118,18 @@ UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPred
 
     if (entry.valid) {
         FillStageLoop(s) stagePreds[s].btbEntries.push_back(BTBEntry(entry));
-        if (entry.isCond()) {
+        if (entry.slot.isCond()) {
             // the always taken field of BTBEntry is ignored in uBTB
             // uBTB always assumes present entries to be taken
             FillStageLoop(s) stagePreds[s].condTakens.push_back(
                 {entry.slot.pc, true});
-        } else if (entry.isIndirect()) {
+        } else if (entry.slot.isIndirect()) {
             // Set predicted target for indirect branches
             DPRINTF(UBTB, "setting indirect target for pc %#lx to %#lx\n",
                     entry.slot.pc, entry.slot.target);
             FillStageLoop(s) stagePreds[s].indirectTargets.push_back(
                 {entry.slot.pc, entry.slot.target});
-            if (entry.isReturn()) {
+            if (entry.slot.isReturn()) {
                 FillStageLoop(s) stagePreds[s].returnTarget =
                     entry.slot.target;
             }
@@ -321,7 +321,8 @@ UBTB::update(const FetchTarget &stream)
                     }) : ubtb.end();
 
     if (stream.exeTaken) {
-        if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
+        if (!pred_hit_entry.valid ||
+            pred_hit_entry.slot != stream.exeBranchInfo) {
             DPRINTF(UBTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
             ubtbStats.updateMiss++;
         }else {

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -154,7 +154,8 @@ class UBTB : public TimedBaseBTBPredictor
     void printTickedUBTBEntry(const TickedUBTBEntry &e) {
         DPRINTF(UBTB, "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, tick:%lu\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.tick);
+            e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
+            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(), e.tick);
     }
 
     void dumpMruList() {

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -155,7 +155,8 @@ class UBTB : public TimedBaseBTBPredictor
         DPRINTF(UBTB, "uBTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, tick:%lu\n",
             e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
-            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(), e.tick);
+            e.slot.isCond(), e.slot.isIndirect(), e.slot.isCall(),
+            e.slot.isReturn(), e.tick);
     }
 
     void dumpMruList() {

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -455,6 +455,16 @@ using CondTakens = std::vector<std::pair<Addr, bool>>;
 // {branch pc -> target pc} maps
 using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
+struct FetchPredictionSnapshot
+{
+    bool taken = false;        // whether the final prediction is taken
+    Addr fallThrough = 0;      // predicted stream end pc
+    BranchSlot branchSlot;     // predicted taken branch slot
+    bool btbHit = false;       // whether any BTB entry was predicted
+    bool falseHit = false;     // not used
+    std::vector<BTBEntry> btbEntries; // predicted BTB entries
+};
+
 #define CondTakens_find(condTakens, branch_pc) \
     std::find_if(condTakens.begin(), condTakens.end(), \
                  [&branch_pc](const auto &p) { return p.first == branch_pc; })
@@ -479,13 +489,7 @@ struct FetchTarget
     ThreadID tid;
     uint8_t asidHash;
     Addr startPC;       // start pc of the stream
-    bool predTaken;     // whether the FetchTarget has taken branch
-    Addr predEndPC;     // predicted stream end pc (fall through pc)
-    BranchSlot predBranchInfo; // predicted branch slot
-
-    bool isHit;          // whether the predicted btb entry is hit
-    bool falseHit;       // not used
-    std::vector<BTBEntry> predBTBEntries;   // record predicted BTB entries
+    FetchPredictionSnapshot prediction; // final prediction snapshot
 
     // for commit, write at redirect or fetch
     bool exeTaken;         // whether the branch is taken(resolved)
@@ -499,7 +503,7 @@ struct FetchTarget
     // used to decide which branches to update (don't update if not actually executed)
     Addr updateEndInstPC;   // end pc of the squash inst/taken inst
     // for components to decide which entries to update
-    std::vector<BTBEntry> updateBTBEntries; // mostly like predBTBEntries
+    std::vector<BTBEntry> updateBTBEntries; // mostly like prediction.btbEntries
 
     int squashType;         // squash type
     Addr squashPC;         // pc of the squash inst
@@ -524,11 +528,7 @@ struct FetchTarget
        : tid(0),
          asidHash(0),
          startPC(0),
-         predTaken(false),
-         predEndPC(0),
-         predBranchInfo(BranchInfo()),
-         isHit(false),
-         falseHit(false),
+         prediction(),
          exeTaken(false),
          exeBranchInfo(BranchInfo()),
          updateNewBTBEntry(BTBEntry()),
@@ -547,24 +547,26 @@ struct FetchTarget
          commitInstNum(0)
    {
        predMetas.fill(nullptr);
-       predBTBEntries.clear();
        updateBTBEntries.clear();
    }
 
     // the default exe result should be consistent with prediction
     void setDefaultResolve() {
         resolved = false;
-        exeBranchInfo = predBranchInfo;
-        exeTaken = predTaken;
+        exeBranchInfo = prediction.branchSlot;
+        exeTaken = prediction.taken;
     }
 
     // bool getEnded() const { return resolved ? exeEnded : predEnded; }
-    BranchSlot getBranchSlot() const { return resolved ? exeBranchInfo : predBranchInfo; }
+    BranchSlot getBranchSlot() const
+    {
+        return resolved ? exeBranchInfo : prediction.branchSlot;
+    }
     BranchSlot getBranchInfo() const { return getBranchSlot(); }
     Addr getControlPC() const { return getBranchSlot().pc; }
     // FIXME: should be end of squash inst when non-control squash of trap squash.
     Addr getEndPC() const { return getBranchSlot().getEnd(); }
-    Addr getTaken() const { return resolved ? exeTaken : predTaken; }
+    Addr getTaken() const { return resolved ? exeTaken : prediction.taken; }
     Addr getTakenTarget() const { return getBranchSlot().target; }
 
     Addr getRealStartPC() const {
@@ -575,7 +577,7 @@ struct FetchTarget
         Addr squash_pc, bool is_cond, bool actually_taken) const
     {
         DirectionHistoryUpdate update;
-        for (auto &entry : predBTBEntries) {
+        for (auto &entry : prediction.btbEntries) {
             if (entry.valid && entry.slot.pc >= startPC &&
                 entry.slot.pc < squash_pc) {
                 update.shamt++;
@@ -592,7 +594,7 @@ struct FetchTarget
         Addr squash_pc, bool is_cond, bool actually_taken, Addr target) const
     {
         DirectionHistoryUpdate update;
-        for (auto &entry : predBTBEntries) {
+        for (auto &entry : prediction.btbEntries) {
             if (entry.valid && entry.slot.pc >= startPC &&
                 entry.slot.pc < squash_pc) {
                 update.shamt++;
@@ -636,7 +638,7 @@ struct FetchTarget
     void setUpdateBTBEntries()
     {
         updateBTBEntries.clear();
-        for (auto &entry : predBTBEntries) {
+        for (auto &entry : prediction.btbEntries) {
             if (entry.valid && entry.slot.pc >= startPC &&
                 entry.slot.pc <= updateEndInstPC) {
                 updateBTBEntries.push_back(entry);

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -474,12 +474,25 @@ struct FetchResolveResult
     Addr squashPC = 0;         // pc of the squash inst
 };
 
+struct FetchUpdateEntrySelection
+{
+    BTBEntry entry;            // old entry to update, or possible new entry
+    bool isOldEntry = false;   // true: update old entry; false: use entry
+};
+
 struct FetchUpdatePayload
 {
     BTBEntry newBTBEntry;      // possible new entry from L1 BTB update prep
     bool isOldEntry = false;   // true: update old entry; false: use newBTBEntry
     Addr endInstPC = 0;        // end pc of the squash inst/taken inst
     std::vector<BTBEntry> btbEntries; // entries that were actually executed
+
+    void
+    setEntrySelection(const FetchUpdateEntrySelection &selection)
+    {
+        newBTBEntry = selection.entry;
+        isOldEntry = selection.isOldEntry;
+    }
 };
 
 #define CondTakens_find(condTakens, branch_pc) \

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -10,6 +10,7 @@
 // #include "arch/generic/pcstate.hh"
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
+#include "cpu/pred/btb/prediction_result.hh"
 #include "cpu/pred/general_arch_db.hh"
 #include "cpu/static_inst.hh"
 
@@ -455,22 +456,6 @@ using IndirectTargets = std::vector<std::pair<Addr, Addr>>;
 
 #define FillStageLoop(x) for (int x = getDelay(); x < stagePreds.size(); ++x)
 
-struct DirectionHistoryUpdate
-{
-    int shamt = 0;
-    bool taken = false;
-};
-
-struct PathHistoryUpdate
-{
-    static constexpr int NumShift = 2;
-
-    int shamt = NumShift;
-    bool taken = false;
-    Addr pc = 0;
-    Addr target = 0;
-};
-
 /**
  * @brief Fetch Stream representing a sequence of instructions with prediction info
  *
@@ -679,24 +664,10 @@ struct FetchTarget
  */
 struct FullBTBPrediction
 {
-    struct TakenSlotResult
-    {
-        BTBEntry entry;
-        Addr target = 0;
-        Addr fallThrough = 0;
-
-        bool taken() const { return entry.valid; }
-        Addr controlPC() const { return entry.slot.pc; }
-        Addr endPC() const { return taken() ? entry.slot.getEnd() : fallThrough; }
-
-        BranchSlot
-        resolvedSlot() const
-        {
-            auto resolved_slot = entry.slot;
-            resolved_slot.target = target;
-            return resolved_slot;
-        }
-    };
+    using PredictionResult =
+        PredictionBlockResultView<std::vector<BTBEntry>, CondTakens,
+                                  IndirectTargets>;
+    using TakenSlotResult = PredictionResult::TakenSlotResult;
 
     ThreadID tid;
     uint8_t asidHash;
@@ -733,172 +704,87 @@ struct FullBTBPrediction
         s1Source(-1),
         s3Source(-1) {}
 
+    PredictionResult
+    resultView() const
+    {
+        return PredictionResult(bbStart, btbEntries, condTakens,
+                                indirectTargets, returnTarget);
+    }
+
     BTBEntry getTakenEntry() const {
-        // IMPORTANT: assume entries are sorted
-        for (const auto &entry : this->btbEntries) {
-            // hit
-            if (entry.valid) {
-                if (entry.slot.isCond()) {
-                    // find corresponding direction pred in condTakens
-                    // TODO: use lower-bit offset of branch instruction
-                    const auto& pc = entry.slot.pc;
-                    auto it = CondTakens_find(condTakens, pc);
-                    if (it != condTakens.end()) {
-                        if (it->second) {   // find and taken, return the entry
-                            return entry;
-                        }
-                    }
-                }
-                if (entry.slot.isUncond()) { // find the first uncond entry
-                    return entry;
-                }
-            }
-        }
-        return BTBEntry(); // not found, return empty entry
+        return resultView().getTakenEntry();
     }
 
     bool isTaken() const {
-        return getTakenEntry().valid;   // if find a taken entry, return true
+        return resultView().isTaken();
     }
 
     Addr getFallThrough(Addr predictWidth) const {
-        // max 64 byte block, 32 byte aligned
-        return (bbStart + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
+        return resultView().getFallThrough(predictWidth);
     }
 
     Addr getEntryTarget(const BTBEntry &entry) const {
-        Addr target = entry.slot.target;
-        // indirect target should come from ipred or ras,
-        // or btb itself when ipred miss
-        if (entry.slot.isIndirect()) {
-            if (!entry.slot.isReturn()) { // normal indirect, see ittage
-                const auto& pc = entry.slot.pc;
-                auto it = IndirectTakens_find(indirectTargets, pc);
-                if (it != indirectTargets.end()) { // found in ittage, use it
-                    target = it->second;
-                }
-            } else { // indirect return, use RAS target
-                target = returnTarget;
-            }
-        } // else: normal taken, use btb target
-        return target;
+        return resultView().getEntryTarget(entry);
     }
 
     TakenSlotResult getTakenSlotResult(Addr predictWidth) const
     {
-        TakenSlotResult result;
-        result.fallThrough = getFallThrough(predictWidth);
-        result.entry = getTakenEntry();
-        result.target = result.entry.valid ? getEntryTarget(result.entry) :
-                                             result.fallThrough;
-        return result;
+        return resultView().getTakenSlotResult(predictWidth);
     }
 
     Addr getTarget(Addr predictWidth) const {
-        return getTakenSlotResult(predictWidth).target;
+        return resultView().getTarget(predictWidth);
     }
 
     Addr getEnd(Addr predictWidth) const {
-        return getTakenSlotResult(predictWidth).endPC();
+        return resultView().getEnd(predictWidth);
     }
 
     Addr controlAddr() const {
-        const auto &entry = getTakenEntry();
-        if (entry.valid) {
-            return entry.slot.pc;
-        }
-        return 0;
+        return resultView().controlAddr();
     }
 
     std::pair<bool, OverrideReason> match(const FullBTBPrediction &other,
                                           Addr predictWidth) const
     {
-        auto this_taken_entry = this->getTakenEntry();
-        auto other_taken_entry = other.getTakenEntry();
-        if (this_taken_entry.valid != other_taken_entry.valid) {
-            return std::make_pair(false, OverrideReason::FALL_THRU);
-        } else {
-            // all taken or all not taken, check target and end
-            if (this_taken_entry.valid && other_taken_entry.valid) {
-                if (this->controlAddr() != other.controlAddr()) {
-                    return std::make_pair(false, OverrideReason::CONTROL_ADDR);
-                }
-                else if (this->getTarget(predictWidth) != other.getTarget(predictWidth)) {
-                    return std::make_pair(false, OverrideReason::TARGET);
-                }
-                else {
-                    return std::make_pair(true, btb_pred::OverrideReason::NO_OVERRIDE);
-                }
-            } else {
-                return std::make_pair(true, btb_pred::OverrideReason::NO_OVERRIDE);
-            }
-        }
+        const auto match =
+            resultView().match(other.resultView(), predictWidth);
+        return std::make_pair(match.matches,
+                              toOverrideReason(match.reason));
     }
 
     DirectionHistoryUpdate getGHistUpdate() const  //global or local
     {
-        DirectionHistoryUpdate update; // shamt is the number of bits to shift in history update
-        for (const auto &entry : btbEntries) {
-            if (entry.valid) {
-                if (entry.slot.isCond()) { // if found a cond branch, shamt++
-                    update.shamt++;
-                    const auto& pc = entry.slot.pc;
-                    auto it = CondTakens_find(condTakens, pc);
-                    if (it != condTakens.end()) {
-                        if (it->second) { // if the cond branch is taken, taken = true
-                            update.taken = true;
-                            break;
-                        }
-                    }
-                } else {
-                    // uncond
-                    break;
-                }
-            }
-        }
-        // For example, return (3, true) means 3 bits to shift in history update,
-        // and the third branch is taken, new hist = xxx001
-        return update;
+        return resultView().getGHistUpdate();
     }
 
     DirectionHistoryUpdate getBwHistUpdate() const //global backward or imli
     {
-        DirectionHistoryUpdate update;
-        for (const auto &entry : btbEntries) {
-            if (entry.valid) {
-                if (entry.slot.isCond()) {
-                    update.shamt++;
-                    const auto& pc = entry.slot.pc;
-                    auto it = CondTakens_find(condTakens, pc);
-                    if (it != condTakens.end()) {
-                        if (it->second) {
-                            // branch is backward if target < pc
-                            update.taken =
-                                (entry.slot.target < entry.slot.pc);
-                            break;
-                        }
-                    }
-                } else {
-                    // uncond
-                    break;
-                }
-            }
-        }
-        return update;
+        return resultView().getBwHistUpdate();
     }
 
     PathHistoryUpdate getPHistUpdate() const //path
     {
-        PathHistoryUpdate update;
-        const auto &entry = getTakenEntry();
-        if (entry.valid) {
-            update.taken = true;
-            update.pc = entry.slot.pc;
-            update.target = getEntryTarget(entry);
-        }
-        return update;
+        return resultView().getPHistUpdate();
     }
 
+  private:
+    static OverrideReason
+    toOverrideReason(PredictionResultMismatchReason reason)
+    {
+        switch (reason) {
+          case PredictionResultMismatchReason::NoOverride:
+            return OverrideReason::NO_OVERRIDE;
+          case PredictionResultMismatchReason::FallThrough:
+            return OverrideReason::FALL_THRU;
+          case PredictionResultMismatchReason::ControlAddr:
+            return OverrideReason::CONTROL_ADDR;
+          case PredictionResultMismatchReason::Target:
+            return OverrideReason::TARGET;
+        }
+
+        return OverrideReason::NO_OVERRIDE;
+    }
 };
 
 struct TageMissTrace : public Record

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -104,6 +104,14 @@ enum class OverrideReason
     HIST_INFO
 };
 
+struct FinalPredictionMetadata
+{
+    unsigned firstMatchingStage = 0;
+    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
+    int s1Source = -1;
+    int s3Source = -1;
+};
+
 enum class HistoryType
 {
     GLOBAL,
@@ -495,8 +503,7 @@ struct FetchTarget
 
     int squashType;         // squash type
     Addr squashPC;         // pc of the squash inst
-    unsigned predSource;   // source of the prediction(numStage)
-    OverrideReason overrideReason; // reason of the override(for profiling)
+    FinalPredictionMetadata finalPredMetadata; // final prediction attribution
 
     // prediction metas
     // FIXME: use vec
@@ -512,9 +519,6 @@ struct FetchTarget
     // for profiling
     int fetchInstNum;
     int commitInstNum;
-
-    int s1Source; // which stage the prediction comes from
-    int s3Source; // which stage the prediction comes from
 
    FetchTarget()
        : tid(0),
@@ -533,16 +537,14 @@ struct FetchTarget
          updateEndInstPC(0),
          squashType(SquashType::SQUASH_NONE),
          squashPC(0),
-         predSource(0),
+         finalPredMetadata(),
          predTick(0),
          history(),
          phistory(),
          bwhistory(),
          lhistory(),
          fetchInstNum(0),
-         commitInstNum(0),
-         s1Source(-1),
-         s3Source(-1)
+         commitInstNum(0)
    {
        predMetas.fill(nullptr);
        predBTBEntries.clear();
@@ -682,13 +684,7 @@ struct FullBTBPrediction
 
     std::unordered_map<Addr, TageInfoForMGSC> tageInfoForMgscs;
 
-    unsigned predSource;
-    OverrideReason overrideReason;
     Tick predTick;
-
-    //only use for countering the source of the prediction
-    int s1Source;
-    int s3Source;
 
     FullBTBPrediction() :
         tid(0),
@@ -699,10 +695,7 @@ struct FullBTBPrediction
         indirectTargets(),
         returnTarget(0),
         tageInfoForMgscs(),
-        predSource(0),
-        predTick(0),
-        s1Source(-1),
-        s3Source(-1) {}
+        predTick(0) {}
 
     PredictionResult
     resultView() const

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -465,6 +465,23 @@ struct FetchPredictionSnapshot
     std::vector<BTBEntry> btbEntries; // predicted BTB entries
 };
 
+struct FetchResolveResult
+{
+    bool valid = false;        // whether execution resolved this stream
+    bool taken = false;        // actual taken result
+    BranchSlot branchSlot;     // executed branch slot
+    SquashType squashType = SquashType::SQUASH_NONE;
+    Addr squashPC = 0;         // pc of the squash inst
+};
+
+struct FetchUpdatePayload
+{
+    BTBEntry newBTBEntry;      // possible new entry from L1 BTB update prep
+    bool isOldEntry = false;   // true: update old entry; false: use newBTBEntry
+    Addr endInstPC = 0;        // end pc of the squash inst/taken inst
+    std::vector<BTBEntry> btbEntries; // entries that were actually executed
+};
+
 #define CondTakens_find(condTakens, branch_pc) \
     std::find_if(condTakens.begin(), condTakens.end(), \
                  [&branch_pc](const auto &p) { return p.first == branch_pc; })
@@ -491,22 +508,8 @@ struct FetchTarget
     Addr startPC;       // start pc of the stream
     FetchPredictionSnapshot prediction; // final prediction snapshot
 
-    // for commit, write at redirect or fetch
-    bool exeTaken;         // whether the branch is taken(resolved)
-    BranchSlot exeBranchInfo; // executed branch slot
-
-    BTBEntry updateNewBTBEntry; // the possible new entry, set by L1BTB.getAndSetNewBTBEntry, used by L1BTB/L0BTB.update
-    bool updateIsOldEntry; // whether the BTB entry is old, true: update the old entry, false: use updateNewBTBEntry
-    bool resolved;  // whether the branch is resolved/executed
-
-    // below two should be set before components update
-    // used to decide which branches to update (don't update if not actually executed)
-    Addr updateEndInstPC;   // end pc of the squash inst/taken inst
-    // for components to decide which entries to update
-    std::vector<BTBEntry> updateBTBEntries; // mostly like prediction.btbEntries
-
-    int squashType;         // squash type
-    Addr squashPC;         // pc of the squash inst
+    FetchResolveResult resolve; // execution result written by squash/commit
+    FetchUpdatePayload update;  // payload prepared before predictor update
     FinalPredictionMetadata finalPredMetadata; // final prediction attribution
 
     // prediction metas
@@ -529,14 +532,8 @@ struct FetchTarget
          asidHash(0),
          startPC(0),
          prediction(),
-         exeTaken(false),
-         exeBranchInfo(BranchInfo()),
-         updateNewBTBEntry(BTBEntry()),
-         updateIsOldEntry(false),
-         resolved(false),
-         updateEndInstPC(0),
-         squashType(SquashType::SQUASH_NONE),
-         squashPC(0),
+         resolve(),
+         update(),
          finalPredMetadata(),
          predTick(0),
          history(),
@@ -547,26 +544,27 @@ struct FetchTarget
          commitInstNum(0)
    {
        predMetas.fill(nullptr);
-       updateBTBEntries.clear();
    }
 
     // the default exe result should be consistent with prediction
     void setDefaultResolve() {
-        resolved = false;
-        exeBranchInfo = prediction.branchSlot;
-        exeTaken = prediction.taken;
+        resolve.valid = false;
+        resolve.branchSlot = prediction.branchSlot;
+        resolve.taken = prediction.taken;
+        resolve.squashType = SQUASH_NONE;
+        resolve.squashPC = 0;
     }
 
     // bool getEnded() const { return resolved ? exeEnded : predEnded; }
     BranchSlot getBranchSlot() const
     {
-        return resolved ? exeBranchInfo : prediction.branchSlot;
+        return resolve.valid ? resolve.branchSlot : prediction.branchSlot;
     }
     BranchSlot getBranchInfo() const { return getBranchSlot(); }
     Addr getControlPC() const { return getBranchSlot().pc; }
     // FIXME: should be end of squash inst when non-control squash of trap squash.
     Addr getEndPC() const { return getBranchSlot().getEnd(); }
-    Addr getTaken() const { return resolved ? exeTaken : prediction.taken; }
+    Addr getTaken() const { return resolve.valid ? resolve.taken : prediction.taken; }
     Addr getTakenTarget() const { return getBranchSlot().target; }
 
     Addr getRealStartPC() const {
@@ -622,26 +620,27 @@ struct FetchTarget
     // should be called before components update
     void setUpdateInstEndPC(unsigned predictWidth)
     {
-        if (squashType == SQUASH_NONE) {
-            if (exeTaken) { // taken inst pc
-                updateEndInstPC = getControlPC();
+        if (resolve.squashType == SQUASH_NONE) {
+            if (resolve.taken) { // taken inst pc
+                update.endInstPC = getControlPC();
             } else { // natural fall through, align to the next block
                 // assert(halfAligned);
-                updateEndInstPC = (startPC + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
+                update.endInstPC =
+                    (startPC + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
             }
         } else {
-            updateEndInstPC = squashPC;
+            update.endInstPC = resolve.squashPC;
         }
     }
 
     // should be called before components update, after setUpdateInstEndPC
     void setUpdateBTBEntries()
     {
-        updateBTBEntries.clear();
+        update.btbEntries.clear();
         for (auto &entry : prediction.btbEntries) {
             if (entry.valid && entry.slot.pc >= startPC &&
-                entry.slot.pc <= updateEndInstPC) {
-                updateBTBEntries.push_back(entry);
+                entry.slot.pc <= update.endInstPC) {
+                update.btbEntries.push_back(entry);
             }
         }
     }
@@ -650,7 +649,7 @@ struct FetchTarget
     // Just ignore it in that case.
     void markBTBEntryResolved(Addr resolvedInstPC)
     {
-        for (auto &entry : updateBTBEntries) {
+        for (auto &entry : update.btbEntries) {
             if (entry.valid && entry.slot.pc == resolvedInstPC) {
                 entry.slot.resolved = true;
             }

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -113,15 +113,15 @@ enum class HistoryType
 };
 
 /**
- * @brief Branch information structure containing branch properties and targets
+ * @brief Branch slot observed in a fetch block
  *
- * Stores essential information about a branch instruction including:
+ * Stores essential information about a branch instruction slot including:
  * - PC and target address
  * - Resolved bit
  * - Branch type (conditional, indirect, call, return)
  * - Instruction size
  */
-struct BranchInfo
+struct BranchSlot
 {
   public:
     Addr pc;
@@ -233,7 +233,7 @@ struct BranchInfo
     bool isUncond() const { return !isCond(); }
     bool needIttage() const { return attribute.needIttage(); }
     Addr getEnd() const { return this->pc + this->size; }
-    BranchInfo()
+    BranchSlot()
         : pc(0),
           target(0),
           resolved(false),
@@ -241,7 +241,8 @@ struct BranchInfo
           size(0)
     {
     }
-    BranchInfo(const Addr &control_pc, const Addr &target_pc, const StaticInstPtr &static_inst, unsigned size)
+    BranchSlot(const Addr &control_pc, const Addr &target_pc,
+               const StaticInstPtr &static_inst, unsigned size)
         : pc(control_pc),
           target(target_pc),
           resolved(false),
@@ -294,27 +295,29 @@ struct BranchInfo
         }
     }
 
-    bool operator < (const BranchInfo &other) const
+    bool operator < (const BranchSlot &other) const
     {
         return this->pc < other.pc;
     }
 
-    bool operator == (const BranchInfo &other) const
+    bool operator == (const BranchSlot &other) const
     {
         return this->pc == other.pc;
     }
 
-    bool operator > (const BranchInfo &other) const
+    bool operator > (const BranchSlot &other) const
     {
         return this->pc > other.pc;
     }
 
-    bool operator != (const BranchInfo &other) const
+    bool operator != (const BranchSlot &other) const
     {
         return this->pc != other.pc;
     }
 
 };
+
+using BranchInfo = BranchSlot;
 
 
 /**
@@ -328,7 +331,7 @@ struct BranchInfo
  */
 struct BTBEntry
 {
-    BranchInfo slot;
+    BranchSlot slot;
     bool valid;
     bool alwaysTaken;
     int ctr;
@@ -344,8 +347,8 @@ struct BTBEntry
           source(-1)
     {
     }
-    BTBEntry(const BranchInfo &bi)
-        : slot(bi),
+    BTBEntry(const BranchSlot &branch_slot)
+        : slot(branch_slot),
           valid(true),
           alwaysTaken(true),
           ctr(0),
@@ -353,17 +356,6 @@ struct BTBEntry
           source(-1)
     {
     }
-    BranchInfo getBranchInfo() const { return slot; }
-
-    bool isCond() const { return slot.isCond(); }
-    bool isIndirect() const { return slot.isIndirect(); }
-    bool isDirect() const { return slot.isDirect(); }
-    bool isCall() const { return slot.isCall(); }
-    bool isReturn() const { return slot.isReturn(); }
-    bool isUncond() const { return slot.isUncond(); }
-    bool needIttage() const { return slot.needIttage(); }
-    Addr getEnd() const { return slot.getEnd(); }
-    int getType() const { return slot.getType(); }
 
     bool operator < (const BTBEntry &other) const
     {
@@ -373,11 +365,6 @@ struct BTBEntry
     bool operator == (const BTBEntry &other) const
     {
         return slot == other.slot;
-    }
-
-    bool operator == (const BranchInfo &other) const
-    {
-        return slot == other;
     }
 
     bool operator > (const BTBEntry &other) const
@@ -390,11 +377,6 @@ struct BTBEntry
         return slot != other.slot;
     }
 
-    bool operator != (const BranchInfo &other) const
-    {
-        return slot != other;
-    }
-
     int getsource() const {
         return source;
     }
@@ -403,18 +385,6 @@ struct BTBEntry
         source = src;
     }
 };
-
-inline bool
-operator == (const BranchInfo &lhs, const BTBEntry &rhs)
-{
-    return lhs == rhs.getBranchInfo();
-}
-
-inline bool
-operator != (const BranchInfo &lhs, const BTBEntry &rhs)
-{
-    return lhs != rhs.getBranchInfo();
-}
 
 /**
  * @brief Tage prediction info for MGSC
@@ -518,7 +488,7 @@ struct FetchTarget
     Addr startPC;       // start pc of the stream
     bool predTaken;     // whether the FetchTarget has taken branch
     Addr predEndPC;     // predicted stream end pc (fall through pc)
-    BranchInfo predBranchInfo; // predicted branch info
+    BranchSlot predBranchInfo; // predicted branch slot
 
     bool isHit;          // whether the predicted btb entry is hit
     bool falseHit;       // not used
@@ -526,7 +496,7 @@ struct FetchTarget
 
     // for commit, write at redirect or fetch
     bool exeTaken;         // whether the branch is taken(resolved)
-    BranchInfo exeBranchInfo; // executed branch info
+    BranchSlot exeBranchInfo; // executed branch slot
 
     BTBEntry updateNewBTBEntry; // the possible new entry, set by L1BTB.getAndSetNewBTBEntry, used by L1BTB/L0BTB.update
     bool updateIsOldEntry; // whether the BTB entry is old, true: update the old entry, false: use updateNewBTBEntry
@@ -602,11 +572,13 @@ struct FetchTarget
     }
 
     // bool getEnded() const { return resolved ? exeEnded : predEnded; }
-    BranchInfo getBranchInfo() const { return resolved ? exeBranchInfo : predBranchInfo; }
-    Addr getControlPC() const { return getBranchInfo().pc; }
-    Addr getEndPC() const { return getBranchInfo().getEnd(); } // FIXME: should be end of squash inst when non-control squash of trap squash
+    BranchSlot getBranchSlot() const { return resolved ? exeBranchInfo : predBranchInfo; }
+    BranchSlot getBranchInfo() const { return getBranchSlot(); }
+    Addr getControlPC() const { return getBranchSlot().pc; }
+    // FIXME: should be end of squash inst when non-control squash of trap squash.
+    Addr getEndPC() const { return getBranchSlot().getEnd(); }
     Addr getTaken() const { return resolved ? exeTaken : predTaken; }
-    Addr getTakenTarget() const { return getBranchInfo().target; }
+    Addr getTakenTarget() const { return getBranchSlot().target; }
 
     Addr getRealStartPC() const {
         return startPC;
@@ -707,6 +679,25 @@ struct FetchTarget
  */
 struct FullBTBPrediction
 {
+    struct TakenSlotResult
+    {
+        BTBEntry entry;
+        Addr target = 0;
+        Addr fallThrough = 0;
+
+        bool taken() const { return entry.valid; }
+        Addr controlPC() const { return entry.slot.pc; }
+        Addr endPC() const { return taken() ? entry.slot.getEnd() : fallThrough; }
+
+        BranchSlot
+        resolvedSlot() const
+        {
+            auto resolved_slot = entry.slot;
+            resolved_slot.target = target;
+            return resolved_slot;
+        }
+    };
+
     ThreadID tid;
     uint8_t asidHash;
     Addr bbStart;
@@ -742,15 +733,15 @@ struct FullBTBPrediction
         s1Source(-1),
         s3Source(-1) {}
 
-    BTBEntry getTakenEntry() {
+    BTBEntry getTakenEntry() const {
         // IMPORTANT: assume entries are sorted
-        for (auto &entry : this->btbEntries) {
+        for (const auto &entry : this->btbEntries) {
             // hit
             if (entry.valid) {
-                if (entry.isCond()) {
+                if (entry.slot.isCond()) {
                     // find corresponding direction pred in condTakens
                     // TODO: use lower-bit offset of branch instruction
-                    auto& pc = entry.slot.pc;
+                    const auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {   // find and taken, return the entry
@@ -758,7 +749,7 @@ struct FullBTBPrediction
                         }
                     }
                 }
-                if (entry.isUncond()) { // find the first uncond entry
+                if (entry.slot.isUncond()) { // find the first uncond entry
                     return entry;
                 }
             }
@@ -766,22 +757,22 @@ struct FullBTBPrediction
         return BTBEntry(); // not found, return empty entry
     }
 
-    bool isTaken() {
+    bool isTaken() const {
         return getTakenEntry().valid;   // if find a taken entry, return true
     }
 
-    Addr getFallThrough(Addr predictWidth) {
+    Addr getFallThrough(Addr predictWidth) const {
         // max 64 byte block, 32 byte aligned
         return (bbStart + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
     }
 
-    Addr getEntryTarget(const BTBEntry &entry) {
+    Addr getEntryTarget(const BTBEntry &entry) const {
         Addr target = entry.slot.target;
         // indirect target should come from ipred or ras,
         // or btb itself when ipred miss
-        if (entry.isIndirect()) {
-            if (!entry.isReturn()) { // normal indirect, see ittage
-                auto& pc = entry.slot.pc;
+        if (entry.slot.isIndirect()) {
+            if (!entry.slot.isReturn()) { // normal indirect, see ittage
+                const auto& pc = entry.slot.pc;
                 auto it = IndirectTakens_find(indirectTargets, pc);
                 if (it != indirectTargets.end()) { // found in ittage, use it
                     target = it->second;
@@ -793,31 +784,34 @@ struct FullBTBPrediction
         return target;
     }
 
-    Addr getTarget(Addr predictWidth) {
-        Addr target;
+    TakenSlotResult getTakenSlotResult(Addr predictWidth) const
+    {
+        TakenSlotResult result;
+        result.fallThrough = getFallThrough(predictWidth);
+        result.entry = getTakenEntry();
+        result.target = result.entry.valid ? getEntryTarget(result.entry) :
+                                             result.fallThrough;
+        return result;
+    }
+
+    Addr getTarget(Addr predictWidth) const {
+        return getTakenSlotResult(predictWidth).target;
+    }
+
+    Addr getEnd(Addr predictWidth) const {
+        return getTakenSlotResult(predictWidth).endPC();
+    }
+
+    Addr controlAddr() const {
         const auto &entry = getTakenEntry();
-        if (entry.valid) { // found a taken entry
-            target = getEntryTarget(entry);
-        } else {
-            target = getFallThrough(predictWidth);
+        if (entry.valid) {
+            return entry.slot.pc;
         }
-        return target;
+        return 0;
     }
 
-    Addr getEnd(Addr predictWidth) {
-        if (isTaken()) {
-            return getTakenEntry().getEnd();
-        } else {
-            return getFallThrough(predictWidth);
-        }
-    }
-
-
-    Addr controlAddr() {
-        return getTakenEntry().slot.pc;
-    }
-
-    std::pair<bool, OverrideReason> match(FullBTBPrediction &other, Addr predictWidth)
+    std::pair<bool, OverrideReason> match(const FullBTBPrediction &other,
+                                          Addr predictWidth) const
     {
         auto this_taken_entry = this->getTakenEntry();
         auto other_taken_entry = other.getTakenEntry();
@@ -841,14 +835,14 @@ struct FullBTBPrediction
         }
     }
 
-    DirectionHistoryUpdate getGHistUpdate()  //global or local
+    DirectionHistoryUpdate getGHistUpdate() const  //global or local
     {
         DirectionHistoryUpdate update; // shamt is the number of bits to shift in history update
-        for (auto &entry : btbEntries) {
+        for (const auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond()) { // if found a cond branch, shamt++
+                if (entry.slot.isCond()) { // if found a cond branch, shamt++
                     update.shamt++;
-                    auto& pc = entry.slot.pc;
+                    const auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) { // if the cond branch is taken, taken = true
@@ -867,14 +861,14 @@ struct FullBTBPrediction
         return update;
     }
 
-    DirectionHistoryUpdate getBwHistUpdate() //global backward or imli
+    DirectionHistoryUpdate getBwHistUpdate() const //global backward or imli
     {
         DirectionHistoryUpdate update;
-        for (auto &entry : btbEntries) {
+        for (const auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond()) {
+                if (entry.slot.isCond()) {
                     update.shamt++;
-                    auto& pc = entry.slot.pc;
+                    const auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
@@ -893,7 +887,7 @@ struct FullBTBPrediction
         return update;
     }
 
-    PathHistoryUpdate getPHistUpdate() //path
+    PathHistoryUpdate getPHistUpdate() const //path
     {
         PathHistoryUpdate update;
         const auto &entry = getTakenEntry();

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -112,7 +112,6 @@ enum class HistoryType
     PATH
 };
 
-
 /**
  * @brief Branch information structure containing branch properties and targets
  *
@@ -124,6 +123,7 @@ enum class HistoryType
  */
 struct BranchInfo
 {
+  public:
     Addr pc;
     Addr target;
     // An independent resolved bit to indicate whether CFI is resolved
@@ -131,54 +131,161 @@ struct BranchInfo
     // it's necessary to know whether the branch is resolved and skip
     // the BTB entry or not.
     bool resolved;
-    bool isCond;
-    bool isIndirect;
-    bool isDirect;
-    bool isCall;
-    bool isReturn;
+
+  private:
+    /**
+     * Branch control-flow class and RAS action.
+     *
+     * This keeps branch kind and RAS behavior as one semantic attribute instead
+     * of spreading legal combinations across public bools.
+     */
+    struct Attribute
+    {
+        Attribute() = default;
+
+        static Attribute
+        fromFlags(bool is_cond, bool is_indirect, bool is_direct,
+                  bool is_call, bool is_return)
+        {
+            ControlType control_type = ControlType::None;
+            if (is_cond) {
+                control_type = ControlType::Conditional;
+            } else if (is_indirect) {
+                control_type = ControlType::Indirect;
+            } else if (is_direct || is_call || is_return) {
+                control_type = ControlType::Direct;
+            }
+
+            RasAction ras_action = RasAction::None;
+            if (is_call && is_return) {
+                ras_action = RasAction::PopAndPush;
+            } else if (is_call) {
+                ras_action = RasAction::Push;
+            } else if (is_return) {
+                ras_action = RasAction::Pop;
+            }
+
+            return Attribute(control_type, ras_action);
+        }
+
+        bool isConditional() const
+        {
+            return controlType == ControlType::Conditional;
+        }
+
+        bool isDirect() const { return controlType == ControlType::Direct; }
+
+        bool isIndirect() const
+        {
+            return controlType == ControlType::Indirect;
+        }
+
+        bool isCall() const
+        {
+            return rasAction == RasAction::Push ||
+                   rasAction == RasAction::PopAndPush;
+        }
+
+        bool isReturn() const
+        {
+            return rasAction == RasAction::Pop ||
+                   rasAction == RasAction::PopAndPush;
+        }
+
+        bool needIttage() const { return isIndirect() && !isReturn(); }
+
+      private:
+        enum class ControlType : uint8_t
+        {
+            None,
+            Conditional,
+            Direct,
+            Indirect
+        };
+
+        enum class RasAction : uint8_t
+        {
+            None,
+            Push,
+            Pop,
+            PopAndPush
+        };
+
+        Attribute(ControlType control_type, RasAction ras_action)
+            : controlType(control_type), rasAction(ras_action)
+        {
+        }
+
+        ControlType controlType = ControlType::None;
+        RasAction rasAction = RasAction::None;
+    };
+
+    Attribute attribute;
+
+  public:
     uint8_t size;
-    bool isUncond() const { return !this->isCond; }
-    Addr getEnd() { return this->pc + this->size; }
+
+    bool isCond() const { return attribute.isConditional(); }
+    bool isIndirect() const { return attribute.isIndirect(); }
+    bool isDirect() const { return attribute.isDirect(); }
+    bool isCall() const { return attribute.isCall(); }
+    bool isReturn() const { return attribute.isReturn(); }
+    bool isUncond() const { return !isCond(); }
+    bool needIttage() const { return attribute.needIttage(); }
+    Addr getEnd() const { return this->pc + this->size; }
     BranchInfo()
-        : pc(0), target(0), resolved(false), isCond(false), isIndirect(false), isCall(false), isReturn(false), size(0)
+        : pc(0),
+          target(0),
+          resolved(false),
+          attribute(),
+          size(0)
     {
     }
-    // BranchInfo(const Addr &pc, const Addr &target_pc, bool is_cond) :
-    // pc(pc), target(target_pc), isCond(is_cond), isIndirect(false), isCall(false), isReturn(false), size(0) {}
     BranchInfo(const Addr &control_pc, const Addr &target_pc, const StaticInstPtr &static_inst, unsigned size)
         : pc(control_pc),
           target(target_pc),
           resolved(false),
-          isCond(static_inst->isCondCtrl()),
-          isIndirect(static_inst->isIndirectCtrl()),
-          isDirect(static_inst->isDirectCtrl()),
-          isCall(static_inst->isCall()),
-          isReturn(static_inst->isReturn() && !static_inst->isNonSpeculative() && !static_inst->isDirectCtrl()),
+          attribute(Attribute::fromFlags(
+              static_inst->isCondCtrl(),
+              static_inst->isIndirectCtrl(),
+              static_inst->isDirectCtrl(),
+              static_inst->isCall(),
+              static_inst->isReturn() && !static_inst->isNonSpeculative() &&
+                  !static_inst->isDirectCtrl())),
           size(size)
     {
     }
+
+    void
+    setTypeFromFlags(bool is_cond, bool is_indirect, bool is_direct,
+                     bool is_call, bool is_return)
+    {
+        attribute = Attribute::fromFlags(is_cond, is_indirect, is_direct,
+                                         is_call, is_return);
+    }
+
     int getType() const {
-        if (isCond) {
+        if (isCond()) {
             return BR_COND;
-        } else if (!isIndirect) { // uncond direct
-            if (isReturn) {
+        } else if (!isIndirect()) { // uncond direct
+            if (isReturn()) {
                 fatal("jal return detected!\n");
                 return BR_DIRECT_RET;
             }
-            if (!isCall) {
+            if (!isCall()) {
                 return BR_DIRECT_NORMAL;
             } else {
                 return BR_DIRECT_CALL;
             }
         } else {  // uncond indirect
-            if (!isCall) {
-                if (!isReturn) {
+            if (!isCall()) {
+                if (!isReturn()) {
                     return BR_INDIRECT_NORMAL; // normal indirect
                 } else {
                     return BR_INDIRECT_RET; // indirect return
                 }
             } else {
-                if (!isReturn) { // indirect call
+                if (!isReturn()) { // indirect call
                     return BR_INDIRECT_CALL;
                 } else { // call & return
                     return BR_INDIRECT_CALL_RET;
@@ -206,29 +313,87 @@ struct BranchInfo
     {
         return this->pc != other.pc;
     }
+
 };
 
 
 /**
- * @brief Branch Target Buffer entry extending BranchInfo with prediction metadata
+ * @brief Branch Target Buffer entry containing a branch slot plus BTB metadata
  *
- * Contains branch information plus prediction state:
+ * Contains the branch slot observed in a fetch block plus prediction state:
  * - Valid bit
  * - Always taken bit
  * - Counter for prediction
  * - Tag for BTB lookup
  */
-struct BTBEntry : BranchInfo
+struct BTBEntry
 {
+    BranchInfo slot;
     bool valid;
     bool alwaysTaken;
     int ctr;
     Addr tag;
     int source;//only use for countering the source of the entry
     // Addr offset; // retrived from lowest bits of pc
-    BTBEntry() : BranchInfo(), valid(false), alwaysTaken(false), ctr(0), tag(0) ,source(-1){}
-    BTBEntry(const BranchInfo &bi) : BranchInfo(bi), valid(true), alwaysTaken(true), ctr(0),source(-1){}
-    BranchInfo getBranchInfo() { return BranchInfo(*this); }
+    BTBEntry()
+        : slot(),
+          valid(false),
+          alwaysTaken(false),
+          ctr(0),
+          tag(0),
+          source(-1)
+    {
+    }
+    BTBEntry(const BranchInfo &bi)
+        : slot(bi),
+          valid(true),
+          alwaysTaken(true),
+          ctr(0),
+          tag(0),
+          source(-1)
+    {
+    }
+    BranchInfo getBranchInfo() const { return slot; }
+
+    bool isCond() const { return slot.isCond(); }
+    bool isIndirect() const { return slot.isIndirect(); }
+    bool isDirect() const { return slot.isDirect(); }
+    bool isCall() const { return slot.isCall(); }
+    bool isReturn() const { return slot.isReturn(); }
+    bool isUncond() const { return slot.isUncond(); }
+    bool needIttage() const { return slot.needIttage(); }
+    Addr getEnd() const { return slot.getEnd(); }
+    int getType() const { return slot.getType(); }
+
+    bool operator < (const BTBEntry &other) const
+    {
+        return slot < other.slot;
+    }
+
+    bool operator == (const BTBEntry &other) const
+    {
+        return slot == other.slot;
+    }
+
+    bool operator == (const BranchInfo &other) const
+    {
+        return slot == other;
+    }
+
+    bool operator > (const BTBEntry &other) const
+    {
+        return slot > other.slot;
+    }
+
+    bool operator != (const BTBEntry &other) const
+    {
+        return slot != other.slot;
+    }
+
+    bool operator != (const BranchInfo &other) const
+    {
+        return slot != other;
+    }
 
     int getsource() const {
         return source;
@@ -238,6 +403,18 @@ struct BTBEntry : BranchInfo
         source = src;
     }
 };
+
+inline bool
+operator == (const BranchInfo &lhs, const BTBEntry &rhs)
+{
+    return lhs == rhs.getBranchInfo();
+}
+
+inline bool
+operator != (const BranchInfo &lhs, const BTBEntry &rhs)
+{
+    return lhs != rhs.getBranchInfo();
+}
 
 /**
  * @brief Tage prediction info for MGSC
@@ -440,7 +617,8 @@ struct FetchTarget
     {
         DirectionHistoryUpdate update;
         for (auto &entry : predBTBEntries) {
-            if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
+            if (entry.valid && entry.slot.pc >= startPC &&
+                entry.slot.pc < squash_pc) {
                 update.shamt++;
             }
         }
@@ -456,7 +634,8 @@ struct FetchTarget
     {
         DirectionHistoryUpdate update;
         for (auto &entry : predBTBEntries) {
-            if (entry.valid && entry.pc >= startPC && entry.pc < squash_pc) {
+            if (entry.valid && entry.slot.pc >= startPC &&
+                entry.slot.pc < squash_pc) {
                 update.shamt++;
             }
         }
@@ -499,7 +678,8 @@ struct FetchTarget
     {
         updateBTBEntries.clear();
         for (auto &entry : predBTBEntries) {
-            if (entry.valid && entry.pc >= startPC && entry.pc <= updateEndInstPC) {
+            if (entry.valid && entry.slot.pc >= startPC &&
+                entry.slot.pc <= updateEndInstPC) {
                 updateBTBEntries.push_back(entry);
             }
         }
@@ -510,8 +690,8 @@ struct FetchTarget
     void markBTBEntryResolved(Addr resolvedInstPC)
     {
         for (auto &entry : updateBTBEntries) {
-            if (entry.valid && entry.pc == resolvedInstPC) {
-                entry.resolved = true;
+            if (entry.valid && entry.slot.pc == resolvedInstPC) {
+                entry.slot.resolved = true;
             }
         }
     }
@@ -567,10 +747,10 @@ struct FullBTBPrediction
         for (auto &entry : this->btbEntries) {
             // hit
             if (entry.valid) {
-                if (entry.isCond) {
+                if (entry.isCond()) {
                     // find corresponding direction pred in condTakens
                     // TODO: use lower-bit offset of branch instruction
-                    auto& pc = entry.pc;
+                    auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {   // find and taken, return the entry
@@ -596,12 +776,12 @@ struct FullBTBPrediction
     }
 
     Addr getEntryTarget(const BTBEntry &entry) {
-        Addr target = entry.target;
+        Addr target = entry.slot.target;
         // indirect target should come from ipred or ras,
         // or btb itself when ipred miss
-        if (entry.isIndirect) {
-            if (!entry.isReturn) { // normal indirect, see ittage
-                auto& pc = entry.pc;
+        if (entry.isIndirect()) {
+            if (!entry.isReturn()) { // normal indirect, see ittage
+                auto& pc = entry.slot.pc;
                 auto it = IndirectTakens_find(indirectTargets, pc);
                 if (it != indirectTargets.end()) { // found in ittage, use it
                     target = it->second;
@@ -634,7 +814,7 @@ struct FullBTBPrediction
 
 
     Addr controlAddr() {
-        return getTakenEntry().pc;
+        return getTakenEntry().slot.pc;
     }
 
     std::pair<bool, OverrideReason> match(FullBTBPrediction &other, Addr predictWidth)
@@ -666,9 +846,9 @@ struct FullBTBPrediction
         DirectionHistoryUpdate update; // shamt is the number of bits to shift in history update
         for (auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond) { // if found a cond branch, shamt++
+                if (entry.isCond()) { // if found a cond branch, shamt++
                     update.shamt++;
-                    auto& pc = entry.pc;
+                    auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) { // if the cond branch is taken, taken = true
@@ -692,13 +872,15 @@ struct FullBTBPrediction
         DirectionHistoryUpdate update;
         for (auto &entry : btbEntries) {
             if (entry.valid) {
-                if (entry.isCond) {
+                if (entry.isCond()) {
                     update.shamt++;
-                    auto& pc = entry.pc;
+                    auto& pc = entry.slot.pc;
                     auto it = CondTakens_find(condTakens, pc);
                     if (it != condTakens.end()) {
                         if (it->second) {
-                            update.taken = (entry.target < entry.pc); // branch is backward if target < pc
+                            // branch is backward if target < pc
+                            update.taken =
+                                (entry.slot.target < entry.slot.pc);
                             break;
                         }
                     }
@@ -717,7 +899,7 @@ struct FullBTBPrediction
         const auto &entry = getTakenEntry();
         if (entry.valid) {
             update.taken = true;
-            update.pc = entry.pc;
+            update.pc = entry.slot.pc;
             update.target = getEntryTarget(entry);
         }
         return update;

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -353,88 +353,25 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
         printFullBTBPrediction(predsOfEachStage[i]);
     }
 
-    // 2. Select the most accurate prediction (prioritize later stages)
-    // Initially assume stage 0 (UBTB) prediction
-    FullBTBPrediction *chosenPrediction = &predsOfEachStage[0];
-
-    // Search from last stage to first for valid predictions
-    for (int i = (int)numStages - 1; i >= 0; i--) {
-        if (predsOfEachStage[i].btbEntries.size() > 0) {
-            chosenPrediction = &predsOfEachStage[i];
-            DPRINTF(Override, "Selected prediction from stage %d\n", i);
-            break;
-        }
-    }
+    const FinalPredictionSelectorConfig selector_config{
+        ras->getComponentIdx(),
+        ittage->getComponentIdx(),
+        tage->getComponentIdx(),
+        mbtb->getComponentIdx(),
+    };
+    const auto selection =
+        selectFinalPrediction(predsOfEachStage, predictWidth, selector_config,
+                              [this]() { return ittage->tageHit(); });
+    DPRINTF(Override, "Selected prediction from stage %u\n",
+            selection.chosenStage);
 
     // Store the chosen prediction as our final prediction
-    finalPred = *chosenPrediction;
-
-    finalPred.s1Source = -1;//meaning fallthrough
-    finalPred.s3Source = -1;
-
-    if (predsOfEachStage[0].btbEntries.size() != 0) {
-        for (auto entry : predsOfEachStage[0].btbEntries){
-            if (entry.slot.isIndirect() || entry.slot.isDirect() ||
-                entry.ctr >= 0 || entry.alwaysTaken) {
-                finalPred.s1Source = entry.source;
-                break;
-            }
-        }
-    }
-
-    bool found_s3_taken = false;
-    bool na_s3_taken_but_have_cond = false;
-
-    for (BTBEntry entry : predsOfEachStage[2].btbEntries) {
-        if (entry.slot.isDirect() || entry.slot.isIndirect() ||
-            entry.ctr >= 0 || entry.alwaysTaken) {
-            found_s3_taken = true;
-        } else if (entry.slot.isCond()) {
-            //only use when there's no taken prediction in s3
-            na_s3_taken_but_have_cond = true;
-        }
-    }
-
-    if (found_s3_taken) {
-        auto pred_taken_entry = finalPred.getTakenEntry();
-        if (pred_taken_entry.valid) {
-            if (pred_taken_entry.slot.isReturn()) {
-                finalPred.s3Source = ras->getComponentIdx();
-            } else if (pred_taken_entry.slot.isIndirect() && ittage->tageHit()) {
-                finalPred.s3Source = ittage->getComponentIdx();
-            } else if (pred_taken_entry.slot.isCond()) {
-                finalPred.s3Source = tage->getComponentIdx();
-            } else {
-                finalPred.s3Source = mbtb->getComponentIdx();
-            }
-        }else {
-            if (na_s3_taken_but_have_cond) {
-                finalPred.s3Source = tage->getComponentIdx();
-            }else {
-                finalPred.s3Source = -1;
-            }
-        }
-    }
-
-
-
-    // 3. Calculate override bubbles needed for pipeline consistency
-    // Override bubbles are needed when earlier stages predict differently from later stages
-    unsigned first_hit_stage = 0;
-    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
-
-    // Find first stage that matches the chosen prediction
-    while (first_hit_stage < numStages - 1) {
-        auto [matches, reason] = predsOfEachStage[first_hit_stage].match(*chosenPrediction, predictWidth);
-        if (matches) {
-            break;
-        }
-        first_hit_stage++;
-        overrideReason = reason;
-    }
+    finalPred = predsOfEachStage[selection.chosenStage];
+    finalPred.s1Source = selection.s1Source;
+    finalPred.s3Source = selection.s3Source;
 
     // update ubtb/abtb using final S3 prediction
-    if (predsOfEachStage[numStages - 1].btbEntries.size() > 0) {
+    if (selection.updateAheadFromLastStage) {
         if (ubtb->isEnabled()) {
             ubtb->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
         }
@@ -447,23 +384,24 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     }
 
     // 4. Record override bubbles and update statistics
-    if (first_hit_stage > 0) {
+    if (selection.firstMatchingStage > 0) {
         dbpBtbStats.overrideCount++;
     }
 
     // 5. Finalize prediction process
-    finalPred.predSource = first_hit_stage;
-    finalPred.overrideReason = overrideReason;
+    finalPred.predSource = selection.firstMatchingStage;
+    finalPred.overrideReason = selection.overrideReason;
 
     // Debug output for final prediction
     printFullBTBPrediction(finalPred);
-    dbpBtbStats.predsOfEachStage[first_hit_stage]++;
+    dbpBtbStats.predsOfEachStage[selection.firstMatchingStage]++;
 
     // Clear stage predictions for next cycle
     clearPreds(tid);
 
-    DPRINTF(Override, "Prediction complete: override bubbles=%d\n", first_hit_stage);
-    threads[tid].numOverrideBubbles = first_hit_stage;
+    DPRINTF(Override, "Prediction complete: override bubbles=%d\n",
+            selection.firstMatchingStage);
+    threads[tid].numOverrideBubbles = selection.firstMatchingStage;
 }
 
 // this function enqueues fsq and update s0PC and s0History

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -728,7 +728,8 @@ DecoupledBPUWithBTB::prepareResolveUpdateEntries(unsigned &target_id, ThreadID t
 
         // only mbtb can generate new entry
         if (mbtb->isEnabled()) {
-            mbtb->getAndSetNewBTBEntry(target);
+            target.update.setEntrySelection(
+                mbtb->selectUpdateEntry(target));
         }
     }
 }
@@ -761,7 +762,8 @@ DecoupledBPUWithBTB::updatePredictorComponents(FetchTarget &target)
 
         // only mbtb can generate new entry
         if (mbtb->isEnabled()) {
-            mbtb->getAndSetNewBTBEntry(target);
+            target.update.setEntrySelection(
+                mbtb->selectUpdateEntry(target));
         }
 
         // Update predictor components

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -511,15 +511,15 @@ DecoupledBPUWithBTB::handleSquash(ThreadID tid, unsigned target_id,
     auto &target = ftq.get(target_id, tid);
 
     // Update target state
-    target.resolved = true;
-    target.exeTaken = actually_taken;
-    target.squashPC = squash_pc.instAddr();
-    target.squashType = squash_type;
+    target.resolve.valid = true;
+    target.resolve.taken = actually_taken;
+    target.resolve.squashPC = squash_pc.instAddr();
+    target.resolve.squashType = squash_type;
 
     // Special handling for control squash - create branch info
     if (squash_type == SQUASH_CTRL && static_inst) {
         // Use full branch info with static_inst if available
-        target.exeBranchInfo = BranchInfo(squash_pc.instAddr(), redirect_pc, static_inst, control_inst_size);
+        target.resolve.branchSlot = BranchInfo(squash_pc.instAddr(), redirect_pc, static_inst, control_inst_size);
         dumpFsq("Before control squash");
     }
 
@@ -633,8 +633,8 @@ DecoupledBPUWithBTB::commit(unsigned target_id, ThreadID tid)
                 "Commit target start %#lx, which is predicted, "
                 "final br addr: %#lx, final target: %#lx, pred br addr: %#lx, "
                 "pred target: %#lx\n",
-                target.startPC, target.exeBranchInfo.pc,
-                target.exeBranchInfo.target, target.prediction.branchSlot.pc,
+                target.startPC, target.resolve.branchSlot.pc,
+                target.resolve.branchSlot.target, target.prediction.branchSlot.pc,
                 target.prediction.branchSlot.target);
 
         // Update statistics
@@ -666,7 +666,7 @@ DecoupledBPUWithBTB::resolveUpdate(unsigned &target_id, ThreadID tid)
     auto &target = ftq.get(target_id, tid);
 
     // Update predictor components only if the target is hit or taken
-    if (!(target.prediction.btbHit || target.exeTaken)) {
+    if (!(target.prediction.btbHit || target.resolve.taken)) {
         return true;
     }
 
@@ -721,7 +721,7 @@ DecoupledBPUWithBTB::prepareResolveUpdateEntries(unsigned &target_id, ThreadID t
     }
     auto &target = ftq.get(target_id, tid);
 
-    if (target.prediction.btbHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.resolve.taken) {
         // Prepare target for update
         target.setUpdateInstEndPC(predictWidth);
         target.setUpdateBTBEntries();
@@ -743,8 +743,8 @@ DecoupledBPUWithBTB::markCFIResolved(unsigned &target_id, uint64_t resolvedInstP
     }
     auto &target = ftq.get(target_id, tid);
 
-    if (target.updateNewBTBEntry.slot.pc == resolvedInstPC) {
-        target.updateNewBTBEntry.slot.resolved = true;
+    if (target.update.newBTBEntry.slot.pc == resolvedInstPC) {
+        target.update.newBTBEntry.slot.resolved = true;
     }
 
     target.markBTBEntryResolved(resolvedInstPC);
@@ -754,7 +754,7 @@ void
 DecoupledBPUWithBTB::updatePredictorComponents(FetchTarget &target)
 {
     // Update predictor components only if the target is hit or taken
-    if (target.prediction.btbHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.resolve.taken) {
         // Prepare target for update
         target.setUpdateInstEndPC(predictWidth);
         target.setUpdateBTBEntries();
@@ -1083,7 +1083,7 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     if (squash_type == SQUASH_CTRL) {
         historyManagers[tid].squash(target_id, ghist_update,
                                     phist_update,
-                                    target.exeBranchInfo);
+                                    target.resolve.branchSlot);
     } else {
         historyManagers[tid].squash(target_id, ghist_update,
                                     phist_update, BranchInfo());

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -122,9 +122,6 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
 
         thread.s0PC = 0x80000000;
         thread.predsOfEachStage.resize(numStages);
-        for (unsigned i = 0; i < numStages; i++) {
-            thread.predsOfEachStage[i].predSource = i;
-        }
         thread.s0History.resize(historyBits, 0);
         thread.s0PHistory.resize(historyBits, 0);
         thread.s0BwHistory.resize(historyBits, 0);
@@ -323,7 +320,6 @@ DecoupledBPUWithBTB::requestNewPrediction(ThreadID tid)
         predsOfEachStage[i].tid = tid;
         predsOfEachStage[i].asidHash = asid_hash;
         predsOfEachStage[i].bbStart = thread.s0PC;
-        predsOfEachStage[i].predSource = i;
     }
 
     // Query each predictor component with current PC and history
@@ -347,6 +343,7 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 
     auto& predsOfEachStage = threads[tid].predsOfEachStage;
     auto& finalPred = threads[tid].finalPred;
+    auto& finalPredMetadata = threads[tid].finalPredMetadata;
 
     // 1. Debug output: dump predictions from all stages
     for (int i = 0; i < numStages; i++) {
@@ -367,8 +364,7 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 
     // Store the chosen prediction as our final prediction
     finalPred = predsOfEachStage[selection.chosenStage];
-    finalPred.s1Source = selection.s1Source;
-    finalPred.s3Source = selection.s3Source;
+    finalPredMetadata = selection.metadata;
 
     // update ubtb/abtb using final S3 prediction
     if (selection.updateAheadFromLastStage) {
@@ -384,24 +380,20 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     }
 
     // 4. Record override bubbles and update statistics
-    if (selection.firstMatchingStage > 0) {
+    if (finalPredMetadata.firstMatchingStage > 0) {
         dbpBtbStats.overrideCount++;
     }
 
-    // 5. Finalize prediction process
-    finalPred.predSource = selection.firstMatchingStage;
-    finalPred.overrideReason = selection.overrideReason;
-
     // Debug output for final prediction
     printFullBTBPrediction(finalPred);
-    dbpBtbStats.predsOfEachStage[selection.firstMatchingStage]++;
+    dbpBtbStats.predsOfEachStage[finalPredMetadata.firstMatchingStage]++;
 
     // Clear stage predictions for next cycle
     clearPreds(tid);
 
     DPRINTF(Override, "Prediction complete: override bubbles=%d\n",
-            selection.firstMatchingStage);
-    threads[tid].numOverrideBubbles = selection.firstMatchingStage;
+            finalPredMetadata.firstMatchingStage);
+    threads[tid].numOverrideBubbles = finalPredMetadata.firstMatchingStage;
 }
 
 // this function enqueues fsq and update s0PC and s0History
@@ -823,6 +815,7 @@ DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
     auto& s0BwHistory = threads[tid].s0BwHistory;
     auto& s0LHistory = threads[tid].s0LHistory;
     auto& finalPred = threads[tid].finalPred;
+    const auto &finalPredMetadata = threads[tid].finalPredMetadata;
 
     // Create a new fetch target entry
     FetchTarget entry;
@@ -853,11 +846,7 @@ DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
     entry.bwhistory = s0BwHistory;
     entry.lhistory = s0LHistory;
     entry.predTick = finalPred.predTick;
-    entry.predSource = finalPred.predSource;
-    entry.overrideReason = finalPred.overrideReason;
-
-    entry.s1Source = finalPred.s1Source;
-    entry.s3Source = finalPred.s3Source;
+    entry.finalPredMetadata = finalPredMetadata;
 
     // Save predictors' metadata
     for (int i = 0; i < numComponents; i++) {

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -374,7 +374,8 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 
     if (predsOfEachStage[0].btbEntries.size() != 0) {
         for (auto entry : predsOfEachStage[0].btbEntries){
-            if (entry.isIndirect() || entry.isDirect() || entry.ctr >= 0 ||entry.alwaysTaken){
+            if (entry.slot.isIndirect() || entry.slot.isDirect() ||
+                entry.ctr >= 0 || entry.alwaysTaken) {
                 finalPred.s1Source = entry.source;
                 break;
             }
@@ -385,9 +386,10 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     bool na_s3_taken_but_have_cond = false;
 
     for (BTBEntry entry : predsOfEachStage[2].btbEntries) {
-        if (entry.isDirect() || entry.isIndirect() || entry.ctr >= 0 || entry.alwaysTaken) {
+        if (entry.slot.isDirect() || entry.slot.isIndirect() ||
+            entry.ctr >= 0 || entry.alwaysTaken) {
             found_s3_taken = true;
-        }else if (entry.isCond()){
+        } else if (entry.slot.isCond()) {
             //only use when there's no taken prediction in s3
             na_s3_taken_but_have_cond = true;
         }
@@ -396,11 +398,11 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     if (found_s3_taken) {
         auto pred_taken_entry = finalPred.getTakenEntry();
         if (pred_taken_entry.valid) {
-            if (pred_taken_entry.isReturn()) {
+            if (pred_taken_entry.slot.isReturn()) {
                 finalPred.s3Source = ras->getComponentIdx();
-            } else if (pred_taken_entry.isIndirect() && ittage->tageHit()) {
+            } else if (pred_taken_entry.slot.isIndirect() && ittage->tageHit()) {
                 finalPred.s3Source = ittage->getComponentIdx();
-            }else if (pred_taken_entry.isCond()) {
+            } else if (pred_taken_entry.slot.isCond()) {
                 finalPred.s3Source = tage->getComponentIdx();
             } else {
                 finalPred.s3Source = mbtb->getComponentIdx();
@@ -891,9 +893,9 @@ DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
     entry.startPC = s0PC;
 
     // Extract branch prediction information
-    bool taken = finalPred.isTaken();
-    Addr fallThroughAddr = finalPred.getFallThrough(predictWidth);
-    Addr nextPC = finalPred.getTarget(predictWidth);
+    auto takenResult = finalPred.getTakenSlotResult(predictWidth);
+    bool taken = takenResult.taken();
+    Addr fallThroughAddr = takenResult.fallThrough;
 
     // Configure target entry with prediction details
     entry.isHit = !finalPred.btbEntries.empty();
@@ -904,8 +906,7 @@ DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
 
     // Set branch info for taken predictions
     if (taken) {
-        entry.predBranchInfo = finalPred.getTakenEntry().getBranchInfo();
-        entry.predBranchInfo.target = nextPC; // Use final target (may not be from BTB)
+        entry.predBranchInfo = takenResult.resolvedSlot();
     }
 
     // Record current history and prediction metadata

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -633,8 +633,9 @@ DecoupledBPUWithBTB::commit(unsigned target_id, ThreadID tid)
                 "Commit target start %#lx, which is predicted, "
                 "final br addr: %#lx, final target: %#lx, pred br addr: %#lx, "
                 "pred target: %#lx\n",
-                target.startPC, target.exeBranchInfo.pc, target.exeBranchInfo.target, target.predBranchInfo.pc,
-                target.predBranchInfo.target);
+                target.startPC, target.exeBranchInfo.pc,
+                target.exeBranchInfo.target, target.prediction.branchSlot.pc,
+                target.prediction.branchSlot.target);
 
         // Update statistics
         updateStatistics(target);
@@ -665,7 +666,7 @@ DecoupledBPUWithBTB::resolveUpdate(unsigned &target_id, ThreadID tid)
     auto &target = ftq.get(target_id, tid);
 
     // Update predictor components only if the target is hit or taken
-    if (!(target.isHit || target.exeTaken)) {
+    if (!(target.prediction.btbHit || target.exeTaken)) {
         return true;
     }
 
@@ -720,7 +721,7 @@ DecoupledBPUWithBTB::prepareResolveUpdateEntries(unsigned &target_id, ThreadID t
     }
     auto &target = ftq.get(target_id, tid);
 
-    if (target.isHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.exeTaken) {
         // Prepare target for update
         target.setUpdateInstEndPC(predictWidth);
         target.setUpdateBTBEntries();
@@ -753,7 +754,7 @@ void
 DecoupledBPUWithBTB::updatePredictorComponents(FetchTarget &target)
 {
     // Update predictor components only if the target is hit or taken
-    if (target.isHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.exeTaken) {
         // Prepare target for update
         target.setUpdateInstEndPC(predictWidth);
         target.setUpdateBTBEntries();
@@ -829,15 +830,15 @@ DecoupledBPUWithBTB::createFetchTargetEntry(ThreadID tid)
     Addr fallThroughAddr = takenResult.fallThrough;
 
     // Configure target entry with prediction details
-    entry.isHit = !finalPred.btbEntries.empty();
-    entry.falseHit = false;
-    entry.predBTBEntries = finalPred.btbEntries;
-    entry.predTaken = taken;
-    entry.predEndPC = fallThroughAddr;
+    entry.prediction.btbHit = !finalPred.btbEntries.empty();
+    entry.prediction.falseHit = false;
+    entry.prediction.btbEntries = finalPred.btbEntries;
+    entry.prediction.taken = taken;
+    entry.prediction.fallThrough = fallThroughAddr;
 
     // Set branch info for taken predictions
     if (taken) {
-        entry.predBranchInfo = takenResult.resolvedSlot();
+        entry.prediction.branchSlot = takenResult.resolvedSlot();
     }
 
     // Record current history and prediction metadata
@@ -959,7 +960,8 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry)
     // Update history manager and verify TAGE folded history
     historyManagers[tid].addSpeculativeHist(
         entry.startPC, entry.history, entry.phistory, ghist_update,
-        phist_update, entry.predBranchInfo, ftq.backId(tid) + 1);
+        phist_update, entry.prediction.branchSlot,
+        ftq.backId(tid) + 1);
 
     // Update global backward history
     histShiftIn(bwhist_update.shamt, bwhist_update.taken, s0BwHistory);

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -374,7 +374,7 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
 
     if (predsOfEachStage[0].btbEntries.size() != 0) {
         for (auto entry : predsOfEachStage[0].btbEntries){
-            if (entry.isIndirect || entry.isDirect || entry.ctr >= 0 ||entry.alwaysTaken){
+            if (entry.isIndirect() || entry.isDirect() || entry.ctr >= 0 ||entry.alwaysTaken){
                 finalPred.s1Source = entry.source;
                 break;
             }
@@ -385,9 +385,9 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     bool na_s3_taken_but_have_cond = false;
 
     for (BTBEntry entry : predsOfEachStage[2].btbEntries) {
-        if (entry.isDirect || entry.isIndirect || entry.ctr >= 0 || entry.alwaysTaken) {
+        if (entry.isDirect() || entry.isIndirect() || entry.ctr >= 0 || entry.alwaysTaken) {
             found_s3_taken = true;
-        }else if (entry.isCond){
+        }else if (entry.isCond()){
             //only use when there's no taken prediction in s3
             na_s3_taken_but_have_cond = true;
         }
@@ -396,11 +396,11 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     if (found_s3_taken) {
         auto pred_taken_entry = finalPred.getTakenEntry();
         if (pred_taken_entry.valid) {
-            if (pred_taken_entry.isReturn) {
+            if (pred_taken_entry.isReturn()) {
                 finalPred.s3Source = ras->getComponentIdx();
-            } else if (pred_taken_entry.isIndirect && ittage->tageHit()) {
+            } else if (pred_taken_entry.isIndirect() && ittage->tageHit()) {
                 finalPred.s3Source = ittage->getComponentIdx();
-            }else if (pred_taken_entry.isCond) {
+            }else if (pred_taken_entry.isCond()) {
                 finalPred.s3Source = tage->getComponentIdx();
             } else {
                 finalPred.s3Source = mbtb->getComponentIdx();
@@ -810,8 +810,8 @@ DecoupledBPUWithBTB::markCFIResolved(unsigned &target_id, uint64_t resolvedInstP
     }
     auto &target = ftq.get(target_id, tid);
 
-    if (target.updateNewBTBEntry.pc == resolvedInstPC) {
-        target.updateNewBTBEntry.resolved = true;
+    if (target.updateNewBTBEntry.slot.pc == resolvedInstPC) {
+        target.updateNewBTBEntry.slot.resolved = true;
     }
 
     target.markBTBEntryResolved(resolvedInstPC);

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -209,7 +209,9 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void printBTBEntry(const BTBEntry &e) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken);
+            e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
+            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.alwaysTaken);
     }
 
     void printFullBTBPrediction(const FullBTBPrediction &pred) {

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -210,7 +210,8 @@ class DecoupledBPUWithBTB : public BPredUnit
     void printBTBEntry(const BTBEntry &e) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d\n",
             e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
-            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.slot.isCond(), e.slot.isIndirect(), e.slot.isCall(),
+            e.slot.isReturn(),
             e.alwaysTaken);
     }
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -139,6 +139,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         std::vector<boost::dynamic_bitset<>> s0LHistory;  ///< local History bits
         boost::dynamic_bitset<> commitHistory;
         FullBTBPrediction finalPred;      ///< Final prediction
+        FinalPredictionMetadata finalPredMetadata; ///< Final attribution
         unsigned numOverrideBubbles{0};
         bool validprediction{false};
         bool squashing{false};
@@ -202,7 +203,6 @@ class DecoupledBPUWithBTB : public BPredUnit
     void clearPreds(ThreadID tid) {
         for (int i = 0; i < threads[tid].predsOfEachStage.size(); ++i) {
             threads[tid].predsOfEachStage[i] = FullBTBPrediction();
-            threads[tid].predsOfEachStage[i].predSource = i;
         }
     }
 
@@ -390,7 +390,8 @@ class DecoupledBPUWithBTB : public BPredUnit
             _tick = curTick();
             set(id, entry.startPC, entry.predTaken, entry.predEndPC,
                 entry.getControlPC(), entry.getTakenTarget(),
-                entry.predSource, entry.isHit ? 1 : 0);
+                entry.finalPredMetadata.firstMatchingStage,
+                entry.isHit ? 1 : 0);
         }
     };
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -20,6 +20,7 @@
 #include "cpu/pred/btb/btb_tage.hh"
 #include "cpu/pred/btb/btb_ubtb.hh"
 #include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/final_prediction_selector.hh"
 #include "cpu/pred/btb/ftq.hh"
 #include "cpu/pred/btb/history_manager.hh"
 #include "cpu/pred/btb/mbtb.hh"

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -178,7 +178,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     void printTarget(const FetchTarget &e)
     {
-        if (!e.resolved) {
+        if (!e.resolve.valid) {
             DPRINTFR(DecoupleBPProbe, "FSQ Predicted target: ");
         } else {
             DPRINTFR(DecoupleBPProbe, "FSQ Resolved target: ");

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -388,10 +388,11 @@ class DecoupledBPUWithBTB : public BPredUnit
 
         PredictionTrace(uint64_t id, const FetchTarget &entry) {
             _tick = curTick();
-            set(id, entry.startPC, entry.predTaken, entry.predEndPC,
+            set(id, entry.startPC, entry.prediction.taken,
+                entry.prediction.fallThrough,
                 entry.getControlPC(), entry.getTakenTarget(),
                 entry.finalPredMetadata.firstMatchingStage,
-                entry.isHit ? 1 : 0);
+                entry.prediction.btbHit ? 1 : 0);
         }
     };
 

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -320,9 +320,7 @@ DecoupledBPUWithBTB::dumpStats()
         for (int i = 0; i <= outputTopNEntries && i < btbEntries.size(); i++) {
             const auto &entry = btbEntries[i];
             out << "," << std::hex << std::get<0>(entry);
-            // BTBEntry.getType() is not a const method, need to create a copy
-            BTBEntry btbEntry = std::get<1>(entry);
-            out << "," << std::dec << btbEntry.getType();
+            out << "," << std::dec << std::get<1>(entry).slot.getType();
         }
 
         out << std::endl;

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -695,9 +695,9 @@ void
 DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
 {
     // Check if this target was mispredicted
-    bool miss_predicted = target.squashType == SQUASH_CTRL;
+    bool miss_predicted = target.resolve.squashType == SQUASH_CTRL;
     // Track indirect mispredictions
-    if (miss_predicted && target.exeBranchInfo.isIndirect()) {
+    if (miss_predicted && target.resolve.branchSlot.isIndirect()) {
         topMispredIndirect[target.startPC]++;
     }
 
@@ -707,11 +707,11 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
         dbpBtbStats.btbHit++;
     } else {
         // Count BTB misses for taken branches
-        if (target.exeTaken) {
+        if (target.resolve.taken) {
             dbpBtbStats.btbMiss++;
             DPRINTF(BTB, "BTB miss detected when update, target start %#lx, predTick %lu, printing branch info:\n",
                     target.startPC, target.predTick);
-            auto &slot = target.exeBranchInfo;
+            auto &slot = target.resolve.branchSlot;
             DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n",
                 slot.pc, slot.size, slot.target, slot.isCond(), slot.isIndirect(), slot.isCall(), slot.isReturn());
         }
@@ -722,16 +722,16 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
         }
     }
 
-    if (target.prediction.btbHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.resolve.taken) {
         // Update BTB entry statistics
         auto it = totalBTBEntries.find(target.startPC);
         if (it == totalBTBEntries.end()) {
-            auto &btb_entry = target.updateNewBTBEntry;
+            auto &btb_entry = target.update.newBTBEntry;
             totalBTBEntries[target.startPC] = std::make_pair(btb_entry, 1);
             dbpBtbStats.btbEntriesWithDifferentStart++;
         } else {
             it->second.second++;
-            it->second.first = target.updateNewBTBEntry;
+            it->second.first = target.update.newBTBEntry;
         }
     }
 
@@ -745,7 +745,7 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
     dbpBtbStats.commitFsqEntryHasInsts.sample(target.commitInstNum, 1);
     if (target.commitInstNum >= 0 && target.commitInstNum <= maxInstsNum) {
         commitFsqEntryHasInstsVector[target.commitInstNum]++;
-        if (target.commitInstNum == 1 && target.exeBranchInfo.isUncond()) {
+        if (target.commitInstNum == 1 && target.resolve.branchSlot.isUncond()) {
             dbpBtbStats.commitFsqEntryOnlyHasOneJump++;
         }
     }
@@ -758,11 +758,11 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
 
     // --- Misprediction Statistics ---
     // Track control squashes (mispredictions)
-    if (target.squashType == SQUASH_CTRL) {
+    if (target.resolve.squashType == SQUASH_CTRL) {
         // Record mispredict pair (start PC, branch PC)
-        auto find_it = topMispredicts.find(std::make_pair(target.startPC, target.exeBranchInfo.pc));
+        auto find_it = topMispredicts.find(std::make_pair(target.startPC, target.resolve.branchSlot.pc));
         if (find_it == topMispredicts.end()) {
-            topMispredicts[std::make_pair(target.startPC, target.exeBranchInfo.pc)] = 1;
+            topMispredicts[std::make_pair(target.startPC, target.resolve.branchSlot.pc)] = 1;
         } else {
             find_it->second++;
         }
@@ -848,9 +848,9 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
     int s1PredSource = entry.finalPredMetadata.s1Source;
     int s3PredSource = entry.finalPredMetadata.s3Source;
 
-    auto exeBranchInfo = entry.exeBranchInfo;
+    auto resolvedSlot = entry.resolve.branchSlot;
 
-    bool onlyDirectionWrong = entry.exeTaken != entry.prediction.taken;
+    bool onlyDirectionWrong = entry.resolve.taken != entry.prediction.taken;
 
     assert(s1PredSource < mbtbid);
     if (s1PredSource == ubtbid) {
@@ -862,23 +862,23 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
     }
 
     if (s3PredSource == rasid) {
-        if (exeBranchInfo.isCond()) {
+        if (resolvedSlot.isCond()) {
             dbpBtbStats.s3PredWrongTage++;
-        } else if (exeBranchInfo.isReturn()) {
+        } else if (resolvedSlot.isReturn()) {
             dbpBtbStats.s3PredWrongRas++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
     } else if (s3PredSource == ittageid) {
-        if (exeBranchInfo.isIndirect()) {
+        if (resolvedSlot.isIndirect()) {
             dbpBtbStats.s3PredWrongIttage++;
-        } else if (exeBranchInfo.isCond()) {
+        } else if (resolvedSlot.isCond()) {
             dbpBtbStats.s3PredWrongTage++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
     } else if (s3PredSource == tageid) {
-        if (exeBranchInfo.isCond()) {
+        if (resolvedSlot.isCond()) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
             } else {
@@ -888,13 +888,13 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
             dbpBtbStats.s3PredWrongMbtb++;
         }
     }else if (s3PredSource == mbtbid) {
-        if (exeBranchInfo.isCond()) {
+        if (resolvedSlot.isCond()) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
             } else {
                 dbpBtbStats.s3PredWrongMbtb++;
             }
-        } else if (exeBranchInfo.isIndirect()) {
+        } else if (resolvedSlot.isIndirect()) {
             dbpBtbStats.s3PredWrongIttage++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -342,7 +342,9 @@ DecoupledBPUWithBTB::BpTrace::BpTrace(uint64_t fsqId, FetchTarget &target, const
     Addr targetpc = rv_pc.npc();
     Addr fallThru = rv_pc.getFallThruPC();
     BranchInfo info(pc, targetpc, inst->staticInst, fallThru-pc);
-    set(fsqId, target.startPC, pc, info.getType(), inst->branching(), mispred, fallThru, target.predSource, targetpc);
+    set(fsqId, target.startPC, pc, info.getType(), inst->branching(),
+        mispred, fallThru, target.finalPredMetadata.firstMatchingStage,
+        targetpc);
     // for (auto it = _uint64_data.begin(); it != _uint64_data.end(); it++) {
     //     printf("%s: %ld\n", it->first.c_str(), it->second);
     // }
@@ -734,8 +736,9 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
     }
 
     // Track which predictor stage was used
-    dbpBtbStats.commitPredsFromEachStage[target.predSource]++;
-    overrideStats(target.overrideReason);
+    dbpBtbStats.commitPredsFromEachStage[
+        target.finalPredMetadata.firstMatchingStage]++;
+    overrideStats(target.finalPredMetadata.overrideReason);
 
     // --- Instruction Statistics ---
     // Track committed instruction counts
@@ -842,8 +845,8 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
     int ittageid = ittage->getComponentIdx();
     int rasid = ras->getComponentIdx();
 
-    int s1PredSource = entry.s1Source;
-    int s3PredSource = entry.s3Source;
+    int s1PredSource = entry.finalPredMetadata.s1Source;
+    int s3PredSource = entry.finalPredMetadata.s3Source;
 
     auto exeBranchInfo = entry.exeBranchInfo;
 

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -697,7 +697,7 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
     // Check if this target was mispredicted
     bool miss_predicted = target.squashType == SQUASH_CTRL;
     // Track indirect mispredictions
-    if (miss_predicted && target.exeBranchInfo.isIndirect) {
+    if (miss_predicted && target.exeBranchInfo.isIndirect()) {
         topMispredIndirect[target.startPC]++;
     }
 
@@ -713,7 +713,7 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
                     target.startPC, target.predTick);
             auto &slot = target.exeBranchInfo;
             DPRINTF(BTB, "    pc:%#lx, size:%d, target:%#lx, cond:%d, indirect:%d, call:%d, return:%d\n",
-                slot.pc, slot.size, slot.target, slot.isCond, slot.isIndirect, slot.isCall, slot.isReturn);
+                slot.pc, slot.size, slot.target, slot.isCond(), slot.isIndirect(), slot.isCall(), slot.isReturn());
         }
 
         // Count false hits
@@ -861,23 +861,23 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
     }
 
     if (s3PredSource == rasid) {
-        if (exeBranchInfo.isCond) {
+        if (exeBranchInfo.isCond()) {
             dbpBtbStats.s3PredWrongTage++;
-        } else if (exeBranchInfo.isReturn) {
+        } else if (exeBranchInfo.isReturn()) {
             dbpBtbStats.s3PredWrongRas++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
     } else if (s3PredSource == ittageid) {
-        if (exeBranchInfo.isIndirect) {
+        if (exeBranchInfo.isIndirect()) {
             dbpBtbStats.s3PredWrongIttage++;
-        } else if (exeBranchInfo.isCond) {
+        } else if (exeBranchInfo.isCond()) {
             dbpBtbStats.s3PredWrongTage++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
         }
     } else if (s3PredSource == tageid) {
-        if (exeBranchInfo.isCond) {
+        if (exeBranchInfo.isCond()) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
             } else {
@@ -887,13 +887,13 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
             dbpBtbStats.s3PredWrongMbtb++;
         }
     }else if (s3PredSource == mbtbid) {
-        if (exeBranchInfo.isCond) {
+        if (exeBranchInfo.isCond()) {
             if (onlyDirectionWrong) {
                 dbpBtbStats.s3PredWrongTage++;
             } else {
                 dbpBtbStats.s3PredWrongMbtb++;
             }
-        } else if (exeBranchInfo.isIndirect) {
+        } else if (exeBranchInfo.isIndirect()) {
             dbpBtbStats.s3PredWrongIttage++;
         } else {
             dbpBtbStats.s3PredWrongMbtb++;
@@ -983,13 +983,13 @@ DecoupledBPUWithBTB::processMisprediction(
     if (mispred) {
         if (!taken) {
             // Only conditional branches can be not-taken
-            assert(info.isCond);
+            assert(info.isCond());
             mispredType = DIR_WRONG; // Direction was wrong
         } else {
             // Check if this branch was in the predicted BTB entries
             bool predBranchInBTB = false;
             for (auto &e: entry.predBTBEntries) {
-                if (e.pc == branchAddr) {
+                if (e.slot.pc == branchAddr) {
                     predBranchInBTB = true;
                     break;
                 }

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -702,7 +702,7 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
     }
 
     // --- BTB Statistics ---
-    if (target.isHit) {
+    if (target.prediction.btbHit) {
         // Count BTB hits
         dbpBtbStats.btbHit++;
     } else {
@@ -717,12 +717,12 @@ DecoupledBPUWithBTB::updateStatistics(const FetchTarget &target)
         }
 
         // Count false hits
-        if (target.falseHit) {
+        if (target.prediction.falseHit) {
             dbpBtbStats.commitFalseHit++;
         }
     }
 
-    if (target.isHit || target.exeTaken) {
+    if (target.prediction.btbHit || target.exeTaken) {
         // Update BTB entry statistics
         auto it = totalBTBEntries.find(target.startPC);
         if (it == totalBTBEntries.end()) {
@@ -850,7 +850,7 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
 
     auto exeBranchInfo = entry.exeBranchInfo;
 
-    bool onlyDirectionWrong = entry.exeTaken != entry.predTaken;
+    bool onlyDirectionWrong = entry.exeTaken != entry.prediction.taken;
 
     assert(s1PredSource < mbtbid);
     if (s1PredSource == ubtbid) {
@@ -989,7 +989,7 @@ DecoupledBPUWithBTB::processMisprediction(
         } else {
             // Check if this branch was in the predicted BTB entries
             bool predBranchInBTB = false;
-            for (auto &e: entry.predBTBEntries) {
+            for (auto &e: entry.prediction.btbEntries) {
                 if (e.slot.pc == branchAddr) {
                     predBranchInBTB = true;
                     break;
@@ -998,7 +998,8 @@ DecoupledBPUWithBTB::processMisprediction(
 
             if (!predBranchInBTB) {
                 mispredType = NO_PRED; // Branch wasn't predicted at all
-            } else if (entry.predTaken && entry.predBranchInfo.pc == branchAddr) {
+            } else if (entry.prediction.taken &&
+                       entry.prediction.branchSlot.pc == branchAddr) {
                 mispredType = TARGET_WRONG; // Branch predicted taken but wrong target
             } else {
                 // Branch predicted not taken or different branch predicted taken

--- a/src/cpu/pred/btb/final_prediction_selector.hh
+++ b/src/cpu/pred/btb/final_prediction_selector.hh
@@ -1,0 +1,192 @@
+#ifndef __CPU_PRED_BTB_FINAL_PREDICTION_SELECTOR_HH__
+#define __CPU_PRED_BTB_FINAL_PREDICTION_SELECTOR_HH__
+
+#include <cassert>
+#include <utility>
+#include <vector>
+
+#include "base/types.hh"
+#include "cpu/pred/btb/common.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+struct FinalPredictionSelectorConfig
+{
+    int rasSource = -1;
+    int ittageSource = -1;
+    int tageSource = -1;
+    int mbtbSource = -1;
+    bool ittageHit = false;
+    unsigned s1SourceStage = 0;
+    unsigned s3SourceStage = 2;
+};
+
+struct FinalPredictionSelection
+{
+    unsigned chosenStage = 0;
+    unsigned firstMatchingStage = 0;
+    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
+    int s1Source = -1;
+    int s3Source = -1;
+    bool updateAheadFromLastStage = false;
+};
+
+inline unsigned
+chooseFinalPredictionStage(const std::vector<FullBTBPrediction> &stage_preds)
+{
+    assert(!stage_preds.empty());
+
+    for (int stage = static_cast<int>(stage_preds.size()) - 1; stage >= 0;
+         --stage) {
+        if (!stage_preds[stage].btbEntries.empty()) {
+            return stage;
+        }
+    }
+
+    return 0;
+}
+
+inline int
+findS1PredictionSource(const std::vector<FullBTBPrediction> &stage_preds,
+                       unsigned stage)
+{
+    if (stage >= stage_preds.size()) {
+        return -1;
+    }
+
+    for (const auto &entry : stage_preds[stage].btbEntries) {
+        if (entry.slot.isIndirect() || entry.slot.isDirect() ||
+            entry.ctr >= 0 || entry.alwaysTaken) {
+            return entry.source;
+        }
+    }
+
+    return -1;
+}
+
+template <typename IttageHitProvider>
+inline int
+findS3PredictionSource(const std::vector<FullBTBPrediction> &stage_preds,
+                       unsigned chosen_stage,
+                       const FinalPredictionSelectorConfig &config,
+                       IttageHitProvider ittage_hit)
+{
+    if (config.s3SourceStage >= stage_preds.size()) {
+        return -1;
+    }
+
+    const auto &s3_pred = stage_preds[config.s3SourceStage];
+    bool found_s3_taken = false;
+    bool na_s3_taken_but_have_cond = false;
+
+    for (const auto &entry : s3_pred.btbEntries) {
+        if (entry.slot.isDirect() || entry.slot.isIndirect() ||
+            entry.ctr >= 0 || entry.alwaysTaken) {
+            found_s3_taken = true;
+        } else if (entry.slot.isCond()) {
+            // Only used when there is no taken prediction in final selection.
+            na_s3_taken_but_have_cond = true;
+        }
+    }
+
+    if (!found_s3_taken) {
+        return -1;
+    }
+
+    const auto pred_taken_entry = stage_preds[chosen_stage].getTakenEntry();
+    if (!pred_taken_entry.valid) {
+        return na_s3_taken_but_have_cond ? config.tageSource : -1;
+    }
+
+    if (pred_taken_entry.slot.isReturn()) {
+        return config.rasSource;
+    }
+
+    if (pred_taken_entry.slot.isIndirect() && ittage_hit()) {
+        return config.ittageSource;
+    }
+
+    if (pred_taken_entry.slot.isCond()) {
+        return config.tageSource;
+    }
+
+    return config.mbtbSource;
+}
+
+inline std::pair<unsigned, OverrideReason>
+findFirstMatchingStage(const std::vector<FullBTBPrediction> &stage_preds,
+                       unsigned chosen_stage, Addr predict_width)
+{
+    assert(!stage_preds.empty());
+
+    const auto &chosen_pred = stage_preds[chosen_stage];
+    unsigned first_matching_stage = 0;
+    OverrideReason override_reason = OverrideReason::NO_OVERRIDE;
+
+    while (first_matching_stage < stage_preds.size() - 1) {
+        const auto [matches, reason] =
+            stage_preds[first_matching_stage].match(chosen_pred,
+                                                    predict_width);
+        if (matches) {
+            break;
+        }
+
+        first_matching_stage++;
+        override_reason = reason;
+    }
+
+    return std::make_pair(first_matching_stage, override_reason);
+}
+
+template <typename IttageHitProvider>
+inline FinalPredictionSelection
+selectFinalPrediction(const std::vector<FullBTBPrediction> &stage_preds,
+                      Addr predict_width,
+                      const FinalPredictionSelectorConfig &config,
+                      IttageHitProvider ittage_hit)
+{
+    assert(!stage_preds.empty());
+
+    FinalPredictionSelection selection;
+    selection.chosenStage = chooseFinalPredictionStage(stage_preds);
+    selection.s1Source =
+        findS1PredictionSource(stage_preds, config.s1SourceStage);
+    selection.s3Source =
+        findS3PredictionSource(stage_preds, selection.chosenStage,
+                               config, ittage_hit);
+
+    const auto [first_matching_stage, override_reason] =
+        findFirstMatchingStage(stage_preds, selection.chosenStage,
+                               predict_width);
+    selection.firstMatchingStage = first_matching_stage;
+    selection.overrideReason = override_reason;
+    selection.updateAheadFromLastStage = !stage_preds.back().btbEntries.empty();
+
+    return selection;
+}
+
+inline FinalPredictionSelection
+selectFinalPrediction(const std::vector<FullBTBPrediction> &stage_preds,
+                      Addr predict_width,
+                      const FinalPredictionSelectorConfig &config)
+{
+    return selectFinalPrediction(stage_preds, predict_width, config,
+                                 [&config]() {
+                                     return config.ittageHit;
+                                 });
+}
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5
+
+#endif // __CPU_PRED_BTB_FINAL_PREDICTION_SELECTOR_HH__

--- a/src/cpu/pred/btb/final_prediction_selector.hh
+++ b/src/cpu/pred/btb/final_prediction_selector.hh
@@ -31,10 +31,7 @@ struct FinalPredictionSelectorConfig
 struct FinalPredictionSelection
 {
     unsigned chosenStage = 0;
-    unsigned firstMatchingStage = 0;
-    OverrideReason overrideReason = OverrideReason::NO_OVERRIDE;
-    int s1Source = -1;
-    int s3Source = -1;
+    FinalPredictionMetadata metadata;
     bool updateAheadFromLastStage = false;
 };
 
@@ -156,17 +153,17 @@ selectFinalPrediction(const std::vector<FullBTBPrediction> &stage_preds,
 
     FinalPredictionSelection selection;
     selection.chosenStage = chooseFinalPredictionStage(stage_preds);
-    selection.s1Source =
+    selection.metadata.s1Source =
         findS1PredictionSource(stage_preds, config.s1SourceStage);
-    selection.s3Source =
+    selection.metadata.s3Source =
         findS3PredictionSource(stage_preds, selection.chosenStage,
                                config, ittage_hit);
 
     const auto [first_matching_stage, override_reason] =
         findFirstMatchingStage(stage_preds, selection.chosenStage,
                                predict_width);
-    selection.firstMatchingStage = first_matching_stage;
-    selection.overrideReason = override_reason;
+    selection.metadata.firstMatchingStage = first_matching_stage;
+    selection.metadata.overrideReason = override_reason;
     selection.updateAheadFromLastStage = !stage_preds.back().btbEntries.empty();
 
     return selection;

--- a/src/cpu/pred/btb/history_manager.hh
+++ b/src/cpu/pred/btb/history_manager.hh
@@ -123,8 +123,8 @@ class HistoryManager
                             const uint64_t stream_id)
     {
         // Extract branch type information from BranchInfo
-        bool is_call = bi.isCall;
-        bool is_return = bi.isReturn;
+        bool is_call = bi.isCall();
+        bool is_return = bi.isReturn();
         Addr retAddr = bi.getEnd();
 
         // Add new entry to the end of speculative history list
@@ -206,8 +206,8 @@ class HistoryManager
                 it->phistUpdate = phist_update;
 
                 // Update branch type information
-                it->is_call = bi.isCall;
-                it->is_return = bi.isReturn;
+                it->is_call = bi.isCall();
+                it->is_return = bi.isReturn();
                 it->retAddr = bi.getEnd();
 
                 // Move to next entry

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -193,13 +193,13 @@ MBTB::processEntries(const std::vector<TickedBTBEntry>& entries, Addr startAddr)
     // Sort by instruction order
     std::sort(processed_entries.begin(), processed_entries.end(), 
              [](const BTBEntry &a, const BTBEntry &b) {
-                 return a.pc < b.pc;
+                 return a.slot.pc < b.slot.pc;
              });
     
     // Remove entries before the start PC
     auto it = std::remove_if(processed_entries.begin(), processed_entries.end(),
                            [startAddr](const BTBEntry &e) {
-                               return e.pc < startAddr;
+                               return e.slot.pc < startAddr;
                            });
     processed_entries.erase(it, processed_entries.end());
 
@@ -207,7 +207,7 @@ MBTB::processEntries(const std::vector<TickedBTBEntry>& entries, Addr startAddr)
     Addr mbtb_end = (startAddr + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
     it = std::remove_if(processed_entries.begin(), processed_entries.end(),
                         [mbtb_end](const BTBEntry &e) {
-                            return e.pc >= mbtb_end;
+                            return e.slot.pc >= mbtb_end;
                         });
     processed_entries.erase(it, processed_entries.end());
 
@@ -258,19 +258,22 @@ MBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
     // Set predictions for each branch
     for (auto &e : entries) {
         assert(e.valid);
-        if (e.isCond) {
+        if (e.isCond()) {
             // TODO: a performance bug here, mbtb should not update condTakens!
 
-            FillStageLoop(s) stagePreds[s].condTakens.push_back({e.pc, e.alwaysTaken || (e.ctr >= 0)});
+            FillStageLoop(s) stagePreds[s].condTakens.push_back(
+                {e.slot.pc, e.alwaysTaken || (e.ctr >= 0)});
 
-        } else if (e.isIndirect) {
+        } else if (e.isIndirect()) {
             // Set predicted target for indirect branches
-            DPRINTF(BTB, "setting indirect target for pc %#lx to %#lx\n", e.pc, e.target);
+            DPRINTF(BTB, "setting indirect target for pc %#lx to %#lx\n",
+                    e.slot.pc, e.slot.target);
 
-            FillStageLoop(s) stagePreds[s].indirectTargets.push_back({e.pc, e.target});
+            FillStageLoop(s) stagePreds[s].indirectTargets.push_back(
+                {e.slot.pc, e.slot.target});
 
-            if (e.isReturn) {
-                FillStageLoop(s) stagePreds[s].returnTarget = e.target;
+            if (e.isReturn()) {
+                FillStageLoop(s) stagePreds[s].returnTarget = e.slot.target;
             }
             break;
         }
@@ -385,7 +388,7 @@ MBTB::lookup(Addr block_pc, uint8_t asidHash, std::shared_ptr<BTBMeta> meta)
     // Sort entries by PC order
     std::sort(res.begin(), res.end(),
              [](const TickedBTBEntry &a, const TickedBTBEntry &b) {
-                 return a.pc < b.pc;
+                 return a.slot.pc < b.slot.pc;
              });
 
     DPRINTF(BTB, "MBTB: Half-aligned lookup results:\n");
@@ -432,7 +435,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
         BTBEntry new_entry = BTBEntry(stream.exeBranchInfo);
         new_entry.valid = true;
         // For conditional branches, initialize as always taken
-        if (new_entry.isCond) {
+        if (new_entry.isCond()) {
             new_entry.alwaysTaken = true;
             new_entry.ctr = 0;  // Start with positive prediction
             btbStats.newEntryWithCond++;
@@ -441,7 +444,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
         }
         btbStats.newEntry++;
         entry_to_write = new_entry;
-        entry_to_write.resolved = stream.exeBranchInfo.resolved;
+        entry_to_write.slot.resolved = stream.exeBranchInfo.resolved;
         is_old_entry = false;
     } else {
         DPRINTF(BTB, "Not creating new entry: pred_branch_hit=%d, stream.exeTaken=%d\n",
@@ -450,7 +453,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
     }
 
     // Set tag and update stream metadata for use in update()
-    entry_to_write.tag = getTag(entry_to_write.pc, stream.asidHash);
+    entry_to_write.tag = getTag(entry_to_write.slot.pc, stream.asidHash);
     stream.updateNewBTBEntry = entry_to_write;
     stream.updateIsOldEntry = is_old_entry;
 }
@@ -492,13 +495,13 @@ MBTB::updateBTBEntry(const BTBEntry& entry, const FetchTarget &stream)
 {
     btbStats.updateTotal++;
     // Select SRAM based on entry PC's 32B-aligned address
-    Addr alignedPC = entry.pc & ~(blockSize - 1);
+    Addr alignedPC = entry.slot.pc & ~(blockSize - 1);
     int sram_id = getSRAMId(alignedPC);
     auto& target_sram = (sram_id == 0) ? sram0 : sram1;
     auto& target_mru = (sram_id == 0) ? mru0 : mru1;
     
     // Calculate index and tag for this entry
-    Addr btb_idx = getIndex(entry.pc, stream.asidHash);
+    Addr btb_idx = getIndex(entry.slot.pc, stream.asidHash);
 
     // Look for matching entry in the target SRAM
     bool found = false;
@@ -514,7 +517,7 @@ MBTB::updateBTBEntry(const BTBEntry& entry, const FetchTarget &stream)
     int vc_idx = -1;
     for (int i = 0; i < (int)victimCache.size(); i++) {
         auto &vc_entry = victimCache[i];
-        if (vc_entry.valid && vc_entry.pc == entry.pc) {    // pc is tag compared
+        if (vc_entry.valid && vc_entry.slot.pc == entry.slot.pc) {    // pc is tag compared
             found_in_vc = true;
             vc_idx = i;
             break;
@@ -550,20 +553,21 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
                         const FetchTarget &stream)
 {
     // For conditional branches, prefer the existing entry to preserve up-to-date ctr
-    auto entry_to_write = (req_entry.isCond && existing_entry)
+    auto entry_to_write = (req_entry.isCond() && existing_entry)
                               ? BTBEntry(*existing_entry)
                               : req_entry;
     // Always recalculate tag based on the actual PC being written
-    entry_to_write.tag = getTag(entry_to_write.pc, stream.asidHash);
-    entry_to_write.resolved = false; // reset resolved status
+    entry_to_write.tag = getTag(entry_to_write.slot.pc, stream.asidHash);
+    entry_to_write.slot.resolved = false; // reset resolved status
 
     // Update saturating counter and alwaysTaken
-    if (entry_to_write.isCond) {
-        bool this_cond_taken = stream.exeTaken && stream.getControlPC() == entry_to_write.pc;
+    if (entry_to_write.isCond()) {
+        bool this_cond_taken = stream.exeTaken &&
+            stream.getControlPC() == entry_to_write.slot.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
             DPRINTF(BTB, "BTB: unset alwaysTaken, pc %#lx, alwaysTaken %d\n",
-                    entry_to_write.pc, entry_to_write.alwaysTaken);
+                    entry_to_write.slot.pc, entry_to_write.alwaysTaken);
         }
         if (!entry_to_write.alwaysTaken) {
             updateCtr(entry_to_write.ctr, this_cond_taken);
@@ -571,8 +575,9 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
     }
 
     // Update indirect target if necessary
-    if (entry_to_write.isIndirect && stream.exeTaken && stream.getControlPC() == entry_to_write.pc) {
-        entry_to_write.target = stream.exeBranchInfo.target;
+    if (entry_to_write.isIndirect() && stream.exeTaken &&
+        stream.getControlPC() == entry_to_write.slot.pc) {
+        entry_to_write.slot.target = stream.exeBranchInfo.target;
     }
     return entry_to_write;
 }
@@ -583,7 +588,7 @@ MBTB::updateExistingInSRAMSet(Addr btb_idx,
                               BTBSetIter it_found,
                               const TickedBTBEntry &ticked_entry)
 {
-    if (it_found->target != ticked_entry.target) {
+    if (it_found->slot.target != ticked_entry.slot.target) {
         btbStats.updateFixTarget++;
     }
     // Update existing entry
@@ -591,8 +596,8 @@ MBTB::updateExistingInSRAMSet(Addr btb_idx,
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(ticked_entry.pc, ticked_entry.getType(),
-                ticked_entry.target, btb_idx, Mode::WRITE, 1);
+        rec.set(ticked_entry.slot.pc, ticked_entry.getType(),
+                ticked_entry.slot.target, btb_idx, Mode::WRITE, 1);
         btbTrace->write_record(rec);
     }
 #endif
@@ -600,8 +605,9 @@ MBTB::updateExistingInSRAMSet(Addr btb_idx,
     std::make_heap(heap.begin(), heap.end(), older());
 
     // Ensure single source of truth: remove duplicate from victim cache if any
-    if (eraseFromVictimCacheByPC(ticked_entry.pc)) {
-        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM update, pc %#lx\n", ticked_entry.pc);
+    if (eraseFromVictimCacheByPC(ticked_entry.slot.pc)) {
+        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM update, pc %#lx\n",
+                ticked_entry.slot.pc);
     }
 }
 
@@ -619,8 +625,8 @@ MBTB::replaceOldestInSRAMSet(int sram_id,
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                entry_in_btb_now->target, btb_idx, Mode::EVICT, 0);
+        rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+                entry_in_btb_now->slot.target, btb_idx, Mode::EVICT, 0);
         btbTrace->write_record(rec);
     }
 #endif
@@ -634,21 +640,22 @@ MBTB::replaceOldestInSRAMSet(int sram_id,
     }
     btbStats.updateReplace++;
     DPRINTF(BTB, "BTB: Replacing entry with tag %#lx, pc %#lx in set %#lx\n",
-            entry_in_btb_now->tag, entry_in_btb_now->pc, btb_idx);
+            entry_in_btb_now->tag, entry_in_btb_now->slot.pc, btb_idx);
     *entry_in_btb_now = ticked_entry;
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(entry_in_btb_now->pc, entry_in_btb_now->getType(),
-                entry_in_btb_now->target, btb_idx, Mode::WRITE, 0);
+        rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+                entry_in_btb_now->slot.target, btb_idx, Mode::WRITE, 0);
         btbTrace->write_record(rec);
     }
 #endif
     std::make_heap(heap.begin(), heap.end(), older());
 
     // Ensure single source of truth: remove duplicate from victim cache if any
-    if (eraseFromVictimCacheByPC(ticked_entry.pc)) {
-        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM replace, pc %#lx\n", ticked_entry.pc);
+    if (eraseFromVictimCacheByPC(ticked_entry.slot.pc)) {
+        DPRINTF(BTB, "BTB: removed duplicate from VC after SRAM replace, pc %#lx\n",
+                ticked_entry.slot.pc);
     }
 }
 
@@ -692,7 +699,8 @@ MBTB::prepareUpdateEntries(const FetchTarget &stream) {
     // Add potential new BTB entry if it's a btb miss during prediction
     if (!stream.updateIsOldEntry) {
         BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken && stream.getControlPC() == potential_new_entry.pc;
+        bool new_entry_taken = stream.exeTaken &&
+            stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
         }
@@ -702,7 +710,7 @@ MBTB::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !e.resolved; });
+            [](const BTBEntry &e) { return !e.slot.resolved; });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -722,13 +730,13 @@ MBTB::lookupVictimCache(Addr block_pc, uint8_t asidHash)
     for (auto &entry : victimCache) {
         if (!entry.valid) continue;
 
-        Addr entryAlignedPC = entry.pc & ~(blockSize - 1);
+        Addr entryAlignedPC = entry.slot.pc & ~(blockSize - 1);
         // Check if this entry is in either of the two 32B blocks we're looking for
         if (entryAlignedPC == alignedPC || entryAlignedPC == (alignedPC + blockSize)) {
-            Addr current_tag = getTag(entry.pc, asidHash);
+            Addr current_tag = getTag(entry.slot.pc, asidHash);
             if (entry.tag == current_tag) {
                 results.push_back(entry);
-                DPRINTF(BTB, "Victim cache hit for pc %#lx\n", entry.pc);
+                DPRINTF(BTB, "Victim cache hit for pc %#lx\n", entry.slot.pc);
                 // refresh LRU timestamp on hit
                 entry.tick = curTick();
             }
@@ -744,7 +752,7 @@ MBTB::eraseFromVictimCacheByPC(Addr pc)
 {
     bool erased = false;
     for (auto &entry : victimCache) {
-        if (entry.valid && entry.pc == pc) {
+        if (entry.valid && entry.slot.pc == pc) {
             entry.valid = false;
             erased = true;
             break;
@@ -760,7 +768,7 @@ MBTB::insertVictimCache(const TickedBTBEntry& evicted_entry)
 
     // 1) If same PC exists, update and refresh tick
     for (auto &entry : victimCache) {
-        if (entry.valid && entry.pc == evicted_entry.pc) {
+        if (entry.valid && entry.slot.pc == evicted_entry.slot.pc) {
             entry = evicted_entry;
             entry.tick = curTick();
             return;
@@ -785,7 +793,7 @@ MBTB::insertVictimCache(const TickedBTBEntry& evicted_entry)
         }
     }
     DPRINTF(BTB, "LRU replace in victim cache, evict pc %#lx with pc %#lx\n",
-            lru_it->pc, evicted_entry.pc);
+            lru_it->slot.pc, evicted_entry.slot.pc);
     *lru_it = evicted_entry;
     lru_it->tick = curTick();
 }
@@ -803,7 +811,7 @@ MBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     bool this_branch_hit = false;
     auto entry = BTBEntry();
     for (auto e : hit_entries) {
-        if (e.pc == pc) {
+        if (e.slot.pc == pc) {
             this_branch_hit = true;
             entry = e;
             break;
@@ -843,7 +851,7 @@ MBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         if (!inst->isNonSpeculative()) {
             if (inst->isIndirectCtrl()) {
                 btbStats.indirectHits++;
-                Addr pred_target = entry.target;
+                Addr pred_target = entry.slot.target;
                 if (pred_target == this_branch_target) {
                     btbStats.indirectPredCorrect++;
                 } else {

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -397,22 +397,22 @@ MBTB::lookup(Addr block_pc, uint8_t asidHash, std::shared_ptr<BTBMeta> meta)
 }
 
 /*
- * Generate a new BTB entry or update an existing one based on execution results
- * 
+ * Select a new BTB entry or an existing one based on execution results.
+ *
  * This function is called during BTB update to:
  * 1. Check if the executed branch was predicted (hit in BTB)
  * 2. If hit, prepare to update the existing entry
  * 3. If miss and branch was taken:
  *    - Create a new entry
  *    - For conditional branches, initialize as always taken with counter = 1
- * 4. Set the tag and update stream metadata for later use in update()
- * 
+ * 4. Set the tag and return the update-entry selection
+ *
  * Note: This is only called in L1 BTB during update
  */
-void
-MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
+FetchUpdateEntrySelection
+MBTB::selectUpdateEntry(const FetchTarget &stream)
 {
-    DPRINTF(BTB, "getAndSetNewBTBEntry called for pc %#lx\n", stream.startPC);
+    DPRINTF(BTB, "selectUpdateEntry called for pc %#lx\n", stream.startPC);
     // Get prediction metadata from previous stages
     auto meta = std::static_pointer_cast<BTBMeta>(stream.predMetas[getComponentIdx()]);
     auto &predBTBEntries = meta->hit_entries;
@@ -452,10 +452,12 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
         // Existing entries will be updated in update()
     }
 
-    // Set tag and update stream metadata for use in update()
+    // Set tag and return update entry selection for use in update()
     entry_to_write.tag = getTag(entry_to_write.slot.pc, stream.asidHash);
-    stream.update.newBTBEntry = entry_to_write;
-    stream.update.isOldEntry = is_old_entry;
+    return FetchUpdateEntrySelection{
+        entry_to_write,
+        is_old_entry,
+    };
 }
 
 /**

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -421,7 +421,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
     bool pred_branch_hit = false;
     BTBEntry entry_to_write = BTBEntry();
     for (auto &e: predBTBEntries) {
-        if (stream.exeBranchInfo == e.slot) {
+        if (stream.resolve.branchSlot == e.slot) {
             pred_branch_hit = true;
             entry_to_write = e;
             break;
@@ -430,9 +430,9 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
     bool is_old_entry = pred_branch_hit;
 
     // If branch was not predicted but was actually taken in execution, create new entry
-    if (!pred_branch_hit && stream.exeTaken) {
-        DPRINTF(BTB, "Creating new BTB entry for pc %#lx\n", stream.exeBranchInfo.pc);
-        BTBEntry new_entry = BTBEntry(stream.exeBranchInfo);
+    if (!pred_branch_hit && stream.resolve.taken) {
+        DPRINTF(BTB, "Creating new BTB entry for pc %#lx\n", stream.resolve.branchSlot.pc);
+        BTBEntry new_entry = BTBEntry(stream.resolve.branchSlot);
         new_entry.valid = true;
         // For conditional branches, initialize as always taken
         if (new_entry.slot.isCond()) {
@@ -444,18 +444,18 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
         }
         btbStats.newEntry++;
         entry_to_write = new_entry;
-        entry_to_write.slot.resolved = stream.exeBranchInfo.resolved;
+        entry_to_write.slot.resolved = stream.resolve.branchSlot.resolved;
         is_old_entry = false;
     } else {
-        DPRINTF(BTB, "Not creating new entry: pred_branch_hit=%d, stream.exeTaken=%d\n",
-                pred_branch_hit, stream.exeTaken);
+        DPRINTF(BTB, "Not creating new entry: pred_branch_hit=%d, stream.resolve.taken=%d\n",
+                pred_branch_hit, stream.resolve.taken);
         // Existing entries will be updated in update()
     }
 
     // Set tag and update stream metadata for use in update()
     entry_to_write.tag = getTag(entry_to_write.slot.pc, stream.asidHash);
-    stream.updateNewBTBEntry = entry_to_write;
-    stream.updateIsOldEntry = is_old_entry;
+    stream.update.newBTBEntry = entry_to_write;
+    stream.update.isOldEntry = is_old_entry;
 }
 
 /**
@@ -467,13 +467,13 @@ MBTB::checkPredictionHit(const FetchTarget &stream, const BTBMeta* meta)
 {
     bool pred_branch_hit = false;
     for (auto &e : meta->hit_entries) {
-        if (stream.exeBranchInfo == e.slot) {
+        if (stream.resolve.branchSlot == e.slot) {
             pred_branch_hit = true;
             break;
         }
     }
-    if (!pred_branch_hit && stream.exeTaken) {
-        DPRINTF(BTB, "update miss detected, pc %#lx, predTick %lu\n", stream.exeBranchInfo.pc, stream.predTick);
+    if (!pred_branch_hit && stream.resolve.taken) {
+        DPRINTF(BTB, "update miss detected, pc %#lx, predTick %lu\n", stream.resolve.branchSlot.pc, stream.predTick);
         btbStats.updateMiss++;
     } else {
         btbStats.updateHit++;
@@ -562,7 +562,7 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
 
     // Update saturating counter and alwaysTaken
     if (entry_to_write.slot.isCond()) {
-        bool this_cond_taken = stream.exeTaken &&
+        bool this_cond_taken = stream.resolve.taken &&
             stream.getControlPC() == entry_to_write.slot.pc;
         if (!this_cond_taken) {
             entry_to_write.alwaysTaken = false;
@@ -575,9 +575,9 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
     }
 
     // Update indirect target if necessary
-    if (entry_to_write.slot.isIndirect() && stream.exeTaken &&
+    if (entry_to_write.slot.isIndirect() && stream.resolve.taken &&
         stream.getControlPC() == entry_to_write.slot.pc) {
-        entry_to_write.slot.target = stream.exeBranchInfo.target;
+        entry_to_write.slot.target = stream.resolve.branchSlot.target;
     }
     return entry_to_write;
 }
@@ -696,12 +696,12 @@ MBTB::update(const FetchTarget &stream)
 
 std::vector<BTBEntry>
 MBTB::prepareUpdateEntries(const FetchTarget &stream) {
-    auto all_entries = stream.updateBTBEntries;
+    auto all_entries = stream.update.btbEntries;
 
     // Add potential new BTB entry if it's a btb miss during prediction
-    if (!stream.updateIsOldEntry) {
-        BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken &&
+    if (!stream.update.isOldEntry) {
+        BTBEntry potential_new_entry = stream.update.newBTBEntry;
+        bool new_entry_taken = stream.resolve.taken &&
             stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
@@ -821,7 +821,7 @@ MBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     }
     // bool this_branch_miss = !this_branch_hit;
     bool cond_not_taken = inst->isCondCtrl() && !inst->branching();
-    bool this_branch_taken = stream.exeTaken && stream.getControlPC() == pc; // all uncond should be taken
+    bool this_branch_taken = stream.resolve.taken && stream.getControlPC() == pc; // all uncond should be taken
     Addr this_branch_target = npc;
     if (this_branch_hit) {
         btbStats.allBranchHits++;

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -258,13 +258,13 @@ MBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
     // Set predictions for each branch
     for (auto &e : entries) {
         assert(e.valid);
-        if (e.isCond()) {
+        if (e.slot.isCond()) {
             // TODO: a performance bug here, mbtb should not update condTakens!
 
             FillStageLoop(s) stagePreds[s].condTakens.push_back(
                 {e.slot.pc, e.alwaysTaken || (e.ctr >= 0)});
 
-        } else if (e.isIndirect()) {
+        } else if (e.slot.isIndirect()) {
             // Set predicted target for indirect branches
             DPRINTF(BTB, "setting indirect target for pc %#lx to %#lx\n",
                     e.slot.pc, e.slot.target);
@@ -272,7 +272,7 @@ MBTB::fillStagePredictions(const std::vector<TickedBTBEntry>& entries,
             FillStageLoop(s) stagePreds[s].indirectTargets.push_back(
                 {e.slot.pc, e.slot.target});
 
-            if (e.isReturn()) {
+            if (e.slot.isReturn()) {
                 FillStageLoop(s) stagePreds[s].returnTarget = e.slot.target;
             }
             break;
@@ -421,7 +421,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
     bool pred_branch_hit = false;
     BTBEntry entry_to_write = BTBEntry();
     for (auto &e: predBTBEntries) {
-        if (stream.exeBranchInfo == e) {
+        if (stream.exeBranchInfo == e.slot) {
             pred_branch_hit = true;
             entry_to_write = e;
             break;
@@ -435,7 +435,7 @@ MBTB::getAndSetNewBTBEntry(FetchTarget &stream)
         BTBEntry new_entry = BTBEntry(stream.exeBranchInfo);
         new_entry.valid = true;
         // For conditional branches, initialize as always taken
-        if (new_entry.isCond()) {
+        if (new_entry.slot.isCond()) {
             new_entry.alwaysTaken = true;
             new_entry.ctr = 0;  // Start with positive prediction
             btbStats.newEntryWithCond++;
@@ -467,7 +467,7 @@ MBTB::checkPredictionHit(const FetchTarget &stream, const BTBMeta* meta)
 {
     bool pred_branch_hit = false;
     for (auto &e : meta->hit_entries) {
-        if (stream.exeBranchInfo == e) {
+        if (stream.exeBranchInfo == e.slot) {
             pred_branch_hit = true;
             break;
         }
@@ -553,7 +553,7 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
                         const FetchTarget &stream)
 {
     // For conditional branches, prefer the existing entry to preserve up-to-date ctr
-    auto entry_to_write = (req_entry.isCond() && existing_entry)
+    auto entry_to_write = (req_entry.slot.isCond() && existing_entry)
                               ? BTBEntry(*existing_entry)
                               : req_entry;
     // Always recalculate tag based on the actual PC being written
@@ -561,7 +561,7 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
     entry_to_write.slot.resolved = false; // reset resolved status
 
     // Update saturating counter and alwaysTaken
-    if (entry_to_write.isCond()) {
+    if (entry_to_write.slot.isCond()) {
         bool this_cond_taken = stream.exeTaken &&
             stream.getControlPC() == entry_to_write.slot.pc;
         if (!this_cond_taken) {
@@ -575,7 +575,7 @@ MBTB::buildUpdatedEntry(const BTBEntry& req_entry,
     }
 
     // Update indirect target if necessary
-    if (entry_to_write.isIndirect() && stream.exeTaken &&
+    if (entry_to_write.slot.isIndirect() && stream.exeTaken &&
         stream.getControlPC() == entry_to_write.slot.pc) {
         entry_to_write.slot.target = stream.exeBranchInfo.target;
     }
@@ -596,7 +596,7 @@ MBTB::updateExistingInSRAMSet(Addr btb_idx,
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(ticked_entry.slot.pc, ticked_entry.getType(),
+        rec.set(ticked_entry.slot.pc, ticked_entry.slot.getType(),
                 ticked_entry.slot.target, btb_idx, Mode::WRITE, 1);
         btbTrace->write_record(rec);
     }
@@ -625,7 +625,8 @@ MBTB::replaceOldestInSRAMSet(int sram_id,
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+        rec.set(entry_in_btb_now->slot.pc,
+                entry_in_btb_now->slot.getType(),
                 entry_in_btb_now->slot.target, btb_idx, Mode::EVICT, 0);
         btbTrace->write_record(rec);
     }
@@ -645,7 +646,8 @@ MBTB::replaceOldestInSRAMSet(int sram_id,
 #ifndef UNIT_TEST
     if (enableDB) {
         BTBTrace rec;
-        rec.set(entry_in_btb_now->slot.pc, entry_in_btb_now->getType(),
+        rec.set(entry_in_btb_now->slot.pc,
+                entry_in_btb_now->slot.getType(),
                 entry_in_btb_now->slot.target, btb_idx, Mode::WRITE, 0);
         btbTrace->write_record(rec);
     }

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -171,7 +171,9 @@ class MBTB : public TimedBaseBTBPredictor
     void printBTBEntry(const BTBEntry &e, uint64_t tick = 0) {
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
-            e.valid, e.pc, e.tag, e.size, e.target, e.isCond, e.isIndirect, e.isCall, e.isReturn, e.alwaysTaken, tick);
+            e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
+            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.alwaysTaken, tick);
     }
 
     void printTickedBTBEntry(const TickedBTBEntry &e) {
@@ -322,11 +324,11 @@ class MBTB : public TimedBaseBTBPredictor
         Addr last = 0;
         bool misorder = false;
         for (auto &entry : es) {
-            if (entry.pc <= last) {
+            if (entry.slot.pc <= last) {
                 misorder = true;
                 break;
             }
-            last = entry.pc;
+            last = entry.slot.pc;
         }
         if (misorder) {
             panic("BTB entries are not in ascending order");

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -172,7 +172,8 @@ class MBTB : public TimedBaseBTBPredictor
         DPRINTF(BTB, "BTB entry: valid %d, pc:%#lx, tag: %#lx, size:%d, target:%#lx, \
             cond:%d, indirect:%d, call:%d, return:%d, always_taken:%d, tick:%lu\n",
             e.valid, e.slot.pc, e.tag, e.slot.size, e.slot.target,
-            e.isCond(), e.isIndirect(), e.isCall(), e.isReturn(),
+            e.slot.isCond(), e.slot.isIndirect(), e.slot.isCall(),
+            e.slot.isReturn(),
             e.alwaysTaken, tick);
     }
 

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -151,12 +151,11 @@ class MBTB : public TimedBaseBTBPredictor
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
     /**
-     * @brief derive new btb entry from old ones and set update payload in stream
-     *        only in L1BTB will this function be called before update
-     * 
-     * @param stream 
+     * @brief derive the old or new BTB entry used by update payload
+     *
+     * Only the L1 BTB prepares this selection before component updates.
      */
-    void getAndSetNewBTBEntry(FetchTarget &stream);
+    FetchUpdateEntrySelection selectUpdateEntry(const FetchTarget &stream);
 
     /** Updates the BTB with the branch info of a block and execution result.
      *  This function:

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -151,7 +151,7 @@ class MBTB : public TimedBaseBTBPredictor
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
     /**
-     * @brief derive new btb entry from old ones and set updateNewBTBEntry field in stream
+     * @brief derive new btb entry from old ones and set update payload in stream
      *        only in L1BTB will this function be called before update
      * 
      * @param stream 

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -214,7 +214,9 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
                                  std::shared_ptr<TageMeta> predMeta,
                                  ThreadID tid,
                                  uint8_t asidHash) {
-    DPRINTF(UTAGE, "generateSinglePrediction for btbEntry: %#lx\n", btb_entry.pc);
+    const Addr branch_pc = btb_entry.slot.pc;
+    DPRINTF(UTAGE, "generateSinglePrediction for btbEntry: %#lx\n",
+            branch_pc);
     const auto &state = historyState(tid);
 
     bool provided = false;
@@ -222,7 +224,7 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
 
     // Search from highest to lowest table for matches
     // Calculate branch position within the block (like RTL's cfiPosition)
-    unsigned position = getBranchIndexInBlock(btb_entry.pc, startPC);
+    unsigned position = getBranchIndexInBlock(branch_pc, startPC);
 
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
@@ -252,7 +254,8 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
                 // Do not use LRU; keep logic simple and align with CBP-style replacement
 
                 DPRINTF(UTAGE, "hit  table %d[%lu][%u]: valid %d, tag %lu, ctr %d, useful %d, btb_pc %#lx, pos %u\n",
-                    i, index, way, entry.valid, entry.tag, entry.counter, entry.useful, btb_entry.pc, position);
+                    i, index, way, entry.valid, entry.tag, entry.counter,
+                    entry.useful, branch_pc, position);
                 break;  // only one way can be matched, avoid multi-hit, TODO: RTL behavior?
             }
         }
@@ -265,7 +268,7 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
             }
         } else {
             DPRINTF(UTAGE, "miss table %d[%lu] for tag %lu (with pos %u), btb_pc %#lx\n",
-                i, index, tag, position, btb_entry.pc);
+                i, index, tag, position, branch_pc);
         }
     }
 
@@ -275,11 +278,11 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
 
     bool taken = provided ? main_taken : base_pred;
 
-    DPRINTF(UTAGE, "tage predict %#lx taken %d\n", btb_entry.pc, taken);
+    DPRINTF(UTAGE, "tage predict %#lx taken %d\n", branch_pc, taken);
     DPRINTF(UTAGE, "tage main provided %d ? main_taken %d : base_taken %d\n",
             provided, main_taken, base_pred);
 
-    return TagePrediction(btb_entry.pc, main_info, provided, taken, base_pred);
+    return TagePrediction(branch_pc, main_info, provided, taken, base_pred);
 }
 
 /**
@@ -298,12 +301,13 @@ MicroTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEnt
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond && btb_entry.valid) {
+        if (btb_entry.isCond() && btb_entry.valid) {
             auto pred = generateSinglePrediction(btb_entry, startPC, nullptr,
                                                  tid, asidHash);
-            threadMeta[tid]->preds[btb_entry.pc] = pred;
+            threadMeta[tid]->preds[btb_entry.slot.pc] = pred;
             tageStats.updateStatsWithTagePrediction(pred, true);
-            results.push_back({btb_entry.pc, pred.taken || btb_entry.alwaysTaken});
+            results.push_back(
+                {btb_entry.slot.pc, pred.taken || btb_entry.alwaysTaken});
         }
     }
 }
@@ -397,7 +401,8 @@ MicroTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Add potential new BTB entry if it's a btb miss during prediction
     if (!stream.updateIsOldEntry) {
         BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken && stream.getControlPC() == potential_new_entry.pc;
+        bool new_entry_taken = stream.exeTaken &&
+            stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
         }
@@ -407,11 +412,11 @@ MicroTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken && e.resolved); });
+            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken && e.slot.resolved); });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond && !e.alwaysTaken); });
+            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken); });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -513,7 +518,7 @@ MicroTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
 
     // Check if misprediction occurred
     bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
-                               stream.squashPC == entry.pc;
+                               stream.squashPC == entry.slot.pc;
     // No allocation if no misprediction
     if (!this_fb_mispred) {
         return false;
@@ -549,7 +554,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
     // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
 
     // Calculate branch position within the block (like RTL's cfiPosition)
-    unsigned position = getBranchIndexInBlock(entry.pc, startPC);
+    unsigned position = getBranchIndexInBlock(entry.slot.pc, startPC);
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
         Addr newIndex = getTageIndex(startPC, ti,
@@ -567,8 +572,9 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
             if (!cand.valid || (!cand.useful && weakish)) {
                 short newCounter = actual_taken ? 0 : -1;
                 DPRINTF(UTAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
-                        ti, newIndex, way, newTag, position, newCounter, entry.pc);
-                cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
+                        ti, newIndex, way, newTag, position, newCounter,
+                        entry.slot.pc);
+                cand = TageEntry(newTag, newCounter, entry.slot.pc); // u = 0 default
                 tageStats.updateAllocSuccess++;
                 allocated_table = ti;
                 allocated_index = newIndex;
@@ -687,12 +693,12 @@ MicroTAGE::update(const FetchTarget &stream) {
             recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta,
                                                  stream.tid, stream.asidHash);
         } else { // otherwise, use the prediction from the prediction-time main/alt
-            auto pred_it = predMeta->preds.find(btb_entry.pc);
+            auto pred_it = predMeta->preds.find(btb_entry.slot.pc);
             if (pred_it != predMeta->preds.end()) {
                 recomputed = pred_it->second;
             } else {
                 DPRINTF(UTAGE, "update: missing predMeta entry for pc %#lx, recompute with snapshot\n",
-                        btb_entry.pc);
+                        btb_entry.slot.pc);
                 recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta,
                                                      stream.tid, stream.asidHash);
             }

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -396,12 +396,12 @@ MicroTAGE::getPredictionMeta(ThreadID tid) {
  */
 std::vector<BTBEntry>
 MicroTAGE::prepareUpdateEntries(const FetchTarget &stream) {
-    auto all_entries = stream.updateBTBEntries;
+    auto all_entries = stream.update.btbEntries;
 
     // Add potential new BTB entry if it's a btb miss during prediction
-    if (!stream.updateIsOldEntry) {
-        BTBEntry potential_new_entry = stream.updateNewBTBEntry;
-        bool new_entry_taken = stream.exeTaken &&
+    if (!stream.update.isOldEntry) {
+        BTBEntry potential_new_entry = stream.update.newBTBEntry;
+        bool new_entry_taken = stream.resolve.taken &&
             stream.getControlPC() == potential_new_entry.slot.pc;
         if (!new_entry_taken) {
             potential_new_entry.alwaysTaken = false;
@@ -521,8 +521,8 @@ MicroTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     }
 
     // Check if misprediction occurred
-    bool this_fb_mispred = stream.squashType == SquashType::SQUASH_CTRL &&
-                               stream.squashPC == entry.slot.pc;
+    bool this_fb_mispred = stream.resolve.squashType == SquashType::SQUASH_CTRL &&
+                               stream.resolve.squashPC == entry.slot.pc;
     // No allocation if no misprediction
     if (!this_fb_mispred) {
         return false;
@@ -690,8 +690,8 @@ MicroTAGE::update(const FetchTarget &stream) {
     bool utage_hit = false;
     // Process each BTB entry
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken &&
-            stream.exeBranchInfo == btb_entry.slot;
+        bool actual_taken = stream.resolve.taken &&
+            stream.resolve.branchSlot == btb_entry.slot;
         TagePrediction recomputed;
         if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)
@@ -788,10 +788,10 @@ MicroTAGE::checkUtageUpdateMisspred(const FetchTarget &stream) {
             break;
         }
     }
-    bool fallthrough_mispred = (!has_taken_pred && stream.exeTaken) ||
-                                (has_taken_pred && !stream.exeTaken);
-    bool branch_mispred = stream.exeTaken && has_taken_pred &&
-                          first_taken_pc != stream.exeBranchInfo.pc;
+    bool fallthrough_mispred = (!has_taken_pred && stream.resolve.taken) ||
+                                (has_taken_pred && !stream.resolve.taken);
+    bool branch_mispred = stream.resolve.taken && has_taken_pred &&
+                          first_taken_pc != stream.resolve.branchSlot.pc;
     if (fallthrough_mispred || branch_mispred) {
         tageStats.updateMispred++;
     }
@@ -1171,7 +1171,7 @@ MicroTAGE::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         pred_taken = it->second.taken;
         pred_hit = true;
     }
-    bool this_cond_taken = stream.exeTaken && stream.exeBranchInfo.pc == pc;
+    bool this_cond_taken = stream.resolve.taken && stream.resolve.branchSlot.pc == pc;
     bool predcorrect = (pred_taken == this_cond_taken);
     if (!predcorrect) {
         tageStats.condPredwrong++;

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -301,7 +301,7 @@ MicroTAGE::lookupHelper(const Addr &startPC, const std::vector<BTBEntry> &btbEnt
     // Process each BTB entry to make predictions
     for (auto &btb_entry : btbEntries) {
         // Only predict for valid conditional branches
-        if (btb_entry.isCond() && btb_entry.valid) {
+        if (btb_entry.slot.isCond() && btb_entry.valid) {
             auto pred = generateSinglePrediction(btb_entry, startPC, nullptr,
                                                  tid, asidHash);
             threadMeta[tid]->preds[btb_entry.slot.pc] = pred;
@@ -412,11 +412,15 @@ MicroTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     // Filter: only keep conditional branches that are not always taken
     if (getResolvedUpdate()) {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken && e.slot.resolved); });
+            [](const BTBEntry &e) {
+                return !(e.slot.isCond() && !e.alwaysTaken && e.slot.resolved);
+            });
         all_entries.erase(remove_it, all_entries.end());
     } else {
         auto remove_it = std::remove_if(all_entries.begin(), all_entries.end(),
-            [](const BTBEntry &e) { return !(e.isCond() && !e.alwaysTaken); });
+            [](const BTBEntry &e) {
+                return !(e.slot.isCond() && !e.alwaysTaken);
+            });
         all_entries.erase(remove_it, all_entries.end());
     }
 
@@ -686,7 +690,8 @@ MicroTAGE::update(const FetchTarget &stream) {
     bool utage_hit = false;
     // Process each BTB entry
     for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
+        bool actual_taken = stream.exeTaken &&
+            stream.exeBranchInfo == btb_entry.slot;
         TagePrediction recomputed;
         if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
             // Re-read providers using snapshot (do not rely on prediction-time main/alt)

--- a/src/cpu/pred/btb/prediction_result.hh
+++ b/src/cpu/pred/btb/prediction_result.hh
@@ -1,0 +1,301 @@
+#ifndef __CPU_PRED_BTB_PREDICTION_RESULT_HH__
+#define __CPU_PRED_BTB_PREDICTION_RESULT_HH__
+
+#include "base/bitfield.hh"
+#include "base/intmath.hh"
+#include "base/types.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+enum class PredictionResultMismatchReason
+{
+    NoOverride,
+    FallThrough,
+    ControlAddr,
+    Target
+};
+
+struct PredictionResultMatch
+{
+    bool matches;
+    PredictionResultMismatchReason reason;
+};
+
+struct DirectionHistoryUpdate
+{
+    int shamt = 0;
+    bool taken = false;
+};
+
+struct PathHistoryUpdate
+{
+    static constexpr int NumShift = 2;
+
+    int shamt = NumShift;
+    bool taken = false;
+    Addr pc = 0;
+    Addr target = 0;
+};
+
+/**
+ * Resolves a fetch block prediction into the first taken branch and its target.
+ *
+ * The view keeps the stage-prediction storage outside this module, but owns the
+ * rules that combine BTB entries, direction predictions, indirect targets, and
+ * RAS targets into the final fetch-block result.
+ */
+template <typename Entries, typename CondTakenMap, typename IndirectTargetMap>
+class PredictionBlockResultView
+{
+  public:
+    using Entry = typename Entries::value_type;
+
+    struct TakenSlotResult
+    {
+        Entry entry;
+        Addr target = 0;
+        Addr fallThrough = 0;
+
+        bool taken() const { return entry.valid; }
+        Addr controlPC() const { return entry.slot.pc; }
+        Addr endPC() const
+        {
+            return taken() ? entry.slot.getEnd() : fallThrough;
+        }
+
+        auto
+        resolvedSlot() const
+        {
+            auto resolved_slot = entry.slot;
+            resolved_slot.target = target;
+            return resolved_slot;
+        }
+    };
+
+    PredictionBlockResultView(Addr block_start, const Entries &entries,
+                              const CondTakenMap &cond_taken_map,
+                              const IndirectTargetMap &indirect_target_map,
+                              Addr ras_return_target)
+        : blockStart(block_start),
+          btbEntries(entries),
+          condTakens(cond_taken_map),
+          indirectTargets(indirect_target_map),
+          returnTarget(ras_return_target)
+    {
+    }
+
+    Entry
+    getTakenEntry() const
+    {
+        // IMPORTANT: callers provide entries sorted by instruction order.
+        for (const auto &entry : btbEntries) {
+            if (!entry.valid) {
+                continue;
+            }
+
+            if (entry.slot.isCond()) {
+                if (condTaken(entry.slot.pc)) {
+                    return entry;
+                }
+                continue;
+            }
+
+            if (entry.slot.isUncond()) {
+                return entry;
+            }
+        }
+
+        return Entry();
+    }
+
+    bool isTaken() const { return getTakenEntry().valid; }
+
+    Addr
+    getFallThrough(Addr predict_width) const
+    {
+        // max 64 byte block, 32 byte aligned
+        return (blockStart + predict_width) &
+               ~mask(floorLog2(predict_width) - 1);
+    }
+
+    Addr
+    getEntryTarget(const Entry &entry) const
+    {
+        Addr target = entry.slot.target;
+
+        if (entry.slot.isIndirect()) {
+            if (!entry.slot.isReturn()) {
+                Addr indirect_target = 0;
+                if (findIndirectTarget(entry.slot.pc, indirect_target)) {
+                    target = indirect_target;
+                }
+            } else {
+                target = returnTarget;
+            }
+        }
+
+        return target;
+    }
+
+    TakenSlotResult
+    getTakenSlotResult(Addr predict_width) const
+    {
+        TakenSlotResult result;
+        result.fallThrough = getFallThrough(predict_width);
+        result.entry = getTakenEntry();
+        result.target = result.entry.valid ? getEntryTarget(result.entry) :
+                                             result.fallThrough;
+        return result;
+    }
+
+    Addr getTarget(Addr predict_width) const
+    {
+        return getTakenSlotResult(predict_width).target;
+    }
+
+    Addr getEnd(Addr predict_width) const
+    {
+        return getTakenSlotResult(predict_width).endPC();
+    }
+
+    Addr
+    controlAddr() const
+    {
+        const auto entry = getTakenEntry();
+        return entry.valid ? entry.slot.pc : 0;
+    }
+
+    PredictionResultMatch
+    match(const PredictionBlockResultView &other, Addr predict_width) const
+    {
+        const auto this_taken_entry = getTakenEntry();
+        const auto other_taken_entry = other.getTakenEntry();
+
+        if (this_taken_entry.valid != other_taken_entry.valid) {
+            return {false, PredictionResultMismatchReason::FallThrough};
+        }
+
+        if (!this_taken_entry.valid) {
+            return {true, PredictionResultMismatchReason::NoOverride};
+        }
+
+        if (controlAddr() != other.controlAddr()) {
+            return {false, PredictionResultMismatchReason::ControlAddr};
+        }
+
+        if (getTarget(predict_width) != other.getTarget(predict_width)) {
+            return {false, PredictionResultMismatchReason::Target};
+        }
+
+        return {true, PredictionResultMismatchReason::NoOverride};
+    }
+
+    DirectionHistoryUpdate
+    getGHistUpdate() const
+    {
+        DirectionHistoryUpdate update;
+
+        for (const auto &entry : btbEntries) {
+            if (!entry.valid) {
+                continue;
+            }
+
+            if (entry.slot.isCond()) {
+                update.shamt++;
+                if (condTaken(entry.slot.pc)) {
+                    update.taken = true;
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        return update;
+    }
+
+    DirectionHistoryUpdate
+    getBwHistUpdate() const
+    {
+        DirectionHistoryUpdate update;
+
+        for (const auto &entry : btbEntries) {
+            if (!entry.valid) {
+                continue;
+            }
+
+            if (entry.slot.isCond()) {
+                update.shamt++;
+                if (condTaken(entry.slot.pc)) {
+                    update.taken = entry.slot.target < entry.slot.pc;
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        return update;
+    }
+
+    PathHistoryUpdate
+    getPHistUpdate() const
+    {
+        PathHistoryUpdate update;
+        const auto entry = getTakenEntry();
+        if (entry.valid) {
+            update.taken = true;
+            update.pc = entry.slot.pc;
+            update.target = getEntryTarget(entry);
+        }
+
+        return update;
+    }
+
+  private:
+    bool
+    condTaken(Addr branch_pc) const
+    {
+        for (const auto &prediction : condTakens) {
+            if (prediction.first == branch_pc) {
+                return prediction.second;
+            }
+        }
+
+        return false;
+    }
+
+    bool
+    findIndirectTarget(Addr branch_pc, Addr &target) const
+    {
+        for (const auto &prediction : indirectTargets) {
+            if (prediction.first == branch_pc) {
+                target = prediction.second;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    Addr blockStart;
+    const Entries &btbEntries;
+    const CondTakenMap &condTakens;
+    const IndirectTargetMap &indirectTargets;
+    Addr returnTarget;
+};
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5
+
+#endif // __CPU_PRED_BTB_PREDICTION_RESULT_HH__

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -130,24 +130,25 @@ BTBRAS::specUpdateState(FullBTBPrediction &pred)
     // do push & pops on prediction
     // pred.returnTarget = stack[sp].retAddr;
     auto takenEntry = pred.getTakenEntry();
+    auto takenSlot = takenEntry.slot;
     DPRINTFR(RAS, "Do specUpdate for PC %lx pred target %lx ", pred.bbStart, pred.returnTarget);
 
-    if (takenEntry.isCall()) {
-        Addr retAddr = takenEntry.slot.pc + takenEntry.slot.size;
+    if (takenSlot.isCall()) {
+        Addr retAddr = takenSlot.pc + takenSlot.size;
         push(tid, retAddr);
     }
-    if (takenEntry.isReturn()) {
+    if (takenSlot.isReturn()) {
         // do pop
         pop(tid);
     }
-    if (takenEntry.isCall()) {
-        DPRINTFR(RAS, "IsCall spec PC %lx\n", takenEntry.slot.pc);
+    if (takenSlot.isCall()) {
+        DPRINTFR(RAS, "IsCall spec PC %lx\n", takenSlot.pc);
     }
-    if (takenEntry.isReturn()) {
-        DPRINTFR(RAS, "IsRet spec PC %lx\n", takenEntry.slot.pc);
+    if (takenSlot.isReturn()) {
+        DPRINTFR(RAS, "IsRet spec PC %lx\n", takenSlot.pc);
     }
     
-    if (takenEntry.isCall() || takenEntry.isReturn())
+    if (takenSlot.isCall() || takenSlot.isReturn())
         printStack("after specUpdateState", tid);
     DPRINTFR(RAS, "meta TOSR %d TOSW %d\n", state.meta->TOSR, state.meta->TOSW);
 }
@@ -158,9 +159,9 @@ BTBRAS::recoverState(const FetchTarget &entry)
     const ThreadID tid = entry.tid;
     assert(tid < numThreads);
     auto &state = threadStates[tid];
-    auto takenEntry = entry.exeBranchInfo;
+    auto takenSlot = entry.exeBranchInfo;
     /*
-    if (takenEntry.isCall() || takenEntry.isReturn()) {
+    if (takenSlot.isCall() || takenSlot.isReturn()) {
         printStack("before recoverState", tid);
     }*/
     // recover sp and tos first
@@ -172,14 +173,14 @@ BTBRAS::recoverState(const FetchTarget &entry)
     state.TOSW = meta_ptr->TOSW;
     state.ssp = meta_ptr->ssp;
     state.sctr = meta_ptr->sctr;
-    Addr retAddr = takenEntry.pc + takenEntry.size;
+    Addr retAddr = takenSlot.pc + takenSlot.size;
 
     // do push & pops on control squash
     if (entry.exeTaken) {
-        if (takenEntry.isCall()) {
+        if (takenSlot.isCall()) {
             push(tid, retAddr);
         }
-        if (takenEntry.isReturn()) {
+        if (takenSlot.isReturn()) {
             pop(tid);
             //TOSW = (TOSR + 1) % numInflightEntries;
         }
@@ -187,10 +188,12 @@ BTBRAS::recoverState(const FetchTarget &entry)
 
     
     if (entry.exeTaken) {
-        DPRINTF(RAS, "isCall %d, isRet %d\n", takenEntry.isCall(), takenEntry.isReturn());
-        if (takenEntry.isReturn()) {
+        DPRINTF(RAS, "isCall %d, isRet %d\n", takenSlot.isCall(),
+                takenSlot.isReturn());
+        if (takenSlot.isReturn()) {
             DPRINTF(RAS, "IsRet expect target %lx, preded %lx, pred taken %d pred target %lx\n",
-                takenEntry.target, meta_ptr->target, entry.predTaken, entry.predBranchInfo.target);
+                takenSlot.target, meta_ptr->target, entry.predTaken,
+                entry.predBranchInfo.target);
         }
         printStack("after recoverState", tid);
     }
@@ -204,7 +207,7 @@ BTBRAS::update(const FetchTarget &entry)
     assert(tid < numThreads);
     auto &state = threadStates[tid];
     auto meta_ptr = std::static_pointer_cast<RASMeta>(entry.predMetas[getComponentIdx()]);
-    auto takenEntry = entry.exeBranchInfo;
+    auto takenSlot = entry.exeBranchInfo;
     if (entry.exeTaken) {
         if (meta_ptr->ssp != state.nsp || meta_ptr->sctr != state.stack[state.nsp].data.ctr) {
             DPRINTF(RAS, "ssp and nsp mismatch, recovering, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n",
@@ -213,19 +216,19 @@ BTBRAS::update(const FetchTarget &entry)
         } else
             DPRINTF(RAS, "ssp and nsp match, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n",
                 meta_ptr->ssp, meta_ptr->sctr, state.nsp, state.stack[state.nsp].data.ctr);
-        if (takenEntry.isCall()) {
+        if (takenSlot.isCall()) {
             DPRINTF(RAS, "real update call BTB hit %d meta TOSR %d TOSW %d\n entry PC %lx",
                 entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
-            Addr retAddr = takenEntry.pc + takenEntry.size;
+            Addr retAddr = takenSlot.pc + takenSlot.size;
             push_stack(tid, retAddr);
             state.BOS = inflightPtrPlus1(meta_ptr->TOSW);
         }
-        if (takenEntry.isReturn()) {
+        if (takenSlot.isReturn()) {
             DPRINTF(RAS, "update ret entry PC %lx\n", entry.startPC);
             pop_stack(tid);
         }
     }
-    if (takenEntry.isCall() || takenEntry.isReturn()) {
+    if (takenSlot.isCall() || takenSlot.isReturn()) {
         printStack("after update(commit)", tid);
     }
 }

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -109,11 +109,6 @@ BTBRAS::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history,
     for (int i = getDelay(); i < stagePreds.size(); i++) {
         stagePreds[i].returnTarget = top.retAddr;
     }
-    /*
-    if (stagePreds.back().btbEntry.slots[0].isCall || stagePreds.back().btbEntry.slots[0].isReturn || stagePreds.back().btbEntry.slots[1].isCall || stagePreds.back().btbEntry.slots[1].isReturn) {
-        printStack("putPCHistory", tid);
-    }
-    */
 }
 
 std::shared_ptr<void>
@@ -137,22 +132,22 @@ BTBRAS::specUpdateState(FullBTBPrediction &pred)
     auto takenEntry = pred.getTakenEntry();
     DPRINTFR(RAS, "Do specUpdate for PC %lx pred target %lx ", pred.bbStart, pred.returnTarget);
 
-    if (takenEntry.isCall) {
-        Addr retAddr = takenEntry.pc + takenEntry.size;
+    if (takenEntry.isCall()) {
+        Addr retAddr = takenEntry.slot.pc + takenEntry.slot.size;
         push(tid, retAddr);
     }
-    if (takenEntry.isReturn) {
+    if (takenEntry.isReturn()) {
         // do pop
         pop(tid);
     }
-    if (takenEntry.isCall) {
-        DPRINTFR(RAS, "IsCall spec PC %lx\n", takenEntry.pc);
+    if (takenEntry.isCall()) {
+        DPRINTFR(RAS, "IsCall spec PC %lx\n", takenEntry.slot.pc);
     }
-    if (takenEntry.isReturn) {
-        DPRINTFR(RAS, "IsRet spec PC %lx\n", takenEntry.pc);
+    if (takenEntry.isReturn()) {
+        DPRINTFR(RAS, "IsRet spec PC %lx\n", takenEntry.slot.pc);
     }
     
-    if (takenEntry.isCall || takenEntry.isReturn)
+    if (takenEntry.isCall() || takenEntry.isReturn())
         printStack("after specUpdateState", tid);
     DPRINTFR(RAS, "meta TOSR %d TOSW %d\n", state.meta->TOSR, state.meta->TOSW);
 }
@@ -165,7 +160,7 @@ BTBRAS::recoverState(const FetchTarget &entry)
     auto &state = threadStates[tid];
     auto takenEntry = entry.exeBranchInfo;
     /*
-    if (takenEntry.isCall || takenEntry.isReturn) {
+    if (takenEntry.isCall() || takenEntry.isReturn()) {
         printStack("before recoverState", tid);
     }*/
     // recover sp and tos first
@@ -181,10 +176,10 @@ BTBRAS::recoverState(const FetchTarget &entry)
 
     // do push & pops on control squash
     if (entry.exeTaken) {
-        if (takenEntry.isCall) {
+        if (takenEntry.isCall()) {
             push(tid, retAddr);
         }
-        if (takenEntry.isReturn) {
+        if (takenEntry.isReturn()) {
             pop(tid);
             //TOSW = (TOSR + 1) % numInflightEntries;
         }
@@ -192,8 +187,8 @@ BTBRAS::recoverState(const FetchTarget &entry)
 
     
     if (entry.exeTaken) {
-        DPRINTF(RAS, "isCall %d, isRet %d\n", takenEntry.isCall, takenEntry.isReturn);
-        if (takenEntry.isReturn) {
+        DPRINTF(RAS, "isCall %d, isRet %d\n", takenEntry.isCall(), takenEntry.isReturn());
+        if (takenEntry.isReturn()) {
             DPRINTF(RAS, "IsRet expect target %lx, preded %lx, pred taken %d pred target %lx\n",
                 takenEntry.target, meta_ptr->target, entry.predTaken, entry.predBranchInfo.target);
         }
@@ -218,19 +213,19 @@ BTBRAS::update(const FetchTarget &entry)
         } else
             DPRINTF(RAS, "ssp and nsp match, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n",
                 meta_ptr->ssp, meta_ptr->sctr, state.nsp, state.stack[state.nsp].data.ctr);
-        if (takenEntry.isCall) {
+        if (takenEntry.isCall()) {
             DPRINTF(RAS, "real update call BTB hit %d meta TOSR %d TOSW %d\n entry PC %lx",
                 entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
             Addr retAddr = takenEntry.pc + takenEntry.size;
             push_stack(tid, retAddr);
             state.BOS = inflightPtrPlus1(meta_ptr->TOSW);
         }
-        if (takenEntry.isReturn) {
+        if (takenEntry.isReturn()) {
             DPRINTF(RAS, "update ret entry PC %lx\n", entry.startPC);
             pop_stack(tid);
         }
     }
-    if (takenEntry.isCall || takenEntry.isReturn) {
+    if (takenEntry.isCall() || takenEntry.isReturn()) {
         printStack("after update(commit)", tid);
     }
 }

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -159,7 +159,7 @@ BTBRAS::recoverState(const FetchTarget &entry)
     const ThreadID tid = entry.tid;
     assert(tid < numThreads);
     auto &state = threadStates[tid];
-    auto takenSlot = entry.exeBranchInfo;
+    auto takenSlot = entry.resolve.branchSlot;
     /*
     if (takenSlot.isCall() || takenSlot.isReturn()) {
         printStack("before recoverState", tid);
@@ -177,7 +177,7 @@ BTBRAS::recoverState(const FetchTarget &entry)
     Addr retAddr = takenSlot.pc + takenSlot.size;
 
     // do push & pops on control squash
-    if (entry.exeTaken) {
+    if (entry.resolve.taken) {
         if (takenSlot.isCall()) {
             push(tid, retAddr);
         }
@@ -188,7 +188,7 @@ BTBRAS::recoverState(const FetchTarget &entry)
     }
 
     
-    if (entry.exeTaken) {
+    if (entry.resolve.taken) {
         DPRINTF(RAS, "isCall %d, isRet %d\n", takenSlot.isCall(),
                 takenSlot.isReturn());
         if (takenSlot.isReturn()) {
@@ -208,8 +208,8 @@ BTBRAS::update(const FetchTarget &entry)
     assert(tid < numThreads);
     auto &state = threadStates[tid];
     auto meta_ptr = std::static_pointer_cast<RASMeta>(entry.predMetas[getComponentIdx()]);
-    auto takenSlot = entry.exeBranchInfo;
-    if (entry.exeTaken) {
+    auto takenSlot = entry.resolve.branchSlot;
+    if (entry.resolve.taken) {
         if (meta_ptr->ssp != state.nsp || meta_ptr->sctr != state.stack[state.nsp].data.ctr) {
             DPRINTF(RAS, "ssp and nsp mismatch, recovering, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n",
                 meta_ptr->ssp, meta_ptr->sctr, state.nsp, state.stack[state.nsp].data.ctr);

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -167,7 +167,8 @@ BTBRAS::recoverState(const FetchTarget &entry)
     // recover sp and tos first
     auto meta_ptr = std::static_pointer_cast<RASMeta>(entry.predMetas[getComponentIdx()]);
     DPRINTF(RAS, "recover called, meta TOSR %d TOSW %d ssp %d sctr %u entry PC %lx end PC %lx\n",
-        meta_ptr->TOSR, meta_ptr->TOSW, meta_ptr->ssp, meta_ptr->sctr, entry.startPC, entry.predEndPC);
+        meta_ptr->TOSR, meta_ptr->TOSW, meta_ptr->ssp, meta_ptr->sctr,
+        entry.startPC, entry.prediction.fallThrough);
 
     state.TOSR = meta_ptr->TOSR;
     state.TOSW = meta_ptr->TOSW;
@@ -192,8 +193,8 @@ BTBRAS::recoverState(const FetchTarget &entry)
                 takenSlot.isReturn());
         if (takenSlot.isReturn()) {
             DPRINTF(RAS, "IsRet expect target %lx, preded %lx, pred taken %d pred target %lx\n",
-                takenSlot.target, meta_ptr->target, entry.predTaken,
-                entry.predBranchInfo.target);
+                takenSlot.target, meta_ptr->target, entry.prediction.taken,
+                entry.prediction.branchSlot.target);
         }
         printStack("after recoverState", tid);
     }
@@ -218,7 +219,8 @@ BTBRAS::update(const FetchTarget &entry)
                 meta_ptr->ssp, meta_ptr->sctr, state.nsp, state.stack[state.nsp].data.ctr);
         if (takenSlot.isCall()) {
             DPRINTF(RAS, "real update call BTB hit %d meta TOSR %d TOSW %d\n entry PC %lx",
-                entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
+                entry.prediction.btbHit, meta_ptr->TOSR, meta_ptr->TOSW,
+                entry.startPC);
             Addr retAddr = takenSlot.pc + takenSlot.size;
             push_stack(tid, retAddr);
             state.BOS = inflightPtrPlus1(meta_ptr->TOSW);

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -44,6 +44,10 @@ GTest('history_manager.test',
     'history_manager.test.cc',
 )
 
+GTest('prediction_result.test',
+    'prediction_result.test.cc',
+)
+
 # add --unit-test to enable unit test mode for RAS
 # TODO: Fix RAS test
 # GTest('ras.test',
@@ -59,6 +63,7 @@ env.Append(UNITTESTS=['uras.test',
         'mgsc.test',
         'folded_hist.test',
         'history_manager.test',
+        'prediction_result.test',
         'jump_ahead.test',
         'fetch_target_queue.test',
         'decoupled_bpred.test'])

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -48,6 +48,10 @@ GTest('prediction_result.test',
     'prediction_result.test.cc',
 )
 
+GTest('final_prediction_selector.test',
+    'final_prediction_selector.test.cc',
+)
+
 # add --unit-test to enable unit test mode for RAS
 # TODO: Fix RAS test
 # GTest('ras.test',
@@ -64,6 +68,7 @@ env.Append(UNITTESTS=['uras.test',
         'folded_hist.test',
         'history_manager.test',
         'prediction_result.test',
+        'final_prediction_selector.test',
         'jump_ahead.test',
         'fetch_target_queue.test',
         'decoupled_bpred.test'])

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -3,7 +3,6 @@ Import('*')
 # all below tests must add --unit-test to enable unit test mode!
 # eg: scons build/RISCV/cpu/pred/btb/test/tage.test.debug --unit-test -j100
 
-# Add the test source files
 GTest('uras.test', 'uras_test.cc')
 
 # Add BTB test with minimal dependencies

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -33,12 +33,12 @@ FetchTarget createStream(Addr startPC, FullBTBPrediction &pred, AheadBTB *abtb) 
 }
 
 void resolveStream(FetchTarget &stream, bool taken, Addr brPc, Addr target, bool isCond, int size=4) {
-    stream.resolved = true;
-    stream.exeBranchInfo.pc = brPc;
-    stream.exeBranchInfo.target = target;
-    stream.exeBranchInfo.setTypeFromFlags(isCond, false, !isCond, false, false);
-    stream.exeBranchInfo.size = size;
-    stream.exeTaken = taken;
+    stream.resolve.valid = true;
+    stream.resolve.branchSlot.pc = brPc;
+    stream.resolve.branchSlot.target = target;
+    stream.resolve.branchSlot.setTypeFromFlags(isCond, false, !isCond, false, false);
+    stream.resolve.branchSlot.size = size;
+    stream.resolve.taken = taken;
 }
 
 FullBTBPrediction makePrediction(Addr startPC, AheadBTB *abtb,

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -36,7 +36,7 @@ void resolveStream(FetchTarget &stream, bool taken, Addr brPc, Addr target, bool
     stream.resolved = true;
     stream.exeBranchInfo.pc = brPc;
     stream.exeBranchInfo.target = target;
-    stream.exeBranchInfo.isCond = isCond;
+    stream.exeBranchInfo.setTypeFromFlags(isCond, false, !isCond, false, false);
     stream.exeBranchInfo.size = size;
     stream.exeTaken = taken;
 }
@@ -118,8 +118,8 @@ TEST_F(ABTBTest, BasicPredictionUpdateCycle){
     auto pred_B_test = makePrediction(startPC_B, abtb);
     EXPECT_EQ(pred_B_test.btbEntries.size(), 1);
     if (!pred_B_test.btbEntries.empty()) {
-        EXPECT_EQ(pred_B_test.btbEntries[0].pc, brPC_B);
-        EXPECT_EQ(pred_B_test.btbEntries[0].target, target_B);
+        EXPECT_EQ(pred_B_test.btbEntries[0].slot.pc, brPC_B);
+        EXPECT_EQ(pred_B_test.btbEntries[0].slot.target, target_B);
     }
 
 }
@@ -194,8 +194,8 @@ TEST_F(ABTBTest, AheadPipelineIsThreadIsolated){
 
     EXPECT_EQ(pred_t0_test.btbEntries.size(), 1);
     if (!pred_t0_test.btbEntries.empty()) {
-        EXPECT_EQ(pred_t0_test.btbEntries[0].pc, t0BrPC);
-        EXPECT_EQ(pred_t0_test.btbEntries[0].target, t0Target);
+        EXPECT_EQ(pred_t0_test.btbEntries[0].slot.pc, t0BrPC);
+        EXPECT_EQ(pred_t0_test.btbEntries[0].slot.target, t0Target);
     }
 }
 

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -23,11 +23,11 @@ FetchTarget createStream(Addr startPC, FullBTBPrediction &pred, AheadBTB *abtb) 
     stream.asidHash = pred.asidHash;
     stream.startPC = startPC;
     Addr fallThroughAddr = pred.getFallThrough(abtb->predictWidth);
-    stream.isHit = pred.btbEntries.size() > 0; // TODO: fix isHit and falseHit
-    stream.falseHit = false;
-    stream.predBTBEntries = pred.btbEntries;
-    stream.predTaken = pred.isTaken();
-    stream.predEndPC = fallThroughAddr;
+    stream.prediction.btbHit = pred.btbEntries.size() > 0;
+    stream.prediction.falseHit = false;
+    stream.prediction.btbEntries = pred.btbEntries;
+    stream.prediction.taken = pred.isTaken();
+    stream.prediction.fallThrough = fallThroughAddr;
     stream.predMetas[0] = abtb->getPredictionMeta(stream.tid);
     return stream;
 }

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -48,7 +48,6 @@ FullBTBPrediction makePrediction(Addr startPC, AheadBTB *abtb,
         stagePreds[i].tid = tid;
         stagePreds[i].asidHash = asidHash;
         stagePreds[i].bbStart = startPC;
-        stagePreds[i].predSource = i;
     }
     boost::dynamic_bitset<> history(8, 0); // history does not matter for BTB
     abtb->putPCHistory(startPC, history, stagePreds);

--- a/src/cpu/pred/btb/test/abtb.test.cc
+++ b/src/cpu/pred/btb/test/abtb.test.cc
@@ -61,7 +61,7 @@ void clearAheadPipeline(AheadBTB *abtb, ThreadID tid) {
 }
 
 void updateBTB(FetchTarget &stream, AheadBTB *abtb, MBTB *mbtb) {
-    mbtb->getAndSetNewBTBEntry(stream); // usually called by mbtb, here for testing purpose
+    stream.update.setEntrySelection(mbtb->selectUpdateEntry(stream));
     abtb->update(stream);
 }
 

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -36,10 +36,7 @@ BranchInfo createBranchInfo(Addr pc, Addr target, bool isCond = false,
     BranchInfo info;
     info.pc = pc;
     info.target = target;
-    info.isCond = isCond;
-    info.isIndirect = isIndirect;
-    info.isCall = isCall;
-    info.isReturn = isReturn;
+    info.setTypeFromFlags(isCond, isIndirect, false, isCall, isReturn);
     info.size = size;
     return info;
 }
@@ -136,9 +133,9 @@ predictUpdateCycle(MBTB* btb,
     btb->getAndSetNewBTBEntry(stream);
 
     for (auto &entry : stream.updateBTBEntries) {
-        entry.resolved = true;
+        entry.slot.resolved = true;
     }
-    stream.updateNewBTBEntry.resolved = true;
+    stream.updateNewBTBEntry.slot.resolved = true;
 
     btb->update(stream);
 
@@ -164,8 +161,10 @@ void verifyPrediction(const std::vector<FullBTBPrediction>& stagePreds,
     for (int i = delay; i < stagePreds.size(); i++) {
         ASSERT_EQ(stagePreds[i].btbEntries.size(), expectedEntries.size());
         for (size_t j = 0; j < expectedEntries.size(); j++) {
-            EXPECT_EQ(stagePreds[i].btbEntries[j].pc, expectedEntries[j].pc);
-            EXPECT_EQ(stagePreds[i].btbEntries[j].target, expectedEntries[j].target);
+            EXPECT_EQ(stagePreds[i].btbEntries[j].slot.pc,
+                      expectedEntries[j].pc);
+            EXPECT_EQ(stagePreds[i].btbEntries[j].slot.target,
+                      expectedEntries[j].target);
         }
     }
 }

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -131,7 +131,7 @@ predictUpdateCycle(MBTB* btb,
             stagePreds[btb->getDelay()].btbEntries;
     }
     stream.setUpdateBTBEntries();
-    btb->getAndSetNewBTBEntry(stream);
+    stream.update.setEntrySelection(btb->selectUpdateEntry(stream));
 
     for (auto &entry : stream.update.btbEntries) {
         entry.slot.resolved = true;
@@ -210,7 +210,7 @@ TEST_F(BTBTest, EmptyPrediction) {
 // BTB actual update process:
 // 1. putPCHistory, store result in stagePreds, update meta
 // 2. getPredictionMeta, set to stream.predMetas[0]
-// 3. getAndSetNewBTBEntry, only L1 BTB has this function
+// 3. selectUpdateEntry, only L1 BTB has this function
 // 4. update, update btb entries
 
 // Test basic prediction after update
@@ -367,7 +367,7 @@ TEST_F(BTBTest, MultipleBranchPrediction) {
     auto meta = mbtb->getPredictionMeta();
 
     FetchTarget stream = setupStream(0x1000, branch2, true, meta, 0x1008);
-    mbtb->getAndSetNewBTBEntry(stream);
+    stream.update.setEntrySelection(mbtb->selectUpdateEntry(stream));
     mbtb->update(stream);
     
     // Check final predictions

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -127,7 +127,8 @@ predictUpdateCycle(MBTB* btb,
     // Populate predicted BTB entries in stream from stage predictions
     // Use entries from the first valid stage (delay)
     if (btb->getDelay() < stagePreds.size()) {
-        stream.predBTBEntries = stagePreds[btb->getDelay()].btbEntries;
+        stream.prediction.btbEntries =
+            stagePreds[btb->getDelay()].btbEntries;
     }
     stream.setUpdateBTBEntries();
     btb->getAndSetNewBTBEntry(stream);

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -55,12 +55,12 @@ FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
                        std::shared_ptr<void> meta, Addr endInstPC) {
     FetchTarget stream;
     stream.startPC = startPC;
-    stream.resolved = true;
-    stream.exeBranchInfo = branch;
-    stream.exeTaken = taken;
+    stream.resolve.valid = true;
+    stream.resolve.branchSlot = branch;
+    stream.resolve.taken = taken;
     stream.predMetas[0] = meta;
-    stream.updateEndInstPC = endInstPC;
-    stream.squashType = SQUASH_CTRL; // mispredict default
+    stream.update.endInstPC = endInstPC;
+    stream.resolve.squashType = SQUASH_CTRL; // mispredict default
     return stream;
 }
 
@@ -133,10 +133,10 @@ predictUpdateCycle(MBTB* btb,
     stream.setUpdateBTBEntries();
     btb->getAndSetNewBTBEntry(stream);
 
-    for (auto &entry : stream.updateBTBEntries) {
+    for (auto &entry : stream.update.btbEntries) {
         entry.slot.resolved = true;
     }
-    stream.updateNewBTBEntry.slot.resolved = true;
+    stream.update.newBTBEntry.slot.resolved = true;
 
     btb->update(stream);
 

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -297,7 +297,7 @@ struct MgscHarness
             recover_stream.startPC = start_pc;
             recover_stream.predMetas[mgsc.getComponentIdx()] = meta;
             recover_stream.resolved = true;
-            recover_stream.exeBranchInfo = entry.getBranchInfo();
+            recover_stream.exeBranchInfo = entry.slot;
             recover_stream.exeTaken = actual_taken;
             recover_stream.squashPC = entry.slot.pc;
 
@@ -327,7 +327,7 @@ struct MgscHarness
         update_stream.updateBTBEntries = {entry};
         update_stream.updateIsOldEntry = true;
         update_stream.resolved = true;
-        update_stream.exeBranchInfo = entry.getBranchInfo();
+        update_stream.exeBranchInfo = entry.slot;
         update_stream.exeTaken = actual_taken;
         update_stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(update_stream);
@@ -515,7 +515,7 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
         stream.updateBTBEntries = {entry};
         stream.updateIsOldEntry = true;
         stream.resolved = true;
-        stream.exeBranchInfo = entry.getBranchInfo();
+        stream.exeBranchInfo = entry.slot;
         stream.exeTaken = true;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);
@@ -529,7 +529,7 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
         stream.updateBTBEntries = {entry};
         stream.updateIsOldEntry = true;
         stream.resolved = true;
-        stream.exeBranchInfo = entry.getBranchInfo();
+        stream.exeBranchInfo = entry.slot;
         stream.exeTaken = false;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -296,10 +296,10 @@ struct MgscHarness
             FetchTarget recover_stream;
             recover_stream.startPC = start_pc;
             recover_stream.predMetas[mgsc.getComponentIdx()] = meta;
-            recover_stream.resolved = true;
-            recover_stream.exeBranchInfo = entry.slot;
-            recover_stream.exeTaken = actual_taken;
-            recover_stream.squashPC = entry.slot.pc;
+            recover_stream.resolve.valid = true;
+            recover_stream.resolve.branchSlot = entry.slot;
+            recover_stream.resolve.taken = actual_taken;
+            recover_stream.resolve.squashPC = entry.slot.pc;
 
             mgsc.recoverHist(ghr, recover_stream, ghist.shamt, actual_taken);
             const auto actual_phist = recover_stream.getPHistUpdateDuringSquash(
@@ -324,11 +324,11 @@ struct MgscHarness
         // Training update using prediction meta
         FetchTarget update_stream;
         update_stream.startPC = start_pc;
-        update_stream.updateBTBEntries = {entry};
-        update_stream.updateIsOldEntry = true;
-        update_stream.resolved = true;
-        update_stream.exeBranchInfo = entry.slot;
-        update_stream.exeTaken = actual_taken;
+        update_stream.update.btbEntries = {entry};
+        update_stream.update.isOldEntry = true;
+        update_stream.resolve.valid = true;
+        update_stream.resolve.branchSlot = entry.slot;
+        update_stream.resolve.taken = actual_taken;
         update_stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(update_stream);
 
@@ -512,11 +512,11 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
     {
         FetchTarget stream;
         stream.startPC = start_pc;
-        stream.updateBTBEntries = {entry};
-        stream.updateIsOldEntry = true;
-        stream.resolved = true;
-        stream.exeBranchInfo = entry.slot;
-        stream.exeTaken = true;
+        stream.update.btbEntries = {entry};
+        stream.update.isOldEntry = true;
+        stream.resolve.valid = true;
+        stream.resolve.branchSlot = entry.slot;
+        stream.resolve.taken = true;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);
         EXPECT_EQ(bw_table[0][bw_i1][bw_i2], before);
@@ -526,11 +526,11 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
     {
         FetchTarget stream;
         stream.startPC = start_pc;
-        stream.updateBTBEntries = {entry};
-        stream.updateIsOldEntry = true;
-        stream.resolved = true;
-        stream.exeBranchInfo = entry.slot;
-        stream.exeTaken = false;
+        stream.update.btbEntries = {entry};
+        stream.update.isOldEntry = true;
+        stream.resolve.valid = true;
+        stream.resolve.branchSlot = entry.slot;
+        stream.resolve.taken = false;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);
         EXPECT_EQ(bw_table[0][bw_i1][bw_i2], static_cast<int16_t>(before - 1));

--- a/src/cpu/pred/btb/test/btb_mgsc.test.cc
+++ b/src/cpu/pred/btb/test/btb_mgsc.test.cc
@@ -23,12 +23,12 @@ BTBEntry
 makeCondBTBEntry(Addr pc)
 {
     BTBEntry entry;
-    entry.pc = pc;
-    entry.target = pc + 4;
-    entry.isCond = true;
+    entry.slot.pc = pc;
+    entry.slot.target = pc + 4;
+    entry.slot.setTypeFromFlags(true, false, false, false, false);
     entry.valid = true;
     entry.alwaysTaken = false;
-    entry.size = 4;
+    entry.slot.size = 4;
     return entry;
 }
 
@@ -227,11 +227,12 @@ struct MgscHarness
     StepResult
     step(Addr start_pc, const BTBEntry &entry, const TageInfoForMGSC &tage_info, bool actual_taken)
     {
+        const Addr branch_pc = entry.slot.pc;
         for (auto &pred : stage_preds) {
             pred.bbStart = start_pc;
             pred.btbEntries = {entry};
             pred.tageInfoForMgscs.clear();
-            pred.tageInfoForMgscs[entry.pc] = tage_info;
+            pred.tageInfoForMgscs[branch_pc] = tage_info;
         }
 
         // Prediction
@@ -243,7 +244,7 @@ struct MgscHarness
         mgsc.putPCHistory(start_pc, ghr, stage_preds);
         auto meta = mgsc.getPredictionMeta();
 
-        auto [found, pred_taken] = findCondTaken(stage_preds[1].condTakens, entry.pc);
+        auto [found, pred_taken] = findCondTaken(stage_preds[1].condTakens, branch_pc);
         EXPECT_TRUE(found);
 
         // Snapshot per-branch MGSC prediction info (indexes/percsums/thresholds).
@@ -251,7 +252,7 @@ struct MgscHarness
         result.predicted_taken = pred_taken;
         {
             const auto &preds = BTBMGSC::TestAccess::preds(mgsc);
-            auto it = preds.find(entry.pc);
+            auto it = preds.find(branch_pc);
             EXPECT_NE(it, preds.end());
             if (it != preds.end()) {
                 result.mgsc_pred = it->second;
@@ -296,16 +297,17 @@ struct MgscHarness
             recover_stream.startPC = start_pc;
             recover_stream.predMetas[mgsc.getComponentIdx()] = meta;
             recover_stream.resolved = true;
-            recover_stream.exeBranchInfo = entry;
+            recover_stream.exeBranchInfo = entry.getBranchInfo();
             recover_stream.exeTaken = actual_taken;
-            recover_stream.squashPC = entry.pc;
+            recover_stream.squashPC = entry.slot.pc;
 
             mgsc.recoverHist(ghr, recover_stream, ghist.shamt, actual_taken);
             const auto actual_phist = recover_stream.getPHistUpdateDuringSquash(
-                entry.pc, actual_taken, entry.target);
+                entry.slot.pc, actual_taken, entry.slot.target);
             mgsc.recoverPHist(phr, recover_stream, actual_phist);
 
-            bool actual_bw_taken = actual_taken && (entry.target < entry.pc);
+            bool actual_bw_taken =
+                actual_taken && (entry.slot.target < entry.slot.pc);
             mgsc.recoverBwHist(bwhr, recover_stream,
                                bwhist.shamt, actual_bw_taken);
             mgsc.recoverIHist(recover_stream, bwhist.shamt, actual_bw_taken);
@@ -325,7 +327,7 @@ struct MgscHarness
         update_stream.updateBTBEntries = {entry};
         update_stream.updateIsOldEntry = true;
         update_stream.resolved = true;
-        update_stream.exeBranchInfo = entry;
+        update_stream.exeBranchInfo = entry.getBranchInfo();
         update_stream.exeTaken = actual_taken;
         update_stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(update_stream);
@@ -513,7 +515,7 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
         stream.updateBTBEntries = {entry};
         stream.updateIsOldEntry = true;
         stream.resolved = true;
-        stream.exeBranchInfo = entry;
+        stream.exeBranchInfo = entry.getBranchInfo();
         stream.exeTaken = true;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);
@@ -527,7 +529,7 @@ TEST(BTBMGSCTest, UpdateOnlyOnWrongOrLowMargin)
         stream.updateBTBEntries = {entry};
         stream.updateIsOldEntry = true;
         stream.resolved = true;
-        stream.exeBranchInfo = entry;
+        stream.exeBranchInfo = entry.getBranchInfo();
         stream.exeTaken = false;
         stream.predMetas[mgsc.getComponentIdx()] = meta;
         mgsc.update(stream);
@@ -593,7 +595,7 @@ TEST(BTBMGSCTest, BwTableLearnsAlternatingPatternOnBackwardBranches)
     const Addr start_pc = 0x1000;
     const Addr branch_pc = 0x1000;
     auto entry = makeCondBTBEntry(branch_pc);
-    entry.target = branch_pc - 4; // backward branch so bw_taken == taken
+    entry.slot.target = branch_pc - 4; // backward branch so bw_taken == taken
 
     const TageInfoForMGSC tage_info(
         /*tage_pred_taken=*/false,
@@ -638,7 +640,7 @@ TEST(BTBMGSCTest, ITableLearnsFixedTripCountLoop)
     const Addr start_pc = 0x1000;
     const Addr branch_pc = 0x1000;
     auto entry = makeCondBTBEntry(branch_pc);
-    entry.target = branch_pc - 4; // backward loop branch
+    entry.slot.target = branch_pc - 4; // backward loop branch
 
     const TageInfoForMGSC tage_info(
         /*tage_pred_taken=*/false,
@@ -823,7 +825,7 @@ TEST(BTBMGSCTest, PTableLearnsOutcomeFromPreviousTakenBranchTarget)
 
     for (int i = 0; i < iters; ++i) {
         bool use_target0 = (i % 2) == 0;
-        entry_a.target = use_target0 ? target0 : target1;
+        entry_a.slot.target = use_target0 ? target0 : target1;
 
         // Step A: always taken so path history is updated with its (pc,target) hash.
         (void)h.step(start_pc_a, entry_a, tage_info, /*actual_taken=*/true);
@@ -853,19 +855,20 @@ TEST(BTBMGSCTest, SpecUpdatePHistUsesIndirectTargetOverride)
     MgscHarness h;
 
     BTBEntry entry = makeCondBTBEntry(0x1000);
-    entry.isIndirect = true;
-    entry.target = 0x2000;
+    entry.slot.setTypeFromFlags(false, true, false, false, false);
+    entry.slot.target = 0x2000;
     const Addr indirectTarget = 0x3000;
 
-    ASSERT_NE(pathHash(entry.pc, entry.target), pathHash(entry.pc, indirectTarget));
+    ASSERT_NE(pathHash(entry.slot.pc, entry.slot.target),
+              pathHash(entry.slot.pc, indirectTarget));
 
     FullBTBPrediction pred;
     pred.btbEntries = {entry};
-    pred.condTakens.push_back({entry.pc, true});
-    pred.indirectTargets.push_back({entry.pc, indirectTarget});
+    pred.condTakens.push_back({entry.slot.pc, true});
+    pred.indirectTargets.push_back({entry.slot.pc, indirectTarget});
 
     boost::dynamic_bitset<> expected_phr = h.phr;
-    pHistShiftIn(2, true, expected_phr, entry.pc, indirectTarget);
+    pHistShiftIn(2, true, expected_phr, entry.slot.pc, indirectTarget);
 
     h.mgsc.specUpdatePHist(h.phr, pred, pred.getPHistUpdate());
     h.mgsc.checkFoldedHist(h.ghr, expected_phr, h.lhr,
@@ -877,20 +880,20 @@ TEST(BTBMGSCTest, SpecUpdatePHistUsesReturnTargetOverride)
     MgscHarness h;
 
     BTBEntry entry = makeCondBTBEntry(0x1000);
-    entry.isIndirect = true;
-    entry.isReturn = true;
-    entry.target = 0x2000;
+    entry.slot.setTypeFromFlags(false, true, false, false, true);
+    entry.slot.target = 0x2000;
     const Addr returnTarget = 0x3400;
 
-    ASSERT_NE(pathHash(entry.pc, entry.target), pathHash(entry.pc, returnTarget));
+    ASSERT_NE(pathHash(entry.slot.pc, entry.slot.target),
+              pathHash(entry.slot.pc, returnTarget));
 
     FullBTBPrediction pred;
     pred.btbEntries = {entry};
-    pred.condTakens.push_back({entry.pc, true});
+    pred.condTakens.push_back({entry.slot.pc, true});
     pred.returnTarget = returnTarget;
 
     boost::dynamic_bitset<> expected_phr = h.phr;
-    pHistShiftIn(2, true, expected_phr, entry.pc, returnTarget);
+    pHistShiftIn(2, true, expected_phr, entry.slot.pc, returnTarget);
 
     h.mgsc.specUpdatePHist(h.phr, pred, pred.getPHistUpdate());
     h.mgsc.checkFoldedHist(h.ghr, expected_phr, h.lhr,

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -62,20 +62,20 @@ FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
                          std::shared_ptr<void> meta) {
     FetchTarget stream;
     stream.startPC = startPC;
-    stream.exeBranchInfo = entry.slot;
-    stream.exeTaken = taken;
-    // Mark as resolved so recover paths use exe* info
-    stream.resolved = true;
+    stream.resolve.branchSlot = entry.slot;
+    stream.resolve.taken = taken;
+    // Mark as resolved so recover paths use actual branch info
+    stream.resolve.valid = true;
     stream.prediction.branchSlot = entry.slot; // keep fields consistent
-    stream.updateBTBEntries = {entry};
-    stream.updateIsOldEntry = true;
+    stream.update.btbEntries = {entry};
+    stream.update.isOldEntry = true;
     stream.predMetas[0] = meta;
     return stream;
 }
 
 FetchTarget setMispredStream(FetchTarget stream) {
-    stream.squashType = SquashType::SQUASH_CTRL;
-    stream.squashPC = stream.exeBranchInfo.pc;
+    stream.resolve.squashType = SquashType::SQUASH_CTRL;
+    stream.resolve.squashPC = stream.resolve.branchSlot.pc;
     return stream;
 }
 
@@ -153,7 +153,7 @@ void applyActualHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
 PathHistoryUpdate getActualPathUpdate(const FetchTarget& stream)
 {
     return stream.getPHistUpdateDuringSquash(
-        stream.squashPC, stream.exeTaken, stream.exeBranchInfo.target);
+        stream.resolve.squashPC, stream.resolve.taken, stream.resolve.branchSlot.target);
 }
 
 TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
@@ -284,10 +284,10 @@ TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
         FetchTarget stream;
         stream.startPC = 0x1000;
         stream.prediction.btbEntries = c.predictedBeforeSquash;
-        stream.exeBranchInfo = c.resolvedEntry.slot;
-        stream.exeTaken = c.actualTaken;
-        stream.resolved = true;
-        stream.squashPC = c.squashPC;
+        stream.resolve.branchSlot = c.resolvedEntry.slot;
+        stream.resolve.taken = c.actualTaken;
+        stream.resolve.valid = true;
+        stream.resolve.squashPC = c.squashPC;
 
         const auto ghist = stream.getGHistUpdateDuringSquash(
             c.squashPC, c.isCond, c.actualTaken);
@@ -415,7 +415,7 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
         const auto path_update = getActualPathUpdate(stream);
         recoverSelectedHistory(tage, history, stream, 1, actual_taken,
                                path_update);
-        applyActualHistory(tage, history, stream.exeBranchInfo, 1, actual_taken);
+        applyActualHistory(tage, history, stream.resolve.branchSlot, 1, actual_taken);
         tage->checkFoldedHist(history, "recover");
     }
 
@@ -710,8 +710,8 @@ TEST_F(BTBTAGETest, EntryAllocationAndReplacement) {
     // Although it has the same PC, we'll treat it as a different branch context
     // by setting a specific tag that doesn't match existing entries
     FetchTarget stream = createStream(0x1000, entry2, !predicted, meta);
-    stream.squashType = SquashType::SQUASH_CTRL; // Mark as control misprediction
-    stream.squashPC = 0x1000;
+    stream.resolve.squashType = SquashType::SQUASH_CTRL; // Mark as control misprediction
+    stream.resolve.squashPC = 0x1000;
 
     // Update the predictor. With RTL-aligned highest-table gating, this should
     // not report a final allocation failure.
@@ -733,8 +733,8 @@ TEST_F(BTBTAGETest, HighestTableProviderSuppressesAllocation) {
     auto meta = tage->getPredictionMeta();
 
     FetchTarget stream = createStream(0x1000, entry, false, meta);
-    stream.squashType = SquashType::SQUASH_CTRL;
-    stream.squashPC = 0x1000;
+    stream.resolve.squashType = SquashType::SQUASH_CTRL;
+    stream.resolve.squashPC = 0x1000;
 
     int alloc_failed_before = tage->tageStats.updateAllocFailureNoValidTable;
     tage->update(stream);
@@ -813,8 +813,8 @@ TEST_F(BTBTAGETest, MultipleBranchSequence) {
 
     // Update second branch (incorrect prediction), allocate 1 entry
     FetchTarget stream2 = createStream(0x1000, btbEntries[1], !second_pred, meta);
-    stream2.squashType = SquashType::SQUASH_CTRL;
-    stream2.squashPC = 0x1004;
+    stream2.resolve.squashType = SquashType::SQUASH_CTRL;
+    stream2.resolve.squashPC = 0x1004;
     tage->update(stream2);
 
     // Verify both branches have entries allocated
@@ -1198,13 +1198,13 @@ TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry.slot;
-    stream.exeTaken = true;
-    stream.resolved = true;
+    stream.resolve.branchSlot = newEntry.slot;
+    stream.resolve.taken = true;
+    stream.resolve.valid = true;
     stream.prediction.branchSlot = newEntry.slot;
-    stream.updateBTBEntries.clear();
-    stream.updateIsOldEntry = false;
-    stream.updateNewBTBEntry = newEntry;
+    stream.update.btbEntries.clear();
+    stream.update.isOldEntry = false;
+    stream.update.newBTBEntry = newEntry;
     stream.predMetas[0] = meta;
     stream = setMispredStream(stream);
 
@@ -1385,13 +1385,13 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry.slot;
-    stream.exeTaken = true;
-    stream.resolved = true;
+    stream.resolve.branchSlot = newEntry.slot;
+    stream.resolve.taken = true;
+    stream.resolve.valid = true;
     stream.prediction.branchSlot = newEntry.slot;
-    stream.updateBTBEntries.clear();
-    stream.updateIsOldEntry = false;
-    stream.updateNewBTBEntry = newEntry;
+    stream.update.btbEntries.clear();
+    stream.update.isOldEntry = false;
+    stream.update.newBTBEntry = newEntry;
     stream.predMetas[0] = meta;
     stream = setMispredStream(stream);
 

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -284,7 +284,7 @@ TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
         FetchTarget stream;
         stream.startPC = 0x1000;
         stream.prediction.btbEntries = c.predictedBeforeSquash;
-        stream.exeBranchInfo = c.resolvedEntry;
+        stream.exeBranchInfo = c.resolvedEntry.slot;
         stream.exeTaken = c.actualTaken;
         stream.resolved = true;
         stream.squashPC = c.squashPC;

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -62,11 +62,11 @@ FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
                          std::shared_ptr<void> meta) {
     FetchTarget stream;
     stream.startPC = startPC;
-    stream.exeBranchInfo = entry.getBranchInfo();
+    stream.exeBranchInfo = entry.slot;
     stream.exeTaken = taken;
     // Mark as resolved so recover paths use exe* info
     stream.resolved = true;
-    stream.predBranchInfo = entry.getBranchInfo(); // keep fields consistent
+    stream.predBranchInfo = entry.slot; // keep fields consistent
     stream.updateBTBEntries = {entry};
     stream.updateIsOldEntry = true;
     stream.predMetas[0] = meta;
@@ -1198,10 +1198,10 @@ TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry.getBranchInfo();
+    stream.exeBranchInfo = newEntry.slot;
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry.getBranchInfo();
+    stream.predBranchInfo = newEntry.slot;
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;
@@ -1385,10 +1385,10 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry.getBranchInfo();
+    stream.exeBranchInfo = newEntry.slot;
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry.getBranchInfo();
+    stream.predBranchInfo = newEntry.slot;
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -66,7 +66,7 @@ FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
     stream.exeTaken = taken;
     // Mark as resolved so recover paths use exe* info
     stream.resolved = true;
-    stream.predBranchInfo = entry.slot; // keep fields consistent
+    stream.prediction.branchSlot = entry.slot; // keep fields consistent
     stream.updateBTBEntries = {entry};
     stream.updateIsOldEntry = true;
     stream.predMetas[0] = meta;
@@ -283,7 +283,7 @@ TEST(FetchTargetHistoryUpdateTest, SquashUpdateSeparatesDirectionAndPath)
 
         FetchTarget stream;
         stream.startPC = 0x1000;
-        stream.predBTBEntries = c.predictedBeforeSquash;
+        stream.prediction.btbEntries = c.predictedBeforeSquash;
         stream.exeBranchInfo = c.resolvedEntry;
         stream.exeTaken = c.actualTaken;
         stream.resolved = true;
@@ -1201,7 +1201,7 @@ TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
     stream.exeBranchInfo = newEntry.slot;
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry.slot;
+    stream.prediction.branchSlot = newEntry.slot;
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;
@@ -1388,7 +1388,7 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
     stream.exeBranchInfo = newEntry.slot;
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry.slot;
+    stream.prediction.branchSlot = newEntry.slot;
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -38,9 +38,9 @@ namespace test
 BTBEntry createBTBEntry(Addr pc, bool isCond = true, bool valid = true,
                         bool alwaysTaken = false, int ctr = 0, Addr target = 0) {
     BTBEntry entry;
-    entry.pc = pc;
-    entry.target = target ? target : (pc + 4);
-    entry.isCond = isCond;
+    entry.slot.pc = pc;
+    entry.slot.target = target ? target : (pc + 4);
+    entry.slot.setTypeFromFlags(isCond, false, !isCond, false, false);
     entry.valid = valid;
     entry.alwaysTaken = alwaysTaken;
     entry.ctr = ctr;
@@ -62,11 +62,11 @@ FetchTarget createStream(Addr startPC, const BTBEntry& entry, bool taken,
                          std::shared_ptr<void> meta) {
     FetchTarget stream;
     stream.startPC = startPC;
-    stream.exeBranchInfo = entry;
+    stream.exeBranchInfo = entry.getBranchInfo();
     stream.exeTaken = taken;
     // Mark as resolved so recover paths use exe* info
     stream.resolved = true;
-    stream.predBranchInfo = entry; // keep fields consistent
+    stream.predBranchInfo = entry.getBranchInfo(); // keep fields consistent
     stream.updateBTBEntries = {entry};
     stream.updateIsOldEntry = true;
     stream.predMetas[0] = meta;
@@ -143,7 +143,7 @@ void applyActualHistory(BTBTAGE* tage, boost::dynamic_bitset<>& history,
 {
     if (tage->usesPathHistory()) {
         if (taken) {
-            applyPathHistoryTaken(history, entry.pc, entry.target);
+            applyPathHistoryTaken(history, entry.slot.pc, entry.slot.target);
         }
     } else {
         applyOutcomeHistory(history, shamt, taken);
@@ -345,7 +345,8 @@ bool predictTAGE(BTBTAGE* tage, Addr startPC,
 
     // Return prediction for first entry if exists
     if (!entries.empty()) {
-        auto result = findCondTaken(stagePreds[1].condTakens, entries[0].pc);
+        auto result = findCondTaken(stagePreds[1].condTakens,
+                                    entries[0].slot.pc);
         bool found = result.first;
         bool taken = result.second;
         if (found) {
@@ -375,9 +376,9 @@ bool predictUpdateCycle(BTBTAGE* tage, Addr startPC,
     tage->putPCHistory(startPC, history, stagePreds);
 
     // 2. Get predicted result
-    Addr branch_pc = entry.pc;
+    Addr branch_pc = entry.slot.pc;
     auto it = CondTakens_find(stagePreds[1].condTakens, branch_pc);
-    // ASSERT_TRUE(it != stagePreds[1].condTakens.end()) << "Prediction not found for PC " << std::hex << entry.pc;
+    // ASSERT_TRUE(it != stagePreds[1].condTakens.end());
     bool predicted_taken = it->second;
 
     // 3. Speculatively update folded history
@@ -1025,7 +1026,8 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
 
     // Get prediction for entry1
     bool pred1 = false;
-    auto result_entry1 = findCondTaken(stagePreds[1].condTakens, entry1.pc);
+    auto result_entry1 = findCondTaken(stagePreds[1].condTakens,
+                                       entry1.slot.pc);
     if (result_entry1.first) {
         pred1 = result_entry1.second;
     }
@@ -1043,7 +1045,8 @@ TEST_F(BTBTAGETest, SetAssociativeConflictHandling) {
 
     // Get prediction for entry2
     bool pred2 = false;
-    auto result_entry2 = findCondTaken(stagePreds[1].condTakens, entry2.pc);
+    auto result_entry2 = findCondTaken(stagePreds[1].condTakens,
+                                       entry2.slot.pc);
     if (result_entry2.first) {
         pred2 = result_entry2.second;
     }
@@ -1177,7 +1180,7 @@ TEST_F(BTBTAGETest, AllocationReplacesStrongNotUsefulEntry) {
     bool found = false;
     for (unsigned way = 0; way < tage->numWays[testTable]; way++) {
         if (tage->tageTable[testTable][testIndex][way].valid &&
-            tage->tageTable[testTable][testIndex][way].pc == newEntry.pc) {
+            tage->tageTable[testTable][testIndex][way].pc == newEntry.slot.pc) {
             found = true;
             break;
         }
@@ -1195,10 +1198,10 @@ TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry;
+    stream.exeBranchInfo = newEntry.getBranchInfo();
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry;
+    stream.predBranchInfo = newEntry.getBranchInfo();
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;
@@ -1207,7 +1210,7 @@ TEST_F(BTBTAGETest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
 
     tage->update(stream);
 
-    int table = findTableWithEntry(tage, 0x1000, newEntry.pc);
+    int table = findTableWithEntry(tage, 0x1000, newEntry.slot.pc);
     EXPECT_GE(table, 0)
         << "New conditional entry should still allocate without prediction-time meta";
 }
@@ -1327,9 +1330,9 @@ TEST_F(BTBTAGEUpperBoundTest, ExactContextLookup) {
     boost::dynamic_bitset<> historyB(128, 0);
     historyB[0] = true;
 
-    ASSERT_TRUE(tage->insertExactEntry(3, entry.pc, historyA, 2));
-    EXPECT_TRUE(tage->hasExactEntry(3, entry.pc, historyA));
-    EXPECT_FALSE(tage->hasExactEntry(3, entry.pc, historyB));
+    ASSERT_TRUE(tage->insertExactEntry(3, entry.slot.pc, historyA, 2));
+    EXPECT_TRUE(tage->hasExactEntry(3, entry.slot.pc, historyA));
+    EXPECT_FALSE(tage->hasExactEntry(3, entry.slot.pc, historyB));
 
     bool predA = predictTAGE(tage, 0x1000, {entry}, historyA, stagePreds);
     bool predB = predictTAGE(tage, 0x1000, {entry}, historyB, stagePreds);
@@ -1341,12 +1344,12 @@ TEST_F(BTBTAGEUpperBoundTest, ExactContextLookup) {
 TEST_F(BTBTAGEUpperBoundTest, ProviderAltSelection) {
     BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1);
 
-    ASSERT_TRUE(tage->insertExactEntry(3, entry.pc, history, 0));
-    ASSERT_TRUE(tage->insertExactEntry(1, entry.pc, history, -2));
+    ASSERT_TRUE(tage->insertExactEntry(3, entry.slot.pc, history, 0));
+    ASSERT_TRUE(tage->insertExactEntry(1, entry.slot.pc, history, -2));
 
     predictTAGE(tage, 0x1000, {entry}, history, stagePreds);
     auto meta = std::static_pointer_cast<BTBTAGE::TageMeta>(tage->getPredictionMeta());
-    auto pred = meta->preds[entry.pc];
+    auto pred = meta->preds[entry.slot.pc];
 
     EXPECT_EQ(pred.mainInfo.table, 3u);
     EXPECT_EQ(pred.altInfo.table, 1u);
@@ -1369,8 +1372,8 @@ TEST_F(BTBTAGEUpperBoundTest, AllocationUsesPredictionTimeHistory) {
     tage->recoverHist(historyB, stream, 1, true);
     tage->update(stream);
 
-    EXPECT_TRUE(tage->hasExactEntry(0, entry.pc, historyA));
-    EXPECT_FALSE(tage->hasExactEntry(0, entry.pc, historyB));
+    EXPECT_TRUE(tage->hasExactEntry(0, entry.slot.pc, historyA));
+    EXPECT_FALSE(tage->hasExactEntry(0, entry.slot.pc, historyB));
 }
 
 TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrains) {
@@ -1382,10 +1385,10 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
     BTBEntry newEntry = createBTBEntry(0x1010, true, true, false, -1);
     FetchTarget stream;
     stream.startPC = 0x1000;
-    stream.exeBranchInfo = newEntry;
+    stream.exeBranchInfo = newEntry.getBranchInfo();
     stream.exeTaken = true;
     stream.resolved = true;
-    stream.predBranchInfo = newEntry;
+    stream.predBranchInfo = newEntry.getBranchInfo();
     stream.updateBTBEntries.clear();
     stream.updateIsOldEntry = false;
     stream.updateNewBTBEntry = newEntry;
@@ -1394,20 +1397,20 @@ TEST_F(BTBTAGEUpperBoundTest, NewConditionalEntryWithoutPredictionMetaStillTrain
 
     tage->update(stream);
 
-    EXPECT_TRUE(tage->hasExactEntry(0, newEntry.pc, historyA));
+    EXPECT_TRUE(tage->hasExactEntry(0, newEntry.slot.pc, historyA));
 }
 
 TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesPathHashHistorySnapshot) {
     BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1, 0x2000);
     boost::dynamic_bitset<> pathHistoryA(128, 0);
     boost::dynamic_bitset<> pathHistoryB(128, 0);
-    applyPathHistoryTaken(pathHistoryB, entry.pc, entry.target);
+    applyPathHistoryTaken(pathHistoryB, entry.slot.pc, entry.slot.target);
 
-    ASSERT_TRUE(tage->insertExactEntry(2, entry.pc, pathHistoryB, 2));
+    ASSERT_TRUE(tage->insertExactEntry(2, entry.slot.pc, pathHistoryB, 2));
 
     FullBTBPrediction pred;
     pred.btbEntries.push_back(entry);
-    pred.condTakens.push_back({entry.pc, true});
+    pred.condTakens.push_back({entry.slot.pc, true});
     tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
 
     bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
@@ -1416,54 +1419,55 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesPathHashHistorySnapshot) {
 }
 
 TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesIndirectOverridePathHashSnapshot) {
-    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1, 0x2000);
-    entry.isIndirect = true;
+    BTBEntry indirectEntry = createBTBEntry(0x1000, false, true, false, -1, 0x2000);
+    indirectEntry.slot.setTypeFromFlags(false, true, false, false, false);
+    BTBEntry condEntry = createBTBEntry(0x1004, true, true, false, -1, 0x2010);
     const Addr indirectTarget = 0x3000;
 
-    ASSERT_NE(pathHash(entry.pc, entry.target), pathHash(entry.pc, indirectTarget));
+    ASSERT_NE(pathHash(indirectEntry.slot.pc, indirectEntry.slot.target),
+              pathHash(indirectEntry.slot.pc, indirectTarget));
 
     boost::dynamic_bitset<> pathHistoryA(128, 0);
     boost::dynamic_bitset<> pathHistoryB(128, 0);
-    applyPathHistoryTaken(pathHistoryB, entry.pc, indirectTarget);
+    applyPathHistoryTaken(pathHistoryB, indirectEntry.slot.pc, indirectTarget);
 
-    ASSERT_TRUE(tage->insertExactEntry(2, entry.pc, pathHistoryB, 2));
+    ASSERT_TRUE(tage->insertExactEntry(2, condEntry.slot.pc, pathHistoryB, 2));
 
     FullBTBPrediction pred;
-    pred.btbEntries.push_back(entry);
-    pred.condTakens.push_back({entry.pc, true});
-    pred.indirectTargets.push_back({entry.pc, indirectTarget});
+    pred.btbEntries.push_back(indirectEntry);
+    pred.indirectTargets.push_back({indirectEntry.slot.pc, indirectTarget});
 
     tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
     tage->checkFoldedHist(pathHistoryB, "indirect target override");
 
-    bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
+    bool predicted = predictTAGE(tage, 0x1000, {condEntry}, outcomeHistory, stagePreds);
 
     EXPECT_TRUE(predicted);
 }
 
 TEST_F(BTBTAGEUpperBoundPathHashTest, PredictionUsesReturnOverridePathHashSnapshot) {
-    BTBEntry entry = createBTBEntry(0x1000, true, true, false, -1, 0x2000);
-    entry.isIndirect = true;
-    entry.isReturn = true;
+    BTBEntry returnEntry = createBTBEntry(0x1000, false, true, false, -1, 0x2000);
+    returnEntry.slot.setTypeFromFlags(false, true, false, false, true);
+    BTBEntry condEntry = createBTBEntry(0x1004, true, true, false, -1, 0x2010);
     const Addr returnTarget = 0x3400;
 
-    ASSERT_NE(pathHash(entry.pc, entry.target), pathHash(entry.pc, returnTarget));
+    ASSERT_NE(pathHash(returnEntry.slot.pc, returnEntry.slot.target),
+              pathHash(returnEntry.slot.pc, returnTarget));
 
     boost::dynamic_bitset<> pathHistoryA(128, 0);
     boost::dynamic_bitset<> pathHistoryB(128, 0);
-    applyPathHistoryTaken(pathHistoryB, entry.pc, returnTarget);
+    applyPathHistoryTaken(pathHistoryB, returnEntry.slot.pc, returnTarget);
 
-    ASSERT_TRUE(tage->insertExactEntry(2, entry.pc, pathHistoryB, 2));
+    ASSERT_TRUE(tage->insertExactEntry(2, condEntry.slot.pc, pathHistoryB, 2));
 
     FullBTBPrediction pred;
-    pred.btbEntries.push_back(entry);
-    pred.condTakens.push_back({entry.pc, true});
+    pred.btbEntries.push_back(returnEntry);
     pred.returnTarget = returnTarget;
 
     tage->specUpdatePHist(pathHistoryA, pred, pred.getPHistUpdate());
     tage->checkFoldedHist(pathHistoryB, "return target override");
 
-    bool predicted = predictTAGE(tage, 0x1000, {entry}, outcomeHistory, stagePreds);
+    bool predicted = predictTAGE(tage, 0x1000, {condEntry}, outcomeHistory, stagePreds);
 
     EXPECT_TRUE(predicted);
 }
@@ -1472,7 +1476,7 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
     BTBEntry entry = createBTBEntry(0x1000, false, true, true, -1, 0x2040);
     boost::dynamic_bitset<> pathHistoryBefore(128, 0);
     boost::dynamic_bitset<> pathHistoryAfter(128, 0);
-    applyPathHistoryTaken(pathHistoryAfter, entry.pc, entry.target);
+    applyPathHistoryTaken(pathHistoryAfter, entry.slot.pc, entry.slot.target);
 
     FullBTBPrediction pred;
     pred.btbEntries.push_back(entry);
@@ -1482,14 +1486,15 @@ TEST_F(BTBTAGEUpperBoundPathHashTest, RecoverPHistUsesTakenControlPath) {
     FetchTarget stream = createStream(0x1000, entry, true, meta);
     stream = setMispredStream(stream);
 
-    const auto ghist = stream.getGHistUpdateDuringSquash(entry.pc, false, true);
+    const auto ghist = stream.getGHistUpdateDuringSquash(
+        entry.slot.pc, false, true);
     const auto phist = stream.getPHistUpdateDuringSquash(
-        entry.pc, true, entry.target);
+        entry.slot.pc, true, entry.slot.target);
     EXPECT_EQ(ghist.shamt, 0);
     EXPECT_FALSE(ghist.taken);
     EXPECT_TRUE(phist.taken);
-    EXPECT_EQ(phist.pc, entry.pc);
-    EXPECT_EQ(phist.target, entry.target);
+    EXPECT_EQ(phist.pc, entry.slot.pc);
+    EXPECT_EQ(phist.target, entry.slot.target);
 
     tage->recoverPHist(pathHistoryBefore, stream, phist);
     tage->checkFoldedHist(pathHistoryAfter, "recover taken control path");

--- a/src/cpu/pred/btb/test/final_prediction_selector.test.cc
+++ b/src/cpu/pred/btb/test/final_prediction_selector.test.cc
@@ -70,7 +70,6 @@ makeStagePreds(unsigned num_stages = 4)
     std::vector<FullBTBPrediction> stage_preds(num_stages);
     for (unsigned stage = 0; stage < num_stages; ++stage) {
         stage_preds[stage].bbStart = 0x1000;
-        stage_preds[stage].predSource = stage;
     }
     return stage_preds;
 }
@@ -97,8 +96,9 @@ TEST(FinalPredictionSelectorTest, EmptyPredictionsFallBackToStageZero)
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
 
     EXPECT_EQ(selection.chosenStage, 0);
-    EXPECT_EQ(selection.firstMatchingStage, 0);
-    EXPECT_EQ(selection.overrideReason, OverrideReason::NO_OVERRIDE);
+    EXPECT_EQ(selection.metadata.firstMatchingStage, 0);
+    EXPECT_EQ(selection.metadata.overrideReason,
+              OverrideReason::NO_OVERRIDE);
     EXPECT_FALSE(selection.updateAheadFromLastStage);
 }
 
@@ -114,8 +114,9 @@ TEST(FinalPredictionSelectorTest, FirstMatchingStageKeepsEarlierMismatchReason)
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
 
     EXPECT_EQ(selection.chosenStage, 3);
-    EXPECT_EQ(selection.firstMatchingStage, 1);
-    EXPECT_EQ(selection.overrideReason, OverrideReason::FALL_THRU);
+    EXPECT_EQ(selection.metadata.firstMatchingStage, 1);
+    EXPECT_EQ(selection.metadata.overrideReason,
+              OverrideReason::FALL_THRU);
 }
 
 TEST(FinalPredictionSelectorTest, S1SourceUsesFirstTakenLikeEntrySource)
@@ -129,7 +130,7 @@ TEST(FinalPredictionSelectorTest, S1SourceUsesFirstTakenLikeEntrySource)
     const auto selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
 
-    EXPECT_EQ(selection.s1Source, 7);
+    EXPECT_EQ(selection.metadata.s1Source, 7);
 }
 
 TEST(FinalPredictionSelectorTest, S3SourceClassifiesTakenEntry)
@@ -141,28 +142,28 @@ TEST(FinalPredictionSelectorTest, S3SourceClassifiesTakenEntry)
 
     auto selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
-    EXPECT_EQ(selection.s3Source, RasSource);
+    EXPECT_EQ(selection.metadata.s3Source, RasSource);
 
     stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, false, true)};
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(true));
-    EXPECT_EQ(selection.s3Source, IttageSource);
+    EXPECT_EQ(selection.metadata.s3Source, IttageSource);
 
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(false));
-    EXPECT_EQ(selection.s3Source, MbtbSource);
+    EXPECT_EQ(selection.metadata.s3Source, MbtbSource);
 
     stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, true)};
     stage_preds[2].condTakens = {{0x1010, true}};
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
-    EXPECT_EQ(selection.s3Source, TageSource);
+    EXPECT_EQ(selection.metadata.s3Source, TageSource);
 
     stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200)};
     stage_preds[2].condTakens.clear();
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
-    EXPECT_EQ(selection.s3Source, MbtbSource);
+    EXPECT_EQ(selection.metadata.s3Source, MbtbSource);
 }
 
 TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
@@ -178,7 +179,7 @@ TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
     auto selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
                               ittage_hit);
-    EXPECT_EQ(selection.s3Source, MbtbSource);
+    EXPECT_EQ(selection.metadata.s3Source, MbtbSource);
     EXPECT_EQ(ittage_hit_calls, 0);
 
     stage_preds[2].btbEntries = {
@@ -187,7 +188,7 @@ TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
                               ittage_hit);
-    EXPECT_EQ(selection.s3Source, RasSource);
+    EXPECT_EQ(selection.metadata.s3Source, RasSource);
     EXPECT_EQ(ittage_hit_calls, 0);
 
     stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, true)};
@@ -195,7 +196,7 @@ TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
                               ittage_hit);
-    EXPECT_EQ(selection.s3Source, TageSource);
+    EXPECT_EQ(selection.metadata.s3Source, TageSource);
     EXPECT_EQ(ittage_hit_calls, 0);
 
     stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, false, true)};
@@ -203,7 +204,7 @@ TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
     selection =
         selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
                               ittage_hit);
-    EXPECT_EQ(selection.s3Source, IttageSource);
+    EXPECT_EQ(selection.metadata.s3Source, IttageSource);
     EXPECT_EQ(ittage_hit_calls, 1);
 }
 
@@ -222,7 +223,7 @@ TEST(FinalPredictionSelectorTest, S3TakenLikeEntryPlusCondCanAttributeToTage)
 
     EXPECT_EQ(selection.chosenStage, 3);
     EXPECT_FALSE(stage_preds[selection.chosenStage].isTaken());
-    EXPECT_EQ(selection.s3Source, TageSource);
+    EXPECT_EQ(selection.metadata.s3Source, TageSource);
 }
 
 TEST(FinalPredictionSelectorTest, AheadUpdateUsesLastStage)

--- a/src/cpu/pred/btb/test/final_prediction_selector.test.cc
+++ b/src/cpu/pred/btb/test/final_prediction_selector.test.cc
@@ -1,0 +1,249 @@
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/final_prediction_selector.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+namespace
+{
+
+constexpr int RasSource = 10;
+constexpr int IttageSource = 11;
+constexpr int TageSource = 12;
+constexpr int MbtbSource = 13;
+
+FinalPredictionSelectorConfig
+makeSelectorConfig(bool ittage_hit = false)
+{
+    FinalPredictionSelectorConfig config;
+    config.rasSource = RasSource;
+    config.ittageSource = IttageSource;
+    config.tageSource = TageSource;
+    config.mbtbSource = MbtbSource;
+    config.ittageHit = ittage_hit;
+    return config;
+}
+
+BranchSlot
+makeSlot(Addr pc, Addr target, bool is_cond, bool is_indirect,
+         bool is_call = false, bool is_return = false, uint8_t size = 4)
+{
+    BranchSlot slot;
+    slot.pc = pc;
+    slot.target = target;
+    slot.setTypeFromFlags(is_cond, is_indirect, !is_cond && !is_indirect,
+                          is_call, is_return);
+    slot.size = size;
+    return slot;
+}
+
+BTBEntry
+makeEntry(Addr pc, Addr target, bool is_cond = false,
+          bool is_indirect = false, bool is_call = false,
+          bool is_return = false, int source = -1)
+{
+    BTBEntry entry(
+        makeSlot(pc, target, is_cond, is_indirect, is_call, is_return));
+    entry.source = source;
+    return entry;
+}
+
+BTBEntry
+makeNotTakenCondEntry(Addr pc, Addr target, int source = -1)
+{
+    auto entry = makeEntry(pc, target, true, false, false, false, source);
+    entry.ctr = -1;
+    entry.alwaysTaken = false;
+    return entry;
+}
+
+std::vector<FullBTBPrediction>
+makeStagePreds(unsigned num_stages = 4)
+{
+    std::vector<FullBTBPrediction> stage_preds(num_stages);
+    for (unsigned stage = 0; stage < num_stages; ++stage) {
+        stage_preds[stage].bbStart = 0x1000;
+        stage_preds[stage].predSource = stage;
+    }
+    return stage_preds;
+}
+
+TEST(FinalPredictionSelectorTest, ChoosesLatestStageWithEntries)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[1].btbEntries = {makeEntry(0x1010, 0x1200)};
+    stage_preds[3].btbEntries = {makeNotTakenCondEntry(0x1020, 0x1300)};
+    stage_preds[3].condTakens = {{0x1020, false}};
+
+    const auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+
+    EXPECT_EQ(selection.chosenStage, 3);
+    EXPECT_FALSE(stage_preds[selection.chosenStage].isTaken());
+}
+
+TEST(FinalPredictionSelectorTest, EmptyPredictionsFallBackToStageZero)
+{
+    const auto stage_preds = makeStagePreds();
+
+    const auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+
+    EXPECT_EQ(selection.chosenStage, 0);
+    EXPECT_EQ(selection.firstMatchingStage, 0);
+    EXPECT_EQ(selection.overrideReason, OverrideReason::NO_OVERRIDE);
+    EXPECT_FALSE(selection.updateAheadFromLastStage);
+}
+
+TEST(FinalPredictionSelectorTest, FirstMatchingStageKeepsEarlierMismatchReason)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[0].btbEntries = {makeNotTakenCondEntry(0x1010, 0x1200)};
+    stage_preds[0].condTakens = {{0x1010, false}};
+    stage_preds[1].btbEntries = {makeEntry(0x1020, 0x1300)};
+    stage_preds[3].btbEntries = {makeEntry(0x1020, 0x1300)};
+
+    const auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+
+    EXPECT_EQ(selection.chosenStage, 3);
+    EXPECT_EQ(selection.firstMatchingStage, 1);
+    EXPECT_EQ(selection.overrideReason, OverrideReason::FALL_THRU);
+}
+
+TEST(FinalPredictionSelectorTest, S1SourceUsesFirstTakenLikeEntrySource)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[0].btbEntries = {
+        makeNotTakenCondEntry(0x1008, 0x1100, 3),
+        makeEntry(0x1010, 0x1200, false, false, false, false, 7),
+    };
+
+    const auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+
+    EXPECT_EQ(selection.s1Source, 7);
+}
+
+TEST(FinalPredictionSelectorTest, S3SourceClassifiesTakenEntry)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[2].btbEntries = {
+        makeEntry(0x1010, 0x1200, false, true, false, true),
+    };
+
+    auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+    EXPECT_EQ(selection.s3Source, RasSource);
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, false, true)};
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(true));
+    EXPECT_EQ(selection.s3Source, IttageSource);
+
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(false));
+    EXPECT_EQ(selection.s3Source, MbtbSource);
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, true)};
+    stage_preds[2].condTakens = {{0x1010, true}};
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+    EXPECT_EQ(selection.s3Source, TageSource);
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200)};
+    stage_preds[2].condTakens.clear();
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+    EXPECT_EQ(selection.s3Source, MbtbSource);
+}
+
+TEST(FinalPredictionSelectorTest, IttageHitProviderIsLazy)
+{
+    auto stage_preds = makeStagePreds();
+    unsigned ittage_hit_calls = 0;
+    const auto ittage_hit = [&ittage_hit_calls]() {
+        ittage_hit_calls++;
+        return true;
+    };
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200)};
+    auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
+                              ittage_hit);
+    EXPECT_EQ(selection.s3Source, MbtbSource);
+    EXPECT_EQ(ittage_hit_calls, 0);
+
+    stage_preds[2].btbEntries = {
+        makeEntry(0x1010, 0x1200, false, true, false, true),
+    };
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
+                              ittage_hit);
+    EXPECT_EQ(selection.s3Source, RasSource);
+    EXPECT_EQ(ittage_hit_calls, 0);
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, true)};
+    stage_preds[2].condTakens = {{0x1010, true}};
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
+                              ittage_hit);
+    EXPECT_EQ(selection.s3Source, TageSource);
+    EXPECT_EQ(ittage_hit_calls, 0);
+
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200, false, true)};
+    stage_preds[2].condTakens.clear();
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig(),
+                              ittage_hit);
+    EXPECT_EQ(selection.s3Source, IttageSource);
+    EXPECT_EQ(ittage_hit_calls, 1);
+}
+
+TEST(FinalPredictionSelectorTest, S3TakenLikeEntryPlusCondCanAttributeToTage)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[2].btbEntries = {
+        makeEntry(0x1010, 0x1200),
+        makeNotTakenCondEntry(0x1020, 0x1300),
+    };
+    stage_preds[3].btbEntries = {makeNotTakenCondEntry(0x1030, 0x1400)};
+    stage_preds[3].condTakens = {{0x1030, false}};
+
+    const auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+
+    EXPECT_EQ(selection.chosenStage, 3);
+    EXPECT_FALSE(stage_preds[selection.chosenStage].isTaken());
+    EXPECT_EQ(selection.s3Source, TageSource);
+}
+
+TEST(FinalPredictionSelectorTest, AheadUpdateUsesLastStage)
+{
+    auto stage_preds = makeStagePreds();
+    stage_preds[2].btbEntries = {makeEntry(0x1010, 0x1200)};
+
+    auto selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+    EXPECT_FALSE(selection.updateAheadFromLastStage);
+
+    stage_preds[3].btbEntries = {makeEntry(0x1020, 0x1300)};
+    selection =
+        selectFinalPrediction(stage_preds, 64, makeSelectorConfig());
+    EXPECT_TRUE(selection.updateAheadFromLastStage);
+}
+
+} // namespace
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5

--- a/src/cpu/pred/btb/test/history_manager.test.cc
+++ b/src/cpu/pred/btb/test/history_manager.test.cc
@@ -53,7 +53,7 @@ makeBranchInfo(Addr pc, Addr target, bool is_cond)
     BranchInfo info;
     info.pc = pc;
     info.target = target;
-    info.isCond = is_cond;
+    info.setTypeFromFlags(is_cond, false, !is_cond, false, false);
     info.size = 4;
     return info;
 }

--- a/src/cpu/pred/btb/test/prediction_result.test.cc
+++ b/src/cpu/pred/btb/test/prediction_result.test.cc
@@ -1,0 +1,280 @@
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/common.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+namespace
+{
+
+using PredictionResult =
+    PredictionBlockResultView<std::vector<BTBEntry>, CondTakens,
+                              IndirectTargets>;
+
+BranchSlot
+makeSlot(Addr pc, Addr target, bool is_cond, bool is_indirect,
+         bool is_call = false, bool is_return = false, uint8_t size = 4)
+{
+    BranchSlot slot;
+    slot.pc = pc;
+    slot.target = target;
+    slot.setTypeFromFlags(is_cond, is_indirect, !is_cond && !is_indirect,
+                          is_call, is_return);
+    slot.size = size;
+    return slot;
+}
+
+BTBEntry
+makeEntry(Addr pc, Addr target, bool is_cond = false,
+          bool is_indirect = false, bool is_call = false,
+          bool is_return = false)
+{
+    return BTBEntry(
+        makeSlot(pc, target, is_cond, is_indirect, is_call, is_return));
+}
+
+PredictionResult
+makeResult(Addr bb_start, const std::vector<BTBEntry> &entries,
+           const CondTakens &cond_takens,
+           const IndirectTargets &indirect_targets, Addr return_target = 0)
+{
+    return PredictionResult(
+        bb_start, entries, cond_takens, indirect_targets, return_target);
+}
+
+TEST(PredictionBlockResultTest, NotTakenConditionalFallsThrough)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1100, true),
+    };
+    const CondTakens cond_takens = {{0x1020, false}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1004, entries, cond_takens, indirect_targets);
+
+    EXPECT_FALSE(result.isTaken());
+    EXPECT_EQ(result.getTarget(64), 0x1040);
+    EXPECT_EQ(result.getEnd(64), 0x1040);
+    EXPECT_EQ(result.controlAddr(), 0);
+    const auto phist = result.getPHistUpdate();
+    EXPECT_FALSE(phist.taken);
+    EXPECT_EQ(phist.pc, 0);
+    EXPECT_EQ(phist.target, 0);
+}
+
+TEST(PredictionBlockResultTest, TakenConditionalUsesBranchTarget)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1100, true),
+    };
+    const CondTakens cond_takens = {{0x1020, true}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+    const auto taken = result.getTakenSlotResult(64);
+
+    EXPECT_TRUE(taken.taken());
+    EXPECT_EQ(taken.controlPC(), 0x1020);
+    EXPECT_EQ(taken.target, 0x1100);
+    EXPECT_EQ(taken.endPC(), 0x1024);
+    EXPECT_EQ(result.getTarget(64), 0x1100);
+    EXPECT_EQ(result.getEnd(64), 0x1024);
+}
+
+TEST(PredictionBlockResultTest, EarlierTakenEntryWins)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1010, 0x1200, true),
+        makeEntry(0x1020, 0x1300),
+    };
+    const CondTakens cond_takens = {{0x1010, true}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    EXPECT_EQ(result.controlAddr(), 0x1010);
+    EXPECT_EQ(result.getTarget(64), 0x1200);
+}
+
+TEST(PredictionBlockResultTest, LaterUnconditionalWinsAfterNotTakenCond)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1010, 0x1200, true),
+        makeEntry(0x1020, 0x1300),
+    };
+    const CondTakens cond_takens = {{0x1010, false}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    EXPECT_EQ(result.controlAddr(), 0x1020);
+    EXPECT_EQ(result.getTarget(64), 0x1300);
+}
+
+TEST(PredictionBlockResultTest, IndirectTargetOverrideUsesIpredWhenPresent)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1100, false, true),
+    };
+    const CondTakens cond_takens;
+    const IndirectTargets indirect_targets = {{0x1020, 0x2200}};
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+    const auto slot = result.getTakenSlotResult(64).resolvedSlot();
+
+    EXPECT_EQ(result.getTarget(64), 0x2200);
+    const auto phist = result.getPHistUpdate();
+    EXPECT_TRUE(phist.taken);
+    EXPECT_EQ(phist.pc, 0x1020);
+    EXPECT_EQ(phist.target, 0x2200);
+    EXPECT_EQ(slot.pc, 0x1020);
+    EXPECT_EQ(slot.target, 0x2200);
+}
+
+TEST(PredictionBlockResultTest, IndirectTargetFallsBackToBtbTarget)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1100, false, true),
+    };
+    const CondTakens cond_takens;
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    EXPECT_EQ(result.getTarget(64), 0x1100);
+    const auto phist = result.getPHistUpdate();
+    EXPECT_TRUE(phist.taken);
+    EXPECT_EQ(phist.pc, 0x1020);
+    EXPECT_EQ(phist.target, 0x1100);
+}
+
+TEST(PredictionBlockResultTest, ReturnAlwaysUsesRasTarget)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1100, false, true, false, true),
+    };
+    const CondTakens cond_takens;
+    const IndirectTargets indirect_targets = {{0x1020, 0x2200}};
+
+    const auto result = makeResult(0x1000, entries, cond_takens,
+                                   indirect_targets, 0x3300);
+
+    EXPECT_EQ(result.getTarget(64), 0x3300);
+    const auto phist = result.getPHistUpdate();
+    EXPECT_TRUE(phist.taken);
+    EXPECT_EQ(phist.pc, 0x1020);
+    EXPECT_EQ(phist.target, 0x3300);
+}
+
+TEST(PredictionBlockResultTest, HistoryCountsNotTakenCondsBeforeWinner)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1008, 0x1100, true),
+        makeEntry(0x1010, 0x1200, true),
+        makeEntry(0x1020, 0x1300),
+    };
+    const CondTakens cond_takens = {{0x1008, false}, {0x1010, true}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    const auto ghist = result.getGHistUpdate();
+    EXPECT_EQ(ghist.shamt, 2);
+    EXPECT_TRUE(ghist.taken);
+}
+
+TEST(PredictionBlockResultTest, UnconditionalStopsHistoryWithoutIncrement)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1008, 0x1100, true),
+        makeEntry(0x1010, 0x1200),
+        makeEntry(0x1020, 0x1300, true),
+    };
+    const CondTakens cond_takens = {{0x1008, false}, {0x1020, true}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    const auto ghist = result.getGHistUpdate();
+    EXPECT_EQ(ghist.shamt, 1);
+    EXPECT_FALSE(ghist.taken);
+}
+
+TEST(PredictionBlockResultTest, BackwardHistoryUsesRawBtbTarget)
+{
+    const std::vector<BTBEntry> entries = {
+        makeEntry(0x1020, 0x1010, true),
+    };
+    const CondTakens cond_takens = {{0x1020, true}};
+    const IndirectTargets indirect_targets;
+
+    const auto result =
+        makeResult(0x1000, entries, cond_takens, indirect_targets);
+
+    const auto bwhist = result.getBwHistUpdate();
+    EXPECT_EQ(bwhist.shamt, 1);
+    EXPECT_TRUE(bwhist.taken);
+}
+
+TEST(PredictionBlockResultTest, MatchPreservesOverridePriority)
+{
+    const std::vector<BTBEntry> not_taken_entries = {
+        makeEntry(0x1010, 0x1200, true),
+    };
+    const std::vector<BTBEntry> taken_entries = {
+        makeEntry(0x1010, 0x1200, true),
+    };
+    const std::vector<BTBEntry> different_control_entries = {
+        makeEntry(0x1020, 0x1200),
+    };
+    const std::vector<BTBEntry> different_target_entries = {
+        makeEntry(0x1010, 0x1300, true),
+    };
+    const CondTakens not_taken_cond = {{0x1010, false}};
+    const CondTakens taken_cond = {{0x1010, true}};
+    const CondTakens empty_cond;
+    const IndirectTargets indirect_targets;
+
+    const auto not_taken =
+        makeResult(0x1000, not_taken_entries, not_taken_cond,
+                   indirect_targets);
+    const auto taken =
+        makeResult(0x1000, taken_entries, taken_cond, indirect_targets);
+    const auto different_control =
+        makeResult(0x1000, different_control_entries, empty_cond,
+                   indirect_targets);
+    const auto different_target =
+        makeResult(0x1000, different_target_entries, taken_cond,
+                   indirect_targets);
+
+    EXPECT_EQ(not_taken.match(taken, 64).reason,
+              PredictionResultMismatchReason::FallThrough);
+    EXPECT_EQ(taken.match(different_control, 64).reason,
+              PredictionResultMismatchReason::ControlAddr);
+    EXPECT_EQ(taken.match(different_target, 64).reason,
+              PredictionResultMismatchReason::Target);
+    EXPECT_TRUE(taken.match(taken, 64).matches);
+}
+
+} // namespace
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5

--- a/src/cpu/pred/btb/test/ras_test.cc
+++ b/src/cpu/pred/btb/test/ras_test.cc
@@ -79,10 +79,10 @@ protected:
                                        std::shared_ptr<void> meta, bool taken = true) {
         FetchTarget stream;
         stream.startPC = startPC;
-        stream.exeTaken = taken;
-        stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
-        stream.exeBranchInfo.size = size;
+        stream.resolve.taken = taken;
+        stream.resolve.branchSlot.pc = branchPC;
+        stream.resolve.branchSlot.setTypeFromFlags(false, false, true, true, false);
+        stream.resolve.branchSlot.size = size;
         stream.predMetas[0] = meta;
         return stream;
     }
@@ -92,10 +92,10 @@ protected:
                                          std::shared_ptr<void> meta, bool taken = true) {
         FetchTarget stream;
         stream.startPC = startPC;
-        stream.exeTaken = taken;
-        stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
-        stream.exeBranchInfo.size = size;
+        stream.resolve.taken = taken;
+        stream.resolve.branchSlot.pc = branchPC;
+        stream.resolve.branchSlot.setTypeFromFlags(false, true, false, false, true);
+        stream.resolve.branchSlot.size = size;
         stream.predMetas[0] = meta;
         return stream;
     }
@@ -105,11 +105,11 @@ protected:
                                      std::shared_ptr<void> meta, bool taken = false) {
         FetchTarget stream;
         stream.startPC = startPC;
-        stream.exeTaken = taken;
-        stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.setTypeFromFlags(false, !isCall, isCall,
+        stream.resolve.taken = taken;
+        stream.resolve.branchSlot.pc = branchPC;
+        stream.resolve.branchSlot.setTypeFromFlags(false, !isCall, isCall,
                                               isCall, !isCall);
-        stream.exeBranchInfo.size = size;
+        stream.resolve.branchSlot.size = size;
         stream.predMetas[0] = meta;
         return stream;
     }
@@ -220,7 +220,7 @@ TEST_F(RASTest, BasicRecovery) {
     // Create recovery stream
     FetchTarget recoverStream;
     recoverStream.startPC = 0x1000;
-    recoverStream.exeTaken = false;  // Not taken, so no actual call
+    recoverStream.resolve.taken = false;  // Not taken, so no actual call
     recoverStream.predMetas[0] = initialMeta;
 
     // Recover to initial state
@@ -403,11 +403,11 @@ TEST_F(RASTest, ComplexRecovery) {
     // Recover to the state after first call (simulate misprediction)
     FetchTarget recoverStream;
     recoverStream.startPC = 0x2000;
-    recoverStream.exeTaken = true;  // The first call was actually taken
-    recoverStream.exeBranchInfo.pc = 0x1000;
-    recoverStream.exeBranchInfo.setTypeFromFlags(false, false, true, true,
+    recoverStream.resolve.taken = true;  // The first call was actually taken
+    recoverStream.resolve.branchSlot.pc = 0x1000;
+    recoverStream.resolve.branchSlot.setTypeFromFlags(false, false, true, true,
                                                  false);
-    recoverStream.exeBranchInfo.size = 4;
+    recoverStream.resolve.branchSlot.size = 4;
     recoverStream.predMetas[0] = meta1;
 
     ras->recoverState(recoverStream);

--- a/src/cpu/pred/btb/test/ras_test.cc
+++ b/src/cpu/pred/btb/test/ras_test.cc
@@ -32,11 +32,10 @@ protected:
     BTBEntry createCallEntry(Addr pc, Addr target, unsigned size = 4) {
         BTBEntry entry;
         entry.valid = true;
-        entry.pc = pc;
-        entry.isCall = true;
-        entry.isReturn = false;
-        entry.size = size;
-        entry.target = target;
+        entry.slot.pc = pc;
+        entry.slot.setTypeFromFlags(false, false, true, true, false);
+        entry.slot.size = size;
+        entry.slot.target = target;
         return entry;
     }
 
@@ -44,11 +43,10 @@ protected:
     BTBEntry createReturnEntry(Addr pc, Addr target, unsigned size = 4) {
         BTBEntry entry;
         entry.valid = true;
-        entry.pc = pc;
-        entry.isCall = false;
-        entry.isReturn = true;
-        entry.size = size;
-        entry.target = target;
+        entry.slot.pc = pc;
+        entry.slot.setTypeFromFlags(false, true, false, false, true);
+        entry.slot.size = size;
+        entry.slot.target = target;
         return entry;
     }
 
@@ -83,8 +81,7 @@ protected:
         stream.startPC = startPC;
         stream.exeTaken = taken;
         stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.isCall = true;
-        stream.exeBranchInfo.isReturn = false;
+        stream.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
         stream.exeBranchInfo.size = size;
         stream.predMetas[0] = meta;
         return stream;
@@ -97,8 +94,7 @@ protected:
         stream.startPC = startPC;
         stream.exeTaken = taken;
         stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.isCall = false;
-        stream.exeBranchInfo.isReturn = true;
+        stream.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
         stream.exeBranchInfo.size = size;
         stream.predMetas[0] = meta;
         return stream;
@@ -111,8 +107,8 @@ protected:
         stream.startPC = startPC;
         stream.exeTaken = taken;
         stream.exeBranchInfo.pc = branchPC;
-        stream.exeBranchInfo.isCall = isCall;
-        stream.exeBranchInfo.isReturn = !isCall;
+        stream.exeBranchInfo.setTypeFromFlags(false, !isCall, isCall,
+                                              isCall, !isCall);
         stream.exeBranchInfo.size = size;
         stream.predMetas[0] = meta;
         return stream;
@@ -409,7 +405,8 @@ TEST_F(RASTest, ComplexRecovery) {
     recoverStream.startPC = 0x2000;
     recoverStream.exeTaken = true;  // The first call was actually taken
     recoverStream.exeBranchInfo.pc = 0x1000;
-    recoverStream.exeBranchInfo.isCall = true;
+    recoverStream.exeBranchInfo.setTypeFromFlags(false, false, true, true,
+                                                 false);
     recoverStream.exeBranchInfo.size = 4;
     recoverStream.predMetas[0] = meta1;
 

--- a/src/cpu/pred/btb/test/uras_test.cc
+++ b/src/cpu/pred/btb/test/uras_test.cc
@@ -81,9 +81,9 @@ public:
         auto &sp = specSp;
         // do push & pops on prediction
         pred.returnTarget = stack[sp].retAddr;
-        auto takenSlot = pred.getTakenEntry();
+        auto takenSlot = pred.getTakenEntry().slot;
         if (takenSlot.isCall()) { // call inst, push retAddr to spec stack
-            Addr retAddr = takenSlot.slot.pc + takenSlot.slot.size;
+            Addr retAddr = takenSlot.pc + takenSlot.size;
             push(retAddr, stack, sp);
         }
         if (takenSlot.isReturn()) { // return inst, pop retAddr from spec stack

--- a/src/cpu/pred/btb/test/uras_test.cc
+++ b/src/cpu/pred/btb/test/uras_test.cc
@@ -94,7 +94,7 @@ public:
     }
 
     // recover state, from entry.predMetas[0] to recover sp and tos
-    // then if exeTaken, do push & pops on control squash
+    // then if actually taken, do push & pops on control squash
     // input: only entry is used.
     // used when branch prediction error
     // two steps:
@@ -106,11 +106,11 @@ public:
         auto &sp = specSp;
         // recover sp and tos first
         auto meta_ptr = std::static_pointer_cast<uRASMeta>(entry.predMetas[0]);
-        auto takenSlot = entry.exeBranchInfo;
+        auto takenSlot = entry.resolve.branchSlot;
         sp = meta_ptr->sp;
         stack[sp] = meta_ptr->tos;
 
-        if (entry.exeTaken) {
+        if (entry.resolve.taken) {
             // do push & pops on control squash
             if (takenSlot.isReturn()) {
                 pop(stack, sp);
@@ -417,12 +417,12 @@ TEST_F(URASTest, RecoverStateReturn) {
     meta.sp = 1;
     meta.tos = uRASEntry(0x1000);
     entry.predMetas[0] = std::make_shared<uRASMeta>(meta);
-    
+
     // 设置return指令信息
-    entry.exeTaken = true;
-    entry.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
-    entry.exeBranchInfo.pc = 0x2000;
-    
+    entry.resolve.taken = true;
+    entry.resolve.branchSlot.setTypeFromFlags(false, true, false, false, true);
+    entry.resolve.branchSlot.pc = 0x2000;
+
     // 执行恢复
     uras->recoverState(entry);
 
@@ -439,19 +439,19 @@ TEST_F(URASTest, RecoverStateCall) {
     // 设置初始状态
     auto& stack = uras->getSpecStack();
     auto& sp = uras->getSpecSp();
-    
+
     // 设置meta数据
     uRASMeta meta;
     meta.sp = 0;
     meta.tos = uRASEntry(0x80000000L);
     entry.predMetas[0] = std::make_shared<uRASMeta>(meta);
-    
+
     // 设置call指令信息
-    entry.exeTaken = true;
-    entry.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
-    entry.exeBranchInfo.pc = 0x1000;
-    entry.exeBranchInfo.size = 4;
-    
+    entry.resolve.taken = true;
+    entry.resolve.branchSlot.setTypeFromFlags(false, false, true, true, false);
+    entry.resolve.branchSlot.pc = 0x1000;
+    entry.resolve.branchSlot.size = 4;
+
     // 执行恢复
     uras->recoverState(entry);
 
@@ -467,34 +467,34 @@ TEST_F(URASTest, RecoverStateCallReturn) {
 
     auto& stack = uras->getSpecStack();
     auto& sp = uras->getSpecSp();
-    
+
     // 第一步：call指令恢复
     uRASMeta meta1;
     meta1.sp = 0;
     meta1.tos = uRASEntry(0x80000000L);
     entry1.predMetas[0] = std::make_shared<uRASMeta>(meta1);
-    
-    entry1.exeTaken = true;
-    entry1.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
-    entry1.exeBranchInfo.pc = 0x1000;
-    entry1.exeBranchInfo.size = 4;
-    
+
+    entry1.resolve.taken = true;
+    entry1.resolve.branchSlot.setTypeFromFlags(false, false, true, true, false);
+    entry1.resolve.branchSlot.pc = 0x1000;
+    entry1.resolve.branchSlot.size = 4;
+
     uras->recoverState(entry1);
 
     // 验证call的结果
     EXPECT_EQ(sp, 1);
     EXPECT_EQ(stack[sp].retAddr, 0x1004);
-    
+
     // 第二步：return指令恢复
     uRASMeta meta2;
     meta2.sp = 1;
     meta2.tos = uRASEntry(0x1004);
     entry2.predMetas[0] = std::make_shared<uRASMeta>(meta2);
-    
-    entry2.exeTaken = true;
-    entry2.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
-    entry2.exeBranchInfo.pc = 0x2000;
-    
+
+    entry2.resolve.taken = true;
+    entry2.resolve.branchSlot.setTypeFromFlags(false, true, false, false, true);
+    entry2.resolve.branchSlot.pc = 0x2000;
+
     uras->recoverState(entry2);
 
     // 验证return的结果

--- a/src/cpu/pred/btb/test/uras_test.cc
+++ b/src/cpu/pred/btb/test/uras_test.cc
@@ -82,11 +82,11 @@ public:
         // do push & pops on prediction
         pred.returnTarget = stack[sp].retAddr;
         auto takenSlot = pred.getTakenEntry();
-        if (takenSlot.isCall) { // call inst, push retAddr to spec stack
-            Addr retAddr = takenSlot.pc + takenSlot.size;
+        if (takenSlot.isCall()) { // call inst, push retAddr to spec stack
+            Addr retAddr = takenSlot.slot.pc + takenSlot.slot.size;
             push(retAddr, stack, sp);
         }
-        if (takenSlot.isReturn) { // return inst, pop retAddr from spec stack
+        if (takenSlot.isReturn()) { // return inst, pop retAddr from spec stack
             // do pop
             auto retAddr = stack[sp].retAddr;
             pop(stack, sp);
@@ -112,10 +112,10 @@ public:
 
         if (entry.exeTaken) {
             // do push & pops on control squash
-            if (takenSlot.isReturn) {
+            if (takenSlot.isReturn()) {
                 pop(stack, sp);
             }
-            if (takenSlot.isCall) {
+            if (takenSlot.isCall()) {
                 Addr retAddr = takenSlot.pc + takenSlot.size;
                 push(retAddr, stack, sp);
             }
@@ -287,10 +287,10 @@ TEST_F(URASTest, SpecUpdateStateCall) {
     // Setup a call instruction in BTBEntry
     BTBEntry callEntry;
     callEntry.valid = true;
-    callEntry.pc = 0x1000;
-    callEntry.isCall = true;
-    callEntry.size = 4;
-    callEntry.target = 0x2000;  // 目标地址
+    callEntry.slot.pc = 0x1000;
+    callEntry.slot.setTypeFromFlags(false, false, true, true, false);
+    callEntry.slot.size = 4;
+    callEntry.slot.target = 0x2000;  // 目标地址
     pred.btbEntries.push_back(callEntry);
     
     // 初始状态检查
@@ -322,9 +322,9 @@ TEST_F(URASTest, SpecUpdateStateReturn) {
     // Setup a return instruction in BTBEntry
     BTBEntry retEntry;
     retEntry.valid = true;
-    retEntry.pc = 0x1000;
-    retEntry.isReturn = true;
-    retEntry.target = 0x2000;
+    retEntry.slot.pc = 0x1000;
+    retEntry.slot.setTypeFromFlags(false, true, false, false, true);
+    retEntry.slot.target = 0x2000;
     pred.btbEntries.push_back(retEntry);
     
     // 执行 specUpdateState
@@ -346,10 +346,10 @@ TEST_F(URASTest, SpecUpdateStateCallReturn) {
     
     BTBEntry callEntry;
     callEntry.valid = true;
-    callEntry.pc = 0x1000;
-    callEntry.isCall = true;
-    callEntry.size = 4;
-    callEntry.target = 0x2000;
+    callEntry.slot.pc = 0x1000;
+    callEntry.slot.setTypeFromFlags(false, false, true, true, false);
+    callEntry.slot.size = 4;
+    callEntry.slot.target = 0x2000;
     pred1.btbEntries.push_back(callEntry);
     
     // 执行 call 的 specUpdateState
@@ -361,9 +361,9 @@ TEST_F(URASTest, SpecUpdateStateCallReturn) {
     
     BTBEntry retEntry;
     retEntry.valid = true;
-    retEntry.pc = 0x2000;
-    retEntry.isReturn = true;
-    retEntry.target = 0x1004;  // 返回到call的下一条指令
+    retEntry.slot.pc = 0x2000;
+    retEntry.slot.setTypeFromFlags(false, true, false, false, true);
+    retEntry.slot.target = 0x1004;  // 返回到call的下一条指令
     pred2.btbEntries.push_back(retEntry);
     
     // 执行 return 的 specUpdateState
@@ -420,7 +420,7 @@ TEST_F(URASTest, RecoverStateReturn) {
     
     // 设置return指令信息
     entry.exeTaken = true;
-    entry.exeBranchInfo.isReturn = true;
+    entry.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
     entry.exeBranchInfo.pc = 0x2000;
     
     // 执行恢复
@@ -448,7 +448,7 @@ TEST_F(URASTest, RecoverStateCall) {
     
     // 设置call指令信息
     entry.exeTaken = true;
-    entry.exeBranchInfo.isCall = true;
+    entry.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
     entry.exeBranchInfo.pc = 0x1000;
     entry.exeBranchInfo.size = 4;
     
@@ -475,7 +475,7 @@ TEST_F(URASTest, RecoverStateCallReturn) {
     entry1.predMetas[0] = std::make_shared<uRASMeta>(meta1);
     
     entry1.exeTaken = true;
-    entry1.exeBranchInfo.isCall = true;
+    entry1.exeBranchInfo.setTypeFromFlags(false, false, true, true, false);
     entry1.exeBranchInfo.pc = 0x1000;
     entry1.exeBranchInfo.size = 4;
     
@@ -492,7 +492,7 @@ TEST_F(URASTest, RecoverStateCallReturn) {
     entry2.predMetas[0] = std::make_shared<uRASMeta>(meta2);
     
     entry2.exeTaken = true;
-    entry2.exeBranchInfo.isReturn = true;
+    entry2.exeBranchInfo.setTypeFromFlags(false, true, false, false, true);
     entry2.exeBranchInfo.pc = 0x2000;
     
     uras->recoverState(entry2);

--- a/src/cpu/pred/btb/uras.cc
+++ b/src/cpu/pred/btb/uras.cc
@@ -100,19 +100,19 @@ BTBuRAS::specUpdateState(FullBTBPrediction &pred)
     // do push & pops on prediction
     pred.returnTarget = stack[sp].retAddr;
     auto takenSlot = pred.getTakenEntry();
-    if (takenSlot.isCall) {
-        Addr retAddr = takenSlot.pc + takenSlot.size;
+    if (takenSlot.isCall()) {
+        Addr retAddr = takenSlot.slot.pc + takenSlot.slot.size;
         if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.slot.pc,
                 retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
             specRasTrace->write_record(rec);
         }
         DPRINTF(URAS, "spec stack push addr 0x%llx\n", retAddr);
         push(retAddr, stack, sp);
     }
-    if (takenSlot.isReturn) {
+    if (takenSlot.isReturn()) {
         if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.pc,
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.slot.pc,
                 stack[sp].retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
             specRasTrace->write_record(rec);
         }
@@ -142,7 +142,7 @@ BTBuRAS::recoverState(const FetchTarget &entry)
 
     if (entry.exeTaken) {
         // do push & pops on control squash
-        if (takenSlot.isReturn) {
+        if (takenSlot.isReturn()) {
             if (enableDB) {
                 SpecRASTrace rec(When::REDIRECT, RAS_OP::POP, entry.startPC, takenSlot.pc, stack[sp].retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
                 specRasTrace->write_record(rec);
@@ -150,7 +150,7 @@ BTBuRAS::recoverState(const FetchTarget &entry)
             DPRINTF(URAS, "recover stack pop at pc 0x%llx target %llx\n", entry.startPC, stack[sp].retAddr);
             pop(stack, sp);
         }
-        if (takenSlot.isCall) {
+        if (takenSlot.isCall()) {
             Addr retAddr = takenSlot.pc + takenSlot.size;
             if (enableDB) {
                 SpecRASTrace rec(When::REDIRECT, RAS_OP::PUSH, entry.startPC, takenSlot.pc, retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
@@ -170,12 +170,12 @@ BTBuRAS::update(const FetchTarget &entry)
     auto &sp = nonSpecSp;
     printStack("before update", stack, sp);
     auto takenSlot = entry.exeBranchInfo;
-    if (entry.exeTaken && (takenSlot.isReturn || takenSlot.isCall)) {
+    if (entry.exeTaken && (takenSlot.isReturn() || takenSlot.isCall())) {
         auto meta_ptr = std::static_pointer_cast<uRASMeta>(entry.predMetas[getComponentIdx()]);
         auto pred_sp = meta_ptr->sp;
         auto pred_tos = meta_ptr->tos;
         auto miss = entry.squashType == SQUASH_CTRL && entry.squashPC == entry.exeBranchInfo.pc;
-        if (takenSlot.isCall) {
+        if (takenSlot.isCall()) {
             Addr retAddr = takenSlot.pc + takenSlot.size;
             if (enableDB) {
                 NonSpecRASTrace rec(RAS_OP::PUSH, entry.startPC, takenSlot.pc, retAddr,
@@ -184,7 +184,7 @@ BTBuRAS::update(const FetchTarget &entry)
             }
             push(retAddr, stack, sp);
         }
-        if (takenSlot.isReturn) {
+        if (takenSlot.isReturn()) {
             if (enableDB) {
                 NonSpecRASTrace rec(RAS_OP::POP, entry.startPC, takenSlot.pc, takenSlot.target,
                     pred_sp, pred_tos.retAddr, pred_tos.ctr, sp, stack[sp].retAddr, stack[sp].ctr, miss);

--- a/src/cpu/pred/btb/uras.cc
+++ b/src/cpu/pred/btb/uras.cc
@@ -133,7 +133,7 @@ BTBuRAS::recoverState(const FetchTarget &entry)
     printStack("before recoverState", stack, sp);
     // recover sp and tos first
     auto meta_ptr = std::static_pointer_cast<uRASMeta>(entry.predMetas[getComponentIdx()]);
-    auto takenSlot = entry.exeBranchInfo;
+    auto takenSlot = entry.resolve.branchSlot;
     if (enableDB) {
         SpecRASTrace rec(When::REDIRECT, RAS_OP::RECOVER, entry.startPC, takenSlot.pc, 0, sp, stack[sp].retAddr, stack[sp].ctr);
         specRasTrace->write_record(rec);
@@ -141,7 +141,7 @@ BTBuRAS::recoverState(const FetchTarget &entry)
     sp = meta_ptr->sp;
     stack[sp] = meta_ptr->tos;
 
-    if (entry.exeTaken) {
+    if (entry.resolve.taken) {
         // do push & pops on control squash
         if (takenSlot.isReturn()) {
             if (enableDB) {
@@ -170,12 +170,12 @@ BTBuRAS::update(const FetchTarget &entry)
     auto &stack = nonSpecStack;
     auto &sp = nonSpecSp;
     printStack("before update", stack, sp);
-    auto takenSlot = entry.exeBranchInfo;
-    if (entry.exeTaken && (takenSlot.isReturn() || takenSlot.isCall())) {
+    auto takenSlot = entry.resolve.branchSlot;
+    if (entry.resolve.taken && (takenSlot.isReturn() || takenSlot.isCall())) {
         auto meta_ptr = std::static_pointer_cast<uRASMeta>(entry.predMetas[getComponentIdx()]);
         auto pred_sp = meta_ptr->sp;
         auto pred_tos = meta_ptr->tos;
-        auto miss = entry.squashType == SQUASH_CTRL && entry.squashPC == entry.exeBranchInfo.pc;
+        auto miss = entry.resolve.squashType == SQUASH_CTRL && entry.resolve.squashPC == entry.resolve.branchSlot.pc;
         if (takenSlot.isCall()) {
             Addr retAddr = takenSlot.pc + takenSlot.size;
             if (enableDB) {

--- a/src/cpu/pred/btb/uras.cc
+++ b/src/cpu/pred/btb/uras.cc
@@ -99,11 +99,12 @@ BTBuRAS::specUpdateState(FullBTBPrediction &pred)
     auto &sp = specSp;
     // do push & pops on prediction
     pred.returnTarget = stack[sp].retAddr;
-    auto takenSlot = pred.getTakenEntry();
+    auto takenEntry = pred.getTakenEntry();
+    auto takenSlot = takenEntry.slot;
     if (takenSlot.isCall()) {
-        Addr retAddr = takenSlot.slot.pc + takenSlot.slot.size;
+        Addr retAddr = takenSlot.pc + takenSlot.size;
         if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.slot.pc,
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
                 retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
             specRasTrace->write_record(rec);
         }
@@ -112,7 +113,7 @@ BTBuRAS::specUpdateState(FullBTBPrediction &pred)
     }
     if (takenSlot.isReturn()) {
         if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.slot.pc,
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.pc,
                 stack[sp].retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
             specRasTrace->write_record(rec);
         }


### PR DESCRIPTION
## Summary
- separate branch slot data from BTB entry storage metadata
- extract BTB prediction-result and final-prediction selection helpers
- move final prediction attribution into explicit metadata
- group fetch prediction payload in a FetchPredictionSnapshot

## Motivation
This is a readability/refactor patch to reduce coupling in the BTB BPU top-level data flow. The intent is to make branch-slot, BTB-entry, prediction-result, and FTQ/update payload ownership easier to reason about and easier to unit test.

## Scope and impact
This is intended to be behavior-preserving. There is no intended performance impact; the branch is pushed as a slash-free *-align branch so the 0.3c perf workflow can check that.

## Validation
- scons build/RISCV/cpu/pred/btb/test/final_prediction_selector.test.debug build/RISCV/cpu/pred/btb/test/prediction_result.test.debug build/RISCV/cpu/pred/btb/test/history_manager.test.debug build/RISCV/cpu/pred/btb/test/uras.test.debug build/RISCV/cpu/pred/btb/test/btb.test.debug build/RISCV/cpu/pred/btb/test/abtb.test.debug build/RISCV/cpu/pred/btb/test/tage.test.debug build/RISCV/cpu/pred/btb/test/mgsc.test.debug --unit-test -j100
- ./build/RISCV/cpu/pred/btb/test/final_prediction_selector.test.debug
- ./build/RISCV/cpu/pred/btb/test/prediction_result.test.debug
- ./build/RISCV/cpu/pred/btb/test/history_manager.test.debug
- ./build/RISCV/cpu/pred/btb/test/uras.test.debug
- ./build/RISCV/cpu/pred/btb/test/btb.test.debug
- ./build/RISCV/cpu/pred/btb/test/abtb.test.debug
- ./build/RISCV/cpu/pred/btb/test/tage.test.debug
- ./build/RISCV/cpu/pred/btb/test/mgsc.test.debug
- scons build/RISCV/gem5.opt --gold-linker -j100