### PR TITLE
Calibrate XS-GEM5 RVV WITH XS-RTL

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -932,6 +932,7 @@ IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
         } else {
             ++it;
         }
+    }
     // while (!instList.empty() && instList.front()->seqNum <= seqNum) {
     //     assert(instList.front()->isIssued());
     //     vectorReadyQSeqs.erase(instList.front()->seqNum);

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -419,6 +419,58 @@ IssueQue::issueToFu()
         issued++;
     }
 
+    // Vector memory instructions are issued from vectorReadyQ after replayQ,
+    // and before the normal toFu stream.
+    while (!vectorReadyQ.empty()) {
+        auto inst = vectorReadyQ.front();
+        if (!inst || inst->isSquashed() || inst->canceled()) {
+            if (inst) {
+                vectorReadyQSeqs.erase(inst->seqNum);
+            }
+            vectorReadyQ.pop();
+            continue;
+        }
+
+        bool bypassReady = true;
+        for (int i = 0; i < inst->numSrcRegs(); i++) {
+            auto src = inst->renamedSrcIdx(i);
+            if (src->isFixedMapping()) {
+                continue;
+            }
+            if (!scheduler->bypassScoreboard[src->flatIndex()]) {
+                bypassReady = false;
+                break;
+            }
+        }
+        if (!bypassReady) {
+            // Keep FIFO order in vectorReadyQ and retry in later cycles.
+            break;
+        }
+
+        bool blockLoad = inst->isLoad() && scheduler->lsq->isDcacheRefillTagWrite();
+        if (blockLoad) {
+            incTagRefillBlockStats = true;
+        }
+
+        if (issued >= outports || (inst->isLoad() && (issuedLoad >= numLoadPipe)) ||
+            (inst->isStore() && (issuedStore >= numStorePipe)) || blockLoad) {
+            break;
+        }
+
+        vectorReadyQSeqs.erase(inst->seqNum);
+        vectorReadyQ.pop();
+
+        if (inst->isLoad()) {
+            issuedLoad++;
+        }
+        if (inst->isStore()) {
+            issuedStore++;
+        }
+        addToFu(inst);
+        cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueReadReg);
+        issued++;
+    }
+
     for (int i = 0; i < size; i++) {
         auto inst = toFu->pop();
         if (!inst) {
@@ -431,7 +483,7 @@ IssueQue::issueToFu()
             incTagRefillBlockStats = true;
         }
 
-        if ((i + replayed >= outports) || (inst->isLoad() && (issuedLoad >= numLoadPipe)) ||
+        if ((issued >= outports) || (inst->isLoad() && (issuedLoad >= numLoadPipe)) ||
             (inst->isStore() && (issuedStore >= numStorePipe)) || blockLoad) {
             inst->clearScheduled();
             // only for load/store
@@ -558,15 +610,6 @@ IssueQue::addIfReady(const DynInstPtr& inst)
             DPRINTF(Counters, "set readyTick at addIfReady\n");
         }
 
-        if (inst->isVector() && !inst->isSquashed() &&
-            vectorReadyQSeqs.insert(inst->seqNum).second && inst->isMemRef()) {
-            vectorReadyQ.push(inst);
-            const bool is_micro = inst->isMicroop();
-            const bool is_first_uop = inst->isFirstMicroop();
-            const bool is_last_uop = inst->isLastMicroop();
-            DPRINTF(Schedule, "[sn:%llu] add to vectorReadyQ\n", inst->seqNum);
-        }
-
         // Add the instruction to the proper ready list.
         if (inst->isMemRef()) {
             if (inst->memDepSolved()) {
@@ -577,10 +620,20 @@ IssueQue::addIfReady(const DynInstPtr& inst)
             }
         }
 
+
+
         DPRINTF(Schedule, "[sn:%llu] add to readyInstsQue\n", inst->seqNum);
         inst->clearCancel();
         if (!inst->inReadyQ()) {
-            READYQ_PUSH(inst);
+            if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()) {
+                if (vectorReadyQSeqs.insert(inst->seqNum).second) {
+                    vectorReadyQ.push(inst);
+                    DPRINTF(Schedule, "[sn:%llu] add to vectorReadyQ\n", inst->seqNum);
+                }
+            }
+            else{
+                READYQ_PUSH(inst);
+            }
         }
     }
 }

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -198,6 +198,8 @@ IssueQue::IssueQue(const IssueQueParams& params)
       scheduleToExecDelay(params.scheduleToExecDelay),
       iqname(params.name),
       inflightIssues(scheduleToExecDelay, 0),
