### PR TITLE
[codex] arch-riscv: Align RISC-V timebase to 1MHz

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -693,6 +693,9 @@ def makeXiangshanPlatformSystem(mem_mode, mdesc=None, np=1, ruby=False,
     self.lint.pio = self.iobus.mem_side_ports
     self.lint.pio_addr = 0x38000000
     self.lint.num_threads = num_threads
+    # Keep CLINT mtime in step with the 1MHz timebase advertised in the DTB.
+    self.rtc = RiscvRTC(frequency=Frequency("1MHz"))
+    self.lint.int_pin = self.rtc.int_pin
 
     self.hartctrl = HartCtrl()
     self.hartctrl.pio = self.iobus.mem_side_ports

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -185,7 +185,7 @@ def generate_xiangshan_dtb(system, *, cmdline: str, outdir: str = None) -> str:
     cpus_state = FdtState(addr_cells=1, size_cells=0)
     cpus_node.append(cpus_state.addrCellsProperty())
     cpus_node.append(cpus_state.sizeCellsProperty())
-    cpus_node.append(FdtPropertyWords("timebase-frequency", [10000000]))
+    cpus_node.append(FdtPropertyWords("timebase-frequency", [1000000]))
 
     mmu_type = "riscv,sv48"
     isa_string = "rv64imafdc"

--- a/configs/example/riscv/fs_linux.py
+++ b/configs/example/riscv/fs_linux.py
@@ -165,8 +165,8 @@ system.system_port = system.membus.cpu_side_ports
 # HiFive Platform
 system.platform = HiFive()
 
-# RTCCLK (Set to 100MHz for faster simulation)
-system.platform.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+# RTCCLK matches the RISC-V timebase-frequency advertised in the DTB.
+system.platform.rtc = RiscvRTC(frequency=Frequency("1MHz"))
 system.platform.clint.int_pin = system.platform.rtc.int_pin
 
 # VirtIOMMIO

--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -95,7 +95,7 @@ def createHiFivePlatform(system):
 
     system.platform.pci_host.pio = system.membus.mem_side_ports
 
-    system.platform.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+    system.platform.rtc = RiscvRTC(frequency=Frequency("1MHz"))
     system.platform.clint.int_pin = system.platform.rtc.int_pin
 
     system.pma_checker = PMAChecker(

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -61,6 +61,7 @@
 #include "mem/se_translating_port_proxy.hh"
 #include "mem/translating_port_proxy.hh"
 #include "params/RiscvISA.hh"
+#include "sim/core.hh"
 #include "sim/faults.hh"
 #include "sim/full_system.hh"
 #include "sim/pseudo_inst.hh"
@@ -376,8 +377,14 @@ void ISA::clear()
         miscRegFile[MISCREG_STATUS] = (2ULL << UXL_OFFSET) | (2ULL << SXL_OFFSET) |
                                     (1ULL << FS_OFFSET);
     }
-    miscRegFile[MISCREG_MCOUNTEREN] = 0;
-    miscRegFile[MISCREG_SCOUNTEREN] = 0;
+    if (FullSystem) {
+        miscRegFile[MISCREG_MCOUNTEREN] = 0;
+        miscRegFile[MISCREG_SCOUNTEREN] = 0;
+    } else {
+        // SE runs user-mode code without firmware or an OS to enable counters.
+        miscRegFile[MISCREG_MCOUNTEREN] = 0x7;
+        miscRegFile[MISCREG_SCOUNTEREN] = 0x7;
+    }
     // don't set it to zero; software may try to determine the supported
     // triggers, starting at zero. simply set a different value here.
     miscRegFile[MISCREG_TSELECT] = 1;
@@ -622,9 +629,16 @@ ISA::readMiscReg(int misc_reg)
         }
       case MISCREG_TIME:
         if (hpmCounterEnabled(MISCREG_TIME)) {
-            DPRINTF(RiscvMisc, "Wall-clock counter at: %llu.\n",
-                    std::time(nullptr));
-            return readMiscRegNoEffect(MISCREG_TIME);
+            if (!FullSystem) {
+                const uint64_t seTimebaseHz = 1000000;
+                RegVal time = curTick() / (sim_clock::Frequency / seTimebaseHz);
+                DPRINTF(RiscvMisc, "SE time counter at: %llu.\n", time);
+                return time;
+            } else {
+                DPRINTF(RiscvMisc, "Wall-clock counter at: %llu.\n",
+                        std::time(nullptr));
+                return readMiscRegNoEffect(MISCREG_TIME);
+            }
         } else {
             return 0;
         }

--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -200,7 +200,7 @@ class HiFive(Platform):
 
     def generateDeviceTree(self, state):
         cpus_node = FdtNode("cpus")
-        cpus_node.append(FdtPropertyWords("timebase-frequency", [10000000]))
+        cpus_node.append(FdtPropertyWords("timebase-frequency", [1000000]))
         yield cpus_node
 
         node = FdtNode("soc")

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -192,9 +192,8 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         self.lupio_tmr.num_threads = self.processor.get_num_cores()
         self.clint.num_threads = self.processor.get_num_cores()
 
-        # Add the RTC
-        # TODO: Why 100MHz? Does something else need to change when this does?
-        self.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+        # Add the RTC. This must match the timebase-frequency advertised below.
+        self.rtc = RiscvRTC(frequency=Frequency("1MHz"))
         self.clint.int_pin = self.rtc.int_pin
 
         # Incoherent I/O bus
