### PR TITLE
configs: Centralize prefetcher configuration policy

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -306,9 +306,16 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         help="""
                         Prefetching cache level for SMS'pht""")
 
-    parser.add_argument("--enable-pf-buffer", action="store_true", default=False,
+    parser.set_defaults(enable_pf_buffer=None)
+    parser.add_argument("--enable-pf-buffer", action="store_true",
+                        dest="enable_pf_buffer",
                         help="""
                         Force all hardware prefetchers to enable their
+                        optional prefetch buffer (QueuedPrefetcher.use_pf_buffer).""")
+    parser.add_argument("--disable-pf-buffer", action="store_false",
+                        dest="enable_pf_buffer",
+                        help="""
+                        Force all hardware prefetchers to disable their
                         optional prefetch buffer (QueuedPrefetcher.use_pf_buffer).""")
 
     parser.add_argument("--cpu-clock", action="store", type=str,

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -5,118 +5,175 @@ from common import ObjectList
 from m5.objects.Prefetcher import XSPhysicalSmallBOP, XSVirtualLargeBOP
 
 
+DEFAULT_ENABLE_PF_BUFFER = True
+
+
 def _get_hwp(hwp_option):
     if hwp_option == None:
         return NULL
     hwpClass = ObjectList.hwp_list.get(hwp_option)
     return hwpClass()
 
+def is_pf_buffer_enabled(options):
+    option_value = getattr(options, 'enable_pf_buffer', None)
+    if option_value is None:
+        return DEFAULT_ENABLE_PF_BUFFER
+    return option_value
+
+def _configure_pf_buffer(prefetcher, pf_buffer_enabled):
+    if prefetcher != NULL and hasattr(prefetcher, 'use_pf_buffer'):
+        prefetcher.use_pf_buffer = pf_buffer_enabled
+
+def _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled):
+    if hasattr(prefetcher, 'prefetch_train'):
+        prefetcher.prefetch_train = not pf_buffer_enabled
+    if hasattr(prefetcher, 'queue_filter'):
+        prefetcher.queue_filter = not pf_buffer_enabled
+
+def _register_prefetcher_tlb(prefetcher, cpu):
+    if cpu != NULL:
+        prefetcher.registerTLB(cpu.mmu.dtb, cpu.mmu.functional)
+
+def _configure_xs_composite_common(prefetcher, options):
+    prefetcher.enable_spp = False
+    prefetcher.enable_cplx = False
+    prefetcher.short_stride_thres = options.short_stride_thres
+    prefetcher.fuzzy_stride_matching = False
+    prefetcher.stream_pf_ahead = True
+
+    prefetcher.bop_large.delay_queue_enable = True
+    prefetcher.bop_large.bad_score = 10
+    prefetcher.bop_small.delay_queue_enable = True
+    prefetcher.bop_small.bad_score = 5
+
+    prefetcher.queue_size = 128
+    prefetcher.max_prefetch_requests_with_pending_translation = 128
+    prefetcher.region_size = 64*16  # 64B * blocks per region
+
+    prefetcher.berti.use_byte_addr = True
+    prefetcher.berti.aggressive_pf = False
+    prefetcher.berti.trigger_pht = True
+
+    if options.ideal_cache:
+        prefetcher.stream_pf_ahead = False
+
+def _configure_xs_composite_default(prefetcher, options):
+    prefetcher.enable_activepage = True
+    prefetcher.enable_pht = True
+    prefetcher.enable_berti = True
+    prefetcher.enable_bop = False
+    prefetcher.enable_temporal = True
+    prefetcher.enable_sstride = False
+    prefetcher.enable_xsstream = False
+    prefetcher.enable_opt = False
+    prefetcher.pht_pf_level = options.pht_pf_level
+
+def _configure_xs_composite_kmh_align(prefetcher):
+    prefetcher.enable_activepage = False
+    prefetcher.enable_pht = True
+    prefetcher.enable_berti = False
+    prefetcher.enable_bop = False
+    prefetcher.enable_temporal = False
+    prefetcher.enable_sstride = True
+    prefetcher.enable_xsstream = True
+    prefetcher.enable_opt = False
+    prefetcher.pht_pf_level = 2
+
+def _configure_xs_composite(prefetcher, options, pf_buffer_enabled):
+    _configure_xs_composite_common(prefetcher, options)
+
+    if options.kmh_align:
+        _configure_xs_composite_kmh_align(prefetcher)
+    else:
+        _configure_xs_composite_default(prefetcher, options)
+
+    if options.l1d_enable_spp:
+        prefetcher.enable_spp = True
+    if options.l1d_enable_cplx:
+        prefetcher.enable_cplx = True
+
+    _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled)
+
+def _configure_l2_composite_default(prefetcher):
+    prefetcher.enable_bop = True
+    prefetcher.enable_cdp = True
+    prefetcher.enable_cmc = False
+    prefetcher.enable_despacito_stream = True
+
+def _configure_l2_composite_kmh_align(prefetcher):
+    prefetcher.enable_cmc = True
+    prefetcher.enable_bop = True
+    prefetcher.enable_cdp = False
+    prefetcher.enable_despacito_stream = False
+    prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=True,
+                                             enable_adaptoffset=False)
+    prefetcher.bop_small = XSPhysicalSmallBOP(is_sub_prefetcher=True,
+                                              enable_adaptoffset=False)
+
+def _configure_l2_composite(prefetcher, prefetcher_name, options):
+    if hasattr(prefetcher, 'enable_bop'):
+        prefetcher.enable_bop = True
+
+    if options.kmh_align:
+        assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
+        _configure_l2_composite_kmh_align(prefetcher)
+    elif prefetcher_name == 'L2CompositeWithWorkerPrefetcher':
+        _configure_l2_composite_default(prefetcher)
+
+def _configure_l2_prefetcher(prefetcher, prefetcher_name, options,
+                             pf_buffer_enabled):
+    if options.classic_l2:
+        _configure_l2_composite(prefetcher, prefetcher_name, options)
+        _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled)
+        if options.l1_to_l2_pf_hint:
+            prefetcher.queue_size = 64
+            prefetcher.max_prefetch_requests_with_pending_translation = 128
+    else:
+        assert prefetcher_name == 'PrefetcherForwarder'
+
+def _configure_l2_wrapper_prefetcher(prefetcher, prefetcher_name, options,
+                                     pf_buffer_enabled):
+    if not options.classic_l2:
+        _configure_l2_composite(prefetcher, prefetcher_name, options)
+        _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled)
+        if options.l1_to_l2_pf_hint:
+            prefetcher.queue_size = 32
+            prefetcher.max_prefetch_requests_with_pending_translation = 128
+
+def _configure_l3_prefetcher(prefetcher, options):
+    if options.l2_to_l3_pf_hint:
+        prefetcher.queue_size = 64
+        prefetcher.max_prefetch_requests_with_pending_translation = 128
+
 def create_prefetcher(cpu, cache_level, options):
     prefetcher_attr = '{}_hwp_type'.format(cache_level)
     prefetcher_name = ''
     prefetcher = NULL
