### PR TITLE
configs: Enable L2 CDP for ideal Kmhv3

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -97,7 +97,7 @@ def create_prefetcher(cpu, cache_level, options):
                 prefetcher.enable_bop = True
             if options.kmh_align:
                 assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
-                prefetcher.enable_cmc = True
+                prefetcher.enable_cmc = False
                 prefetcher.enable_bop = True
                 prefetcher.enable_cdp = False
                 prefetcher.enable_despacito_stream = False

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -99,7 +99,7 @@ def create_prefetcher(cpu, cache_level, options):
                 assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
                 prefetcher.enable_cmc = False
                 prefetcher.enable_bop = True
-                prefetcher.enable_cdp = False
+                prefetcher.enable_cdp = True
                 prefetcher.enable_despacito_stream = False
                 if prefetcher.enable_despacito_stream:
                     # if you want to check despacito pattern trace, set this to True

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -95,6 +95,7 @@ def create_prefetcher(cpu, cache_level, options):
         if not options.classic_l2:
             if hasattr(prefetcher, 'enable_bop'):
                 prefetcher.enable_bop = True
+                prefetcher.enable_cdp = True
             if options.kmh_align:
                 assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
                 prefetcher.enable_cmc = False

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -149,7 +149,7 @@ def setKmhV3IdealParams(args, system):
                 if l2_wrapper.prefetcher != NULL:
                     l2_wrapper.prefetcher.enable_cmc = False
                     l2_wrapper.prefetcher.enable_bop = True
-                    l2_wrapper.prefetcher.enable_cdp = False
+                    l2_wrapper.prefetcher.enable_cdp = True
                     l2_wrapper.prefetcher.enable_despacito_stream = False
                     l2_wrapper.prefetcher.bop_large = XSVirtualLargeBOP(
                         is_sub_prefetcher=True, enable_adaptoffset=False)

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -4,6 +4,7 @@ import sys
 import m5
 from m5.defines import buildEnv
 from m5.objects import *
+from m5.objects.Prefetcher import XSPhysicalSmallBOP, XSVirtualLargeBOP
 from m5.util import addToPath, fatal, warn
 from m5.util.fdthelper import *
 
@@ -49,13 +50,26 @@ def setKmhV3IdealParams(args, system):
 
         # scheduler
         cpu.scheduler = KMHV3Scheduler()
+        cpu.scheduler.enableMainRdpOpt = False
+        cpu.scheduler.intRegfileBanks = 4
+        # intiq0
+        cpu.scheduler.IQs[0].oports[0].rp = [IntRD(0, 0), IntRD(1, 0)]
+        cpu.scheduler.IQs[0].oports[1].rp = [IntRD(1, 1), IntRD(7, 2)]
+
+        # intiq1
+        cpu.scheduler.IQs[1].oports[0].rp = [IntRD(2, 0), IntRD(3, 0)]
+        cpu.scheduler.IQs[1].oports[1].rp = [IntRD(3, 1), IntRD(9, 2)]
+
+        # intiq2
+        cpu.scheduler.IQs[2].oports[0].rp = [IntRD(4, 0), IntRD(5, 0)]
+        cpu.scheduler.IQs[2].oports[1].rp = [IntRD(5, 1), IntRD(11, 2)]
 
         # rob
-        cpu.commitWidth = 12
-        cpu.squashWidth = 12
+        cpu.commitWidth = 8
+        cpu.squashWidth = 8
         cpu.phyregReleaseWidth = 8
-        cpu.RobCompressPolicy = 'kmhv3'
-        cpu.numROBEntries = 160
+        cpu.RobCompressPolicy = 'none'
+        cpu.numROBEntries = 352
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression
 
         # lsu
@@ -67,10 +81,10 @@ def setKmhV3IdealParams(args, system):
         cpu.DcacheSetDivNum = 2
 
         # value predictor
-        cpu.valuePred = IdealConstantLVP()
+        # cpu.valuePred = IdealConstantLVP()
 
         # lsq
-        cpu.LQEntries = 128
+        cpu.LQEntries = 120
         cpu.SQEntries = 64
         cpu.RARQEntries = 96
         cpu.RAWQEntries = 56
@@ -80,6 +94,7 @@ def setKmhV3IdealParams(args, system):
         cpu.RAWDequeuePerCycle = 4
         cpu.SbufferEntries = 24
         cpu.SbufferEvictThreshold = 16
+        cpu.enable_storeSet_train = True
         cpu.store_prefetch_train = False
 
         # branch predictor
@@ -95,9 +110,20 @@ def setKmhV3IdealParams(args, system):
         if args.caches:
             cpu.icache.size = '64kB'
             cpu.dcache.size = '64kB'
-            cpu.dcache.tag_load_read_ports = 100
+            cpu.dcache.tag_load_read_ports = 3
             cpu.dcache.mshrs = 16
+            cpu.dcache.do_fast_writeline = True
+            cpu.dcache.pipe_latency = 3
             cpu.dcache.simulate_dcache_refill = True
