### PR TITLE
cpu-o3, mem-cache: Model L1D fake DCache mainpipe

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -498,9 +498,9 @@ IssueQue::issueToFu()
         auto& inst = replayQ.front();
 
         if (inst->isLoad()) {
-            // Check if tag write is happening in the next cycle
-            // if so, load cannot be issued to load pipeline
-            if (scheduler->lsq->isDcacheRefillTagWrite()) {
+            // Loads selected here enter loadpipe S0 next cycle, so block on
+            // the mainpipe tag-write state predicted for that admission point.
+            if (scheduler->lsq->willDcacheRefillTagWriteNextCycle()) {
                 incTagRefillBlockStats = true;
                 break;
             }
@@ -527,9 +527,10 @@ IssueQue::issueToFu()
         if (!inst) {
             continue;
         }
-        // Check if tag write is happening in the next cycle
-        // if so, load cannot be issued to load pipeline
-        bool blockLoad = inst->isLoad() && scheduler->lsq->isDcacheRefillTagWrite();
+        // Loads selected here enter loadpipe S0 next cycle, so block on
+        // the mainpipe tag-write state predicted for that admission point.
+        bool blockLoad = inst->isLoad() &&
+            scheduler->lsq->willDcacheRefillTagWriteNextCycle();
         if (blockLoad) {
             incTagRefillBlockStats = true;
         }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -438,10 +438,13 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
                "Number of pending refill requests blocked by fake dcache mainpipe resources"),
       ADD_STAT(dcacheMainPipeBlockedByDataConflict,
                statistics::units::Count::get(),
-               "Number of fake dcache mainpipe S1 data reads blocked by S3 data writes"),
+               "Number of fake dcache mainpipe S1 data reads blocked by S4 data writes"),
       ADD_STAT(dcacheMainPipeStoreS2IssueBlocked,
                statistics::units::Count::get(),
-               "Number of store buffer requests blocked when issuing from fake dcache mainpipe S2")
+               "Number of store buffer requests blocked when issuing from fake dcache mainpipe S2"),
+      ADD_STAT(dcacheMainPipeStoreS2MissExit,
+               statistics::units::Count::get(),
+               "Number of store buffer requests that miss and exit fake dcache mainpipe at S2")
 {
 }
 
@@ -690,27 +693,35 @@ LSQ::advanceDcacheMainPipe()
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
     const auto &s2_data_resp =
         dcacheMainPipeStage(DcacheMainPipeStage::S2DataResp);
-    const auto &s3_write =
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+    const auto &s3_tag_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite);
+    const auto &s4_data_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S4DataWrite);
 
     auto &next_s1_data_read =
         next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S1DataRead));
     auto &next_s2_data_resp =
         next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S2DataResp));
-    auto &next_s3_write =
-        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S3Write));
+    auto &next_s3_tag_write =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S3TagWrite));
+    auto &next_s4_data_write =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S4DataWrite));
 
-    // S3 resources are modeled as always ready for now. Keeping the local
+    // S4 resources are modeled as always ready for now. Keeping the local
     // variable makes later resource backpressure additions contained here.
-    const bool s3_can_go = true;
-    const bool s3_ready = !s3_write.valid || s3_can_go;
+    const bool s4_can_go = true;
+    const bool s4_ready = !s4_data_write.valid || s4_can_go;
+    const bool s3_can_go = s4_ready;
+    const bool s3_ready = !s3_tag_write.valid || s3_can_go;
     const bool s2_can_go = s3_ready;
 
-    bool s2_issue_done = false;
+    DcacheMainPipeS2Result s2_issue_result =
+        DcacheMainPipeS2Result::Blocked;
     if (s2_data_resp.valid && s2_can_go) {
-        // StoreBuffer S2 issue failure exits the fake pipe and is retried by
-        // the replay queue instead of holding S2.
-        s2_issue_done = !s2_data_resp.req.onS2Issue ||
+        // StoreBuffer S2 issue can either hit and proceed to S3, or miss and
+        // leave the fake pipe while the classic cache tracks the miss.
+        s2_issue_result = !s2_data_resp.req.onS2Issue ?
+            DcacheMainPipeS2Result::GoToS3 :
             s2_data_resp.req.onS2Issue(curTick());
     }
     const bool s2_ready = !s2_data_resp.valid || s2_can_go;
@@ -722,19 +733,26 @@ LSQ::advanceDcacheMainPipe()
         ++stats.dcacheMainPipeBlockedByDataConflict;
     }
 
-    if (s3_write.valid && s3_can_go && s3_write.req.onComplete) {
-        s3_write.req.onComplete(curTick());
+    if (s4_data_write.valid && s4_can_go &&
+        s4_data_write.req.onComplete) {
+        s4_data_write.req.onComplete(curTick());
     }
 
-    if (s3_write.valid && !s3_can_go) {
-        next_s3_write = s3_write;
+    if (s4_data_write.valid && !s4_can_go) {
+        next_s4_data_write = s4_data_write;
+    }
+
+    if (s3_tag_write.valid && !s3_can_go) {
+        next_s3_tag_write = s3_tag_write;
+    } else if (s3_tag_write.valid) {
+        next_s4_data_write = s3_tag_write;
     }
 
     if (s2_data_resp.valid) {
         if (!s2_can_go) {
             next_s2_data_resp = s2_data_resp;
-        } else if (s2_issue_done) {
-            next_s3_write = s2_data_resp;
+        } else if (s2_issue_result == DcacheMainPipeS2Result::GoToS3) {
+            next_s3_tag_write = s2_data_resp;
         }
     }
 
@@ -830,6 +848,7 @@ LSQ::makeStoreBufferMainPipeRequest(
     req.setKey = getDcacheSetKey(entry.blockVaddr);
     req.writeBanks = storeMaskToDcacheBanks(entry.validMask);
     req.needDataWrite = dcacheBankMaskAny(req.writeBanks);
+    req.needTagWrite = false;
 
     DcacheBankMask full_write = fullDcacheBankMask();
     for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
@@ -867,14 +886,14 @@ LSQ::markDcacheMainPipeBusyBanks()
 
     const auto &s1_data_read =
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
-    const auto &s3_write =
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+    const auto &s4_data_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S4DataWrite);
 
     if (s1_data_read.valid && s1_data_read.req.needDataRead) {
         mark_banks(s1_data_read.req, s1_data_read.req.readBanks);
     }
-    if (s3_write.valid && s3_write.req.needDataWrite) {
-        mark_banks(s3_write.req, s3_write.req.writeBanks);
+    if (s4_data_write.valid && s4_data_write.req.needDataWrite) {
+        mark_banks(s4_data_write.req, s4_data_write.req.writeBanks);
     }
 }
 
@@ -901,23 +920,25 @@ LSQ::hasDcacheMainPipeDataArrayConflict() const
 {
     const auto &s1_data_read =
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
-    const auto &s3_write =
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+    const auto &s4_data_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S4DataWrite);
 
     return s1_data_read.valid &&
         s1_data_read.req.needDataRead &&
-        s3_write.valid &&
-        s3_write.req.needDataWrite &&
-        s1_data_read.req.div == s3_write.req.div &&
+        s4_data_write.valid &&
+        s4_data_write.req.needDataWrite &&
+        s1_data_read.req.div == s4_data_write.req.div &&
         dcacheBankMaskOverlap(s1_data_read.req.readBanks,
-                              s3_write.req.writeBanks);
+                              s4_data_write.req.writeBanks);
 }
 
 bool
 LSQ::isDcacheMainPipeSetBlocked(uint64_t set_key) const
 {
+    // S4 only models data write resource usage; it does not block S0 tag/meta
+    // reads by same-set conflict.
     for (unsigned stage = static_cast<unsigned>(DcacheMainPipeStage::S1DataRead);
-         stage <= static_cast<unsigned>(DcacheMainPipeStage::S3Write);
+         stage <= static_cast<unsigned>(DcacheMainPipeStage::S3TagWrite);
          ++stage) {
         const auto &pipe_stage =
             dcacheMainPipeStage(static_cast<DcacheMainPipeStage>(stage));
@@ -934,8 +955,8 @@ LSQ::canEnterDcacheMainPipe(
     const DcacheMainPipeBufferedPipe &next_pipe)
 {
     const bool s0_tag_read_blocked =
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).valid &&
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).req.needTagWrite;
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite).valid &&
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite).req.needTagWrite;
     const bool s1_backpressured =
         next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S1DataRead)).valid;
 
@@ -962,13 +983,6 @@ LSQ::canEnterDcacheMainPipe(
 }
 
 bool
-LSQ::canEnterDcacheMainPipeNow(const DcacheMainPipeRequest &request)
-{
-    DcacheMainPipeBufferedPipe current_pipe = dcacheMainPipe;
-    return canEnterDcacheMainPipe(request, current_pipe);
-}
-
-bool
 LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
 {
     const auto req = makeStoreBufferMainPipeRequest(entry);
@@ -976,8 +990,8 @@ LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
     const bool s1_backpressured =
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead).valid;
     const bool s0_tag_read_blocked =
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).valid &&
-        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).req.needTagWrite;
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite).valid &&
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite).req.needTagWrite;
 
     if (!dcacheMainPipeRefillQ.empty()) {
         if (s1_backpressured) {
@@ -1000,7 +1014,18 @@ LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
         ++stats.dcacheMainPipeStoreBlockedBySet;
         return false;
     }
-    if (!canEnterDcacheMainPipeNow(req)) {
+
+    bool blocked = false;
+    if (s1_backpressured) {
+        ++stats.dcacheMainPipeBlockedByS1Backpressure;
+        ++stats.dcacheMainPipeStoreBlockedByS1Backpressure;
+        blocked = true;
+    }
+    if (s0_tag_read_blocked) {
+        ++stats.dcacheMainPipeStoreBlockedByTagWrite;
+        blocked = true;
+    }
+    if (blocked) {
         return false;
     }
 
@@ -1478,10 +1503,6 @@ LSQ::sbufferEnterDcacheMainPipe(PacketPtr data_pkt)
     assert(!request->sbuffer_entry->sending);
     assert(!request->sbuffer_entry->inDcacheMainPipe);
 
-    if (cacheBlocked()) {
-        ++stats.sbufferDcacheReqBlocked;
-        return false;
-    }
     if (!canEnterStoreBufferDcacheMainPipe(*request->sbuffer_entry)) {
         lastSbufferSendBlockedByMainPipe = true;
         ++stats.sbufferDcacheReqBlocked;
@@ -1493,10 +1514,10 @@ LSQ::sbufferEnterDcacheMainPipe(PacketPtr data_pkt)
     return true;
 }
 
-bool
+LSQ::DcacheMainPipeS2Result
 LSQ::issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt, Tick issue_tick)
 {
-    bool ret = true;
+    DcacheMainPipeS2Result result = DcacheMainPipeS2Result::GoToS3;
     bool cache_got_blocked = false;
 
     auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
@@ -1507,26 +1528,34 @@ LSQ::issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt, Tick issue_tick)
     assert(!request->sbuffer_entry->sending);
 
     data_pkt->sendTick = issue_tick;
+    data_pkt->clearDcacheMainPipeSbufferHit();
+    data_pkt->setDcacheMainPipeSbufferReq();
+    data_pkt->setLSQPtr(this);
 
     // Issue to the real classic cache only at fake S2 so StoreBuffer misses
     // cannot allocate or merge MSHRs at fake-pipe admission time.
     if (!cacheBlocked() && cachePortAvailable(false)) {
         if (!dcachePort.sendTimingReq(data_pkt)) {
-            ret = false;
+            result = DcacheMainPipeS2Result::Blocked;
             cache_got_blocked = true;
         }
     } else {
-        ret = false;
+        result = DcacheMainPipeS2Result::Blocked;
     }
 
-    if (ret) {
+    if (result == DcacheMainPipeS2Result::GoToS3) {
         stats.sbufferDcacheReqFire++;
         cachePortBusy(false);
-        data_pkt->setLSQPtr(this);
         request->_numOutstandingPackets = 1;
         request->sbuffer_entry->inDcacheMainPipe = false;
         request->sbuffer_entry->sending = true;
         resetStoreBufferInactiveCycles();
+        result = data_pkt->isDcacheMainPipeSbufferHit() ?
+            DcacheMainPipeS2Result::GoToS3 :
+            DcacheMainPipeS2Result::ExitPipe;
+        if (result == DcacheMainPipeS2Result::ExitPipe) {
+            ++stats.dcacheMainPipeStoreS2MissExit;
+        }
     } else {
         auto *entry = request->sbuffer_entry;
         stats.sbufferDcacheReqBlocked++;
@@ -1545,7 +1574,7 @@ LSQ::issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt, Tick issue_tick)
         }
     }
 