+      vectorReadyQEvent([this]() { processVectorReadyQ(); },
+                        csprintf("%s.vectorReadyQEvent", params.name)),
       selector(params.sel)
 {
     // TODO: keep this in sync with the current load IQ naming convention.
@@ -379,6 +381,32 @@ IssueQue::addToFu(const DynInstPtr& inst)
 }
 
 void
+IssueQue::processVectorReadyQ()
+{
+    while (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty() &&
+           vectorReadyQReleaseTicks.front() <= curTick()) {
+        auto inst = vectorReadyQ.front();
+        vectorReadyQ.pop();
+        vectorReadyQReleaseTicks.pop();
+
+        if (!inst || inst->isSquashed() || inst->canceled()) {
+            if (inst) {
+                vectorReadyQSeqs.erase(inst->seqNum);
+            }
+            continue;
+        }
+
+        vectorDelayedReadyQ.push(inst);
+        DPRINTF(Schedule, "[sn:%llu] moved to vectorDelayedReadyQ\n",
+                inst->seqNum);
+    }
+
+    if (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty()) {
+        cpu->schedule(vectorReadyQEvent, vectorReadyQReleaseTicks.front());
+    }
+}
+
+void
 IssueQue::issueToFu()
 {
     int size = toFu->size;
@@ -419,15 +447,15 @@ IssueQue::issueToFu()
         issued++;
     }
 
-    // Vector memory instructions are issued from vectorReadyQ after replayQ,
-    // and before the normal toFu stream.
-    while (!vectorReadyQ.empty()) {
-        auto inst = vectorReadyQ.front();
+    // Vector memory instructions are issued from vectorDelayedReadyQ after
+    // replayQ, and before the normal toFu stream.
+    while (!vectorDelayedReadyQ.empty()) {
+        auto inst = vectorDelayedReadyQ.front();
         if (!inst || inst->isSquashed() || inst->canceled()) {
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
             }
-            vectorReadyQ.pop();
+            vectorDelayedReadyQ.pop();
             continue;
         }
 
@@ -443,7 +471,7 @@ IssueQue::issueToFu()
             }
         }
         if (!bypassReady) {
-            // Keep FIFO order in vectorReadyQ and retry in later cycles.
+            // Keep FIFO order in vectorDelayedReadyQ and retry in later cycles.
             break;
         }
 
@@ -458,7 +486,11 @@ IssueQue::issueToFu()
         }
 
         vectorReadyQSeqs.erase(inst->seqNum);
-        vectorReadyQ.pop();
+        vectorDelayedReadyQ.pop();
+
+        if (!checkScoreboard(inst)) {
+            continue;
+        }
 
         if (inst->isLoad()) {
             issuedLoad++;
@@ -549,6 +581,8 @@ IssueQue::idle()
         }
     }
     idle |= replayQ.size() > 0;
+    idle |= vectorReadyQ.size() > 0;
+    idle |= vectorDelayedReadyQ.size() > 0;
     return idle;
 }
 
@@ -627,11 +661,19 @@ IssueQue::addIfReady(const DynInstPtr& inst)
         if (!inst->inReadyQ()) {
             if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()) {
                 if (vectorReadyQSeqs.insert(inst->seqNum).second) {
+                    assert(cpu);
+                    const Tick releaseTick = cpu->clockEdge(Cycles(3));
+                    const bool needSchedule = vectorReadyQ.empty();
                     vectorReadyQ.push(inst);
-                    DPRINTF(Schedule, "[sn:%llu] add to vectorReadyQ\n", inst->seqNum);
+                    vectorReadyQReleaseTicks.push(releaseTick);
+                    DPRINTF(Schedule,
+                            "[sn:%llu] add to vectorReadyQ, release at %llu\n",
+                            inst->seqNum, releaseTick);
+                    if (needSchedule && !vectorReadyQEvent.scheduled()) {
+                        cpu->schedule(vectorReadyQEvent, releaseTick);
+                    }
                 }
-            }
-            else{
+            } else {
                 READYQ_PUSH(inst);
             }
         }