-    pf_buffer_enabled = getattr(options, 'enable_pf_buffer', False)
+    pf_buffer_enabled = is_pf_buffer_enabled(options)
     if hasattr(options, prefetcher_attr):
         prefetcher_name = getattr(options, prefetcher_attr)
         prefetcher = _get_hwp(prefetcher_name)
         print(f"create_prefetcher at {cache_level}: {prefetcher_name}")
 
-    if prefetcher != NULL and pf_buffer_enabled:
-        if hasattr(prefetcher, 'use_pf_buffer'):
-            prefetcher.use_pf_buffer = True
+    _configure_pf_buffer(prefetcher, pf_buffer_enabled)
 
     if prefetcher == NULL:
         return NULL
 
-    if cpu != NULL:
-        prefetcher.registerTLB(cpu.mmu.dtb, cpu.mmu.functional)
+    _register_prefetcher_tlb(prefetcher, cpu)
 
     if prefetcher_name == 'XSCompositePrefetcher':
-        if options.l1d_enable_spp:
-            prefetcher.enable_spp = True
-        if options.l1d_enable_cplx:
-            prefetcher.enable_cplx = True
-        prefetcher.pht_pf_level = 2 if options.kmh_align else options.pht_pf_level
-        prefetcher.short_stride_thres = options.short_stride_thres
-        prefetcher.enable_temporal = not options.kmh_align
-        prefetcher.fuzzy_stride_matching = False
-        prefetcher.stream_pf_ahead = True
-
-        prefetcher.enable_bop = False
-        prefetcher.bop_large.delay_queue_enable = True
-        prefetcher.bop_large.bad_score = 10
-        prefetcher.bop_small.delay_queue_enable = True
-        prefetcher.bop_small.bad_score = 5
-
-        prefetcher.queue_size = 128
-        prefetcher.max_prefetch_requests_with_pending_translation = 128
-        prefetcher.region_size = 64*16  # 64B * blocks per region
-
-        prefetcher.berti.use_byte_addr = True
-        prefetcher.berti.aggressive_pf = False
-        prefetcher.berti.trigger_pht = True
-
-        if options.ideal_cache:
-            prefetcher.stream_pf_ahead = False
-        if options.kmh_align:
-            prefetcher.enable_berti = False
-            prefetcher.enable_sstride = True
-            prefetcher.enable_activepage = False
-            prefetcher.enable_pht = True
-            prefetcher.enable_xsstream = True
-        if hasattr(prefetcher, 'prefetch_train'):
-            prefetcher.prefetch_train = not pf_buffer_enabled
-        if hasattr(prefetcher, 'queue_filter'):
-            prefetcher.queue_filter = not pf_buffer_enabled
+        _configure_xs_composite(prefetcher, options, pf_buffer_enabled)
 
     if cache_level == 'l2':