-    return ret;
+    return result;
 }
 
 void

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -792,6 +792,35 @@ LSQ::dcacheMainPipeStage(DcacheMainPipeStage stage) const
     return dcacheMainPipe.at(dcacheMainPipeIndex(stage));
 }
 
+bool
+LSQ::willDcacheRefillTagWriteNextCycle() const
+{
+    const auto &s2_data_resp =
+        dcacheMainPipeStage(DcacheMainPipeStage::S2DataResp);
+    const auto &s3_tag_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite);
+    const auto &s4_data_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S4DataWrite);
+
+    // Keep these readiness rules aligned with advanceDcacheMainPipe().
+    const bool s4_can_go = true;
+    const bool s4_ready = !s4_data_write.valid || s4_can_go;
+    const bool s3_can_go = s4_ready;
+    const bool s3_ready = !s3_tag_write.valid || s3_can_go;
+    const bool s2_can_go = s3_ready;
+
+    const DcacheMainPipeSlot *next_s3 = nullptr;
+    if (s3_tag_write.valid && !s3_can_go) {
+        next_s3 = &s3_tag_write;
+    } else if (s2_data_resp.valid && s2_can_go) {
+        next_s3 = &s2_data_resp;
+    }
+
+    return next_s3 &&
+        next_s3->req.isRefill() &&
+        next_s3->req.needTagWrite;
+}
+
 LSQ::DcacheBankMask
 LSQ::fullDcacheBankMask() const
 {

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -421,9 +421,27 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
       ADD_STAT(dcacheMainPipeBlockedByS1Backpressure,
                statistics::units::Count::get(),
                "Number of requests blocked by fake dcache mainpipe S1 backpressure"),
+      ADD_STAT(dcacheMainPipeStoreBlockedByS1Backpressure,
+               statistics::units::Count::get(),
+               "Number of store buffer requests blocked by fake dcache mainpipe S1 backpressure"),
+      ADD_STAT(dcacheMainPipeRefillBlockedByS1Backpressure,
+               statistics::units::Count::get(),
+               "Number of refill requests blocked by fake dcache mainpipe S1 backpressure"),
+      ADD_STAT(dcacheMainPipeStoreBlockedByTagWrite,
+               statistics::units::Count::get(),
+               "Number of store buffer requests blocked by fake dcache mainpipe tag write"),
+      ADD_STAT(dcacheMainPipeRefillBlocked,
+               statistics::units::Count::get(),
+               "Number of pending refill requests blocked before fake dcache mainpipe entry"),
+      ADD_STAT(dcacheMainPipeRefillBlockedByPipeResource,
+               statistics::units::Count::get(),
+               "Number of pending refill requests blocked by fake dcache mainpipe resources"),
       ADD_STAT(dcacheMainPipeBlockedByDataConflict,
                statistics::units::Count::get(),
-               "Number of fake dcache mainpipe S1 data reads blocked by S3 data writes")
+               "Number of fake dcache mainpipe S1 data reads blocked by S3 data writes"),
+      ADD_STAT(dcacheMainPipeStoreS2IssueBlocked,
+               statistics::units::Count::get(),
+               "Number of store buffer requests blocked when issuing from fake dcache mainpipe S2")
 {
 }
 
@@ -735,6 +753,9 @@ LSQ::advanceDcacheMainPipe()
             next_s1_data_read.req = queued_refill;
             dcacheMainPipeRefillQ.pop();
             ++stats.dcacheMainPipeRefillEnter;
+        } else {
+            ++stats.dcacheMainPipeRefillBlocked;
+            ++stats.dcacheMainPipeRefillBlockedByPipeResource;
         }
     }
 
@@ -918,11 +939,23 @@ LSQ::canEnterDcacheMainPipe(
     const bool s1_backpressured =
         next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S1DataRead)).valid;
 
+    bool blocked = false;
     if (s1_backpressured) {
         ++stats.dcacheMainPipeBlockedByS1Backpressure;
-        return false;
+        if (request.isStoreBuffer()) {
+            ++stats.dcacheMainPipeStoreBlockedByS1Backpressure;
+        } else if (request.isRefill()) {
+            ++stats.dcacheMainPipeRefillBlockedByS1Backpressure;
+        }
+        blocked = true;
     }
     if (s0_tag_read_blocked) {
+        if (request.isStoreBuffer()) {
+            ++stats.dcacheMainPipeStoreBlockedByTagWrite;
+        }
+        blocked = true;
+    }
+    if (blocked) {
         return false;
     }
     return !isDcacheMainPipeSetBlocked(request.setKey);
@@ -938,13 +971,32 @@ LSQ::canEnterDcacheMainPipeNow(const DcacheMainPipeRequest &request)
 bool
 LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
 {
+    const auto req = makeStoreBufferMainPipeRequest(entry);
+    const bool set_blocked = isDcacheMainPipeSetBlocked(req.setKey);
+    const bool s1_backpressured =
+        dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead).valid;
+    const bool s0_tag_read_blocked =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).valid &&
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).req.needTagWrite;
+
     if (!dcacheMainPipeRefillQ.empty()) {
+        if (s1_backpressured) {
+            ++stats.dcacheMainPipeStoreBlockedByS1Backpressure;
+        }
+        if (s0_tag_read_blocked) {
+            ++stats.dcacheMainPipeStoreBlockedByTagWrite;
+        }
         ++stats.dcacheMainPipeStoreBlockedByRefill;
         return false;
     }
 
-    const auto req = makeStoreBufferMainPipeRequest(entry);
-    if (isDcacheMainPipeSetBlocked(req.setKey)) {
+    if (set_blocked) {
+        if (s1_backpressured) {
+            ++stats.dcacheMainPipeStoreBlockedByS1Backpressure;
+        }
+        if (s0_tag_read_blocked) {
+            ++stats.dcacheMainPipeStoreBlockedByTagWrite;
+        }
         ++stats.dcacheMainPipeStoreBlockedBySet;
         return false;
     }
@@ -1478,6 +1530,7 @@ LSQ::issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt, Tick issue_tick)
     } else {
         auto *entry = request->sbuffer_entry;
         stats.sbufferDcacheReqBlocked++;
+        ++stats.dcacheMainPipeStoreS2IssueBlocked;
         entry->inDcacheMainPipe = false;
         // S2 issue failed. Exit the fake pipe and let the StoreBuffer replay
         // this eviction from S0 through the replay queue.

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -110,6 +110,8 @@ LSQ::StoreBufferEntry::reset(ThreadID tid, InstSeqNum seq_num,
     this->blockVaddr = block_vaddr;
     this->blockPaddr = block_paddr;
     this->sending = false;
+    this->inDcacheMainPipe = false;
+    this->replayQueued = false;
     this->request = nullptr;
     this->vice = nullptr;
 }
@@ -362,6 +364,8 @@ LSQ::StoreBuffer::release(StoreBufferEntry *entry)
     vld_cnt_vec[entry->tid]--;
     assert(vld_cnt_vec[entry->tid] >= 0);
     int index = entry->index;
+    assert(!entry->inDcacheMainPipe);
+    assert(!entry->replayQueued);
     data_vld[index] = false;
     data_map.erase(crossRef[index]);
     assert(std::find(free_list.begin(), free_list.end(), index) ==
@@ -683,7 +687,16 @@ LSQ::advanceDcacheMainPipe()
     const bool s3_can_go = true;
     const bool s3_ready = !s3_write.valid || s3_can_go;
     const bool s2_can_go = s3_ready;
+
+    bool s2_issue_done = false;
+    if (s2_data_resp.valid && s2_can_go) {
+        // StoreBuffer S2 issue failure exits the fake pipe and is retried by
+        // the replay queue instead of holding S2.
+        s2_issue_done = !s2_data_resp.req.onS2Issue ||
+            s2_data_resp.req.onS2Issue(curTick());
+    }
     const bool s2_ready = !s2_data_resp.valid || s2_can_go;
+
     const bool s1_data_conflict = hasDcacheMainPipeDataArrayConflict();
     const bool s1_can_go = s2_ready && !s1_data_conflict;
 
@@ -700,10 +713,10 @@ LSQ::advanceDcacheMainPipe()
     }
 
     if (s2_data_resp.valid) {
-        if (s2_can_go) {
-            next_s3_write = s2_data_resp;
-        } else {
+        if (!s2_can_go) {
             next_s2_data_resp = s2_data_resp;
+        } else if (s2_issue_done) {
+            next_s3_write = s2_data_resp;
         }
     }
 
@@ -786,7 +799,8 @@ LSQ::makeDcacheRefillMainPipeRequest(
 }
 
 LSQ::DcacheMainPipeRequest
-LSQ::makeStoreBufferMainPipeRequest(const StoreBufferEntry &entry) const
+LSQ::makeStoreBufferMainPipeRequest(
+    const StoreBufferEntry &entry, DcacheMainPipeS2Callback on_s2_issue) const
 {
     DcacheMainPipeRequest req;
     req.source = DcacheMainPipeSource::StoreBuffer;
@@ -809,6 +823,7 @@ LSQ::makeStoreBufferMainPipeRequest(const StoreBufferEntry &entry) const
         req.readBanks.at(bank) = req.writeBanks.at(bank) && !full_write.at(bank);
     }
     req.needDataRead = dcacheBankMaskAny(req.readBanks);
+    req.onS2Issue = std::move(on_s2_issue);
     return req;
 }
 
@@ -941,14 +956,19 @@ LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
 }
 
 void
-LSQ::enterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
+LSQ::enterStoreBufferDcacheMainPipe(StoreBufferEntry &entry, PacketPtr data_pkt)
 {
-    const auto req = makeStoreBufferMainPipeRequest(entry);
+    const auto req = makeStoreBufferMainPipeRequest(
+        entry,
+        [this, data_pkt](Tick tick) {
+            return issueSbufferPacketFromDcacheMainPipe(data_pkt, tick);
+        });
     auto &s1_data_read =
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
     assert(!s1_data_read.valid);
     s1_data_read.valid = true;
     s1_data_read.req = req;
+    entry.inDcacheMainPipe = true;
     ++stats.dcacheMainPipeStoreEnter;
 }
 
@@ -1255,6 +1275,11 @@ LSQ::storeBufferWriteback()
         can_evict = false;
     }
 
+    // Replayed S2 exits are retried before pre-admission blocks and new
+    // evictions.
+    if (can_evict && retryReplayStoreBuffer()) {
+        can_evict = false;
+    }
     if (can_evict && retryBlockedStoreBuffer()) {
         can_evict = false;
     }
@@ -1329,12 +1354,43 @@ LSQ::storeBufferWriteback()
                         StoreBufferBlockCause::CachePort);
                 DPRINTF(StoreBuffer, "send packet fail\n");
             } else {
-                DPRINTF(StoreBuffer, "send packet successed\n");
-                entry->sending = true;
+                DPRINTF(StoreBuffer, "enter dcache mainpipe successed\n");
                 resetStoreBufferInactiveCycles();
             }
         }
     }