@@ -858,9 +900,9 @@ IssueQue::insertNonSpec(const DynInstPtr& inst)
 DynInstPtr
 IssueQue::popReadyVectorInst()
 {
-    while (!vectorReadyQ.empty()) {
-        auto inst = vectorReadyQ.front();
-        vectorReadyQ.pop();
+    while (!vectorDelayedReadyQ.empty()) {
+        auto inst = vectorDelayedReadyQ.front();
+        vectorDelayedReadyQ.pop();
 
         if (!inst) {
             continue;

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -380,16 +380,87 @@ IssueQue::addToFu(const DynInstPtr& inst)
     scheduler->addToFU(inst);
 }
 
+bool
+IssueQue::isVectorMemInst(const DynInstPtr& inst) const
+{
+    return inst && inst->isVector() && inst->isMemRef() && !inst->isSquashed();
+}
+
+void
+IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
+{
+    if (!isVectorMemInst(inst) || (!replay && inst->canceled())) {
+        return;
+    }
+
+    if (!vectorReadyQSeqs.insert(inst->seqNum).second) {
+        return;
+    }
+
+    assert(cpu);
+    const Tick releaseTick = cpu->clockEdge(Cycles(3));
+    const bool needSchedule = vectorReadyQ.empty();
+    vectorReadyQ.push(inst);
+    vectorReadyQReleaseTicks.push(releaseTick);
+    vectorReadyQReplay.push(replay);
+    DPRINTF(Schedule,
+            "[sn:%llu] add to vectorReadyQ, replay:%d, release at %llu\n",
+            inst->seqNum, replay, releaseTick);
+
+    if (needSchedule && !vectorReadyQEvent.scheduled()) {
+        cpu->schedule(vectorReadyQEvent, releaseTick);
+    }
+}
+
+void
+IssueQue::releaseVectorDelayedReadyQ()
+{
+    assert(vectorDelayedReadyQ.size() == vectorDelayedReadyQReplay.size());
+    while (!vectorDelayedReadyQ.empty() && !vectorDelayedReadyQReplay.empty()) {
+        auto inst = vectorDelayedReadyQ.front();
+        const bool replay = vectorDelayedReadyQReplay.front();
+        vectorDelayedReadyQ.pop();
+        vectorDelayedReadyQReplay.pop();
+
+        if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
+            if (inst) {
+                vectorReadyQSeqs.erase(inst->seqNum);
+            }
+            continue;
+        }
+
+        vectorReadyQSeqs.erase(inst->seqNum);
+        if (replay) {
+            replayQ.push(inst);
+            DPRINTF(Schedule, "[sn:%llu] released to replayQ after vector delay\n",
+                    inst->seqNum);
+        } else {
+            inst->clearCancel();
+            if (!inst->inReadyQ()) {
+                READYQ_PUSH(inst);
+                DPRINTF(Schedule,
+                        "[sn:%llu] released to readyQ after vector delay\n",
+                        inst->seqNum);
+            }
+        }
+    }
+}
+
 void
 IssueQue::processVectorReadyQ()
 {
+    assert(vectorReadyQ.size() == vectorReadyQReleaseTicks.size());
+    assert(vectorReadyQ.size() == vectorReadyQReplay.size());
     while (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty() &&
+           !vectorReadyQReplay.empty() &&
            vectorReadyQReleaseTicks.front() <= curTick()) {
         auto inst = vectorReadyQ.front();
+        const bool replay = vectorReadyQReplay.front();
         vectorReadyQ.pop();
         vectorReadyQReleaseTicks.pop();
+        vectorReadyQReplay.pop();
 
-        if (!inst || inst->isSquashed() || inst->canceled()) {
+        if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
             }
@@ -397,13 +468,17 @@ IssueQue::processVectorReadyQ()
         }
 
         vectorDelayedReadyQ.push(inst);
-        DPRINTF(Schedule, "[sn:%llu] moved to vectorDelayedReadyQ\n",
-                inst->seqNum);
+        vectorDelayedReadyQReplay.push(replay);
+        DPRINTF(Schedule, "[sn:%llu] moved to vectorDelayedReadyQ, replay:%d\n",
+                inst->seqNum, replay);
     }
 
-    if (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty()) {
+    if (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty() &&
+        !vectorReadyQEvent.scheduled()) {
         cpu->schedule(vectorReadyQEvent, vectorReadyQReleaseTicks.front());
     }
+
+    releaseVectorDelayedReadyQ();
 }
 
 void
@@ -447,62 +522,6 @@ IssueQue::issueToFu()
         issued++;
     }
 
-    // Vector memory instructions are issued from vectorDelayedReadyQ after
-    // replayQ, and before the normal toFu stream.
-    while (!vectorDelayedReadyQ.empty()) {
-        auto inst = vectorDelayedReadyQ.front();
-        if (!inst || inst->isSquashed() || inst->canceled()) {
-            if (inst) {
-                vectorReadyQSeqs.erase(inst->seqNum);
-            }
-            vectorDelayedReadyQ.pop();
-            continue;
-        }
-
-        bool bypassReady = true;
-        for (int i = 0; i < inst->numSrcRegs(); i++) {
-            auto src = inst->renamedSrcIdx(i);
-            if (src->isFixedMapping()) {
-                continue;
-            }
-            if (!scheduler->bypassScoreboard[src->flatIndex()]) {
-                bypassReady = false;
-                break;
-            }
-        }
-        if (!bypassReady) {
-            // Keep FIFO order in vectorDelayedReadyQ and retry in later cycles.
-            break;
-        }
-
-        bool blockLoad = inst->isLoad() && scheduler->lsq->isDcacheRefillTagWrite();
-        if (blockLoad) {
-            incTagRefillBlockStats = true;
-        }
-
-        if (issued >= outports || (inst->isLoad() && (issuedLoad >= numLoadPipe)) ||
-            (inst->isStore() && (issuedStore >= numStorePipe)) || blockLoad) {
-            break;
-        }
-
-        vectorReadyQSeqs.erase(inst->seqNum);
-        vectorDelayedReadyQ.pop();
-
-        if (!checkScoreboard(inst)) {
-            continue;
-        }
-
-        if (inst->isLoad()) {
-            issuedLoad++;
-        }
-        if (inst->isStore()) {
-            issuedStore++;
-        }
-        addToFu(inst);
-        cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueReadReg);
-        issued++;
-    }
-
     for (int i = 0; i < size; i++) {
         auto inst = toFu->pop();
         if (!inst) {
@@ -524,22 +543,6 @@ IssueQue::issueToFu()
             continue;
         }
         if (!checkScoreboard(inst)) {
-            continue;
-        }
-        if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()){
-            if (vectorReadyQSeqs.insert(inst->seqNum).second) {
-                assert(cpu);
-                const Tick releaseTick = cpu->clockEdge(Cycles(3));
-                const bool needSchedule = vectorReadyQ.empty();
-                vectorReadyQ.push(inst);
-                vectorReadyQReleaseTicks.push(releaseTick);
-                DPRINTF(Schedule,
-                        "[sn:%llu] add to vectorReadyQ, release at %llu\n",
-                        inst->seqNum, releaseTick);
-                if (needSchedule && !vectorReadyQEvent.scheduled()) {
-                    cpu->schedule(vectorReadyQEvent, releaseTick);
-                }
-            }
             continue;
         }
 
