### PR TITLE
[codex] Open raw checkpoints read-only

### DIFF
--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -545,7 +545,7 @@ PhysicalMemory::unserializeStoreFrom(std::string filepath,
     bool is_zstd = hasZSTDMagic(fd);
     close(fd);
     if (!is_gz && !is_zstd) {  // Restoring from memory image checkpoint
-        fd = open(filepath.c_str(), O_RDWR);
+        fd = open(filepath.c_str(), O_RDONLY);
 
         assert(mapToRawCpt &&
                "When using raw checkpoint, the memory must be directly mapped "


### PR DESCRIPTION
## Motivation

Raw checkpoint restore currently reopens the checkpoint image with `O_RDWR` after probing the gzip/zstd magic bytes. The raw path only reads the file or maps it with `MAP_PRIVATE`, so requiring write permission is unnecessary and blocks read-only raw binaries.

## Approach

Open raw checkpoint images with `O_RDONLY` in `PhysicalMemory::unserializeStoreFrom`. The small-file path still copies bytes into anonymous/private memory, and the large-file path still uses a private mapping, so writes do not propagate back to the checkpoint file.

## Scope of Impact

This only affects raw checkpoint image opening. Gzip and zstd checkpoint restore paths are unchanged.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Before the fix, a `chmod 0444` raw binary failed at `src/mem/physical.cc` with `Failed to open file`.
- After the fix, the same read-only raw binary restored successfully, entered simulation, and exited via `m5_exit`:
  `env GCBV_REF_SO=/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so timeout 20s ./build/RISCV/gem5.opt -d /tmp/gem5-raw-ro-after ./configs/example/kmhv3.py --raw-cpt --generic-rv-cpt=/tmp/path_signature-riscv64-xs-readonly.bin`