+}
+
+bool
+LSQ::retryReplayStoreBuffer()
+{
+    if (sbufferMainPipeReplayQ.empty()) {
+        return false;
+    }
+
+    // The front replay has priority, but a failed timing send must wait for the
+    // cache retry before it can re-enter the fake pipe.
+    if (cacheBlocked()) {
+        return true;
+    }
+
+    auto *entry = sbufferMainPipeReplayQ.front();
+    assert(entry);
+    assert(entry->replayQueued);
+    assert(!entry->inDcacheMainPipe);
+    assert(!entry->sending);
+    assert(entry->request);
+
+    bool success = entry->request->sendPacketToCache();
+    if (!success) {
+        // Keep the front replay queued; it will retry from S0 later.
+        return true;
+    }
+
+    entry->replayQueued = false;
+    sbufferMainPipeReplayQ.pop_front();
+    resetStoreBufferInactiveCycles();
+    return true;
 }
 
 bool
@@ -1354,23 +1410,26 @@ LSQ::retryBlockedStoreBuffer()
         return true;
     }
 
-    blockedSbufferEntry->sending = true;
     resetStoreBufferInactiveCycles();
     clearBlockedStoreBufferEntry();
     return true;
 }
 
 bool
-LSQ::sbufferSendPacket(PacketPtr data_pkt)
+LSQ::sbufferEnterDcacheMainPipe(PacketPtr data_pkt)
 {
     lastSbufferSendBlockedByMainPipe = false;
-    bool ret = true;
-    bool cache_got_blocked = false;
 
     auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
     assert(request);
     assert(request->sbuffer_entry);
+    assert(!request->sbuffer_entry->sending);
+    assert(!request->sbuffer_entry->inDcacheMainPipe);
 
+    if (cacheBlocked()) {
+        ++stats.sbufferDcacheReqBlocked;
+        return false;
+    }
     if (!canEnterStoreBufferDcacheMainPipe(*request->sbuffer_entry)) {
         lastSbufferSendBlockedByMainPipe = true;
         ++stats.sbufferDcacheReqBlocked;
@@ -1378,6 +1437,27 @@ LSQ::sbufferSendPacket(PacketPtr data_pkt)
         return false;
     }
 
+    enterStoreBufferDcacheMainPipe(*request->sbuffer_entry, data_pkt);
+    return true;
+}
+
+bool
+LSQ::issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt, Tick issue_tick)
+{
+    bool ret = true;
+    bool cache_got_blocked = false;
+
+    auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
+    assert(request);
+    assert(request->sbuffer_entry);
+    assert(request->_numOutstandingPackets == 0);
+    assert(request->sbuffer_entry->inDcacheMainPipe);
+    assert(!request->sbuffer_entry->sending);
+
+    data_pkt->sendTick = issue_tick;
+
+    // Issue to the real classic cache only at fake S2 so StoreBuffer misses
+    // cannot allocate or merge MSHRs at fake-pipe admission time.
     if (!cacheBlocked() && cachePortAvailable(false)) {
         if (!dcachePort.sendTimingReq(data_pkt)) {
             ret = false;
@@ -1390,9 +1470,21 @@ LSQ::sbufferSendPacket(PacketPtr data_pkt)
     if (ret) {
         stats.sbufferDcacheReqFire++;
         cachePortBusy(false);
-        enterStoreBufferDcacheMainPipe(*request->sbuffer_entry);
+        data_pkt->setLSQPtr(this);
+        request->_numOutstandingPackets = 1;
+        request->sbuffer_entry->inDcacheMainPipe = false;
+        request->sbuffer_entry->sending = true;
+        resetStoreBufferInactiveCycles();
     } else {
+        auto *entry = request->sbuffer_entry;
         stats.sbufferDcacheReqBlocked++;
+        entry->inDcacheMainPipe = false;
+        // S2 issue failed. Exit the fake pipe and let the StoreBuffer replay
+        // this eviction from S0 through the replay queue.
+        if (!entry->replayQueued) {
+            entry->replayQueued = true;
+            sbufferMainPipeReplayQ.push_back(entry);
+        }
         if (cache_got_blocked) {
             cacheBlocked(true);
 
@@ -1568,7 +1660,9 @@ LSQ::recvReqRetry()
     iewStage->cacheUnblocked();
     cacheBlocked(false);
 
-    retryBlockedStoreBuffer();
+    if (!retryReplayStoreBuffer()) {
+        retryBlockedStoreBuffer();
+    }
 
     for (ThreadID tid : *activeThreads) {
         thread[tid].recvRetry();
@@ -2287,6 +2381,10 @@ LSQ::willWB()
         if (stage.valid) {
             return true;
         }
+    }
+
+    if (!sbufferMainPipeReplayQ.empty() && !cacheBlocked()) {
+        return true;
     }
 
     if (blockedSbufferEntry && !cacheBlocked()) {
@@ -3231,12 +3329,13 @@ bool
 LSQ::SbufferRequest::sendPacketToCache()
 {
     assert(_numOutstandingPackets == 0);
-    bool success = lsq->sbufferSendPacket(_packets.at(0));
-    DPRINTF(StoreBuffer, "Sbuffer Req::sendPacketToCache: entry[%#x]\n", _packets[0]->getAddr());
-    if (success) {
-        _packets[0]->setLSQPtr(lsq);
-        _numOutstandingPackets = 1;
-    }
+    // This only admits the request into the fake DCache MainPipe. The real
+    // classic-cache timing request is issued by the fake S2 callback.
+    bool success = lsq->sbufferEnterDcacheMainPipe(_packets.at(0));
+    DPRINTF(StoreBuffer,
+            "Sbuffer Req::sendPacketToCache: entry[%#x] %s dcache "
+            "mainpipe\n",
+            _packets[0]->getAddr(), success ? "entered" : "blocked before");
 
     return success;
 }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -986,7 +986,6 @@ bool
 LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
 {
     const auto req = makeStoreBufferMainPipeRequest(entry);
-    const bool set_blocked = isDcacheMainPipeSetBlocked(req.setKey);
     const bool s1_backpressured =
         dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead).valid;
     const bool s0_tag_read_blocked =
@@ -1004,17 +1003,6 @@ LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
         return false;
     }
 
-    if (set_blocked) {
-        if (s1_backpressured) {
-            ++stats.dcacheMainPipeStoreBlockedByS1Backpressure;
-        }
-        if (s0_tag_read_blocked) {
-            ++stats.dcacheMainPipeStoreBlockedByTagWrite;
-        }
-        ++stats.dcacheMainPipeStoreBlockedBySet;
-        return false;
-    }
-
     bool blocked = false;
     if (s1_backpressured) {
         ++stats.dcacheMainPipeBlockedByS1Backpressure;
@@ -1023,6 +1011,10 @@ LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
     }
     if (s0_tag_read_blocked) {
         ++stats.dcacheMainPipeStoreBlockedByTagWrite;
+        blocked = true;
+    }
+    if (isDcacheMainPipeSetBlocked(req.setKey)) {
+        ++stats.dcacheMainPipeStoreBlockedBySet;
         blocked = true;
     }
     if (blocked) {

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -49,6 +49,7 @@
 #include <cstring>
 #include <list>
 #include <string>
+#include <utility>
 
 #include "arch/riscv/insts/fusion.hh"
 #include "arch/riscv/insts/vector.hh"
@@ -690,6 +691,10 @@ LSQ::advanceDcacheMainPipe()
         ++stats.dcacheMainPipeBlockedByDataConflict;
     }
 
+    if (s3_write.valid && s3_can_go && s3_write.req.onComplete) {
+        s3_write.req.onComplete(curTick());
+    }
+
     if (s3_write.valid && !s3_can_go) {
         next_s3_write = s3_write;
     }
@@ -761,7 +766,9 @@ LSQ::storeMaskToDcacheBanks(const std::vector<bool> &mask) const
 }
 
 LSQ::DcacheMainPipeRequest
-LSQ::makeDcacheRefillMainPipeRequest(Addr addr, bool need_data_read) const
+LSQ::makeDcacheRefillMainPipeRequest(
+    Addr addr, bool need_data_read,
+    DcacheMainPipeCompleteCallback on_complete) const
 {
     DcacheMainPipeRequest req;
     req.source = DcacheMainPipeSource::Refill;
@@ -774,6 +781,7 @@ LSQ::makeDcacheRefillMainPipeRequest(Addr addr, bool need_data_read) const
     req.needWritebackPort = need_data_read;
     req.readBanks = need_data_read ? fullDcacheBankMask() : DcacheBankMask{};
     req.writeBanks = fullDcacheBankMask();
+    req.onComplete = std::move(on_complete);
     return req;
 }
 
@@ -996,10 +1004,15 @@ LSQ::loadBankConflictedCheck(Addr vaddr)
 }
 
 void
-LSQ::notifyDcacheRefill(Addr addr, bool need_data_read)
+LSQ::notifyDcacheRefill(
+    Addr addr, bool need_data_read,
+    DcacheMainPipeCompleteCallback on_complete)
 {
     dcacheMainPipeRefillQ.push(
-        makeDcacheRefillMainPipeRequest(addr, need_data_read));
+        makeDcacheRefillMainPipeRequest(
+            addr, need_data_read, std::move(on_complete)));
+    cpu->wakeCPU();
+    cpu->activityThisCycle();
 }
 
 unsigned
@@ -2267,6 +2280,15 @@ LSQ::numStoresToSbuffer(ThreadID tid)
 bool
 LSQ::willWB()
 {
+    if (!dcacheMainPipeRefillQ.empty()) {
+        return true;
+    }
+    for (const auto &stage : dcacheMainPipe) {
+        if (stage.valid) {
+            return true;
+        }
+    }
+
     if (blockedSbufferEntry && !cacheBlocked()) {
         return true;
     }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -399,7 +399,26 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
       ADD_STAT(sbufferDcacheReqFire, statistics::units::Count::get(),
                "Number of sbuffer write requests accepted by dcache"),
       ADD_STAT(sbufferDcacheReqBlocked, statistics::units::Count::get(),
-               "Number of sbuffer write request attempts rejected by dcache")
+               "Number of sbuffer write request attempts rejected by dcache"),
+      ADD_STAT(sbufferDcacheReqBlockedByMainPipe,
+               statistics::units::Count::get(),
+               "Number of sbuffer write requests blocked by fake dcache mainpipe"),
+      ADD_STAT(dcacheMainPipeRefillEnter, statistics::units::Count::get(),
+               "Number of refill requests accepted by fake dcache mainpipe"),
+      ADD_STAT(dcacheMainPipeStoreEnter, statistics::units::Count::get(),
+               "Number of store buffer requests accepted by fake dcache mainpipe"),
+      ADD_STAT(dcacheMainPipeStoreBlockedByRefill,
+               statistics::units::Count::get(),
+               "Number of store buffer requests blocked by pending refill priority"),
+      ADD_STAT(dcacheMainPipeStoreBlockedBySet,
+               statistics::units::Count::get(),
+               "Number of store buffer requests blocked by fake dcache mainpipe set conflict"),
+      ADD_STAT(dcacheMainPipeBlockedByS1Backpressure,
+               statistics::units::Count::get(),
+               "Number of requests blocked by fake dcache mainpipe S1 backpressure"),
+      ADD_STAT(dcacheMainPipeBlockedByDataConflict,
+               statistics::units::Count::get(),
+               "Number of fake dcache mainpipe S1 data reads blocked by S3 data writes")
 {
 }
 
@@ -505,10 +524,6 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     storeBuffer.setData(store_buffer_entries);
     storeBuffer.setMaxThread(numThreads);
     bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
-    pendingDcacheRefill.resize(dcacheSetDivNum, false);
-    dcacheRefillDataRead.resize(dcacheSetDivNum, 0);
-    dcacheRefillDataWrite.resize(dcacheSetDivNum, 0);
-    dcacheRefillTagWrite.resize(dcacheSetDivNum, 0);
 }
 
 
@@ -638,44 +653,307 @@ LSQ::tick()
 void
 LSQ::clearAddresses()
 {
-    for (unsigned div = 0; div < dcacheSetDivNum; div++) {
-        // Check if the current cycle is already occupied by previous operations
-        // (e.g. delayed writeback).
-        bool currentCycleBusy =
-            (dcacheRefillDataRead[div] | dcacheRefillDataWrite[div]) & 0x1;
+    advanceDcacheMainPipe();
+    markDcacheMainPipeBusyBanks();
+    recentlyloadAddr.clear();
+}
 
-        if (pendingDcacheRefill[div]) {
-            // If current cycle is busy, we stall the new request (keep pending).
-            // If free, we issue the new request.
-            if (!currentCycleBusy) {
-                pendingDcacheRefill[div] = false;
-                // Data Read at current cycle (Bit 0)
-                dcacheRefillDataRead[div] |= 0x1;
-                // Tag Write at 3 cycles later (Bit 3)
-                dcacheRefillTagWrite[div] |= (1 << 3);
-                // Data Write at 4 cycles later (Bit 4)
-                dcacheRefillDataWrite[div] |= (1 << 4);
+void
+LSQ::advanceDcacheMainPipe()
+{
+    DcacheMainPipeBufferedPipe next_pipe = {};
 
-                // We just occupied the current cycle.
-                currentCycleBusy = true;
+    const auto &s1_data_read =
+        dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
+    const auto &s2_data_resp =
+        dcacheMainPipeStage(DcacheMainPipeStage::S2DataResp);
+    const auto &s3_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+
+    auto &next_s1_data_read =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S1DataRead));
+    auto &next_s2_data_resp =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S2DataResp));
+    auto &next_s3_write =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S3Write));
+
+    // S3 resources are modeled as always ready for now. Keeping the local
+    // variable makes later resource backpressure additions contained here.
+    const bool s3_can_go = true;
+    const bool s3_ready = !s3_write.valid || s3_can_go;
+    const bool s2_can_go = s3_ready;
+    const bool s2_ready = !s2_data_resp.valid || s2_can_go;
+    const bool s1_data_conflict = hasDcacheMainPipeDataArrayConflict();
+    const bool s1_can_go = s2_ready && !s1_data_conflict;
+
+    if (s1_data_conflict) {
+        ++stats.dcacheMainPipeBlockedByDataConflict;
+    }
+
+    if (s3_write.valid && !s3_can_go) {
+        next_s3_write = s3_write;
+    }
+
+    if (s2_data_resp.valid) {
+        if (s2_can_go) {
+            next_s3_write = s2_data_resp;
+        } else {
+            next_s2_data_resp = s2_data_resp;
+        }
+    }
+
+    if (s1_data_read.valid) {
+        if (s1_can_go) {
+            next_s2_data_resp = s1_data_read;
+        } else {
+            next_s1_data_read = s1_data_read;
+        }
+    }
+
+    if (!dcacheMainPipeRefillQ.empty()) {
+        const auto &queued_refill = dcacheMainPipeRefillQ.front();
+        if (canEnterDcacheMainPipe(queued_refill, next_pipe)) {
+            next_s1_data_read.valid = true;
+            next_s1_data_read.req = queued_refill;
+            dcacheMainPipeRefillQ.pop();
+            ++stats.dcacheMainPipeRefillEnter;
+        }
+    }
+
+    dcacheMainPipe = next_pipe;
+}
+
+LSQ::DcacheMainPipeSlot &
+LSQ::dcacheMainPipeStage(DcacheMainPipeStage stage)
+{
+    return dcacheMainPipe.at(dcacheMainPipeIndex(stage));
+}
+
+const LSQ::DcacheMainPipeSlot &
+LSQ::dcacheMainPipeStage(DcacheMainPipeStage stage) const
+{
+    return dcacheMainPipe.at(dcacheMainPipeIndex(stage));
+}
+
+LSQ::DcacheBankMask
+LSQ::fullDcacheBankMask() const
+{
+    DcacheBankMask mask = {};
+    std::fill(mask.begin(), mask.end(), true);
+    return mask;
+}
+
+LSQ::DcacheBankMask
+LSQ::storeMaskToDcacheBanks(const std::vector<bool> &mask) const
+{
+    assert(mask.size() == DcacheBankCount * 8);
+    DcacheBankMask bank_mask = {};
+    if (sbufferBankWriteAccurately) {
+        for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+            bank_mask.at(bank) = std::any_of(
+                mask.begin() + 8 * bank, mask.begin() + 8 * bank + 8,
+                [](bool v) { return v; });
+        }
+    } else {
+        std::fill(bank_mask.begin(), bank_mask.end(), true);
+    }
+    return bank_mask;
+}
+
+LSQ::DcacheMainPipeRequest
+LSQ::makeDcacheRefillMainPipeRequest(Addr addr, bool need_data_read) const
+{
+    DcacheMainPipeRequest req;
+    req.source = DcacheMainPipeSource::Refill;
+    req.addr = addr;
+    req.div = getDcacheDiv(addr);
+    req.setKey = getDcacheSetKey(addr);
+    req.needDataRead = need_data_read;
+    req.needTagWrite = true;
+    req.needDataWrite = true;
+    req.needWritebackPort = need_data_read;
+    req.readBanks = need_data_read ? fullDcacheBankMask() : DcacheBankMask{};
+    req.writeBanks = fullDcacheBankMask();
+    return req;
+}
+
+LSQ::DcacheMainPipeRequest
+LSQ::makeStoreBufferMainPipeRequest(const StoreBufferEntry &entry) const
+{
+    DcacheMainPipeRequest req;
+    req.source = DcacheMainPipeSource::StoreBuffer;
+    req.addr = entry.blockVaddr;
+    req.div = getDcacheDiv(entry.blockVaddr);
+    req.setKey = getDcacheSetKey(entry.blockVaddr);
+    req.writeBanks = storeMaskToDcacheBanks(entry.validMask);
+    req.needDataWrite = dcacheBankMaskAny(req.writeBanks);
+
+    DcacheBankMask full_write = fullDcacheBankMask();
+    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+        const bool bank_fully_written = std::all_of(
+            entry.validMask.begin() + 8 * bank,
+            entry.validMask.begin() + 8 * bank + 8,
+            [](bool v) { return v; });
+        full_write.at(bank) = bank_fully_written;
+    }
+
+    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+        req.readBanks.at(bank) = req.writeBanks.at(bank) && !full_write.at(bank);
+    }
+    req.needDataRead = dcacheBankMaskAny(req.readBanks);
+    return req;
+}
+
+void
+LSQ::markDcacheMainPipeBusyBanks()
+{
+    for (unsigned div = 0; div < dcacheSetDivNum; ++div) {
+        std::fill(bankOccupied.at(div).begin(), bankOccupied.at(div).end(),
+                  false);
+    }
+
+    auto mark_banks = [this](const DcacheMainPipeRequest &req,
+                             const DcacheBankMask &mask) {
+        for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+            if (mask.at(bank)) {
+                bankOccupied.at(req.div).at(bank) = true;
             }
         }
+    };
 