@@ -584,6 +587,10 @@ IssueQue::retryMem(const DynInstPtr& inst)
             DynInst::LoadPipeSource::ReplayQueue);
     }
     DPRINTF(Schedule, "retry %s [sn:%llu]\n", enums::OpClassStrings[inst->opClass()], inst->seqNum);
+    if (isVectorMemInst(inst)) {
+        enqueueVectorMemDelay(inst, true);
+        return;
+    }
     replayQ.push(inst);
 }
 
@@ -675,23 +682,11 @@ IssueQue::addIfReady(const DynInstPtr& inst)
         DPRINTF(Schedule, "[sn:%llu] add to readyInstsQue\n", inst->seqNum);
         inst->clearCancel();
         if (!inst->inReadyQ()) {
-            // if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()) {
-            //     if (vectorReadyQSeqs.insert(inst->seqNum).second) {
-            //         assert(cpu);
-            //         const Tick releaseTick = cpu->clockEdge(Cycles(3));
-            //         const bool needSchedule = vectorReadyQ.empty();
-            //         vectorReadyQ.push(inst);
-            //         vectorReadyQReleaseTicks.push(releaseTick);
-            //         DPRINTF(Schedule,
-            //                 "[sn:%llu] add to vectorReadyQ, release at %llu\n",
-            //                 inst->seqNum, releaseTick);
-            //         if (needSchedule && !vectorReadyQEvent.scheduled()) {
-            //             cpu->schedule(vectorReadyQEvent, releaseTick);
-            //         }
-            //     }
-            // } else {
+            if (isVectorMemInst(inst)) {
+                enqueueVectorMemDelay(inst, false);
+            } else {
                 READYQ_PUSH(inst);
-            // }
+            }
         }
     }
 }
