### PR TITLE
cpu: Fix RVV split-load replay after decode backpressure change

### DIFF
--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -90,7 +90,8 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
     // This buffer preserves the fetch->decode pipeline contents when decode
     // stalls while TimeBuffer keeps advancing. Its depth matches the original
     // forward pipeline window; fetch is backpressured before full to absorb
-    // the fetch groups already in that window.
+    // both the decode->fetch feedback delay and the request already issued in
+    // the current cycle before decode computes backpressure.
     const auto stallGroupDepth = fetchToDecodeDelay + 1;
     stallBuffer = boost::circular_buffer<DynInstPtr>(
         decodeWidth * stallGroupDepth);
@@ -493,13 +494,10 @@ Decode::tick()
         toFetch->decodeInfo[tid].blockReason =
             stallSig->fetchBlockReason[tid];
     };
-    // Single-thread mode already uses blockDecode feedback for real backend
-    // stalls; this extra FIFO guard is only needed when SMT arbitration can
-    // leave a non-selected thread's fetch groups queued behind another thread.
+    const auto fetchFeedbackReserve = decodeToFetchDelay + 1;
     const bool fifoBackpressured =
-        numThreads > 1 &&
         !stallBuffer.empty() &&
-        eachstallSize.size() + fetchToDecodeDelay >=
+        eachstallSize.size() + fetchFeedbackReserve >=
             eachstallSize.capacity();
     const ThreadID fifoHeadTid =
         !stallBuffer.empty() ? stallBuffer.front()->threadNumber : InvalidThreadID;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2771,11 +2771,16 @@ LSQUnit::writebackReg(const DynInstPtr &inst, PacketPtr pkt)
     }
 
     if (debug::LoadPipeline) {
-        char buffer[8] = {0};
-        if (inst->memData)
-            std::memcpy(buffer, inst->memData, inst->effSize);
+        uint64_t first_word = 0;
+        if (inst->memData) {
+            auto copy_size = inst->effSize;
+            if (copy_size > sizeof(first_word)) {
+                copy_size = sizeof(first_word);
+            }
+            std::memcpy(&first_word, inst->memData, copy_size);
+        }
         DPRINTF(LoadPipeline, "WritebackReg: %s [sn:%lli] data: %#lx\n", enums::OpClassStrings[inst->opClass()],
-                inst->seqNum, ((uint64_t *)buffer));
+                inst->seqNum, first_word);
     }
 
 
@@ -3592,11 +3597,17 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                 }
 
                 if (debug::LoadPipeline) {
-                    char buffer[8] = {0};
-                    if (load_inst->memData) std::memcpy(buffer, load_inst->memData, load_inst->effSize);
+                    uint64_t first_word = 0;
+                    if (load_inst->memData) {
+                        auto copy_size = load_inst->effSize;
+                        if (copy_size > sizeof(first_word)) {
+                            copy_size = sizeof(first_word);
+                        }
+                        std::memcpy(&first_word, load_inst->memData, copy_size);
+                    }
                     DPRINTF(LoadPipeline, "Forwarding from store [sn:%llu] to load [sn:%llu] "
                             "addr %#x, data: %#lx\n", store_it->instruction()->seqNum, load_inst->seqNum,
-                            request->mainReq()->getPaddr(), *((uint64_t*)buffer));
+                            request->mainReq()->getPaddr(), first_word);
                 }
                 load_inst->setFullForward();
 
@@ -3663,10 +3674,16 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
 
                 load_inst->setFullForward();
                 if (debug::LoadPipeline) {
-                    char buffer[8] = {0};
-                    if (load_inst->memData) std::memcpy(buffer, load_inst->memData, load_inst->effSize);
+                    uint64_t first_word = 0;
+                    if (load_inst->memData) {
+                        auto copy_size = load_inst->effSize;
+                        if (copy_size > sizeof(first_word)) {
+                            copy_size = sizeof(first_word);
+                        }
+                        std::memcpy(&first_word, load_inst->memData, copy_size);
+                    }
                     DPRINTF(LoadPipeline, "Load [sn:%llu] forward from sbuffer, data: %lx\n",
-                            load_inst->seqNum, *((uint64_t*)buffer));
+                            load_inst->seqNum, first_word);
                 }
                 return NoFault;
             }
@@ -3730,9 +3747,21 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         }
         if (!request->isSent() && !load_inst->needBankConflictReplay() && !load_inst->needMshrArbFailReplay() &&
             !load_inst->needMshrAliasFailReplay() &&!load_inst->needHitInWriteBufferReplay()) {
+            const bool partialSplitRequest =
+                request->isSplit() && request->_numOutstandingPackets > 0;
             iewStage->blockMemInst(load_inst);
             load_inst->setCacheBlockedReplay();
             DPRINTF(LoadPipeline, "Load [sn:%llu] setCacheBlockedReplay\n", load_inst->seqNum);
+            if (partialSplitRequest) {
+                // A split load may have already sent one fragment before a
+                // later fragment is rejected. Drop the old request so the
+                // in-flight fragment response is ignored and the retry starts
+                // from a clean request.
+                DPRINTF(LoadPipeline,
+                        "Load [sn:%llu] discards partially sent split request\n",
+                        load_inst->seqNum);
+                loadSetReplay(load_inst, request, true);
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

After the SMT/backpressure refactor was merged, three SPEC06 RVV slices started to fail:

- `bzip2_combined_15055`
- `bzip2_html_3216`
- `xalancbmk_30821`

The decode backpressure guard had also been relaxed to SMT-only, which can let the fetch/decode stall buffer overrun the feedback reserve in single-thread RVV runs.

## Approach

- Restore the decode-side backpressure guard for all thread counts, using `decodeToFetchDelay + 1` as the reserve for fetch feedback plus the current-cycle request.
- Fix replay of partially sent split loads: if one fragment of a split load has already been issued and a later fragment is rejected, discard the old request so the late fragment response is ignored and retry starts from a clean request.
- Fix several debug-only 8-byte buffer overflows in LSQ logging by limiting debug copies to the first 64-bit word.

## Validation

- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Targeted RVV failing slices all passed locally:
  - `bzip2_combined_15055`, exit tick `2180873943`
  - `bzip2_html_3216`, exit tick `2272861530`
  - `xalancbmk_30821`, exit tick `4220664777`

Full scalar performance validation is expected from the `perf-align` CI label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of split load requests when cache operations are blocked to prevent incomplete request states.
  * Enhanced robustness of data logging for load operations to safely handle variable-sized memory access without assumptions.

* **Improvements**
  * Optimized fetch-decode backpressure buffering logic for more accurate pipeline flow control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->