-        // Advance the pipeline for the next cycle.
-        dcacheRefillDataRead[div] >>= 1;
-        dcacheRefillTagWrite[div] >>= 1;
-        dcacheRefillDataWrite[div] >>= 1;
+    const auto &s1_data_read =
+        dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
+    const auto &s3_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
 
-        std::fill(bankOccupied[div].begin(), bankOccupied[div].end(),
-                  currentCycleBusy);
+    if (s1_data_read.valid && s1_data_read.req.needDataRead) {
+        mark_banks(s1_data_read.req, s1_data_read.req.readBanks);
     }
-    recentlyloadAddr.clear();
+    if (s3_write.valid && s3_write.req.needDataWrite) {
+        mark_banks(s3_write.req, s3_write.req.writeBanks);
+    }
+}
+
+bool
+LSQ::dcacheBankMaskAny(const DcacheBankMask &mask) const
+{
+    return std::any_of(mask.begin(), mask.end(), [](bool v) { return v; });
+}
+
+bool
+LSQ::dcacheBankMaskOverlap(const DcacheBankMask &lhs,
+                           const DcacheBankMask &rhs) const
+{
+    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+        if (lhs.at(bank) && rhs.at(bank)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+LSQ::hasDcacheMainPipeDataArrayConflict() const
+{
+    const auto &s1_data_read =
+        dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
+    const auto &s3_write =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+
+    return s1_data_read.valid &&
+        s1_data_read.req.needDataRead &&
+        s3_write.valid &&
+        s3_write.req.needDataWrite &&
+        s1_data_read.req.div == s3_write.req.div &&
+        dcacheBankMaskOverlap(s1_data_read.req.readBanks,
+                              s3_write.req.writeBanks);
+}
+
+bool
+LSQ::isDcacheMainPipeSetBlocked(uint64_t set_key) const
+{
+    for (unsigned stage = static_cast<unsigned>(DcacheMainPipeStage::S1DataRead);
+         stage <= static_cast<unsigned>(DcacheMainPipeStage::S3Write);
+         ++stage) {
+        const auto &pipe_stage =
+            dcacheMainPipeStage(static_cast<DcacheMainPipeStage>(stage));
+        if (pipe_stage.valid && pipe_stage.req.setKey == set_key) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+LSQ::canEnterDcacheMainPipe(
+    const DcacheMainPipeRequest &request,
+    const DcacheMainPipeBufferedPipe &next_pipe)
+{
+    const bool s0_tag_read_blocked =
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).valid &&
+        dcacheMainPipeStage(DcacheMainPipeStage::S3Write).req.needTagWrite;
+    const bool s1_backpressured =
+        next_pipe.at(dcacheMainPipeIndex(DcacheMainPipeStage::S1DataRead)).valid;
+
+    if (s1_backpressured) {
+        ++stats.dcacheMainPipeBlockedByS1Backpressure;
+        return false;
+    }
+    if (s0_tag_read_blocked) {
+        return false;
+    }
+    return !isDcacheMainPipeSetBlocked(request.setKey);
+}
+
+bool
+LSQ::canEnterDcacheMainPipeNow(const DcacheMainPipeRequest &request)
+{
+    DcacheMainPipeBufferedPipe current_pipe = dcacheMainPipe;
+    return canEnterDcacheMainPipe(request, current_pipe);
+}
+
+bool
+LSQ::canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
+{
+    if (!dcacheMainPipeRefillQ.empty()) {
+        ++stats.dcacheMainPipeStoreBlockedByRefill;
+        return false;
+    }
+
+    const auto req = makeStoreBufferMainPipeRequest(entry);
+    if (isDcacheMainPipeSetBlocked(req.setKey)) {
+        ++stats.dcacheMainPipeStoreBlockedBySet;
+        return false;
+    }
+    if (!canEnterDcacheMainPipeNow(req)) {
+        return false;
+    }
+
+    return true;
+}
+
+void
+LSQ::enterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry)
+{
+    const auto req = makeStoreBufferMainPipeRequest(entry);
+    auto &s1_data_read =
+        dcacheMainPipeStage(DcacheMainPipeStage::S1DataRead);
+    assert(!s1_data_read.valid);
+    s1_data_read.valid = true;
+    s1_data_read.req = req;
+    ++stats.dcacheMainPipeStoreEnter;
 }
 
 unsigned
 LSQ::getDcacheDiv(Addr vaddr) const
 {
     return (vaddr >> dcacheLineBits) & (dcacheSetDivNum - 1);
+}
+
+uint64_t
+LSQ::getDcacheSetKey(Addr vaddr) const
+{
+    return (vaddr >> dcacheLineBits) & ((1ULL << dcacheSetBits) - 1);
 }
 
 uint64_t
@@ -718,9 +996,10 @@ LSQ::loadBankConflictedCheck(Addr vaddr)
 }
 
 void
-LSQ::notifyDcacheRefill(Addr addr)
+LSQ::notifyDcacheRefill(Addr addr, bool need_data_read)
 {
-    pendingDcacheRefill.at(getDcacheDiv(addr)) = true;
+    dcacheMainPipeRefillQ.push(
+        makeDcacheRefillMainPipeRequest(addr, need_data_read));
 }
 
 unsigned
@@ -1030,12 +1309,15 @@ LSQ::storeBufferWriteback()
             entry->request->sbuffer_entry = entry;
             bool success = entry->request->sendPacketToCache();
             if (!success) {
-                setBlockedStoreBufferEntry(entry);
+                setBlockedStoreBufferEntry(
+                    entry,
+                    lastSbufferSendBlockedByMainPipe ?
+                        StoreBufferBlockCause::MainPipe :
+                        StoreBufferBlockCause::CachePort);
                 DPRINTF(StoreBuffer, "send packet fail\n");
             } else {
                 DPRINTF(StoreBuffer, "send packet successed\n");
                 entry->sending = true;
-                sbufferWriteBank(entry->blockVaddr, entry->validMask);
                 resetStoreBufferInactiveCycles();
             }
         }