@@ -830,6 +825,7 @@ IssueQue::tick()
     instNumInsert = 0;
 
     scheduleInst();
+    processVectorReadyQ();
     inflightIssues.advance();
 
     for (auto& t : portBusy) {
@@ -916,9 +912,11 @@ IssueQue::insertNonSpec(const DynInstPtr& inst)
 DynInstPtr
 IssueQue::popReadyVectorInst()
 {
-    while (!vectorDelayedReadyQ.empty()) {
+    assert(vectorDelayedReadyQ.size() == vectorDelayedReadyQReplay.size());
+    while (!vectorDelayedReadyQ.empty() && !vectorDelayedReadyQReplay.empty()) {
         auto inst = vectorDelayedReadyQ.front();
         vectorDelayedReadyQ.pop();
+        vectorDelayedReadyQReplay.pop();
 
         if (!inst) {
             continue;

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -558,6 +558,15 @@ IssueQue::addIfReady(const DynInstPtr& inst)
             DPRINTF(Counters, "set readyTick at addIfReady\n");
         }
 
+        if (inst->isVector() && !inst->isSquashed() &&
+            vectorReadyQSeqs.insert(inst->seqNum).second && inst->isMemRef()) {
+            vectorReadyQ.push(inst);
+            const bool is_micro = inst->isMicroop();
+            const bool is_first_uop = inst->isFirstMicroop();
+            const bool is_last_uop = inst->isLastMicroop();
+            DPRINTF(Schedule, "[sn:%llu] add to vectorReadyQ\n", inst->seqNum);
+        }
+
         // Add the instruction to the proper ready list.
         if (inst->isMemRef()) {
             if (inst->memDepSolved()) {
@@ -793,6 +802,29 @@ IssueQue::insertNonSpec(const DynInstPtr& inst)
     }
 }
 
+DynInstPtr
+IssueQue::popReadyVectorInst()
+{
+    while (!vectorReadyQ.empty()) {
+        auto inst = vectorReadyQ.front();
+        vectorReadyQ.pop();
+
+        if (!inst) {
+            continue;
+        }
+
+        vectorReadyQSeqs.erase(inst->seqNum);
+
+        if (inst->isSquashed()) {
+            continue;
+        }
+
+        return inst;
+    }
+
+    return nullptr;
+}
+
 void
 IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
 {
@@ -800,11 +832,16 @@ IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
         const auto &inst = *it;
         if (inst->threadNumber == tid && inst->seqNum <= seqNum) {
             assert(inst->isIssued());
+            vectorReadyQSeqs.erase(inst->seqNum);
             it = instList.erase(it);
         } else {
             ++it;
         }
-    }
+    // while (!instList.empty() && instList.front()->seqNum <= seqNum) {
+    //     assert(instList.front()->isIssued());
+    //     vectorReadyQSeqs.erase(instList.front()->seqNum);
+    //     instList.pop_front();
+    // }
 }
 
 void
@@ -827,6 +864,7 @@ IssueQue::doSquash(SquashInfo squashInfo)
             (*it)->setCanCommit();
             (*it)->clearScheduled();
             (*it)->setCancel();
+            vectorReadyQSeqs.erase((*it)->seqNum);
             it = instList.erase(it);
             assert(instList.size() >= instNum);
         } else {

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -526,6 +526,22 @@ IssueQue::issueToFu()
         if (!checkScoreboard(inst)) {
             continue;
         }
+        if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()){
+            if (vectorReadyQSeqs.insert(inst->seqNum).second) {
+                assert(cpu);
+                const Tick releaseTick = cpu->clockEdge(Cycles(3));
+                const bool needSchedule = vectorReadyQ.empty();
+                vectorReadyQ.push(inst);
+                vectorReadyQReleaseTicks.push(releaseTick);
+                DPRINTF(Schedule,
+                        "[sn:%llu] add to vectorReadyQ, release at %llu\n",
+                        inst->seqNum, releaseTick);
+                if (needSchedule && !vectorReadyQEvent.scheduled()) {
+                    cpu->schedule(vectorReadyQEvent, releaseTick);
+                }
+            }
+            continue;
+        }
 
         if (inst->isLoad()) {
             issuedLoad++;
@@ -659,23 +675,23 @@ IssueQue::addIfReady(const DynInstPtr& inst)
         DPRINTF(Schedule, "[sn:%llu] add to readyInstsQue\n", inst->seqNum);
         inst->clearCancel();
         if (!inst->inReadyQ()) {
-            if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()) {
-                if (vectorReadyQSeqs.insert(inst->seqNum).second) {
-                    assert(cpu);
-                    const Tick releaseTick = cpu->clockEdge(Cycles(3));
-                    const bool needSchedule = vectorReadyQ.empty();
-                    vectorReadyQ.push(inst);
-                    vectorReadyQReleaseTicks.push(releaseTick);
-                    DPRINTF(Schedule,
-                            "[sn:%llu] add to vectorReadyQ, release at %llu\n",
-                            inst->seqNum, releaseTick);
-                    if (needSchedule && !vectorReadyQEvent.scheduled()) {
-                        cpu->schedule(vectorReadyQEvent, releaseTick);
-                    }
-                }
-            } else {
+            // if (inst->isVector() && !inst->isSquashed() && inst->isMemRef()) {
+            //     if (vectorReadyQSeqs.insert(inst->seqNum).second) {
+            //         assert(cpu);
+            //         const Tick releaseTick = cpu->clockEdge(Cycles(3));
+            //         const bool needSchedule = vectorReadyQ.empty();
+            //         vectorReadyQ.push(inst);
+            //         vectorReadyQReleaseTicks.push(releaseTick);
+            //         DPRINTF(Schedule,
+            //                 "[sn:%llu] add to vectorReadyQ, release at %llu\n",
+            //                 inst->seqNum, releaseTick);
+            //         if (needSchedule && !vectorReadyQEvent.scheduled()) {
+            //             cpu->schedule(vectorReadyQEvent, releaseTick);
+            //         }
+            //     }
+            // } else {
                 READYQ_PUSH(inst);
-            }
+            // }
         }
     }
 }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -168,6 +168,8 @@ class IssueQue : public SimObject
     std::vector<std::vector<std::pair<uint8_t, DynInstPtr>>> subDepGraph;
 
     std::queue<DynInstPtr> replayQ;  // only for mem
