### PR TITLE
cpu-o3: fix SMT multi-priority thread selection

### DIFF
--- a/src/cpu/o3/smt_sched.hh
+++ b/src/cpu/o3/smt_sched.hh
@@ -107,23 +107,25 @@ class MultiPrioritySched : public SMTScheduler
 
     ThreadID getThread() override
     {
-        for (size_t i = 0; i < counter.size(); ++i) {
-            bool set = false;
-            ThreadID selectedTid = 0;
-            uint64_t minCount = counter[i]->getCounter(0);
-            for (ThreadID tid = 1; tid < numThreads; ++tid) {
-                uint64_t count = counter[i]->getCounter(tid);
-                if (count < minCount) {
-                    minCount = count;
+        ThreadID selectedTid = 0;
+
+        for (ThreadID tid = 1; tid < numThreads; ++tid) {
+            for (size_t i = 0; i < counter.size(); ++i) {
+                uint64_t candidateCount = counter[i]->getCounter(tid);
+                uint64_t selectedCount = counter[i]->getCounter(selectedTid);
+
+                if (candidateCount < selectedCount) {
                     selectedTid = tid;
-                    set = true;
+                    break;
+                }
+
+                if (candidateCount > selectedCount) {
+                    break;
                 }
             }
-            if (set) {
-                return selectedTid;
-            }
         }
-        return 0;
+
+        return selectedTid;
     }
 };
 


### PR DESCRIPTION
Motivation:
MultiPrioritySched selected threads with an asymmetric per-priority scan, which let tid > 0 win on a lower-priority counter even when tid0 should have won on a higher-priority counter. This caused a stable SMT IPC bias toward ipc1.

Approach:
Replace the per-counter scan with a true lexicographic comparison across the priority counters, preserving the intended LSQ -> IQ -> ROB order and keeping the existing tid0 tie-break.

Result:
SMT runs no longer show the systematic ipc1 > ipc0 bias, while overall IPC remains close to baseline.

Change-Id: I2e1a7910beb012fa8725110a42d4f672989879bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the thread-selection algorithm in the CPU scheduler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->