@@ -1051,23 +1333,37 @@ LSQ::retryBlockedStoreBuffer()
 
     bool success = blockedSbufferEntry->request->sendPacketToCache();
     if (!success) {
+        setBlockedStoreBufferEntry(
+            blockedSbufferEntry,
+            lastSbufferSendBlockedByMainPipe ?
+                StoreBufferBlockCause::MainPipe :
+                StoreBufferBlockCause::CachePort);
         return true;
     }
 
     blockedSbufferEntry->sending = true;
-    sbufferWriteBank(blockedSbufferEntry->blockVaddr,
-                     blockedSbufferEntry->validMask);
     resetStoreBufferInactiveCycles();
-    blockedSbufferEntry = nullptr;
+    clearBlockedStoreBufferEntry();
     return true;
 }
 
 bool
 LSQ::sbufferSendPacket(PacketPtr data_pkt)
 {
+    lastSbufferSendBlockedByMainPipe = false;
     bool ret = true;
     bool cache_got_blocked = false;
 
+    auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
+    assert(request);
+    assert(request->sbuffer_entry);
+
+    if (!canEnterStoreBufferDcacheMainPipe(*request->sbuffer_entry)) {
+        lastSbufferSendBlockedByMainPipe = true;
+        ++stats.sbufferDcacheReqBlocked;
+        ++stats.sbufferDcacheReqBlockedByMainPipe;
+        return false;
+    }
 
     if (!cacheBlocked() && cachePortAvailable(false)) {
         if (!dcachePort.sendTimingReq(data_pkt)) {
@@ -1081,13 +1377,12 @@ LSQ::sbufferSendPacket(PacketPtr data_pkt)
     if (ret) {
         stats.sbufferDcacheReqFire++;
         cachePortBusy(false);
+        enterStoreBufferDcacheMainPipe(*request->sbuffer_entry);
     } else {
         stats.sbufferDcacheReqBlocked++;
         if (cache_got_blocked) {
             cacheBlocked(true);
 
-            auto request = dynamic_cast<SbufferRequest *>(data_pkt->senderState);
-            assert(request);
             request->_port.recordStoreBufferBlockedByCache();
         }
     }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -45,6 +45,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <map>
 #include <memory>
@@ -1253,6 +1254,7 @@ class LSQ
     static constexpr unsigned DcacheBankCount = 8;
 
     using DcacheBankMask = std::array<bool, DcacheBankCount>;
+    using DcacheMainPipeCompleteCallback = std::function<void(Tick)>;
 
     enum class DcacheMainPipeSource : unsigned
     {
@@ -1281,6 +1283,7 @@ class LSQ
         bool needWritebackPort = false;
         DcacheBankMask readBanks = {};
         DcacheBankMask writeBanks = {};
+        DcacheMainPipeCompleteCallback onComplete;
 
         bool isRefill() const
         {
@@ -1329,7 +1332,8 @@ class LSQ
     DcacheBankMask storeMaskToDcacheBanks(const std::vector<bool> &mask) const;
 
     DcacheMainPipeRequest makeDcacheRefillMainPipeRequest(
-        Addr addr, bool need_data_read) const;
+        Addr addr, bool need_data_read,
+        DcacheMainPipeCompleteCallback on_complete = {}) const;
     DcacheMainPipeRequest makeStoreBufferMainPipeRequest(
         const StoreBufferEntry &entry) const;
 
@@ -1353,7 +1357,9 @@ class LSQ
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
     std::vector<std::vector<bool>> bankOccupied;
 
-    void notifyDcacheRefill(Addr addr, bool need_data_read = true);
+    void notifyDcacheRefill(
+        Addr addr, bool need_data_read = true,
+        DcacheMainPipeCompleteCallback on_complete = {});
 
     std::queue<DcacheMainPipeRequest> dcacheMainPipeRefillQ;
     DcacheMainPipeBufferedPipe dcacheMainPipe = {};

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1412,6 +1412,8 @@ class LSQ
         return stage.valid && stage.req.isRefill() && stage.req.needTagWrite;
     }
 
+    bool willDcacheRefillTagWriteNextCycle() const;
+
   protected:
     /** D-cache is blocked */
     bool _cacheBlocked;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -45,6 +45,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <list>
 #include <map>
@@ -163,13 +164,18 @@ class LSQ
         std::vector<uint8_t> blockDatas;
         std::vector<bool> validMask;
         bool sending;
+        bool inDcacheMainPipe;
+        // Exited fake MainPipe at S2 and waits to re-enter from S0.
+        bool replayQueued;
         // the another same addr entry when sending
         // another cannot sending until self sending finished
         StoreBufferEntry *vice = nullptr;
         // merged request
         SbufferRequest *request = nullptr;
 
-        StoreBufferEntry(int size, int index) : index(index)
+        StoreBufferEntry(int size, int index)
+            : index(index), sending(false), inDcacheMainPipe(false),
+              replayQueued(false)
         {
             blockDatas.resize(size, 0);
             validMask.resize(size, false);
@@ -184,6 +190,13 @@ class LSQ
 
         bool recordForward(RequestPtr req, LSQRequest *lsqreq,
                            ThreadID load_tid, InstSeqNum load_seq);
+
+        // The eviction packet has been built or sent; younger same-line stores
+        // must go to a vice entry instead of mutating this entry's payload.
+        bool evictionInProgress() const
+        {
+            return sending || inDcacheMainPipe || replayQueued;
+        }
     };
 
     class StoreBuffer
@@ -1191,7 +1204,10 @@ class LSQ
     void incStoreBufferInactiveCycles() { ++storeBufferWritebackInactive; }
     bool storeBufferBlocked() const
     {
-        return blockedSbufferEntry != nullptr;
+        // A replayed eviction is still owned by the StoreBuffer and has priority
+        // over SQ offload or new evictions.
+        return blockedSbufferEntry != nullptr ||
+            !sbufferMainPipeReplayQ.empty();
     }
     void setBlockedStoreBufferEntry(StoreBufferEntry *entry,
                                     StoreBufferBlockCause cause =
@@ -1210,8 +1226,22 @@ class LSQ
         return blockedSbufferEntry != nullptr &&
             blockedSbufferCause == StoreBufferBlockCause::MainPipe;
     }
+    // Retry StoreBuffer evictions that exited the fake MainPipe at S2. The
+    // return value is false only when the replay queue is empty; true means a
+    // replay consumed or blocked this writeback opportunity.
+    bool retryReplayStoreBuffer();
+
+    // Retry a StoreBuffer eviction that was blocked before fake MainPipe
+    // admission.
     bool retryBlockedStoreBuffer();
-    bool sbufferSendPacket(PacketPtr data_pkt);
+
+    // Admit a StoreBuffer packet into the fake DCache MainPipe. This does not
+    // issue the packet to the real classic cache.
+    bool sbufferEnterDcacheMainPipe(PacketPtr data_pkt);
+
+    // Issue a StoreBuffer packet from fake S2 to the real classic cache.
+    bool issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt,
+                                              Tick issue_tick);
     void completeSbufferEvict(PacketPtr pkt);
 
     unsigned getLQEntries() const { return LQEntries; }
@@ -1255,6 +1285,7 @@ class LSQ
 
     using DcacheBankMask = std::array<bool, DcacheBankCount>;
     using DcacheMainPipeCompleteCallback = std::function<void(Tick)>;
+    using DcacheMainPipeS2Callback = std::function<bool(Tick)>;
 
     enum class DcacheMainPipeSource : unsigned
     {
@@ -1284,6 +1315,7 @@ class LSQ
         DcacheBankMask readBanks = {};
         DcacheBankMask writeBanks = {};
         DcacheMainPipeCompleteCallback onComplete;
+        DcacheMainPipeS2Callback onS2Issue;
 
         bool isRefill() const
         {
@@ -1335,7 +1367,8 @@ class LSQ
         Addr addr, bool need_data_read,
         DcacheMainPipeCompleteCallback on_complete = {}) const;
     DcacheMainPipeRequest makeStoreBufferMainPipeRequest(
-        const StoreBufferEntry &entry) const;
+        const StoreBufferEntry &entry,
+        DcacheMainPipeS2Callback on_s2_issue = {}) const;
 
     void markDcacheMainPipeBusyBanks();
 
@@ -1351,7 +1384,10 @@ class LSQ
     bool canEnterDcacheMainPipeNow(
         const DcacheMainPipeRequest &request);
     bool canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry);
-    void enterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry);
+
+    // Put a StoreBuffer request into fake S1 and attach its fake S2 issue hook.
+    void enterStoreBufferDcacheMainPipe(StoreBufferEntry &entry,
+                                        PacketPtr data_pkt);
 
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
@@ -1398,6 +1434,7 @@ class LSQ
     StoreBufferEntry *blockedSbufferEntry = nullptr;
     StoreBufferBlockCause blockedSbufferCause = StoreBufferBlockCause::None;
     bool lastSbufferSendBlockedByMainPipe = false;
+    std::deque<StoreBufferEntry *> sbufferMainPipeReplayQ;
     ThreadID nextStoreBufferOffloadTid = InvalidThreadID;
     ThreadID nextStoreBufferInsertTid  = 0;
 

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -110,6 +110,13 @@ class LSQ
         CachePort
     };
 
+    enum class DcacheMainPipeS2Result : unsigned
+    {
+        Blocked,
+        ExitPipe,
+        GoToS3
+    };
+
     /**
      * DcachePort class for the load/store queue.
      */
@@ -165,7 +172,7 @@ class LSQ
         std::vector<bool> validMask;
         bool sending;
         bool inDcacheMainPipe;
-        // Exited fake MainPipe at S2 and waits to re-enter from S0.
+        // Blocked at fake MainPipe S2 and waits to re-enter from S0.
         bool replayQueued;
         // the another same addr entry when sending
         // another cannot sending until self sending finished
@@ -1239,9 +1246,8 @@ class LSQ
     // issue the packet to the real classic cache.
     bool sbufferEnterDcacheMainPipe(PacketPtr data_pkt);
 
-    // Issue a StoreBuffer packet from fake S2 to the real classic cache.
-    bool issueSbufferPacketFromDcacheMainPipe(PacketPtr data_pkt,
-                                              Tick issue_tick);
+    DcacheMainPipeS2Result issueSbufferPacketFromDcacheMainPipe(
+        PacketPtr data_pkt, Tick issue_tick);
     void completeSbufferEvict(PacketPtr pkt);
 
     unsigned getLQEntries() const { return LQEntries; }
@@ -1285,7 +1291,8 @@ class LSQ
 
     using DcacheBankMask = std::array<bool, DcacheBankCount>;
     using DcacheMainPipeCompleteCallback = std::function<void(Tick)>;
-    using DcacheMainPipeS2Callback = std::function<bool(Tick)>;
+    using DcacheMainPipeS2Callback =
+        std::function<DcacheMainPipeS2Result(Tick)>;
 
     enum class DcacheMainPipeSource : unsigned
     {
@@ -1298,8 +1305,8 @@ class LSQ
         S0TagReadEntry = 0,
         S1DataRead,
         S2DataResp,
-        S3Write,
-        S4Complete,
+        S3TagWrite,
+        S4DataWrite,
     };
 
     struct DcacheMainPipeRequest