+    std::queue<DynInstPtr> vectorReadyQ;
+    std::unordered_set<InstSeqNum> vectorReadyQSeqs;
 
     CPU* cpu = nullptr;
     Scheduler* scheduler = nullptr;
@@ -231,6 +233,9 @@ class IssueQue : public SimObject
 
     void doCommit(const InstSeqNum inst, ThreadID tid);
     void doSquash(SquashInfo squashInfo);
+
+    bool hasReadyVectorInst() const { return !vectorReadyQ.empty(); }
+    DynInstPtr popReadyVectorInst();
 
     int getIssueStages() { return scheduleToExecDelay; }
     int getId() { return IQID; }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -171,7 +171,9 @@ class IssueQue : public SimObject
     std::queue<DynInstPtr> replayQ;  // only for mem
     std::queue<DynInstPtr> vectorReadyQ;
     std::queue<Tick> vectorReadyQReleaseTicks;
+    std::queue<bool> vectorReadyQReplay;
     std::queue<DynInstPtr> vectorDelayedReadyQ;
+    std::queue<bool> vectorDelayedReadyQReplay;
     std::unordered_set<InstSeqNum> vectorReadyQSeqs;
     EventFunctionWrapper vectorReadyQEvent;
 
@@ -202,6 +204,9 @@ class IssueQue : public SimObject
     void replay(const DynInstPtr& inst);
     void addToFu(const DynInstPtr& inst);
     bool checkScoreboard(const DynInstPtr& inst);