-        if options.classic_l2:
-            if hasattr(prefetcher, 'enable_bop'):
-                prefetcher.enable_bop = True
-            if options.kmh_align:
-                assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
-                prefetcher.enable_cmc = True
-                prefetcher.enable_bop = True
-                prefetcher.enable_cdp = False
-                prefetcher.enable_despacito_stream = False
-                prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
-                prefetcher.bop_small = XSPhysicalSmallBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
-            if hasattr(prefetcher, 'prefetch_train'):
-                prefetcher.prefetch_train = not pf_buffer_enabled
-            if hasattr(prefetcher, 'queue_filter'):
-                prefetcher.queue_filter = not pf_buffer_enabled
-            if options.l1_to_l2_pf_hint:
-                prefetcher.queue_size = 64
-                prefetcher.max_prefetch_requests_with_pending_translation = 128
-        else:
-            assert prefetcher_name == 'PrefetcherForwarder'
+        _configure_l2_prefetcher(prefetcher, prefetcher_name, options,
+                                 pf_buffer_enabled)
 
     if cache_level == 'l2_wrapper':
-        if not options.classic_l2:
-            if hasattr(prefetcher, 'enable_bop'):
-                prefetcher.enable_bop = True
-            if options.kmh_align:
-                assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
-                prefetcher.enable_cmc = True
-                prefetcher.enable_bop = True
-                prefetcher.enable_cdp = False
-                prefetcher.enable_despacito_stream = False
-                if prefetcher.enable_despacito_stream:
-                    # if you want to check despacito pattern trace, set this to True
-                    prefetcher.despacito_stream.enable_despacito_db = False
-                prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
-                prefetcher.bop_small = XSPhysicalSmallBOP(is_sub_prefetcher=True,enable_adaptoffset=False)
-            if hasattr(prefetcher, 'prefetch_train'):
-                prefetcher.prefetch_train = not pf_buffer_enabled
-            if hasattr(prefetcher, 'queue_filter'):
-                prefetcher.queue_filter = not pf_buffer_enabled
-            if options.l1_to_l2_pf_hint:
-                prefetcher.queue_size = 32
-                prefetcher.max_prefetch_requests_with_pending_translation = 128
+        _configure_l2_wrapper_prefetcher(prefetcher, prefetcher_name, options,
+                                         pf_buffer_enabled)
 
     if cache_level == 'l3':
-        if options.l2_to_l3_pf_hint:
-            prefetcher.queue_size = 64
-            prefetcher.max_prefetch_requests_with_pending_translation = 128
+        _configure_l3_prefetcher(prefetcher, options)
 
     return prefetcher

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -112,9 +112,9 @@ def setKmhV3IdealParams(args, system):
                     # Configure XSDRRIP replacement policy (DRRIP mode)
                     # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
                     l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
-            system.tol2bus_list[i].forward_latency = 0  # 3->0
-            system.tol2bus_list[i].response_latency = 0  # 3->0
-            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0
+            system.tol2bus_list[i].forward_latency = 3  # 0->3
+            system.tol2bus_list[i].response_latency = 3  # 0->3
+            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 0->1
 
             # Enable dual-port for DCache → L2 communication
             # ReqLayer[0]: ICache+DCache+ITB+DTB → L2, allow 2 requests per cycle
@@ -141,7 +141,7 @@ if __name__ == '__m5_main__':
     args.l2_size = '2MB'
     args.l3_size = '32MB'
     # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = False
+    args.enable_pf_buffer = True
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -140,8 +140,6 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'
-    # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = True
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 

--- a/configs/example/kmhv2.py
+++ b/configs/example/kmhv2.py
@@ -30,8 +30,6 @@ if __name__ == '__m5_main__':
     # disable l1 berti, l2 cdp
     args.l2_wrapper_hwp_type = "L2CompositeWithWorkerPrefetcher"
     args.kmh_align = True
-    # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = True
     assert not args.external_memory_system
 
     test_mem_mode = 'timing'

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -174,9 +174,6 @@ if __name__ == '__m5_main__':
 
     assert not args.external_memory_system
 