@@ -1335,11 +1342,11 @@ class LSQ
     };
 
     // S0 happens at admission time. The stored array keeps the buffered
-    // pipeline slots from S1 to S3, while S4 is the pipe exit.
+    // pipeline slots from S1 to S4.
     static constexpr unsigned FirstBufferedDcacheMainPipeStage =
         static_cast<unsigned>(DcacheMainPipeStage::S1DataRead);
     static constexpr unsigned LastBufferedDcacheMainPipeStage =
-        static_cast<unsigned>(DcacheMainPipeStage::S3Write);
+        static_cast<unsigned>(DcacheMainPipeStage::S4DataWrite);
     static constexpr unsigned NumBufferedDcacheMainPipeStages =
         LastBufferedDcacheMainPipeStage -
         FirstBufferedDcacheMainPipeStage + 1;
@@ -1381,8 +1388,6 @@ class LSQ
     bool canEnterDcacheMainPipe(
         const DcacheMainPipeRequest &request,
         const DcacheMainPipeBufferedPipe &next_pipe);
-    bool canEnterDcacheMainPipeNow(
-        const DcacheMainPipeRequest &request);
     bool canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry);
 
     // Put a StoreBuffer request into fake S1 and attach its fake S2 issue hook.
@@ -1403,7 +1408,7 @@ class LSQ
     bool isDcacheRefillTagWrite() const
     {
         const auto &stage =
-            dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+            dcacheMainPipeStage(DcacheMainPipeStage::S3TagWrite);
         return stage.valid && stage.req.isRefill() && stage.req.needTagWrite;
     }
 
@@ -1499,6 +1504,7 @@ class LSQ
         statistics::Scalar dcacheMainPipeRefillBlockedByPipeResource;
         statistics::Scalar dcacheMainPipeBlockedByDataConflict;
         statistics::Scalar dcacheMainPipeStoreS2IssueBlocked;
+        statistics::Scalar dcacheMainPipeStoreS2MissExit;
     } stats;
 
     void recordStoreBufferEviction(StoreBufferEvictCause cause);

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1492,7 +1492,13 @@ class LSQ
         statistics::Scalar dcacheMainPipeStoreBlockedByRefill;
         statistics::Scalar dcacheMainPipeStoreBlockedBySet;
         statistics::Scalar dcacheMainPipeBlockedByS1Backpressure;
+        statistics::Scalar dcacheMainPipeStoreBlockedByS1Backpressure;
+        statistics::Scalar dcacheMainPipeRefillBlockedByS1Backpressure;
+        statistics::Scalar dcacheMainPipeStoreBlockedByTagWrite;
+        statistics::Scalar dcacheMainPipeRefillBlocked;
+        statistics::Scalar dcacheMainPipeRefillBlockedByPipeResource;
         statistics::Scalar dcacheMainPipeBlockedByDataConflict;
+        statistics::Scalar dcacheMainPipeStoreS2IssueBlocked;
     } stats;
 
     void recordStoreBufferEviction(StoreBufferEvictCause cause);

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -42,6 +42,7 @@
 #ifndef __CPU_O3_LSQ_HH__
 #define __CPU_O3_LSQ_HH__
 
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <list>
@@ -98,6 +99,13 @@ class LSQ
         Full,
         SQFull,
         Timeout
+    };
+
+    enum class StoreBufferBlockCause
+    {
+        None,
+        MainPipe,
+        CachePort
     };
 
     /**
@@ -1118,8 +1126,13 @@ class LSQ
 
     void clearAddresses();
 
+    void advanceDcacheMainPipe();
+
     unsigned
     getDcacheDiv(Addr vaddr) const;
+
+    uint64_t
+    getDcacheSetKey(Addr vaddr) const;
 
     uint64_t
     getDcacheBankSetKey(Addr vaddr) const;
@@ -1130,23 +1143,6 @@ class LSQ
     Addr bankNum(Addr a) const { return (a >> 3) & 0x7; };
 
     bool loadBankConflictedCheck(Addr vaddr);
-
-    void sbufferWriteBank(Addr vaddr, const std::vector<bool>& mask) {
-        assert(mask.size() == 8 * numBank);
-        dcacheWriteStall = true;
-        const unsigned div = getDcacheDiv(vaddr);
-        if (sbufferBankWriteAccurately) {
-            for (int i=0; i<numBank; i++) {
-                if (std::any_of(mask.begin() + 8 * i, mask.begin() + 8 * i + 8,
-                                [](bool v) { return v; })) {
-                    bankOccupied.at(div).at(i) = true;
-                }
-            }
-        } else {
-            std::fill(bankOccupied.at(div).begin(), bankOccupied.at(div).end(),
-                      true);
-        }
-    }
 
     void setDcacheWriteStall(bool t) { dcacheWriteStall = t; }
     bool getDcacheWriteStall() { return dcacheWriteStall; }
@@ -1196,11 +1192,23 @@ class LSQ
     {
         return blockedSbufferEntry != nullptr;
     }
-    void setBlockedStoreBufferEntry(StoreBufferEntry *entry)
+    void setBlockedStoreBufferEntry(StoreBufferEntry *entry,
+                                    StoreBufferBlockCause cause =
+                                        StoreBufferBlockCause::CachePort)
     {
         blockedSbufferEntry = entry;
+        blockedSbufferCause = cause;
     }
-    void clearBlockedStoreBufferEntry() { blockedSbufferEntry = nullptr; }
+    void clearBlockedStoreBufferEntry()
+    {
+        blockedSbufferEntry = nullptr;
+        blockedSbufferCause = StoreBufferBlockCause::None;
+    }
+    bool storeBufferBlockedByMainPipe() const
+    {
+        return blockedSbufferEntry != nullptr &&
+            blockedSbufferCause == StoreBufferBlockCause::MainPipe;
+    }
     bool retryBlockedStoreBuffer();
     bool sbufferSendPacket(PacketPtr data_pkt);
     void completeSbufferEvict(PacketPtr pkt);
@@ -1242,23 +1250,119 @@ class LSQ
     int storeWbStage() const { return _storeWbStage; }
 
   public:
+    static constexpr unsigned DcacheBankCount = 8;
+
+    using DcacheBankMask = std::array<bool, DcacheBankCount>;
+
+    enum class DcacheMainPipeSource : unsigned
+    {
+        Refill,
+        StoreBuffer
+    };
+
+    enum class DcacheMainPipeStage : unsigned
+    {
+        S0TagReadEntry = 0,
+        S1DataRead,
+        S2DataResp,
+        S3Write,
+        S4Complete,
+    };
+
+    struct DcacheMainPipeRequest
+    {
+        DcacheMainPipeSource source = DcacheMainPipeSource::Refill;
+        Addr addr = 0;
+        unsigned div = 0;
+        uint64_t setKey = 0;
+        bool needDataRead = false;
+        bool needTagWrite = false;
+        bool needDataWrite = false;
+        bool needWritebackPort = false;
+        DcacheBankMask readBanks = {};
+        DcacheBankMask writeBanks = {};
+
+        bool isRefill() const
+        {
+            return source == DcacheMainPipeSource::Refill;
+        }
+
+        bool isStoreBuffer() const
+        {
+            return source == DcacheMainPipeSource::StoreBuffer;
+        }
+    };
+
+    struct DcacheMainPipeSlot
+    {
+        bool valid = false;
+        DcacheMainPipeRequest req;
+    };
+
+    // S0 happens at admission time. The stored array keeps the buffered
+    // pipeline slots from S1 to S3, while S4 is the pipe exit.
+    static constexpr unsigned FirstBufferedDcacheMainPipeStage =
+        static_cast<unsigned>(DcacheMainPipeStage::S1DataRead);
+    static constexpr unsigned LastBufferedDcacheMainPipeStage =
+        static_cast<unsigned>(DcacheMainPipeStage::S3Write);
+    static constexpr unsigned NumBufferedDcacheMainPipeStages =
+        LastBufferedDcacheMainPipeStage -
+        FirstBufferedDcacheMainPipeStage + 1;
+
+    using DcacheMainPipeBufferedPipe =
+        std::array<DcacheMainPipeSlot, NumBufferedDcacheMainPipeStages>;
+
+    static constexpr unsigned
+    dcacheMainPipeIndex(DcacheMainPipeStage stage)
+    {
+        return static_cast<unsigned>(stage) -
+            FirstBufferedDcacheMainPipeStage;
+    }
+
+    DcacheMainPipeSlot &
+    dcacheMainPipeStage(DcacheMainPipeStage stage);
+
+    const DcacheMainPipeSlot &
+    dcacheMainPipeStage(DcacheMainPipeStage stage) const;
+
+    DcacheBankMask fullDcacheBankMask() const;
+    DcacheBankMask storeMaskToDcacheBanks(const std::vector<bool> &mask) const;
+
+    DcacheMainPipeRequest makeDcacheRefillMainPipeRequest(
+        Addr addr, bool need_data_read) const;
+    DcacheMainPipeRequest makeStoreBufferMainPipeRequest(
+        const StoreBufferEntry &entry) const;
+
+    void markDcacheMainPipeBusyBanks();
+
+    bool dcacheBankMaskAny(const DcacheBankMask &mask) const;
+    bool dcacheBankMaskOverlap(const DcacheBankMask &lhs,
+                               const DcacheBankMask &rhs) const;
+
+    bool hasDcacheMainPipeDataArrayConflict() const;
+    bool isDcacheMainPipeSetBlocked(uint64_t set_key) const;
+    bool canEnterDcacheMainPipe(
+        const DcacheMainPipeRequest &request,
+        const DcacheMainPipeBufferedPipe &next_pipe);
+    bool canEnterDcacheMainPipeNow(
+        const DcacheMainPipeRequest &request);
+    bool canEnterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry);
+    void enterStoreBufferDcacheMainPipe(const StoreBufferEntry &entry);
+
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
     std::vector<std::vector<bool>> bankOccupied;
 
-    void notifyDcacheRefill(Addr addr);
+    void notifyDcacheRefill(Addr addr, bool need_data_read = true);
 
-    std::vector<bool> pendingDcacheRefill;
-    std::vector<uint32_t> dcacheRefillDataRead;
-    std::vector<uint32_t> dcacheRefillDataWrite;
-    std::vector<uint32_t> dcacheRefillTagWrite;
+    std::queue<DcacheMainPipeRequest> dcacheMainPipeRefillQ;
+    DcacheMainPipeBufferedPipe dcacheMainPipe = {};
+
     bool isDcacheRefillTagWrite() const
     {
-        for (auto stage : dcacheRefillTagWrite) {
-            if (stage & 0x1)
-                return true;
-        }
-        return false;
+        const auto &stage =
+            dcacheMainPipeStage(DcacheMainPipeStage::S3Write);
+        return stage.valid && stage.req.isRefill() && stage.req.needTagWrite;
     }
 
   protected:
@@ -1273,7 +1377,7 @@ class LSQ
     /** The number of used cache ports in this cycle by loads. */
     int usedLoadPorts;
 
-    const int numBank = 8;
+    const int numBank = DcacheBankCount;
     bool dcacheWriteStall = false;
     const uint32_t sbufferEvictThreshold;
     const uint32_t sbufferEntries;
@@ -1286,6 +1390,8 @@ class LSQ
     };
     uint64_t storeBufferWritebackInactive = 0;
     StoreBufferEntry *blockedSbufferEntry = nullptr;
+    StoreBufferBlockCause blockedSbufferCause = StoreBufferBlockCause::None;
+    bool lastSbufferSendBlockedByMainPipe = false;
     ThreadID nextStoreBufferOffloadTid = InvalidThreadID;
     ThreadID nextStoreBufferInsertTid  = 0;
 