@@ -305,9 +304,8 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         cpus_state = FdtState(addr_cells=1, size_cells=0)
         cpus_node.append(cpus_state.addrCellsProperty())
         cpus_node.append(cpus_state.sizeCellsProperty())
-        # Used by the CLINT driver to set the timer frequency. Value taken from
-        # RISC-V kernel docs (Note: freedom-u540 is actually 1MHz)
-        cpus_node.append(FdtPropertyWords("timebase-frequency", [100000000]))
+        # Used by the CLINT driver to set the timer frequency.
+        cpus_node.append(FdtPropertyWords("timebase-frequency", [1000000]))
         for i, core in enumerate(self.get_processor().get_cores()):
             node = FdtNode(f"cpu@{i}")
             node.append(FdtPropertyStrings("device_type", "cpu"))

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -108,9 +108,8 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
         self.platform.attachPlic()
         self.platform.clint.num_threads = self.processor.get_num_cores()
 
-        # Add the RTC
-        # TODO: Why 100MHz? Does something else need to change when this does?
-        self.platform.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+        # Add the RTC. This must match the timebase-frequency advertised below.
+        self.platform.rtc = RiscvRTC(frequency=Frequency("1MHz"))
         self.platform.clint.int_pin = self.platform.rtc.int_pin
 
         # Incoherent I/O bus
@@ -261,9 +260,8 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
         cpus_state = FdtState(addr_cells=1, size_cells=0)
         cpus_node.append(cpus_state.addrCellsProperty())
         cpus_node.append(cpus_state.sizeCellsProperty())
-        # Used by the CLINT driver to set the timer frequency. Value taken from
-        # RISC-V kernel docs (Note: freedom-u540 is actually 1MHz)
-        cpus_node.append(FdtPropertyWords("timebase-frequency", [100000000]))
+        # Used by the CLINT driver to set the timer frequency.
+        cpus_node.append(FdtPropertyWords("timebase-frequency", [1000000]))
 
         for i, core in enumerate(self.get_processor().get_cores()):
             node = FdtNode(f"cpu@{i}")


### PR DESCRIPTION
## Summary

This PR aligns the RISC-V timer/timebase setup around the 1MHz value used by the XiangShan/NEMU workload environment.

Changes:
- use a 1MHz `timebase-frequency` in the XiangShan-generated DTB
- connect the XiangShan FS `Clint` `mtime` source to a 1MHz `RiscvRTC`
- make RISC-V FS board RTC frequencies match the advertised 1MHz timebase
- keep FS counter enable behavior under firmware/software control, while enabling `cycle/time/instret` for SE workloads that do not have firmware or an OS to set `mcounteren/scounteren`
- back SE `rdtime` with a 1MHz simulated time counter instead of leaving it stuck at zero

This incorporates the useful part of #383, but with the timer source standardized to 1MHz instead of the older temporary 10MHz/100MHz direction. After this PR, #383 should only be historical context unless we want to preserve its discussion.

## Why

`timebase-frequency` tells software how fast `mtime`/`rdtime` increments. It is not the CPU clock. The XiangShan/NEMU checkpoint environment already uses 1MHz in `nemu_board` and NEMU, so advertising 10MHz/100MHz from gem5 creates a platform mismatch.

For the XiangShan FS platform, setting the DTS value alone is not enough: `Clint::raiseInterruptPin()` is what increments `mtime`, so `Clint.int_pin` also needs a connected RTC source.

## Validation

- `git diff --check`
- no remaining explicit RISC-V `timebase-frequency` 10MHz/100MHz or `RiscvRTC(...100MHz)` in the touched RISC-V board/config paths
- `scons build/RISCV/gem5.opt --gold-linker -j 16`
- SE counter probe:
  - `rdcycle` delta: `700060`
  - `rdtime` delta: `233`, matching the new 1MHz timebase for the same probe that previously produced about 10x larger deltas under 10MHz
  - `rdinstret` delta: `500007`
- XiangShan raw Linux smoke:
  - `./build/RISCV/gem5.opt -d /tmp/gem5-linux-dtb-1mhz-pr-rtc ./configs/example/kmhv3.py --raw-cpt --generic-rv-cpt /nfs/home/yanyue/workspace/ready-to-run/linux.bin --disable-difftest -I 1000`
  - generated DTS contains `timebase-frequency = <0x000f4240>`
  - generated config connects `system.lint.int_pin = system.rtc.int_pin[0]` and `system.rtc.frequency = 1000000`
- XiangShan CoreMark smoke:
  - `./build/RISCV/gem5.opt -d /tmp/gem5-coremark-1mhz-pr-rtc ./configs/example/kmhv3.py --raw-cpt --generic-rv-cpt /nfs/home/yanyue/workspace/ready-to-run/coremark-2-iteration.bin --disable-difftest`
  - CoreMark ran to `m5_exit` with expected CRC output, including `crcfinal = 0x72be`
  - after connecting RTC to CLINT, CoreMark reports `Total time (ms) : 78` instead of the previous stuck `0ms`
- RTC debug smoke:
  - `./build/RISCV/gem5.opt --debug-flags=MC146818 --debug-file=rtc-debug.log -d /tmp/gem5-coremark-rtc-debug ./configs/example/kmhv3.py --raw-cpt --generic-rv-cpt /nfs/home/yanyue/workspace/ready-to-run/coremark-2-iteration.bin --disable-difftest`
  - `rtc-debug.log` shows `RTC Timer Interrupt` every `1,000,000` gem5 ticks, from `1000000` through `281000000`