-    # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = True
-
     # Set default bp_type based on ideal_kmhv3 flag
     # If user didn't specify bp_type, set default based on ideal_kmhv3
     args.bp_type = 'DecoupledBPUWithBTB'

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -1232,21 +1232,20 @@ class XSCompositePrefetcher(QueuedPrefetcher):
     opt = Param.OptPrefetcher(OptPrefetcher(is_sub_prefetcher=True), "")
     xsstream = Param.XsStreamPrefetcher(XsStreamPrefetcher(is_sub_prefetcher=True), "")
 
-    enable_activepage = Param.Bool(True,"Enable activepage stream prefetcher")
-    enable_pht = Param.Bool(True,"Enable sms pht prefetcher")
-    enable_cplx = Param.Bool(False, "Enable CPLX component")
-    enable_spp = Param.Bool(False, "Enable SPP component")
-    enable_temporal = Param.Bool(False, "Enable temporal component")
-    enable_berti = Param.Bool(True,"Enable berti component")
-    enable_bop = Param.Bool(True, "Enable BOP")
-
-    enable_sstride = Param.Bool(False,"Enable sms stride component")
-    enable_opt = Param.Bool(False,"Enable opt component")
-    enable_xsstream = Param.Bool(False,"Enable xs_stream component")
     short_stride_thres = Param.Unsigned(512, "Ignore short strides when there are long strides (Bytes)")
     pht_early_update = Param.Bool(True, "Enable update pht earlier")
     neighbor_pht_update = Param.Bool(True, "Enable use nearby act entry to update pht")
 
+    enable_activepage = Param.Bool(False,"Enable activepage stream prefetcher")
+    enable_xsstream = Param.Bool(False,"Enable xs_stream component")
+    enable_sstride = Param.Bool(False,"Enable sms stride component")
+    enable_pht = Param.Bool(False,"Enable sms pht prefetcher")
+    enable_bop = Param.Bool(False, "Enable BOP")
+    enable_temporal = Param.Bool(False, "Enable temporal component")
+    enable_berti = Param.Bool(False,"Enable berti component")
+    enable_cplx = Param.Bool(False, "Enable CPLX component")
+    enable_spp = Param.Bool(False, "Enable SPP component")
+    enable_opt = Param.Bool(False,"Enable opt component")
 
 class MultiPrefetcher(BasePrefetcher):
     type = 'MultiPrefetcher'
@@ -1277,9 +1276,9 @@ class L2CompositeWithWorkerPrefetcher(CompositeWithWorkerPrefetcher):
     despacito_stream = Param.DespacitoStreamPrefetcher(DespacitoStreamPrefetcher(is_sub_prefetcher=True),
                                                        "DespacitoStream used in composite prefetcher")
     enable_bop = Param.Bool(False, "Enable BOP")
-    enable_cdp = Param.Bool(True, "Enable CDP")
+    enable_cdp = Param.Bool(False, "Enable CDP")
     enable_cmc = Param.Bool(False, "Enable CMC")
-    enable_despacito_stream = Param.Bool(True, "Enable despacito stream")
+    enable_despacito_stream = Param.Bool(False, "Enable despacito stream")
 
 class L3CompositeWithWorkerPrefetcher(CompositeWithWorkerPrefetcher):
     type = 'L3CompositeWithWorkerPrefetcher'


### PR DESCRIPTION
## Summary
- Move XSComposite and L2Composite component enable policy into PrefetcherConfig helpers while keeping SimObject defaults off.
- Centralize the pf-buffer default in PrefetcherConfig and add explicit enable/disable CLI overrides.
- Remove duplicated pf-buffer assignments from kmhv2, kmhv3, and idealkmhv3.

## Validation
- python3 -B -m compileall -q configs/common/PrefetcherConfig.py configs/common/Options.py configs/example/kmhv2.py configs/example/kmhv3.py configs/example/idealkmhv3.py src/mem/cache/prefetch/Prefetcher.py
- git diff --check -- configs/common/PrefetcherConfig.py configs/common/Options.py configs/example/kmhv2.py configs/example/kmhv3.py configs/example/idealkmhv3.py src/mem/cache/prefetch/Prefetcher.py
- Lightweight stub checks for pf-buffer tri-state behavior and XSComposite/L2Composite profile switches.

Full gem5 build or checkpoint simulation was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Prefetch buffer option now supports explicit `--enable-pf-buffer` and `--disable-pf-buffer` flags with tri-state behavior; defaults to unspecified when neither is provided.

* **Performance Adjustments**
  * Updated interconnect timing parameters for improved performance.
  * Modified default states for several prefetcher components for better system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->