### PR TITLE
arch-riscv,cpu-o3: Fix privilege-return redirects

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2190,7 +2190,8 @@ decode QUADRANT {
                             }
 
 
-                        }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
+                        }}, IsSerializeAfter, IsNonSpeculative, IsReturn,
+                            IsSquashAfter);
                         0x5: wfi({{
                             STATUS status = xc->readMiscReg(MISCREG_STATUS);
                             auto pm = (PrivilegeMode)xc->readMiscReg(
@@ -2250,7 +2251,8 @@ decode QUADRANT {
                             NPC = xc->readMiscReg(MISCREG_MEPC);
                             xc->setMiscReg(MISCREG_VIRMODE,status_mpv);
                         }
-                    }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
+                    }}, IsSerializeAfter, IsNonSpeculative, IsReturn,
+                        IsSquashAfter);
                     0x31: priv({{
                         auto pm = (PrivilegeMode)xc->readMiscReg(
                                 MISCREG_PRV);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1236,9 +1236,12 @@ Commit::commitInsts()
             continue;
         }
 
-            while (num_committed < commit_width &&
-                num_committed_per_thread[commit_thread] <
-                    commit_width_per_thread[commit_thread]) {
+        while (num_committed < commit_width &&
+               num_committed_per_thread[commit_thread] <
+                   commit_width_per_thread[commit_thread] &&
+               (commitStatus[commit_thread] == Running ||
+                commitStatus[commit_thread] == Idle ||
+                commitStatus[commit_thread] == FetchTrapPending)) {
             // hardware transactionally memory
             // If executing within a transaction,
             // need to handle interrupts specially

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1531,7 +1531,8 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             inst->pcState(*new_pc);
         }
 
-        if (inst->mispredicted() && !loadNotExecuted) {
+        if (inst->mispredicted() && !loadNotExecuted &&
+            !inst->isNonSpeculative()) {
             fetchRedirect[tid] = true;
 
             DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "
@@ -1978,7 +1979,7 @@ IEW::checkMisprediction(const DynInstPtr& inst)
             inst->pcState(*new_pc);
         }
 
-        if (inst->mispredicted()) {
+        if (inst->mispredicted() && !inst->isNonSpeculative()) {
             fetchRedirect[tid] = true;
 
             DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "


### PR DESCRIPTION
## Motivation

SMT namd_29146 exposed a privilege-return redirect bug: mret/sret can redirect fetch before their committed privilege state is visible to instruction translation, causing fetch to translate the U-mode return target with stale privilege state.

## Approach

- Mark RISC-V sret/mret as IsSquashAfter so the committed privilege-return instruction flushes younger in-flight work and restarts fetch from the committed PC/state.
- Do not let IEW issue execute-stage redirects for non-speculative instructions; their redirects are handled at commit.
- Make the per-thread SMT commit loop stop selecting a thread after squashAfter() moves it to SquashAfterPending, matching the existing squashAfter contract.

## Validation

- Built build/RISCV/gem5.opt with scons build/RISCV/gem5.opt --gold-linker -j64.
- Rebased on xs-dev after PR #906 was merged.
- namd_29146 reaches --abs-max-tick=100000000 with no panic or difftest mismatch.

## Notes

This PR is intentionally separate from the SMT CI workflow PR #906.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RISC-V privilege control instruction execution behavior and squashing semantics.
  * Refined CPU commit stage logic to better respect thread operational status during instruction retirement.
  * Enhanced branch misprediction detection and handling by properly excluding non-speculative instructions from redirection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->