@@ -1337,6 +1443,13 @@ class LSQ
         /** Handshake-level sbuffer to dcache request outcomes. */
         statistics::Scalar sbufferDcacheReqFire;
         statistics::Scalar sbufferDcacheReqBlocked;
+        statistics::Scalar sbufferDcacheReqBlockedByMainPipe;
+        statistics::Scalar dcacheMainPipeRefillEnter;
+        statistics::Scalar dcacheMainPipeStoreEnter;
+        statistics::Scalar dcacheMainPipeStoreBlockedByRefill;
+        statistics::Scalar dcacheMainPipeStoreBlockedBySet;
+        statistics::Scalar dcacheMainPipeBlockedByS1Backpressure;
+        statistics::Scalar dcacheMainPipeBlockedByDataConflict;
     } stats;
 
     void recordStoreBufferEviction(StoreBufferEvictCause cause);

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -2454,7 +2454,7 @@ LSQUnit::insertStoreBuffer(Addr vaddr, Addr paddr, uint8_t* datas,
     auto entry = storeBuffer.get(lsqID, blockPaddr);
 
     if (entry) {
-        if (entry->sending) {
+        if (entry->evictionInProgress()) {
             if (entry->vice) {
                 // merge into vice
                 stats.sbufferMerge++;

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -888,6 +888,53 @@ BaseCache::handleUncacheableWriteResp(PacketPtr pkt)
     cpuSidePort.schedTimingResp(pkt, completion_time);
 }
 
+bool
+BaseCache::dcacheMainPipeEffectiveMSHRFull() const
+{
+    return mshrQueue.isFullWithExtraAllocated(dcacheMainPipeHeldMSHRCredits);
+}
+
+bool
+BaseCache::dcacheMainPipeCanPrefetch() const
+{
+    return mshrQueue.canPrefetchWithExtraAllocated(
+        dcacheMainPipeHeldMSHRCredits);
+}
+
+void
+BaseCache::holdDcacheMainPipeMSHRCredit()
+{
+    ++dcacheMainPipeHeldMSHRCredits;
+}
+
+void
+BaseCache::scheduleDcacheMainPipeMSHRCreditRelease(Tick tick)
+{
+    Event *event = new EventFunctionWrapper(
+        [this] { releaseDcacheMainPipeMSHRCredit(); },
+        name() + ".dcache_mainpipe_mshr_credit_release", true);
+    schedule(event, std::max(tick, curTick()));
+}
+
+void
+BaseCache::releaseDcacheMainPipeMSHRCredit()
+{
+    const bool was_full = dcacheMainPipeEffectiveMSHRFull();
+    assert(dcacheMainPipeHeldMSHRCredits > 0);
+    --dcacheMainPipeHeldMSHRCredits;
+
+    if (was_full && !dcacheMainPipeEffectiveMSHRFull()) {
+        clearBlocked(Blocked_NoMSHRs);
+    }
+
+    if (prefetcher && dcacheMainPipeCanPrefetch() && !isBlocked()) {
+        Tick next_pf_time = std::max(nextPrefetchReadyTime(), clockEdge());
+        if (next_pf_time != MaxTick) {
+            schedMemSideSendEvent(next_pf_time);
+        }
+    }
+}
+
 void
 BaseCache::recvTimingResp(PacketPtr pkt)
 {
@@ -954,6 +1001,8 @@ BaseCache::recvTimingResp(PacketPtr pkt)
     assert(doFastWriteline ? !mshr->wasWholeLineWrite || pkt->isInvalidate() : true);
 
     CacheBlk *blk = tags->findBlock(pkt->getAddr(), pkt->isSecure());
+    o3::LSQ *dcache_refill_lsq = nullptr;
+    Addr dcache_refill_addr = 0;
 
     if (is_fill && !is_error) {
         DPRINTF(Cache, "Block for addr %#llx being updated in Cache\n",
@@ -964,10 +1013,10 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         // Optionally indicate that the Dcache received a refill request
         // to drive LSQ-side modelling.
         if (simulateDcacheRefill && cacheLevel == 1 && pkt->getLSQPtr()) {
-            const Addr refill_addr =
+            dcache_refill_lsq = pkt->getLSQPtr();
+            dcache_refill_addr =
                 pkt->req && pkt->req->hasVaddr() ? pkt->req->getVaddr() :
                 pkt->getAddr();
-            pkt->getLSQPtr()->notifyDcacheRefill(refill_addr);
             stats.DcacheRefillTimes++;
         }
         blk = handleFill(pkt, blk, writebacks, allocate);
@@ -1000,6 +1049,26 @@ BaseCache::recvTimingResp(PacketPtr pkt)
     }
 
     serviceMSHRTargets(mshr, pkt, blk);
+
+    bool dcache_refill_notified = false;
+    auto notify_dcache_refill = [&](bool hold_mshr_credit) {
+        if (!dcache_refill_lsq) {
+            return;
+        }
+
+        dcache_refill_notified = true;
+        if (hold_mshr_credit) {
+            holdDcacheMainPipeMSHRCredit();
+            dcache_refill_lsq->notifyDcacheRefill(
+                dcache_refill_addr, true,
+                [this](Tick tick) {
+                    scheduleDcacheMainPipeMSHRCreditRelease(tick);
+                });
+        } else {
+            dcache_refill_lsq->notifyDcacheRefill(dcache_refill_addr);
+        }
+    };
+
     // We are stopping servicing targets early for the Locked RMW Read until
     // the write comes.
     if (!mshr->hasLockedRMWReadTarget()) {
@@ -1011,19 +1080,23 @@ BaseCache::recvTimingResp(PacketPtr pkt)
             }
             mshrQueue.markPending(mshr);
             schedMemSideSendEvent(clockEdge() + pkt->payloadDelay);
+            notify_dcache_refill(false);
         } else {
+            // Keep classic-cache release functional, but hold an extra MSHR
+            // credit until the refill leaves the fake mainpipe.
             // while we deallocate an mshr from the queue we still have to
             // check the isFull condition before and after as we might
             // have been using the reserved entries already
-            const bool was_full = mshrQueue.isFull();
+            const bool was_full = dcacheMainPipeEffectiveMSHRFull();
+            notify_dcache_refill(true);
             mshrQueue.deallocate(mshr);
-            if (was_full && !mshrQueue.isFull()) {
+            if (was_full && !dcacheMainPipeEffectiveMSHRFull()) {
                 clearBlocked(Blocked_NoMSHRs);
             }
 
             // Request the bus for a prefetch if this deallocation freed enough
             // MSHRs for a prefetch to take place
-            if (prefetcher && mshrQueue.canPrefetch() && !isBlocked()) {
+            if (prefetcher && dcacheMainPipeCanPrefetch() && !isBlocked()) {
                 Tick next_pf_time = std::max(nextPrefetchReadyTime(), clockEdge());
                 if (next_pf_time != MaxTick)
                     schedMemSideSendEvent(next_pf_time);
@@ -1034,6 +1107,10 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         if (blk == tempBlock && tempBlock->isValid()) {
             evictBlock(blk, writebacks);
         }
+    }
+
+    if (!dcache_refill_notified) {
+        notify_dcache_refill(false);
     }
 
     const Tick forward_time = clockEdge(forwardLatency) + pkt->headerDelay;
@@ -1357,7 +1434,7 @@ BaseCache::getNextQueueEntry()
 
     // fall through... no pending requests.  Try a prefetch.
     assert(!miss_mshr && !wq_entry);
-    if (prefetcher && mshrQueue.canPrefetch() && !isBlocked()) {
+    if (prefetcher && dcacheMainPipeCanPrefetch() && !isBlocked()) {
         // If we have a miss queue slot, we can try a prefetch
         bool has_pending_pkt = prefetcher->hasPendingPacket();
         PacketPtr pkt = nullptr;
@@ -1420,7 +1497,7 @@ BaseCache::getNextQueueEntry()
         }
     }
 
-    if (prefetcher && (!mshrQueue.canPrefetch() || isBlocked()) &&
+    if (prefetcher && (!dcacheMainPipeCanPrefetch() || isBlocked()) &&
         prefetcher->hasHintDownStream() && Prefetch_CanOffload) {
         DPRINTF(HWPrefetch, "Offloading prefetch to downstream cache\n");
         prefetcher->offloadToDownStream();
@@ -2476,7 +2553,7 @@ BaseCache::nextQueueReadyTime() const
 
     // Don't signal prefetch ready time if no MSHRs available
     // Will signal once enoguh MSHRs are deallocated
-    if (prefetcher && mshrQueue.canPrefetch() && !isBlocked()) {
+    if (prefetcher && dcacheMainPipeCanPrefetch() && !isBlocked()) {
         nextReady = std::min(nextReady, nextPrefetchReadyTime());
     }
 

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -1026,11 +1026,10 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         const bool allocate = (writeAllocator && mshr->wasWholeLineWrite) ?
             writeAllocator->allocate() : mshr->allocOnFill();
         const bool is_dcache_mainpipe_refill =
-            allocate && pkt->isRead() &&
-            (mshr->hasFromCPU() || mshr->hasFromPref());
-        // Send L1D fill traffic into the fake mainpipe. Demand responses
-        // carry the LSQ pointer in the packet; prefetch-only responses use
-        // the LSQ owner learned from earlier demand traffic.
+            allocate && (mshr->hasFromCPU() || mshr->hasFromPref());
+        // Send allocated L1D fill/update traffic into the fake mainpipe.
+        // Demand responses carry the LSQ pointer in the packet; prefetch-only
+        // responses use the LSQ owner learned from earlier demand traffic.
         if (simulateDcacheRefill && cacheLevel == 1 &&
             is_dcache_mainpipe_refill) {
             o3::LSQ *packet_lsq = pkt->getLSQPtr();

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -932,7 +932,7 @@ BaseCache::scheduleDcacheMainPipeMSHRCreditRelease(Tick tick)
     Event *event = new EventFunctionWrapper(
         [this] { releaseDcacheMainPipeMSHRCredit(); },
         name() + ".dcache_mainpipe_mshr_credit_release", true);
-    schedule(event, std::max(tick, clockEdge(Cycles(1))));
+    schedule(event, std::max(tick, curTick()));
 }
 
 void

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -664,6 +664,8 @@ BaseCache::calReqInterval(PacketPtr pkt)
 void
 BaseCache::recvTimingReq(PacketPtr pkt)
 {
+    registerDcacheMainPipeLSQ(pkt->getLSQPtr());
+
     calReqInterval(pkt);
 
     if (pkt->isStorePFTrain()) {
@@ -902,6 +904,19 @@ BaseCache::dcacheMainPipeCanPrefetch() const
 }
 
 void
+BaseCache::registerDcacheMainPipeLSQ(o3::LSQ *lsq)
+{
+    if (!lsq || !simulateDcacheRefill || cacheLevel != 1) {
+        return;
+    }
+
+    panic_if(dcacheMainPipeLSQ && dcacheMainPipeLSQ != lsq,
+             "%s: DCache fake mainpipe LSQ owner already set\n",
+             name().c_str());
+    dcacheMainPipeLSQ = lsq;
+}
+
+void
 BaseCache::holdDcacheMainPipeMSHRCredit()
 {
     ++dcacheMainPipeHeldMSHRCredits;
@@ -1010,14 +1025,31 @@ BaseCache::recvTimingResp(PacketPtr pkt)
 
         const bool allocate = (writeAllocator && mshr->wasWholeLineWrite) ?
             writeAllocator->allocate() : mshr->allocOnFill();
-        // Optionally indicate that the Dcache received a refill request
-        // to drive LSQ-side modelling.
-        if (simulateDcacheRefill && cacheLevel == 1 && pkt->getLSQPtr()) {
-            dcache_refill_lsq = pkt->getLSQPtr();
-            dcache_refill_addr =
-                pkt->req && pkt->req->hasVaddr() ? pkt->req->getVaddr() :
-                pkt->getAddr();
-            stats.DcacheRefillTimes++;
+        const bool is_dcache_mainpipe_refill =
+            allocate && pkt->isRead() &&
+            (mshr->hasFromCPU() || mshr->hasFromPref());
+        // Send L1D fill traffic into the fake mainpipe. Demand responses
+        // carry the LSQ pointer in the packet; prefetch-only responses use
+        // the LSQ owner learned from earlier demand traffic.
+        if (simulateDcacheRefill && cacheLevel == 1 &&
+            is_dcache_mainpipe_refill) {
+            o3::LSQ *packet_lsq = pkt->getLSQPtr();
+            registerDcacheMainPipeLSQ(packet_lsq);
+            dcache_refill_lsq = packet_lsq ? packet_lsq : dcacheMainPipeLSQ;
+
+            if (dcache_refill_lsq) {
+                dcache_refill_addr =
+                    pkt->req && pkt->req->hasVaddr() ? pkt->req->getVaddr() :
+                    pkt->getAddr();
+                stats.DcacheRefillTimes++;
+                if (packet_lsq) {
+                    stats.DcacheRefillNotifyFromPacketLSQ++;
+                } else {
+                    stats.DcacheRefillNotifyFromOwnerLSQ++;
+                }
+            } else {
+                stats.DcacheRefillNotifyWithoutLSQ++;
+            }
         }
         blk = handleFill(pkt, blk, writebacks, allocate);
         assert(blk != nullptr);
@@ -3024,6 +3056,12 @@ BaseCache::CacheStats::CacheStats(BaseCache &c)
              "number of MSHR arbitration fails (one miss per cycle)"),
     ADD_STAT(DcacheRefillTimes, statistics::units::Count::get(),
              "number of Dcache refill events"),
+    ADD_STAT(DcacheRefillNotifyFromPacketLSQ, statistics::units::Count::get(),
+             "number of L1D refill events notified with packet LSQ pointer"),
+    ADD_STAT(DcacheRefillNotifyFromOwnerLSQ, statistics::units::Count::get(),
+             "number of L1D refill events notified with cache owner LSQ"),
+    ADD_STAT(DcacheRefillNotifyWithoutLSQ, statistics::units::Count::get(),
+             "number of L1D refill events skipped without an LSQ target"),
     ADD_STAT(MSHRAliasFails, statistics::units::Count::get(),
              "number of MSHR Alias fails (VA diff)"),
     ADD_STAT(FindHitInWriteBuffer, statistics::units::Count::get(),

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -739,6 +739,10 @@ BaseCache::recvTimingReq(PacketPtr pkt)
         }
     }
 
+    if (level() == 1 && !isReadOnly && pkt->isDcacheMainPipeSbufferReq() &&
+        satisfied) {
+        pkt->setDcacheMainPipeSbufferHit();
+    }
 
     // Here we charge the headerDelay that takes into account the latencies
     // of the bus, if the packet comes from it.
@@ -928,7 +932,7 @@ BaseCache::scheduleDcacheMainPipeMSHRCreditRelease(Tick tick)
     Event *event = new EventFunctionWrapper(
         [this] { releaseDcacheMainPipeMSHRCredit(); },
         name() + ".dcache_mainpipe_mshr_credit_release", true);
-    schedule(event, std::max(tick, curTick()));
+    schedule(event, std::max(tick, clockEdge(Cycles(1))));
 }
 
 void

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -670,6 +670,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
     bool dcacheMainPipeEffectiveMSHRFull() const;
     bool dcacheMainPipeCanPrefetch() const;
+    void registerDcacheMainPipeLSQ(o3::LSQ *lsq);
     void holdDcacheMainPipeMSHRCredit();
     void scheduleDcacheMainPipeMSHRCreditRelease(Tick tick);
     void releaseDcacheMainPipeMSHRCredit();
@@ -1352,6 +1353,9 @@ class BaseCache : public ClockedObject, public CacheAccessor
         statistics::Scalar MSHRArbFails;
 
         statistics::Scalar DcacheRefillTimes;
+        statistics::Scalar DcacheRefillNotifyFromPacketLSQ;
+        statistics::Scalar DcacheRefillNotifyFromOwnerLSQ;
+        statistics::Scalar DcacheRefillNotifyWithoutLSQ;
 
         /** Number of MSHR Alias fails (VA diff) . */
         statistics::Scalar MSHRAliasFails;
@@ -1654,6 +1658,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
     const bool forceHit;
     const bool simulateDcacheRefill;
+    o3::LSQ *dcacheMainPipeLSQ = nullptr;
 
 public:
     /**

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -390,6 +390,9 @@ class BaseCache : public ClockedObject, public CacheAccessor
     /** Miss status registers */
     MSHRQueue mshrQueue;
 
+    /** MSHR slots held by fake DCache MainPipe refill timing. */
+    int dcacheMainPipeHeldMSHRCredits = 0;
+
     /** Write/writeback buffer */
     WriteQueue writeBuffer;
 
@@ -481,10 +484,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
      */
     void markInService(MSHR *mshr, bool pending_modified_resp)
     {
-        bool wasFull = mshrQueue.isFull();
+        bool wasFull = dcacheMainPipeEffectiveMSHRFull();
         mshrQueue.markInService(mshr, pending_modified_resp);
 
-        if (wasFull && !mshrQueue.isFull()) {
+        if (wasFull && !dcacheMainPipeEffectiveMSHRFull()) {
             clearBlocked(Blocked_NoMSHRs);
         }
     }
@@ -664,6 +667,12 @@ class BaseCache : public ClockedObject, public CacheAccessor
                                     CacheBlk *blk) = 0;
 
     virtual void sendHintViaMSHRTargets(MSHR *mshr, const PacketPtr pkt) = 0;
+
+    bool dcacheMainPipeEffectiveMSHRFull() const;
+    bool dcacheMainPipeCanPrefetch() const;
+    void holdDcacheMainPipeMSHRCredit();
+    void scheduleDcacheMainPipeMSHRCreditRelease(Tick tick);
+    void releaseDcacheMainPipeMSHRCredit();
 
     /**
      * Handles a response (cache line fill/write ack) from the bus.
@@ -1404,7 +1413,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
                                         pkt, time, order++,
                                         allocOnFill(pkt->cmd));
 
-        if (mshrQueue.isFull()) {
+        if (dcacheMainPipeEffectiveMSHRFull()) {
             setBlocked((BlockedCause)MSHRQueue_MSHRs);
         }
 

--- a/src/mem/cache/mshr_queue.hh
+++ b/src/mem/cache/mshr_queue.hh
@@ -127,6 +127,19 @@ class MSHRQueue : public Queue<MSHR>
         return numEntries;
     }
 
+    bool isFullWithExtraAllocated(int extra) const
+    {
+        return allocated + extra >= numEntries - numReserve;
+    }
+
+    bool canPrefetchWithExtraAllocated(int extra) const
+    {
+        // @todo we may want to revisit the +1, currently added to
+        // keep regressions unchanged
+        return allocated + extra < numEntries -
+            (numReserve + 1 + demandReserve);
+    }
+
     /**
      * Moves the MSHR to the front of the pending list if it is not
      * in service.
@@ -180,9 +193,7 @@ class MSHRQueue : public Queue<MSHR>
      */
     bool canPrefetch() const
     {
-        // @todo we may want to revisit the +1, currently added to
-        // keep regressions unchanged
-        return (allocated < numEntries - (numReserve + 1 + demandReserve));
+        return canPrefetchWithExtraAllocated(0);
     }
 };
 

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -374,7 +374,13 @@ class Packet : public Printable
         MSHR_ALIAS_FAIL       = 0x00040000,
 
         // Signal that the packet hit in the write buffer.
-        HIT_IN_WRITE_BUFFER   = 0x00080000
+        HIT_IN_WRITE_BUFFER   = 0x00080000,
+
+        // Mark StoreBuffer packets issued from the fake DCache mainpipe.
+        DCACHE_MAINPIPE_SBUFFER_REQ = 0x00100000,
+
+        // Record whether the fake-mainpipe StoreBuffer access hit in L1D.
+        DCACHE_MAINPIPE_SBUFFER_HIT = 0x00200000
     };
 
     Flags flags;
@@ -810,6 +816,17 @@ class Packet : public Printable
     void setHitInWriteBuffer() { flags.set(HIT_IN_WRITE_BUFFER); }
     bool isHitInWriteBuffer() const { return flags.isSet(HIT_IN_WRITE_BUFFER); }
     void clearHitInWriteBuffer() { flags.clear(HIT_IN_WRITE_BUFFER); }
+
+    void setDcacheMainPipeSbufferReq()
+    { flags.set(DCACHE_MAINPIPE_SBUFFER_REQ); }
+    bool isDcacheMainPipeSbufferReq() const
+    { return flags.isSet(DCACHE_MAINPIPE_SBUFFER_REQ); }
+    void setDcacheMainPipeSbufferHit()
+    { flags.set(DCACHE_MAINPIPE_SBUFFER_HIT); }
+    bool isDcacheMainPipeSbufferHit() const
+    { return flags.isSet(DCACHE_MAINPIPE_SBUFFER_HIT); }
+    void clearDcacheMainPipeSbufferHit()
+    { flags.clear(DCACHE_MAINPIPE_SBUFFER_HIT); }
 
     void setLSQPtr(o3::LSQ *lsq) { lsqPtr = lsq; }
     o3::LSQ *getLSQPtr() const { return lsqPtr; }


### PR DESCRIPTION
## Motivation

This PR adds a fake L1D DCache mainpipe model for timing and performance modeling.

In the current classic-cache path, L1D refill and StoreBuffer traffic can access cache resources without modeling the same mainpipe-side arbitration and resource conflicts as the hardware pipeline. This can make GEM5 underestimate contention from refill/store traffic, especially bank/data-array conflicts, same-set refill hazards, tag-write blocking, and StoreBuffer backpressure.

The fake mainpipe models these mainpipe-side timing constraints without turning the classic cache into a real mainpipe-based cache implementation. The goal is to improve performance modeling accuracy for L1D refill and StoreBuffer interactions.

## Changes

- Add an LSQ-local fake DCache mainpipe with S1/S2/S3-style buffered stages.
- Model refill and StoreBuffer requests as fake mainpipe requests.
- Model mainpipe resource conflicts, including:
  - bank/data-array conflicts
  - same-set refill hazards
  - tag-write blocking
  - S1 backpressure
  - StoreBuffer replay after failed S2 issue
- Delay effective MSHR availability until the refill has completed fake mainpipe writeback.
- Issue StoreBuffer eviction packets from fake mainpipe S2 instead of sending them to the classic cache before mainpipe admission.
- Route prefetch refill responses through the same fake mainpipe path.
- Count allocated L1D fill/update traffic as fake mainpipe refill traffic.
- Add basic fake mainpipe statistics for refill/store entries and blocking causes.

## Scope

This PR keeps the fake mainpipe as a performance model. It does not make the classic cache use a real DCache mainpipe for functional accesses.

The modeled request sources are currently L1D refill and StoreBuffer traffic.

## Validation

- Built successfully with:

```bash
scons build/RISCV/gem5.opt --gold-linker -j64
```

- Triggered manual performance test:

```text
Manual Performance Test
configuration: idealkmhv3.py
benchmark_type: gcc15-spec06-0.8c
branch: merge/l1d-fake-mainpipe-xs-dev
run: https://github.com/OpenXiangShan/GEM5/actions/runs/27602319072
```

The performance workflow is currently running at the time this PR description is prepared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor / New Features**
  * Introduced a new fake D-cache “MainPipe” flow to orchestrate store-buffer eviction/admission, replay behavior, and eviction blocking.
  * Updated store-buffer writeback routing and writeback completion to reflect MainPipe stage activity and replay queue status.

* **Metrics**
  * Added detailed MainPipe statistics for refill notification outcomes plus store-buffer admission/blocking and replay timing reasons.

* **Cache Behavior**
  * Added MainPipe-aware MSHR credit tracking and updated D-cache prefetch readiness.
  * Added packet flags to track MainPipe store-buffer requests and hits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->