+            cpu.dcache.prefetch_can_offload = False
+            if cpu.dcache.prefetcher != NULL:
+                cpu.dcache.prefetcher.pht_pf_level = 2
+                cpu.dcache.prefetcher.enable_temporal = False
+                cpu.dcache.prefetcher.enable_berti = False
+                cpu.dcache.prefetcher.enable_sstride = True
+                cpu.dcache.prefetcher.enable_activepage = False
+                cpu.dcache.prefetcher.enable_pht = True
+                cpu.dcache.prefetcher.enable_xsstream = True
             set_lsq_bank_conflict_cache_params(cpu, system)
 
     # l2 caches
@@ -105,31 +131,55 @@ def setKmhV3IdealParams(args, system):
         for i in range(args.num_cpus):
             if args.classic_l2:
                 system.l2_caches[i].slice_num = 0 # 4 -> 0, no slice
+                if system.l2_caches[i].prefetcher != NULL:
+                    system.l2_caches[i].prefetcher.enable_cmc = True
+                    system.l2_caches[i].prefetcher.enable_bop = True
+                    system.l2_caches[i].prefetcher.enable_cdp = False
+                    system.l2_caches[i].prefetcher.enable_despacito_stream = False
+                    system.l2_caches[i].prefetcher.bop_large = XSVirtualLargeBOP(
+                        is_sub_prefetcher=True, enable_adaptoffset=False)
+                    system.l2_caches[i].prefetcher.bop_small = XSPhysicalSmallBOP(
+                        is_sub_prefetcher=True, enable_adaptoffset=False)
             else:
                 l2_wrapper = system.l2_wrappers[i]
-                l2_wrapper.data_sram_banks = 2
-                l2_wrapper.dir_sram_banks = 2
-                l2_wrapper.pipe_dir_write_stage = 4
-                l2_wrapper.dir_read_bypass = True
+                l2_wrapper.data_sram_banks = 1
+                l2_wrapper.dir_sram_banks = 1
+                l2_wrapper.pipe_dir_write_stage = 3
+                l2_wrapper.dir_read_bypass = False
+                if l2_wrapper.prefetcher != NULL:
+                    l2_wrapper.prefetcher.enable_cmc = False
+                    l2_wrapper.prefetcher.enable_bop = True
+                    l2_wrapper.prefetcher.enable_cdp = False
+                    l2_wrapper.prefetcher.enable_despacito_stream = False
+                    l2_wrapper.prefetcher.bop_large = XSVirtualLargeBOP(
+                        is_sub_prefetcher=True, enable_adaptoffset=False)
+                    l2_wrapper.prefetcher.bop_small = XSPhysicalSmallBOP(
+                        is_sub_prefetcher=True, enable_adaptoffset=False)
                 for j in range(args.l2_slices):
+                    l2_wrapper.slices[j].inner_cache.wpu = NULL
+                    l2_wrapper.slices[j].inner_cache.do_fast_writeline = True
+                    l2_wrapper.slices[j].inner_cache.prefetch_can_offload = False
                     # Configure XSDRRIP replacement policy (DRRIP mode)
                     # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
                     l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
-            system.tol2bus_list[i].forward_latency = 0  # 3->0
-            system.tol2bus_list[i].response_latency = 0  # 3->0
-            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0
+            system.tol2bus_list[i].forward_latency = 3  # 3->0
+            system.tol2bus_list[i].response_latency = 3  # 3->0
+            system.tol2bus_list[i].hint_wakeup_ahead_cycles = 1  # 1->0
 
             # Enable dual-port for DCache → L2 communication
             # ReqLayer[0]: ICache+DCache+ITB+DTB → L2, allow 2 requests per cycle
             # RespLayer[1]: L2 → DCache, allow 2 responses per cycle
-            system.tol2bus_list[i].layer_bandwidth_configs = [
-                LayerBandwidthConfig(direction="req", port_index=0, max_per_cycle=2),
-                LayerBandwidthConfig(direction="resp", port_index=1, max_per_cycle=2),
-            ]
+            # system.tol2bus_list[i].layer_bandwidth_configs = [
+            #     LayerBandwidthConfig(direction="req", port_index=0, max_per_cycle=2),
+            #     LayerBandwidthConfig(direction="resp", port_index=1, max_per_cycle=2),
+            # ]
 
     # l3 cache
     if args.l3cache:
-        system.l3.mshrs = 128
+        system.l3.mshrs = 64
+        system.l3.do_fast_writeline = True
+        system.l3.prefetch_can_offload = False
+        system.l3.num_slices = 4
 
 if __name__ == '__m5_main__':
     FutureClass = None
@@ -143,8 +193,9 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'
+    args.pht_pf_level = 2
     # Enable prefetch buffers for all hardware prefetchers in this config.
-    args.enable_pf_buffer = False
+    args.enable_pf_buffer = True
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)
 


### PR DESCRIPTION
## Motivation
Enable CDP in the ideal Kmhv3 L2 wrapper prefetcher path so manual performance runs using configs/example/idealkmhv3.py actually exercise L2 CDP.

## Approach
Set l2_wrapper.prefetcher.enable_cdp to true in the non-classic L2 path of idealkmhv3.py.

## Validation
- python3 -m py_compile configs/example/idealkmhv3.py configs/common/PrefetcherConfig.py

## Notes
The previous run archive showed system.l2_wrappers.prefetcher.enable_cdp=false, because idealkmhv3.py overrode the common prefetcher config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated prefetcher enablement configurations and cache timing parameters
  * Adjusted core scheduler, queue sizing, and cache replacement policy settings for system optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->