+    bool isVectorMemInst(const DynInstPtr& inst) const;
+    void enqueueVectorMemDelay(const DynInstPtr& inst, bool replay);
+    void releaseVectorDelayedReadyQ();
     void issueToFu();
     void wakeUpDependents(const DynInstPtr& inst, bool speculative);
     void selectInst();

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -25,6 +25,7 @@
 #include "params/PAgeSelector.hh"
 #include "params/Scheduler.hh"
 #include "params/SpecWakeupChannel.hh"
+#include "sim/eventq.hh"
 #include "sim/sim_object.hh"
 
 namespace gem5
@@ -169,7 +170,10 @@ class IssueQue : public SimObject
 
     std::queue<DynInstPtr> replayQ;  // only for mem
     std::queue<DynInstPtr> vectorReadyQ;
+    std::queue<Tick> vectorReadyQReleaseTicks;
+    std::queue<DynInstPtr> vectorDelayedReadyQ;
     std::unordered_set<InstSeqNum> vectorReadyQSeqs;
+    EventFunctionWrapper vectorReadyQEvent;
 
     CPU* cpu = nullptr;
     Scheduler* scheduler = nullptr;
@@ -204,6 +208,7 @@ class IssueQue : public SimObject
     void scheduleInst();
     void addIfReady(const DynInstPtr& inst);
     void cancel(const DynInstPtr& inst);
+    void processVectorReadyQ();
 
   public:
     inline void clearBusy(uint32_t pi) { portBusy.at(pi) = 0; }
@@ -234,7 +239,7 @@ class IssueQue : public SimObject
     void doCommit(const InstSeqNum inst, ThreadID tid);
     void doSquash(SquashInfo squashInfo);
 
-    bool hasReadyVectorInst() const { return !vectorReadyQ.empty(); }
+    bool hasReadyVectorInst() const { return !vectorDelayedReadyQ.empty(); }
     DynInstPtr popReadyVectorInst();
 
     int getIssueStages() { return scheduleToExecDelay; }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -634,6 +634,12 @@ class LSQ
             return flags.isSet(Flag::Sent);
         }
 
+        virtual bool
+        hasCachePacketProgress() const
+        {
+            return _numOutstandingPackets > 0;
+        }
+
         bool
         isPartialFault()
         {
@@ -795,6 +801,11 @@ class LSQ
         virtual void initiateTranslation();
         virtual bool sendPacketToCache();
         virtual void buildPackets();
+        bool
+        hasCachePacketProgress() const override
+        {
+            return numReceivedPackets > 0 || _numOutstandingPackets > 0;
+        }
 
         virtual Cycles handleLocalAccess(
                 gem5::ThreadContext *thread, PacketPtr pkt);

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -791,30 +791,30 @@ class LSQ
                 bool isLoad, const Addr& addr, const uint32_t& size,
                 const Request::Flags & flags_, PacketDataPtr data=nullptr,
                 uint64_t* res=nullptr);
-        virtual ~SplitDataRequest();
-        virtual void markAsStaleTranslation();
-        virtual void finish(const Fault &fault, const RequestPtr &req,
-                gem5::ThreadContext* tc, BaseMMU::Mode mode);
-        virtual bool recvTimingResp(PacketPtr pkt);
-        virtual void recvFunctionalCustomSignal(PacketPtr pkt);
-        virtual void assemblePackets();
-        virtual void initiateTranslation();
-        virtual bool sendPacketToCache();
-        virtual void buildPackets();
+        ~SplitDataRequest() override;
+        void markAsStaleTranslation() override;
+        void finish(const Fault &fault, const RequestPtr &req,
+                gem5::ThreadContext* tc, BaseMMU::Mode mode) override;
+        bool recvTimingResp(PacketPtr pkt) override;
+        void recvFunctionalCustomSignal(PacketPtr pkt) override;
+        void assemblePackets() override;
+        void initiateTranslation() override;
+        bool sendPacketToCache() override;
+        void buildPackets() override;
         bool
         hasCachePacketProgress() const override
         {
             return numReceivedPackets > 0 || _numOutstandingPackets > 0;
         }
 
