### PR TITLE
arch-riscv: Add L1 direct TLB compression

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -881,6 +881,13 @@ def xiangshan_system_init():
         default=False,
         help="Use BTBTAGEUpperBound in kmhv3 instead of the default BTBTAGE",
     )
+    parser.add_argument(
+        "--disable-l1-direct-compression",
+        action="store_false",
+        dest="enable_l1_direct_compression",
+        default=True,
+        help="Disable L1 direct one-stage TLB compression for A/B validation",
+    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -25,6 +25,8 @@ def setKmhV3Params(args, system):
 
         # fetch (idealfetch not care)
         cpu.mmu.itb.size = 96
+        cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
+        cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2

--- a/src/arch/riscv/RiscvTLB.py
+++ b/src/arch/riscv/RiscvTLB.py
@@ -81,6 +81,8 @@ class RiscvTLB(BaseTLB):
     l2tlb_l0_size = Param.Int(128, "l2TLB_l0 size")
     l2tlb_sp_size = Param.Int(16, "l2TLB_sp size")
     l2tlb_line_size = Param.Int(8, "l2TLB_line size")
+    enable_l1_direct_compression = Param.Bool(
+        True, "enable L1 direct one-stage TLB compression")
     regulation_num = Param.Int(70000, "train nextline num")
     arch_db = Param.ArchDBer(Parent.any, "Arch DB")
     walker = Param.RiscvPagetableWalker(\
@@ -99,4 +101,3 @@ class RiscvTLB(BaseTLB):
 class RiscvTLBL2(RiscvTLB):
     is_L1tlb = False
     is_the_sharedL2 = True
-

--- a/src/arch/riscv/pagetable.cc
+++ b/src/arch/riscv/pagetable.cc
@@ -46,7 +46,12 @@ TlbEntry::serialize(CheckpointOut &cp) const
     SERIALIZE_SCALAR(logBytes);
     SERIALIZE_SCALAR(asid);
     SERIALIZE_SCALAR(pte);
+    SERIALIZE_SCALAR(isCompressed);
+    SERIALIZE_SCALAR(validIdx);
+    SERIALIZE_SCALAR(pteIdx);
+    SERIALIZE_CONTAINER(ppnLow);
     SERIALIZE_SCALAR(lruSeq);
+    SERIALIZE_SCALAR(level);
 }
 
 void
@@ -57,7 +62,12 @@ TlbEntry::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(logBytes);
     UNSERIALIZE_SCALAR(asid);
     UNSERIALIZE_SCALAR(pte);
+    UNSERIALIZE_SCALAR(isCompressed);
+    UNSERIALIZE_SCALAR(validIdx);
+    UNSERIALIZE_SCALAR(pteIdx);
+    arrayParamIn(cp, "ppnLow", ppnLow.data(), ppnLow.size());
     UNSERIALIZE_SCALAR(lruSeq);
+    UNSERIALIZE_SCALAR(level);
 }
 
 } // namespace RiscvISA

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -31,6 +31,8 @@
 #ifndef __ARCH_RISCV_PAGETABLE_H__
 #define __ARCH_RISCV_PAGETABLE_H__
 
+#include <array>
+
 #include "base/bitunion.hh"
 #include "base/logging.hh"
 #include "base/trie.hh"
@@ -207,6 +209,11 @@ struct TlbEntry : public Serializable
     PTE pte;
     PTE pteVS;
 
+    bool isCompressed;
+    uint8_t validIdx;
+    uint8_t pteIdx;
+    std::array<uint8_t, 8> ppnLow;
+
     TlbEntryTrie::Handle trieHandle;
 
     // A sequence number to keep track of LRU.
@@ -235,6 +242,10 @@ struct TlbEntry : public Serializable
           vmid(0),
           pte(),
           pteVS(),
+          isCompressed(false),
+          validIdx(0),
+          pteIdx(0),
+          ppnLow{},
           lruSeq(0),
           level(0),
           VSlevel(0),

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -50,6 +50,7 @@
 
 #include "arch/riscv/pagetable_walker.hh"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <numeric>
@@ -153,7 +154,7 @@ Walker::start(Addr ppn, ThreadContext *_tc, BaseMMU::Translation *_translation,
         if (!regulate)
             autoOpenNextLine = false;
     }
