### PR TITLE
util: set smt idealkmhv3 default dramsim3 config to 8ch

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -1,5 +1,7 @@
 from m5.objects import Root
 
+import os
+
 from m5.util import addToPath
 
 addToPath('../')
@@ -38,6 +40,13 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'
+
+    if args.dramsim3_ini is None:
+        gem5_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+        args.dramsim3_ini = os.path.join(
+            gem5_root,
+            'ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini'
+        )
 
     Simulation.setMemClass(args)
 

--- a/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini
+++ b/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini
@@ -1,0 +1,66 @@
+[dram_structure]
+protocol = DDR4
+bankgroups = 4
+banks_per_group = 4
+rows = 65536
+columns = 1024
+device_width = 8
+BL = 8
+
+[timing]
+tCK = 0.63
+AL = 0
+CL = 16
+CWL = 16
+tRCD = 18
+tRP = 18
+tRAS = 52
+tRFC = 560
+tRFC2 = 416
+tRFC4 = 256
+tREFI = 12480
+tRPRE = 1
+tWPRE = 1
+tRRD_S = 4
+tRRD_L = 8
+tWTR_S = 4
+tWTR_L = 12
+tFAW = 34
+tWR = 24
+tWR2 = 25
+tRTP = 12
+tCCD_S = 4
+tCCD_L = 8
+tCKE = 8
+tCKESR = 9
+tXS = 576
+tXP = 10
+tRTRS = 1
+
+[power]
+VDD = 1.2
+IDD0 = 57
+IPP0 = 3.0
+IDD2P = 25
+IDD2N = 37
+IDD3P = 43
+IDD3N = 52
+IDD4W = 150
+IDD4R = 168
+IDD5AB = 250
+IDD6x = 30
+
+[system]
+channel_size = 16384
+channels = 8
+bus_width = 64
+address_mapping = roracobabgch
+queue_structure = PER_BANK
+refresh_policy = RANK_LEVEL_STAGGERED
+row_buf_policy = OPEN_PAGE
+cmd_queue_size = 8
+trans_queue_size = 128
+
+[other]
+epoch_period = 1587301
+output_level = 1


### PR DESCRIPTION
Add xiangshan_DDR4_8Gb_x8_3200_8ch.ini.

SMT ideal KMHV3 runs now default to the 8-channel DRAMSim3 configuration.

Change-Id: If3a551cb2fafdd4e90e781ced9885156098a64b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new DRAMSim3 memory configuration profile for DDR4 systems with 8-channel support, including timing and power parameters.

* **Chores**
  * Improved automatic path resolution for configuration parameters to simplify system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->