-        virtual Cycles handleLocalAccess(
-                gem5::ThreadContext *thread, PacketPtr pkt);
-        virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask);
+        Cycles handleLocalAccess(
+                gem5::ThreadContext *thread, PacketPtr pkt) override;
+        bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask) override;
 
-        virtual RequestPtr mainReq();
-        virtual RequestPtr mainReq() const;
-        virtual PacketPtr mainPacket();
-        virtual std::string name() const { return "SplitDataRequest"; }
+        RequestPtr mainReq() override;
+        RequestPtr mainReq() const override;
+        PacketPtr mainPacket() override;
+        std::string name() const override { return "SplitDataRequest"; }
     };
 
     class SbufferRequest : public LSQRequest

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2970,6 +2970,38 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
 
     DPRINTF(LSQUnit, "Attempting to send packet for inst [sn:%llu], addr: %#x\n",
             inst->seqNum, data_pkt->getAddr());
+
+    if (isLoad) {
+        const int fwd_base =
+            pkt->req->getVaddr() - request->mainReq()->getVaddr();
+        const int fwd_end = fwd_base + pkt->req->getSize();
+        assert(fwd_base >= 0);
+        for (auto it = request->SBforwardPackets.begin();
+             it != request->SBforwardPackets.end();) {
+            if (it->idx >= fwd_base && it->idx < fwd_end) {
+                it = request->SBforwardPackets.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        const Addr block_addr = pkt->getAddr() & cacheBlockMask;
+        auto entry = lsq->findForwardingStoreBufferEntry(
+            block_addr, lsqID, request->instruction()->seqNum);
+        if (entry) {
+            DPRINTF(StoreBuffer, "sbuffer entry[%#x] coverage %s\n",
+                    entry->blockPaddr, pkt->print());
+            if (entry->recordForward(
+                    pkt->req, request, lsqID,
+                    request->instruction()->seqNum)) {
+                assert(request->isSplit()); // here must be split request
+                stats.sbufferFullForward++;
+            } else if (!request->SBforwardPackets.empty()) {
+                stats.sbufferPartiForward++;
+            }
+        }
+    }
+
     if (!lsq->cacheBlocked() && lsq->cachePortAvailable(isLoad)) {
         if (bank_conflict) {
             ++stats.bankConflictTimes;
@@ -3002,23 +3034,6 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
         }
         lsq->cachePortBusy(isLoad);
         request->packetSent();
-
-        if (isLoad) {
-            const Addr block_addr = pkt->getAddr() & cacheBlockMask;
-            auto entry = lsq->findForwardingStoreBufferEntry(
-                block_addr, lsqID, request->instruction()->seqNum);
-            if (entry) {
-                DPRINTF(StoreBuffer, "sbuffer entry[%#x] coverage %s\n", entry->blockPaddr, pkt->print());
-                if (entry->recordForward(
-                        pkt->req, request, lsqID,
-                        request->instruction()->seqNum)) {
-                    assert(request->isSplit()); // here must be split request
-                    stats.sbufferFullForward++;
-                } else if (!request->SBforwardPackets.empty()) {
-                    stats.sbufferPartiForward++;
-                }
-            }
-        }
     } else {
         if (cache_got_blocked) {
             lsq->cacheBlocked(true);
@@ -3432,7 +3447,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         return NoFault;
     }
 
-    if (request) {
+    if (request && !request->hasCachePacketProgress()) {
         request->SBforwardPackets.clear();
         request->SQforwardPackets.clear();
         request->_sbufferBypass = false;


### PR DESCRIPTION
Temporarily delay the splitting of all vector memory access instructions by three cycles, and let them compete with replayed instructions and normally issued instructions for the load/store pipeline.

This part of the logic will be further refined based on the instruction type, followed by detailed calibration with the RTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delayed-ready pipeline and public query/retrieve for pending vector memory instructions to improve dispatch timing.
* **Bug Fixes**
  * Prevent duplicate scheduling of vector entries and ensure tracking cleanup on commit/squash and when draining delayed vectors.
* **Behavior**
  * Issue queue idle detection and load-blocking now consider vector-ready sources.
  * Load forwarding now occurs earlier in the send path and forwarding-state clearing is tightened based on packet progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->