-    if (currStates.size()) {
+    if (currStates.size()) {    //try to merge
         auto [coalesced, fault] =
             tryCoalesce(_tc, _translation, _req, _mode, from_l2tlb, asid, from_forward_pre_req, from_back_pre_req);
         if (!coalesced) {
@@ -180,7 +181,7 @@ Walker::start(Addr ppn, ThreadContext *_tc, BaseMMU::Translation *_translation,
                     currStates.size(), _req->getPC(), _req->getVaddr());
             return fault;
         }
-    } else {
+    } else {        //merge fail & initiate a new walkerstate
         WalkerState *newState = new WalkerState(this, _translation, _req);
         newState->initState(_tc, _req, _mode, sys->isTimingMode(), from_forward_pre_req, from_back_pre_req);
         currStates.push_back(newState);
@@ -321,7 +322,7 @@ Walker::WalkerState::initState(ThreadContext *_tc, const RequestPtr &_req, BaseM
                                bool _from_forward_pre_req, bool _from_back_pre_req)
 {
     assert(functional || _req != nullptr);
-    if (_req && _req->get_two_stage_state()) {
+    if (_req && _req->get_two_stage_state()) {  //2-stage state
         assert(state == Ready);
         started = false;
         assert(functional || requestors.back().tc == nullptr);
@@ -354,7 +355,7 @@ Walker::WalkerState::initState(ThreadContext *_tc, const RequestPtr &_req, BaseM
                  vsatp, vsatp >> 60, (vsatp >> 44) & 0xffff, vsatp & 0xfffffffffff);
         DPRINTFR(PageTableWalker, "\thgatp %#x(mode: %d, vmid: %#x, ppn:%#x)\n",
                  hgatp, hgatp >> 60, (hgatp >> 44) & 0xffff, hgatp & 0xfffffffffff);
-    } else {
+    } else {    // 1-stage state
         assert(state == Ready);
         started = false;
         assert(functional || requestors.back().tc == nullptr);
@@ -488,16 +489,27 @@ Walker::dol2TLBHit()
         Fault l2tlbFault;
         PrivilegeMode pmodel2 = tlb->getMemPriv(dol2TLBHitrequestors.tc,
                                                 dol2TLBHitrequestors.mode);
-        dol2TLBHitrequestors.req->setPaddr(dol2TLBHitrequestors.Paddr);
-        pma->check(dol2TLBHitrequestors.req);
+        dol2TLBHitrequestors.req->setPaddr(dol2TLBHitrequestors.Paddr); //commit paddr
+        pma->check(dol2TLBHitrequestors.req);   //check privilege
         l2tlbFault =
             pmp->pmpCheck(dol2TLBHitrequestors.req, dol2TLBHitrequestors.mode,
-                          pmodel2, dol2TLBHitrequestors.tc);
+                          pmodel2, dol2TLBHitrequestors.tc);//pmpcheck
         //assert(l2tlbFault == NoFault);
         if (l2tlbFault == NoFault) {
-            if (enableL1L2replace){
-                if (dol2TLBHitrequestors.entry != nullptr)
-                    tlb->insert(dol2TLBHitrequestors.entry->vaddr, *dol2TLBHitrequestors.entry, false, direct);
+            if (enableL1L2replace){ //write back entry from L2 to L1
+                if (dol2TLBHitrequestors.entry != nullptr) {
+                    TlbEntry l1_entry;
+                    if (tlb->isL1DirectCompressionEnabled() &&
+                        tlb->buildSingleL1CompressedEntry(
+                            dol2TLBHitrequestors.req->getVaddr(),
+                            *dol2TLBHitrequestors.entry, direct, l1_entry)) {
+                        tlb->insert(l1_entry.vaddr, l1_entry, false, direct);
+                        tlb->recordL1CompressedEntry(l1_entry);
+                    } else if (!tlb->isL1DirectCompressionEnabled()) {
+                        tlb->insert(dol2TLBHitrequestors.entry->vaddr,
+                                    *dol2TLBHitrequestors.entry, false, direct);
+                    }
+                }
                 if (dol2TLBHitrequestors.entryVsstage != nullptr)
                     tlb->insert(dol2TLBHitrequestors.entryVsstage->vaddr, *dol2TLBHitrequestors.entryVsstage, false,
                             vsstage);
@@ -505,13 +517,13 @@ Walker::dol2TLBHit()
                     tlb->insert(dol2TLBHitrequestors.entryGstage->gpaddr, *dol2TLBHitrequestors.entryGstage, false,
                             gstage);
             }
-            dol2TLBHitrequestors.translation->finish(
+            dol2TLBHitrequestors.translation->finish(   //finish translation
                 l2tlbFault, dol2TLBHitrequestors.req, dol2TLBHitrequestors.tc,
                 dol2TLBHitrequestors.mode);
         }
         else{
             warn("pmp fault in l2tlb\n");
-            dol2TLBHitrequestors.translation->finish(
+            dol2TLBHitrequestors.translation->finish(   //translation fault because of pmp default
                 l2tlbFault, dol2TLBHitrequestors.req, dol2TLBHitrequestors.tc,
                 dol2TLBHitrequestors.mode);
         }
@@ -557,13 +569,13 @@ Walker::WalkerState::startWalk(Addr ppn, int f_level, bool from_l2tlb,
     started = true;
     assert(!(from_forward_req && from_back_req));
 
-    if (translateMode == twoStageMode) {
+    if (translateMode == twoStageMode) {    //2-stage
         fault = setupWalk(ppn, mainReq->getVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
                           from_forward_req, from_back_req);
         if (fault != NoFault)
             return fault;
 
-    } else {
+    } else {    //1-stage
         DPRINTF(PageTableWalker, "startWalk: ppn %#x, f_level %d\n", ppn, f_level);
         if (from_back_req) {
             setupWalk(ppn, mainReq->getBackPreVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
@@ -571,12 +583,12 @@ Walker::WalkerState::startWalk(Addr ppn, int f_level, bool from_l2tlb,
         } else if (from_forward_req) {
             setupWalk(ppn, mainReq->getForwardPreVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
                       from_forward_req, from_back_req);
-        } else {
+        } else {    //setup
             setupWalk(ppn, mainReq->getVaddr(), f_level, from_l2tlb, open_nextline, auto_open_nextline,
                       from_forward_req, from_back_req);
         }
     }
-    if (timing) {
+    if (timing) {   //sendpackets to mem after setup
         nextState = state;
         state = Waiting;
         mainFault = NoFault;
@@ -1165,7 +1177,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
     PTE pte ;
 
     vaddr_choose = (entry.vaddr >> (level * LEVEL_BITS + PageShift)) & VADDR_CHOOSE_MASK;
-    pte = read->getLE_l2tlb<uint64_t>(vaddr_choose);
+    pte = read->getLE_l2tlb<uint64_t>(vaddr_choose);    //choose 1 PTE from 8 entry
 
     DPRINTF(PageTableWalker, "%s: get pte from walker cache.\n", __func__);
     for (int i = 0; i < l2tlbLineSize; i++) {
@@ -1207,9 +1219,9 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
     if (fault != NoFault) {
         DPRINTF(PageTableWalker3, " may pmp fault vaddr %#x\n", entry.vaddr);
     }
-
+    //
     if ((fault == NoFault) && (!nextline)) {
-        // step 3:
+        // step 3:invalid
         if (!pte.v || (!pte.r && pte.w)) {
             doEndWalk = true;
             DPRINTF(PageTableWalker3, "PTE invalid, raising PF\n");
@@ -1242,12 +1254,12 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
 
                 if (fault == NoFault) {
                     // step 7
-                    if (!pte.a) {
+                    if (!pte.a) {//access check
                         DPRINTF(PageTableWalker3,
                                 "PTE needs to write pte.a,raising PF\n");
                         fault = pageFault(true,false);
                     }
-                    if (!pte.d && mode == BaseMMU::Write) {
+                    if (!pte.d && mode == BaseMMU::Write) {//dirty check
                         DPRINTF(PageTableWalker3,
                                 "PTE needs to write pte.d,raising PF\n");
                         fault = pageFault(true,false);
@@ -1266,7 +1278,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                                             BaseMMU::Write, pmode, requestors.back().tc, entry.vaddr);
                     }
                     // perform step 8 only if pmp checks pass
-                    if (fault == NoFault) {
+                    if (fault == NoFault) { //ready for write back data
                         // step 8
                         entry.logBytes = PageShift + (level * LEVEL_BITS);
                         entry.paddr = pte.ppn;
@@ -1276,7 +1288,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         // put it non-writable into the TLB to detect
                         // writes and redo the page table walk in order
                         // to update the dirty flag.
-                        doTLBInsert = true;
+                        doTLBInsert = true; //enable write back signal
                         DPRINTF(PageTableWalker3,
                                 "tlb read paddr %#x vaddr %#x pte %#x level "
                                 "%d pre %d\n",
@@ -1285,7 +1297,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                     }
                 }
             } else {
-                level--;
+                level--;    //non leaf & level-1
                 if (level < 0) {
                     DPRINTF(PageTableWalker3,
                             "No leaf PTE found,"
@@ -1300,7 +1312,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                     inl2Entry.level = l2_level;
 
                     bool has_valid_pte = false;
-                    for (l2_i = 0; l2_i < l2tlbLineSize; l2_i++) {
+                    for (l2_i = 0; l2_i < l2tlbLineSize; l2_i++) {  //write back to medium level
                         inl2Entry.vaddr = (((entry.vaddr >> ((l2_level * LEVEL_BITS + PageShift + L2TLB_BLK_OFFSET)))
                                             << L2TLB_BLK_OFFSET) +
                                            l2_i)
@@ -1386,10 +1398,32 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
             write = NULL;
         }
 
-        if (doTLBInsert) {
+        if (doTLBInsert) {  //write back L1
             if (!functional) {
                 if (((!entry.fromForwardPreReq) && (!entry.fromBackPreReq)) || (preHitInPtw)) {
-                    walker->tlb->insert(entry.vaddr, entry, false, direct);
+                    std::array<PTE, l2tlbLineSize> l1_compress_ptes;
+                    for (int compress_i = 0; compress_i < l2tlbLineSize; compress_i++) {
+                        l1_compress_ptes[compress_i] = read->getLE_l2tlb<uint64_t>(compress_i);
+                    }
+                    walker->tlb->recordL1CompressionPotential(entry.vaddr, entry.pte, l1_compress_ptes, direct,
+                                                                level);
+                    TlbEntry compressed_entry;
+                    if (walker->tlb->isL1DirectCompressionEnabled() &&
+                        walker->tlb->buildL1CompressedEntry(entry.vaddr, entry, l1_compress_ptes, direct, level,
+                                                             compressed_entry)) {
+                        walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, direct); // write back L1
+                        TlbEntry *l1_entry = walker->tlb->lookup(entry.vaddr, entry.asid, BaseMMU::Read, true, false,
+                                                                 direct);
+                        if (l1_entry && l1_entry->isCompressed)
+                            walker->tlb->recordL1CompressedEntry(compressed_entry);
+                    } else if (walker->tlb->isL1DirectCompressionEnabled() &&
+                               walker->tlb->buildSingleL1CompressedEntry(entry.vaddr, entry, direct,
+                                                                          compressed_entry)) {
+                        walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, direct);
+                        walker->tlb->recordL1CompressedEntry(compressed_entry);
+                    } else if (!walker->tlb->isL1DirectCompressionEnabled()) {
+                        walker->tlb->insert(entry.vaddr, entry, false, direct); // write back L1
+                    }
                 }
                 finishDefaultTranslate = true;
 
@@ -1399,7 +1433,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                 inl2Entry.level = level;
                 DPRINTF(PageTableWalker3, "final l1tlb vaddr %#x pre %d\n", entry.vaddr, entry.fromForwardPreReq);
 
-                for (l2_i = 0; l2_i < l2tlbLineSize; l2_i++) {
+                for (l2_i = 0; l2_i < l2tlbLineSize; l2_i++) {  //write back L2
                     inl2Entry.vaddr = ((entry.vaddr >> ((l2_level * LEVEL_BITS + PageShift + L2TLB_BLK_OFFSET))
                                                            << L2TLB_BLK_OFFSET) +
                                        l2_i)
@@ -1657,18 +1691,18 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
 {
     Addr topAddr;
     int top_level;
-    if (translateMode == twoStageMode) {
+    if (translateMode == twoStageMode) {    //2-stage
         panic_if(vsatp.mode == AddrXlateMode::BARE, "should be processed in isVsatpOMode.");
         top_level = PTW_TOP_LEVEL(vsatp.mode);
-    } else {
+    } else {    //1-stage
         top_level = satp.mode == AddrXlateMode::SV48 ? 3: 2;
     }
 
-    if (from_l2tlb){
+    if (from_l2tlb){    //non-leaf level
         level = f_level;
     }
     else {
-        level = top_level;
+        level = top_level;  //full level
         if (mainReq && mainReq->get_level() != top_level)
             level = mainReq->get_level();
         if (isVsatp0Mode)
@@ -1677,9 +1711,9 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
 
     Addr shift = PageShift + LEVEL_BITS * level;
     Addr idx_f = (vaddr >> shift) & LEVEL_MASK;
-    Addr idx = (idx_f >> 3) << 3;
+    Addr idx = (idx_f >> 3) << 3;   //8 byte align
     Fault fault = NoFault;
-    if (translateMode == twoStageMode) {
+    if (translateMode == twoStageMode) {    //2-stage
         nextline = false;
         autoNextlineSign = false;
         preHitInPtw = false;
@@ -1752,7 +1786,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
             endWalk();
             return fault;
         }
-    } else {
+    } else {    // 1-stage begin here
         DPRINTF(PageTableWalker, "setupWalk: ppn %#x, vaddr %#x, level %d\n", ppn, vaddr, level);
 
         vaddr = VADDR_SEXT(satp.mode, vaddr);
@@ -1762,7 +1796,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
         autoNextlineSign = auto_open_nextline;
         preHitInPtw = false;
 
-        if (from_l2tlb) {
+        if (from_l2tlb) {   //non-leaf level
             topAddr = (ppn << PageShift) + (idx * sizeof(PTE));
             nextlineLevelMask = LEVEL_MASK;
             nextlineShift = shift;
@@ -1770,7 +1804,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
             tlbppn = ppn;
             nextlineRead = topAddr;
             nextlineLevel = level;
-        } else {
+        } else {    //top level
             topAddr = (satp.ppn << PageShift) + (idx * sizeof(PTE));
             nextlineLevelMask = LEVEL_MASK;
             nextlineShift = shift;
@@ -1820,7 +1854,7 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
             panic("topAddr can't be 0\n");
         DPRINTF(PageTableWalker, " pte size is %d\n", sizeof(PTE));
 
-        read = new Packet(request, MemCmd::ReadReq);
+        read = new Packet(request, MemCmd::ReadReq);    //build packet
         read->allocate();
     }
     return NoFault;

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -44,6 +44,7 @@
 #include "arch/riscv/pmp.hh"
 #include "arch/riscv/pra_constants.hh"
 #include "arch/riscv/utility.hh"
+#include "base/cprintf.hh"
 #include "base/inifile.hh"
 #include "base/str.hh"
 #include "base/trace.hh"
@@ -81,9 +82,25 @@ buildKey(Addr vpn, uint16_t asid, uint8_t translateMode)
            ((vpn >> PGSHFT) & (((uint64_t)1 << 46) - 1));
 }
 
+static bool
+isCompressibleLeafPte(PTE pte)
+{
+    return pte.v && !(!pte.r && pte.w) && (pte.r || pte.x);
+}
+
+static bool
+hasSameCompressionAttrs(PTE lhs, PTE rhs)
+{
+    return lhs.r == rhs.r && lhs.w == rhs.w && lhs.x == rhs.x &&
+           lhs.u == rhs.u && lhs.g == rhs.g && lhs.a == rhs.a &&
+           lhs.d == rhs.d;
+}
+
 TLB::TLB(const Params &p) :
     BaseTLB(p), is_dtlb(p.is_dtlb),is_L1tlb(p.is_L1tlb),isStage2(p.is_stage2),
-    isTheSharedL2(p.is_the_sharedL2),size(p.size),sizeBack(32),
+    isTheSharedL2(p.is_the_sharedL2),
+    enableL1DirectCompression(p.enable_l1_direct_compression),
+    size(p.size),sizeBack(32),
     l2TlbL3Size(p.l2tlb_l3_size),
     l2TlbL2Size(p.l2tlb_l2_size),l2TlbL1Size(p.l2tlb_l1_size),
     l2TlbL0Size(p.l2tlb_l0_size),l2TlbSpSize(p.l2tlb_sp_size),
@@ -319,6 +336,16 @@ TLB::lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
             bool sign_used, uint8_t translateMode, bool is_prefetch)
 {
     TlbEntry *entry = trie.lookup(buildKey(vpn, asid, translateMode));
+    if (entry && entry->isCompressed) {
+        const uint8_t sub_idx = (vpn >> PageShift) & 0x7;
+        if (!(entry->validIdx & (1 << sub_idx))) {
+            if (!hidden && !is_prefetch)
+                stats.l1CompressedLookupMisses++;
+            entry = nullptr;
+        } else if (!hidden && !is_prefetch) {
+            stats.l1CompressedLookupHits++;
+        }
+    }
 
     if (!hidden) {
         if (entry)
@@ -618,10 +645,28 @@ TLB::lookupL2TLB(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden, int f
 }
 
 TlbEntry *
-TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t translateMode)
+TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t translateMode) //insertion function entry
 {
     DPRINTF(TLBGPre, "insert(vpn=%#x, asid=%#x): ppn=%#x pte=%#x size=%#x\n",
             vpn, translateMode == gstage ? entry.vmid : entry.asid, entry.paddr, entry.pte, entry.size());
+
+    if (!squashed_update && enableL1DirectCompression &&
+        translateMode == direct && !entry.isCompressed) {
+        TlbEntry compressed_entry;
+        panic_if(!buildSingleL1CompressedEntry(vpn, entry, translateMode,
+                                               compressed_entry),
+                 "normal direct L1 entry inserted while compression is "
+                 "enabled: vpn %#x pte %#x level %d\n",
+                 vpn, entry.pte, (int)entry.level);
+        return insert(compressed_entry.vaddr, compressed_entry, false,
+                      translateMode);
+    }
+
+    if (!squashed_update) {
+        TlbEntry *merged_entry = prepareL1CompressedInsert(entry, translateMode);
+        if (merged_entry)
+            return merged_entry;
+    }
 
     // If somebody beat us to it, just use that existing entry.
     TlbEntry *newEntry = nullptr;
@@ -644,6 +689,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
         }
         return newEntry;
     }
+
     if (newEntry) {
         // update PTE flags (maybe we set the dirty/writable flag)
         newEntry->pte = entry.pte;
@@ -671,6 +717,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     if (translateMode == gstage)
         key = buildKey(vpn, entry.vmid, translateMode);
     *newEntry = entry;
+    newEntry->translateMode = translateMode;
     newEntry->lruSeq = nextSeq();
     newEntry->vaddr = vpn;
     newEntry->trieHandle = trie.insert(key, TlbEntryTrie::MaxBits - entry.logBytes + PGSHFT, newEntry);
@@ -683,7 +730,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
 }
 
 TlbEntry *
-TLB::insertForwardPre(Addr vpn, const TlbEntry &entry)
+TLB::insertForwardPre(Addr vpn, const TlbEntry &entry)  //insert pre-fetech
 {
     TlbEntry *newEntry = lookupForwardPre(vpn, entry.asid, true);
     if (newEntry)
@@ -705,7 +752,7 @@ TLB::insertForwardPre(Addr vpn, const TlbEntry &entry)
 }
 
 TlbEntry *
-TLB::insertBackPre(Addr vpn, const TlbEntry &entry)
+TLB::insertBackPre(Addr vpn, const TlbEntry &entry) //insert pre-fetech
 {
     TlbEntry *newEntry = lookupBackPre(vpn, entry.asid, true);
     if (newEntry)
@@ -727,7 +774,7 @@ TLB::insertBackPre(Addr vpn, const TlbEntry &entry)
 
 TlbEntry *
 TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List, TlbEntryTrie *Trie_l2, int sign,
-                   bool squashed_update, uint8_t translateMode)
+                   bool squashed_update, uint8_t translateMode) //normal insertion
 {
     if (!List || !Trie_l2)
         panic("L2TLBInsertIn: List or Trie_l2 should not be 0\n");
@@ -739,12 +786,12 @@ TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List,
             entry.paddr, entry.pte, entry.size(), choose);
     TlbEntry *newEntry;
     Addr key;
-    if (translateMode == gstage)
+    if (translateMode == gstage)    //check if entry has exist
         newEntry = lookupL2TLB(vpn, entry.vmid, BaseMMU::Read, true, choose, false, translateMode);
     else
         newEntry = lookupL2TLB(vpn, entry.asid, BaseMMU::Read, true, choose, false, translateMode);
 
-    Addr step = 0;
+    Addr step = 0;      //caculate steps by types of cache level
     if ((choose == L_L2L3) || (choose == L_L2sp3)) {
         step = 0x1ll << (PageShift + 3 * LEVEL_BITS);
     } else if ((choose == L_L2L2) || (choose == L_L2sp2)) {
@@ -755,7 +802,7 @@ TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List,
         step = 0x1ll << (PageShift + 0 * LEVEL_BITS);
     }
 
-    if (squashed_update) {
+    if (squashed_update) {  //mark an entry as squash,what is this means?
         if (newEntry) {
             if (newEntry->isSquashed) {
                 return newEntry;
@@ -778,7 +825,7 @@ TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List,
         }
         return newEntry;
     }
-    if (newEntry) {
+    if (newEntry) { //obtain new entry
         newEntry->pte = entry.pte;
         if (newEntry->vaddr != vpn) {
             Addr newEntryAddr = ((buildKey(newEntry->vaddr, newEntry->asid, translateMode) >> 12) << 12);
@@ -812,10 +859,10 @@ TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List,
     if ((*List).empty())
         panic("TLB::L2TLBInsertIn freeList should not be empty.");
 
-    newEntry = (*List).front();
+    newEntry = (*List).front(); //find a free entry
     (*List).pop_front();
 
-    key = buildKey(vpn, entry.asid, translateMode);
+    key = buildKey(vpn, entry.asid, translateMode); //build key
     if (translateMode == gstage)
         key = buildKey(vpn, entry.vmid, translateMode);
 
@@ -823,14 +870,14 @@ TLB::L2TLBInsertIn(Addr vpn, const TlbEntry &entry, int choose, EntryList *List,
         panic("TLB::L2TLBInsertIn newEntry should not be nullptr.");
 
     *newEntry = entry;
-    newEntry->lruSeq = nextSeq();
+    newEntry->lruSeq = nextSeq();   //insert entry info
     newEntry->vaddr = vpn;
     if (entry.paddr == 0) {
         DPRINTF(TLB, " l2tlb num is outside vaddr %#x paddr %#x \n",
                 entry.vaddr, entry.paddr);
     }
 
-    newEntry->trieHandle = (*Trie_l2).insert(
+    newEntry->trieHandle = (*Trie_l2).insert(   //insert key
         key, TlbEntryTrie::MaxBits - entry.logBytes + PGSHFT, newEntry);
 
     DPRINTF(TLB, "l2tlb trie insert key %#x logbytes %#x len %#x\n", key,
@@ -1199,15 +1246,239 @@ TLB::createPagefault(Addr vaddr, Addr gPaddr,BaseMMU::Mode mode,bool G)
 }
 
 Addr
+TLB::getEntryPaddr(const TlbEntry *entry, Addr vaddr) const
+{
+    assert(entry != nullptr);
+
+    if (!entry->isCompressed || entry->level != 0)
+        return (entry->paddr << PageShift) | (vaddr & mask(entry->logBytes));
+
+    const uint8_t sub_idx = (vaddr >> PageShift) & 0x7;
+    assert(entry->validIdx & (1 << sub_idx));
+
+    const Addr ppn = (entry->paddr << 3) | entry->ppnLow[sub_idx];
+    return (ppn << PageShift) | (vaddr & mask(PageShift));
+}
+
+TlbEntry *
+TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
+{
+    if (!entry.isCompressed || translateMode != direct)
+        return nullptr;
+
+    TlbEntry *merged_entry = nullptr;
+    const Addr block_base = entry.vaddr;
+    const Addr block_limit = block_base + entry.size();
+
+    for (size_t i = 0; i < size; i++) {
+        TlbEntry &old_entry = tlb[i];
+        if (!old_entry.trieHandle)
+            continue;
+        if (old_entry.translateMode != direct)
+            continue;
+        if (old_entry.asid != entry.asid)
+            continue;
+
+        const Addr old_base = old_entry.vaddr;
+        const Addr old_limit = old_base + old_entry.size();
+        if (old_limit <= block_base || old_base >= block_limit)
+            continue;
+
+        if (old_entry.isCompressed) {
+            if (old_entry.vaddr != block_base ||
+                old_entry.logBytes != entry.logBytes ||
+                old_entry.paddr != entry.paddr ||
+                !hasSameCompressionAttrs(old_entry.pte, entry.pte)) {
+                remove(i);
+                continue;
+            }
+            for (int sub_idx = 0; sub_idx < l2tlbLineSize; sub_idx++) {
+                if (entry.validIdx & (1 << sub_idx))
+                    old_entry.ppnLow[sub_idx] = entry.ppnLow[sub_idx];
+            }
+            old_entry.validIdx |= entry.validIdx;
+            old_entry.pteIdx |= entry.pteIdx;
+            old_entry.pte = entry.pte;
+            old_entry.lruSeq = nextSeq();
+            merged_entry = &old_entry;
+            continue;
+        }
+
+        remove(i);
+    }
+
+    return merged_entry;
+}
+
+bool
+TLB::buildL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
+                            const std::array<PTE, l2tlbLineSize> &ptes,
+                            uint8_t translateMode, int level,
+                            TlbEntry &compressed_entry) const
+{
+    if (translateMode != direct || level != 0)
+        return false;
+
+    if (!isCompressibleLeafPte(base_entry.pte))
+        return false;
+
+    const Addr base_ppn_high = base_entry.pte.ppn >> L2TLB_BLK_OFFSET;
+    uint8_t valid_idx = 0;
+    std::array<uint8_t, l2tlbLineSize> ppn_low{};
+    unsigned valid_count = 0;
+
+    for (int i = 0; i < l2tlbLineSize; i++) {
+        const PTE pte = ptes[i];
+        if (!isCompressibleLeafPte(pte))
+            continue;
+        if (!hasSameCompressionAttrs(pte, base_entry.pte))
+            continue;
+        if ((pte.ppn >> L2TLB_BLK_OFFSET) != base_ppn_high)
+            continue;
+
+        valid_idx |= 1 << i;
+        ppn_low[i] = pte.ppn & VADDR_CHOOSE_MASK;
+        valid_count++;
+    }
+
+    if (valid_count == 0)
+        return false;
+
+    const uint8_t pte_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+    assert(valid_idx & (1 << pte_idx));
+
+    compressed_entry = base_entry;
+    compressed_entry.isCompressed = true;
+    compressed_entry.validIdx = valid_idx;
+    compressed_entry.pteIdx = 1 << pte_idx;
+    compressed_entry.ppnLow = ppn_low;
+    compressed_entry.paddr = base_ppn_high;
+    compressed_entry.vaddr = (vaddr >> (PageShift + L2TLB_BLK_OFFSET))
+                             << (PageShift + L2TLB_BLK_OFFSET);
+    compressed_entry.logBytes = PageShift + L2TLB_BLK_OFFSET;
+    compressed_entry.level = 0;
+
+    return true;
+}
+
+bool
+TLB::buildSingleL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
+                                  uint8_t translateMode,
+                                  TlbEntry &compressed_entry) const
+{
+    if (translateMode != direct)
+        return false;
+
+    if (!isCompressibleLeafPte(base_entry.pte))
+        return false;
+
+    const uint8_t pte_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+
+    compressed_entry = base_entry;
+    compressed_entry.isCompressed = true;
+    compressed_entry.pteIdx = 1 << pte_idx;
+    compressed_entry.ppnLow = {};
+    compressed_entry.trieHandle = nullptr;
+
+    if (base_entry.level == 0) {
+        compressed_entry.validIdx = 1 << pte_idx;
+        compressed_entry.ppnLow[pte_idx] =
+            base_entry.pte.ppn & VADDR_CHOOSE_MASK;
+        compressed_entry.paddr = base_entry.pte.ppn >> L2TLB_BLK_OFFSET;
+        compressed_entry.vaddr = (vaddr >> (PageShift + L2TLB_BLK_OFFSET))
+                                 << (PageShift + L2TLB_BLK_OFFSET);
+        compressed_entry.logBytes = PageShift + L2TLB_BLK_OFFSET;
+    } else {
+        compressed_entry.validIdx = (1 << l2tlbLineSize) - 1;
+        compressed_entry.paddr = base_entry.paddr;
+        compressed_entry.vaddr = (vaddr >> base_entry.logBytes)
+                                 << base_entry.logBytes;
+        compressed_entry.logBytes = base_entry.logBytes;
+    }
+
+    return true;
+}
+
+Addr
 TLB::translateWithTLB(Addr vaddr, uint16_t asid, BaseMMU::Mode mode, uint8_t translateMode)
 {
     TlbEntry *e = lookup(vaddr, asid, mode, false, false, translateMode);
     DPRINTF(TLB, "translateWithTLB vaddr %#x \n", vaddr);
-    assert(e != nullptr);
-    DPRINTF(TLBGPre, "translateWithTLB vaddr %#x paddr %#x\n", vaddr,
-            e->paddr << PageShift | (vaddr & mask(e->logBytes)));
-    return (e->paddr << PageShift) | (vaddr & mask(e->logBytes));
+    panic_if(e == nullptr,
+             "translateWithTLB missed after PTW: vaddr %#x asid %#x mode %d "
+             "translateMode %d\n",
+             vaddr, asid, mode, translateMode);
+    Addr paddr = getEntryPaddr(e, vaddr);
+    DPRINTF(TLBGPre, "translateWithTLB vaddr %#x paddr %#x\n", vaddr, paddr);
+    return paddr;
 }
+
+void
+TLB::recordL1CompressionPotential(Addr vaddr, PTE base_pte,
+                                  const std::array<PTE, l2tlbLineSize> &ptes,
+                                  uint8_t translateMode, int level)
+{
+    if (translateMode != direct || level != 0)
+        return;
+
+    stats.l1CompressPotentialAttempts++;
+
+    unsigned valid_count = 0;
+
+    if (isCompressibleLeafPte(base_pte)) {
+        const Addr base_ppn_high = base_pte.ppn >> L2TLB_BLK_OFFSET;
+
+        for (int i = 0; i < l2tlbLineSize; i++) {
+            const PTE pte = ptes[i];
+            if (!isCompressibleLeafPte(pte))
+                continue;
+            if (!hasSameCompressionAttrs(pte, base_pte))
+                continue;
+            if ((pte.ppn >> L2TLB_BLK_OFFSET) != base_ppn_high)
+                continue;
+
+            valid_count++;
+        }
+
+        if (valid_count > 0)
+            stats.l1CompressPotentialPages += valid_count;
+
+        if (valid_count >= 2) {
+            stats.l1CompressPotentialBlocks++;
+            stats.l1CompressPotentialSavedEntries += valid_count - 1;
+        }
+    }
+
+    stats.l1CompressPotentialPagesPerBlock[valid_count]++;
+
+    DPRINTF(TLBVerbose,
+            "l1 compression potential vaddr %#x pteidx %u valid_count %u "
+            "base_pte_valid %d\n",
+            vaddr, (unsigned)((vaddr >> PageShift) & VADDR_CHOOSE_MASK),
+            valid_count, isCompressibleLeafPte(base_pte));
+}
+
+void
+TLB::recordL1CompressedEntry(const TlbEntry &entry)
+{
+    assert(entry.isCompressed);
+
+    if (entry.level != 0)
+        return;
+
+    unsigned valid_count = 0;
+    for (int i = 0; i < l2tlbLineSize; i++) {
+        if (entry.validIdx & (1 << i))
+            valid_count++;
+    }
+
+    assert(valid_count > 0);
+    stats.l1CompressedBlocks++;
+    stats.l1CompressedPages += valid_count;
+    if (valid_count > 1)
+        stats.l1CompressedSavedEntries += valid_count - 1;
+}
+
 Fault
 TLB::L2TLBPagefault(Addr vaddr, BaseMMU::Mode mode, const RequestPtr &req, bool isPre, bool is_back_pre)
 {
@@ -1356,14 +1627,14 @@ TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req, Thr
     TlbEntry *e_l2tlbVsstage = nullptr;
     TlbEntry *e_l2tlbGstage = nullptr;
 
-    if (hitInSp) {
+    if (hitInSp) {  //hit sp,obtain PA direatly
         if (fault == NoFault) {
             paddr = e_l2tlb->paddr << PageShift | (vaddr & mask(e_l2tlb->logBytes));
             walker->doL2TLBHitSchedule(req, tc, translation, mode, paddr, e_l2tlb, e_l2tlbVsstage, e_l2tlbGstage, 1);
             delayed = true;
             return std::make_pair(true, fault);
         }
-    } else {
+    } else {    //hit l2l1/l2/l3,trigger PTW
         fault = walker->start(e_l2tlb->pte.ppn, tc, translation, req, mode, false, false, level, true, e_l2tlb->asid);
         if (translation != nullptr || fault != NoFault) {
             delayed = true;
@@ -1757,7 +2028,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                  BaseMMU::Translation *translation, BaseMMU::Mode mode,
                  bool &delayed)
 {
-    SATP vsatp = tc->readMiscReg(MISCREG_VSATP);
+    SATP vsatp = tc->readMiscReg(MISCREG_VSATP);    //info get
     HGATP hgatp = tc->readMiscReg(MISCREG_HGATP);
     Addr vaddr = VADDR_SEXT(hgatp.mode, req->getVaddr());
     int virt = tc->readMiscReg(MISCREG_VIRMODE);
@@ -1779,7 +2050,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
 
     assert(l2tlb != nullptr);
 
-    if (mode != BaseMMU::Execute) {
+    if (mode != BaseMMU::Execute) { //mode set
         if (status.mprv) {
             two_stage_pmode = status.mpp;
             virt = status.mpv && (two_stage_pmode != PrivilegeMode::PRV_M);
@@ -1791,7 +2062,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
         }
     }
 
-    if (virt != 0) {
+    if (virt != 0) {    //virt mode inquery
         if (vsatp.mode == 0) {
             req->setVsatp0Mode(true);
             req->setTwoStageState(true, virt, two_stage_pmode);
@@ -1802,14 +2073,14 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
             req->setVsatp0Mode(false);
             req->setTwoStageState(true, virt, two_stage_pmode);
         }
-        std::pair<int, Fault> result = checkHL1Tlb(req, tc, translation, mode);
+        std::pair<int, Fault> result = checkHL1Tlb(req, tc, translation, mode); //inquery L1 TLB
         l1tlbtype = result.first;
         fault = result.second;
 
-        if (fault != NoFault) {
+        if (fault != NoFault) { //fault in L1 TLB
             return fault;
-        } else if ((l1tlbtype == h_l1VSstageHit) || (l1tlbtype == H_L1miss)) {
-            std::pair<int, Fault> result = checkHL2Tlb(req, tc, translation, mode, l1tlbtype);
+        } else if ((l1tlbtype == h_l1VSstageHit) || (l1tlbtype == H_L1miss)) {// full/half miss in L1
+            std::pair<int, Fault> result = checkHL2Tlb(req, tc, translation, mode, l1tlbtype);// inquery L2
             if (result.second != NoFault) {
                 return result.second;
             }
@@ -1891,7 +2162,16 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     TlbEntry *forward_pre[L_L2SUM] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
     TlbEntry *back_pre[L_L2SUM] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
     const bool is_prefetch = req->isPrefetch();
-    e[0] = lookup(vaddr, satp.asid, mode, false, true, direct, is_prefetch);
+    e[0] = lookup(vaddr, satp.asid, mode, false, true, direct, is_prefetch);    //lookup in L1 TLB
+    if (!is_prefetch) {
+        if (e[0]) {
+            stats.l1InitialLookupHits++;
+            if (e[0]->isCompressed)
+                stats.l1InitialCompressedHits++;
+        } else {
+            stats.l1InitialLookupMisses++;
+        }
+    }
     Addr paddr = 0;
     Fault fault = NoFault;
     Fault fault_return = NoFault;
@@ -1935,7 +2215,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     forwardPrePrecision = checkPrePrecision(l2tlb->removeNoUseForwardPre, l2tlb->forwardUsedPre);
 
 
-    for (int i_e = 1; i_e < L_L2SUM; i_e++) {
+    for (int i_e = 1; i_e < L_L2SUM; i_e++) {   //lookup in  L2 TLB
         if ((satp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))
             continue;
         if (!e[0])
@@ -1952,22 +2232,22 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         archDBer->vaddrTrace(curCycle, pc, vaddr, (e[0] || e[L_L2L0]));
     }
 
-    if (!e[0]) {  // look up l2tlb
+    if (!e[0]) {  // check result of L2 TLB lookup
         if (e[L_L2L0] && e[L_L2L0]->pte.v) {  // if hit in l2l0 (leaf 4KB page)
-            DPRINTF(TLBVerbosel2, "hit in l2TLB l0\n");
+            DPRINTF(TLBVerbosel2, "hit in l2TLB l0\n"); //if hit in l2l0, obtain PA direatly
             fault = L2TLBCheck(e[L_L2L0]->pte, L2L0CheckLevel, status, pmode, vaddr, mode, req, false, false);
-            if (hitInSp) {
+            if (hitInSp) {  //this name has a little bit strenge，it means hit leaf
                 e[0] = e[L_L2L0];
                 if (fault == NoFault) {
-                    paddr = e[0]->paddr << PageShift | (vaddr & mask(e[0]->logBytes));
+                    paddr = e[0]->paddr << PageShift | (vaddr & mask(e[0]->logBytes));  //calculate paddr
                     DPRINTF(TLBVerbosel2, "vaddr %#x,paddr %#x,pc %#x\n", vaddr, paddr, req->getPC());
                     TlbEntry *e_l2tlbVsstage = nullptr;
                     TlbEntry *e_l2tlbGstage = nullptr;
                     walker->doL2TLBHitSchedule(req, tc, translation, mode, paddr,
-                                               e[L_L2L0], e_l2tlbVsstage, e_l2tlbGstage, 1);
+                                               e[L_L2L0], e_l2tlbVsstage, e_l2tlbGstage, 1);    //write back to L1 TLB
                     DPRINTF(TLBVerbosel2, "finish Schedule\n");
                     delayed = true;
-                    if ((forward_pre_block != vaddr_block) && (!forward_pre[L_L2L0])
+                    if ((forward_pre_block != vaddr_block) && (!forward_pre[L_L2L0])    //not hit in l2l0
                         && openForwardPre && (!pre_forward)) {
                         if (forward_pre[L_L2L1] || forward_pre[L_L2sp1]) {
                             sendPreHitOnHitRequest(forward_pre[L_L2sp1], forward_pre[L_L2L1], req, forward_pre_block,
@@ -2029,7 +2309,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 L2TLBSendRequest(fault, e[L_L2sp3], req, tc, translation, mode, vaddr, delayed, L2L3CheckLevel - 1);
             if (return_flag)
                 return fault_return;
-        } else if (e[L_L2L1] && e[L_L2L1]->pte.v) {
+        } else if (e[L_L2L1] && e[L_L2L1]->pte.v) { //hit in l2l1
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l1\n");
             DPRINTF(TLBVerbosel2, "hit ppn: %#x\n", e[L_L2L1]->pte.ppn);
             fault = L2TLBCheck(e[L_L2L1]->pte, L2L1CheckLevel, status, pmode, vaddr, mode, req, false, false);
@@ -2039,7 +2319,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 L2TLBSendRequest(fault, e[L_L2L1], req, tc, translation, mode, vaddr, delayed, L2L1CheckLevel - 1);
             if (return_flag)
                 return fault_return;
-        } else if (e[L_L2L2] && e[L_L2L2]->pte.v) {
+        } else if (e[L_L2L2] && e[L_L2L2]->pte.v) { //hit in l2l2
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l2\n");
             DPRINTF(TLBVerbosel2, "hit pte: %#x\n", e[L_L2L2]->pte);
             fault = L2TLBCheck(e[L_L2L2]->pte, L2L2CheckLevel, status, pmode, vaddr, mode, req, false, false);
@@ -2049,7 +2329,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 L2TLBSendRequest(fault, e[L_L2L2], req, tc, translation, mode, vaddr, delayed, L2L2CheckLevel - 1);
             if (return_flag)
                 return fault_return;
-        } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2L3] && e[L_L2L3]->pte.v) {
+        } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2L3] && e[L_L2L3]->pte.v) { //hit in l2l3
             DPRINTF(TLBVerbosel2, "hit in l2 tlb l3\n");
             fault = L2TLBCheck(e[L_L2L3]->pte, L2L3CheckLevel, status, pmode, vaddr, mode, req, false, false);
             if (hitInSp)
@@ -2059,11 +2339,11 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (return_flag)
                 return fault_return;
         } else {
-            DPRINTF(TLB, "miss in l1 tlb + l2 tlb\n");
+            DPRINTF(TLB, "miss in l1 tlb + l2 tlb\n");  //miss in L2 TLB
             DPRINTF(TLBGPre, "pre_req %d vaddr %#x req_vaddr %#x pc %#x\n", req->get_forward_pre_tlb(), vaddr,
                     req->getVaddr(), req->getPC());
 
-            if (traceFlag)
+            if (traceFlag)  //trigger PTW
                 DPRINTF(TLBtrace, "tlb miss vaddr %#x pc %#x\n", vaddr_trace, req->getPC());
             int walk_level = satp.mode == AddrXlateMode::SV48 ? 3 : 2;
             fault = walker->start(0, tc, translation, req, mode, false, false, walk_level, false, 0);
@@ -2073,14 +2353,14 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                 delayed = true;
                 return fault;
             }
-            e[0] = lookup(vaddr, satp.asid, mode, false, true, direct,
-                          is_prefetch);
+            e[0] = lookup(vaddr, satp.asid, mode, false, true, direct,  //re-lookup
+                          is_prefetch); //requery L1 TLB after PTW
             assert(e[0] != nullptr);
         }
     }
     if (!e[0])
         e[0] = lookup(vaddr, satp.asid, mode, false, true, direct,
-                      is_prefetch);
+                      is_prefetch); // ensure？
     assert(e[0] != nullptr);
 
     status = tc->readMiscReg(MISCREG_STATUS);
@@ -2109,7 +2389,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         return fault;
     }
     assert(e[0] != nullptr);
-    paddr = e[0]->paddr << PageShift | (vaddr & mask(e[0]->logBytes));
+    paddr = getEntryPaddr(e[0], vaddr); // L1 paddr calculation
 
     DPRINTF(TLBVerbosel2, "translate(vpn=%#x, asid=%#x): %#x pc%#x\n", vaddr,
             satp.asid, paddr, req->getPC());
@@ -2146,58 +2426,23 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
 
     return NoFault;
 }
+
 PrivilegeMode
-TLB::currentMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
+TLB::getMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
 {
+    if (use_old_priv && mode != BaseMMU::Execute) {
+        if (mode == BaseMMU::Execute) {
+            return old_priv_ex;
+        } else {
+            return old_priv_ldst;
+        }
+    }
     STATUS status = (STATUS)tc->readMiscReg(MISCREG_STATUS);
     PrivilegeMode pmode = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
     if (mode != BaseMMU::Execute && status.mprv == 1)
         pmode = (PrivilegeMode)(RegVal)status.mpp;
     return pmode;
 }
-
-PrivilegeMode
-TLB::getMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
-{
-    if (mode != BaseMMU::Execute) {
-        const int tid = tc->threadId();
-        if (tid >= 0) {
-            const auto thread_idx = static_cast<size_t>(tid);
-            if (thread_idx < oldPrivByThread.size() &&
-                oldPrivByThread[thread_idx].valid) {
-                return oldPrivByThread[thread_idx].ldst;
-            }
-        }
-    }
-    return currentMemPriv(tc, mode);
-}
-
-void
-TLB::setOldPriv(ThreadContext *tc)
-{
-    const int tid = tc->threadId();
-    assert(tid >= 0);
-    const auto thread_idx = static_cast<size_t>(tid);
-    if (oldPrivByThread.size() <= thread_idx) {
-        oldPrivByThread.resize(thread_idx + 1);
-    }
-    oldPrivByThread[thread_idx].valid = true;
-    oldPrivByThread[thread_idx].ldst = currentMemPriv(tc, BaseMMU::Read);
-}
-
-void
-TLB::useNewPriv(ThreadContext *tc)
-{
-    const int tid = tc->threadId();
-    if (tid < 0) {
-        return;
-    }
-    const auto thread_idx = static_cast<size_t>(tid);
-    if (thread_idx < oldPrivByThread.size()) {
-        oldPrivByThread[thread_idx].valid = false;
-    }
-}
-
 bool
 TLB::hasTwoStageTranslation(ThreadContext *tc, const RequestPtr &req, BaseMMU::Mode mode)
 {
@@ -2233,7 +2478,7 @@ TLB::isaMMUCheck(ThreadContext *tc, Addr vaddr, BaseMMU::Mode mode)
     return MMU_DIRECT;
 }
 
-Fault
+Fault   //main entry
 TLB::translate(const RequestPtr &req, ThreadContext *tc,
                BaseMMU::Translation *translation, BaseMMU::Mode mode,
                bool &delayed)
@@ -2254,7 +2499,7 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
 
         Fault fault;
 
-        if (req->getFlags() & Request::PHYSICAL) {
+        if (req->getFlags() & Request::PHYSICAL) {  //phycial visit
             req->setTwoStageState(false, 0, 0);
             /**
              * we simply set the virtual address to physical address
@@ -2269,13 +2514,13 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
                 fault = NoFault;
                 assert(!req->get_h_inst());
             }
-        } else {
+        } else {    //2-stage visit
             two_stage_translation = hasTwoStageTranslation(tc, req, mode);
             if (two_stage_translation) {
                 assert((vsatp.mode == NEMU_SATP_SV39) || (hgatp.mode == NEMU_SATP_SV39)
                        || (vsatp.mode == NEMU_SATP_SV48) || (hgatp.mode == NEMU_SATP_SV48));
                 fault = doTwoStageTranslate(req, tc, translation, mode, delayed);
-            } else {
+            } else {    //normal visit
                 req->setTwoStageState(false, 0, 0);
                 controlNum++;
                 fault = doTranslate(req, tc, translation, mode, delayed);
@@ -2329,7 +2574,7 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
     }
 }
 
-Fault
+Fault   //only focus on correction
 TLB::translateAtomic(const RequestPtr &req, ThreadContext *tc,
                      BaseMMU::Mode mode)
 {
@@ -2337,7 +2582,7 @@ TLB::translateAtomic(const RequestPtr &req, ThreadContext *tc,
     return translate(req, tc, nullptr, mode, delayed);
 }
 
-void
+void        //senstive to timing
 TLB::translateTiming(const RequestPtr &req, ThreadContext *tc,
                      BaseMMU::Translation *translation, BaseMMU::Mode mode)
 {
@@ -2575,6 +2820,32 @@ TLB::TlbStats::TlbStats(statistics::Group *parent)
                "l1tlb used remove"),
       ADD_STAT(l1tlbUnusedRemove, statistics::units::Count::get(),
                "l1tlb unused remove"),
+      ADD_STAT(l1CompressPotentialAttempts, statistics::units::Count::get(),
+               "number of direct level-0 PTW leaf blocks checked for L1 TLB compression"),
+      ADD_STAT(l1CompressPotentialBlocks, statistics::units::Count::get(),
+               "number of direct level-0 PTW leaf blocks with at least two compressible entries"),
+      ADD_STAT(l1CompressPotentialPages, statistics::units::Count::get(),
+               "number of compressible 4KB PTEs seen in checked L1 compression blocks"),
+      ADD_STAT(l1CompressPotentialSavedEntries, statistics::units::Count::get(),
+               "ideal L1 entry savings if each compressible block is stored as one compressed entry"),
+      ADD_STAT(l1CompressPotentialPagesPerBlock, statistics::units::Count::get(),
+               "histogram of compressible 4KB PTE count per checked block"),
+      ADD_STAT(l1CompressedBlocks, statistics::units::Count::get(),
+               "number of direct level-0 PTW leaf blocks inserted as L1 compressed entries"),
+      ADD_STAT(l1CompressedPages, statistics::units::Count::get(),
+               "number of 4KB PTEs covered by inserted L1 compressed entries"),
+      ADD_STAT(l1CompressedSavedEntries, statistics::units::Count::get(),
+               "actual L1 entry savings from inserted L1 compressed entries"),
+      ADD_STAT(l1CompressedLookupHits, statistics::units::Count::get(),
+               "number of demand L1 lookups served by valid compressed entries"),
+      ADD_STAT(l1CompressedLookupMisses, statistics::units::Count::get(),
+               "number of demand L1 lookups that matched a compressed entry but missed its valid index"),
+      ADD_STAT(l1InitialLookupHits, statistics::units::Count::get(),
+               "number of non-prefetch direct one-stage initial L1 lookup hits"),
+      ADD_STAT(l1InitialLookupMisses, statistics::units::Count::get(),
+               "number of non-prefetch direct one-stage initial L1 lookup misses"),
+      ADD_STAT(l1InitialCompressedHits, statistics::units::Count::get(),
+               "number of non-prefetch direct one-stage initial L1 lookup hits served by compressed entries"),
       ADD_STAT(l2tlbRemove, statistics::units::Count::get(),
                "l2tlb remove"),
       ADD_STAT(l2tlbUsedRemove, statistics::units::Count::get(),
@@ -2605,6 +2876,12 @@ TLB::TlbStats::TlbStats(statistics::Group *parent)
     l2tlbUnusedRemove
         .init(L_L2sp3 + 1)
         .flags(gem5::statistics::total);
+    l1CompressPotentialPagesPerBlock
+        .init(l2tlbLineSize + 1)
+        .flags(gem5::statistics::total);
+    for (int i = 0; i <= l2tlbLineSize; i++) {
+        l1CompressPotentialPagesPerBlock.subname(i, csprintf("%d_pages", i));
+    }
 }
 
 Port *

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -32,9 +32,9 @@
 #ifndef __ARCH_RISCV_TLB_HH__
 #define __ARCH_RISCV_TLB_HH__
 
+#include <array>
 #include <cstdint>
 #include <list>
-#include <vector>
 
 #include "arch/generic/tlb.hh"
 #include "arch/riscv/isa.hh"
@@ -43,7 +43,6 @@
 #include "arch/riscv/regs/misc.hh"
 #include "arch/riscv/utility.hh"
 #include "base/statistics.hh"
-#include "base/types.hh"
 #include "mem/request.hh"
 #include "params/RiscvTLB.hh"
 #include "sim/sim_object.hh"
@@ -68,6 +67,7 @@ class TLB : public BaseTLB
     bool is_L1tlb;
     bool isStage2;
     bool isTheSharedL2;
+    bool enableL1DirectCompression;
     size_t size;
     size_t sizeBack;
     size_t l2TlbL3Size;
@@ -109,13 +109,9 @@ class TLB : public BaseTLB
     uint64_t lastPc;
     uint64_t traceFlag;
 
-    struct OldPrivState
-    {
-        bool valid = false;
-        PrivilegeMode ldst = PrivilegeMode::PRV_M;
-    };
-
-    std::vector<OldPrivState> oldPrivByThread;
+    bool use_old_priv;
+    PrivilegeMode old_priv_ldst;
+    PrivilegeMode old_priv_ex;
 
     Walker *walker;
 
@@ -159,6 +155,19 @@ class TLB : public BaseTLB
         statistics::Scalar l1tlbRemove;
         statistics::Scalar l1tlbUsedRemove;
         statistics::Scalar l1tlbUnusedRemove;
+        statistics::Scalar l1CompressPotentialAttempts;
+        statistics::Scalar l1CompressPotentialBlocks;
+        statistics::Scalar l1CompressPotentialPages;
+        statistics::Scalar l1CompressPotentialSavedEntries;
+        statistics::Vector l1CompressPotentialPagesPerBlock;
+        statistics::Scalar l1CompressedBlocks;
+        statistics::Scalar l1CompressedPages;
+        statistics::Scalar l1CompressedSavedEntries;
+        statistics::Scalar l1CompressedLookupHits;
+        statistics::Scalar l1CompressedLookupMisses;
+        statistics::Scalar l1InitialLookupHits;
+        statistics::Scalar l1InitialLookupMisses;
+        statistics::Scalar l1InitialCompressedHits;
 
         statistics::Vector l2tlbRemove;
         statistics::Vector l2tlbUsedRemove;
@@ -230,7 +239,22 @@ class TLB : public BaseTLB
      */
     Port *getTableWalkerPort() override;
 
+    Addr getEntryPaddr(const TlbEntry *entry, Addr vaddr) const;
+    TlbEntry *prepareL1CompressedInsert(const TlbEntry &entry,
+                                        uint8_t translateMode);
+    bool buildL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
+                                const std::array<PTE, l2tlbLineSize> &ptes,
+                                uint8_t translateMode, int level,
+                                TlbEntry &compressed_entry) const;
+    bool buildSingleL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
+                                      uint8_t translateMode,
+                                      TlbEntry &compressed_entry) const;
+    bool isL1DirectCompressionEnabled() const { return enableL1DirectCompression; }
     Addr translateWithTLB(Addr vaddr, uint16_t asid, BaseMMU::Mode mode, uint8_t translateMode);
+    void recordL1CompressionPotential(Addr vaddr, PTE base_pte,
+                                      const std::array<PTE, l2tlbLineSize> &ptes,
+                                      uint8_t translateMode, int level);
+    void recordL1CompressedEntry(const TlbEntry &entry);
 
     Fault L2TLBPagefault(Addr vaddr, BaseMMU::Mode mode, const RequestPtr &req, bool is_pre, bool is_back_pre);
 
@@ -259,7 +283,6 @@ class TLB : public BaseTLB
                               BaseMMU::Translation *translation, BaseMMU::Mode mode) override;
     Fault finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                            BaseMMU::Mode mode) const override;
-    PrivilegeMode currentMemPriv(ThreadContext *tc, BaseMMU::Mode mode);
     TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
                      bool sign_used, uint8_t translateMode,
                      bool is_prefetch = false);
@@ -269,8 +292,14 @@ class TLB : public BaseTLB
     TlbEntry *lookupL2TLB(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden, int f_level, bool sign_used,
                           uint8_t translateMode);
 
-    void setOldPriv(ThreadContext *tc);
-    void useNewPriv(ThreadContext *tc);
+    void setOldPriv(ThreadContext *tc) {
+      use_old_priv = true;
+      old_priv_ex = getMemPriv(tc, BaseMMU::Execute);
+      old_priv_ldst = getMemPriv(tc, BaseMMU::Read);
+    }
+    void useNewPriv(ThreadContext *tc) {
+      use_old_priv = false;
+    }
 
 
     std::vector<TlbEntry> tlbL2L3;  // our TLB


### PR DESCRIPTION
Add L1 direct TLB compression for 

The feature is enabled by default for kmhv3 ITB/DTB.
Use --disable-l1-direct-compression to disable it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added L1 direct compression support to RISC-V TLB.
* New `--disable-l1-direct-compression` CLI option; L1 direct compression is enabled by default.
* L1 direct compression now active in CPU instruction-side and data-side MMU buffers.
* Extended TLB entry structure with compression-related fields and metadata tracking.
* Added compression statistics monitoring and performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->