### PR TITLE
[codex] arch-riscv: Fix O3 fflags sticky updates

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -113,7 +113,7 @@ matrixWriteBlob(ThreadContext *tc, Addr addr, const void *src, size_t size)
 
 } // namespace
 
-[[maybe_unused]] const std::array<const char *, NUM_MISCREGS> MiscRegNames = {{
+[[maybe_unused]] const std::array<const char *, NUM_MISC_AND_HELPER_REGS> MiscRegNames = {{
     [MISCREG_PRV]           = "PRV",
     [MISCREG_VIRMODE]         = "VIRTUALIZATIONMODE",
     [MISCREG_ISA]           = "ISA",
@@ -311,6 +311,7 @@ matrixWriteBlob(ThreadContext *tc, Addr addr, const void *src, size_t size)
     [MISCREG_NMIVEC]        = "NMIVEC",
     [MISCREG_NMIE]          = "NMIE",
     [MISCREG_NMIP]          = "NMIP",
+    [MISCREG_FFLAGS_EXE]    = "FFLAGS_EXE",
 }};
 
 
@@ -569,7 +570,7 @@ ISA::readMiscRegNoEffect(int misc_reg) const
             return miscRegFile[misc_reg] & (mmu->getPMP()->pmpTorMask());
         }
         return 0;
-    } else if (misc_reg > NUM_MISCREGS || misc_reg < 0) {
+    } else if (misc_reg >= NUM_MISCREGS || misc_reg < 0) {
         // Illegal CSR
         panic("Illegal CSR index %#x\n", misc_reg);
         return -1;
@@ -686,6 +687,11 @@ ISA::readMiscReg(int misc_reg)
                   (readMiscRegNoEffect(MISCREG_VXRM) << 1);
         }
         break;
+      case MISCREG_FFLAGS_EXE:
+        {
+            return readMiscRegNoEffect(MISCREG_FFLAGS) & FFLAGS_MASK;
+        }
+        break;
         case MISCREG_PMPADDR00 ... MISCREG_PMPADDR15:
         {
             return readMiscRegNoEffect(misc_reg);
@@ -711,7 +717,7 @@ ISA::readMiscReg(int misc_reg)
 void
 ISA::setMiscRegNoEffect(int misc_reg, RegVal val)
 {
-    if (misc_reg > NUM_MISCREGS || misc_reg < 0) {
+    if (misc_reg >= NUM_MISCREGS || misc_reg < 0) {
         // Illegal CSR
         panic("Illegal CSR index %#x\n", misc_reg);
     }
@@ -932,6 +938,19 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                     ((cur & ~(NEMU_MSTATUS_WMASK)) | (val & NEMU_MSTATUS_WMASK));
                 mstatus.sd = mstatus.fs == 0x3 || mstatus.vs == 0x3;
                 setMiscRegNoEffect(misc_reg, mstatus);
+            }
+            break;
+          case MISCREG_FFLAGS_EXE:
+            {
+                DPRINTF(RiscvMisc, "Will set fs\n");
+                STATUS mstatus = readMiscRegNoEffect(MISCREG_STATUS);
+                mstatus.fs = 3;
+                mstatus.sd = 1;
+                setMiscRegNoEffect(MISCREG_STATUS, mstatus);
+
+                RegVal fflags = readMiscRegNoEffect(MISCREG_FFLAGS);
+                fflags |= (val & FFLAGS_MASK);
+                setMiscRegNoEffect(MISCREG_FFLAGS, fflags);
             }
             break;
             case MISCREG_FFLAGS:

--- a/src/arch/riscv/isa/formats/fp.isa
+++ b/src/arch/riscv/isa/formats/fp.isa
@@ -50,14 +50,12 @@ def template FloatExecute {{
         %(op_decl)s;
         %(op_rd)s;
 
-        RegVal FFLAGS = xc->readMiscReg(MISCREG_FFLAGS);
         feclearexcept(FE_ALL_EXCEPT);
         %(code)s;
 
-        FFLAGS |= softfloat_exceptionFlags;
         if (softfloat_exceptionFlags) {
+            xc->setMiscReg(MISCREG_FFLAGS_EXE, softfloat_exceptionFlags);
             softfloat_exceptionFlags = 0;
-            xc->setMiscReg(MISCREG_FFLAGS, FFLAGS);
         }
 
         %(op_wb)s;

--- a/src/arch/riscv/isa/vector/base/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.isa
@@ -125,13 +125,11 @@ let {{
 
     def fflags_wrapper(code):
         return '''
-        RegVal FFLAGS = xc->readMiscReg(MISCREG_FFLAGS);
         feclearexcept(FE_ALL_EXCEPT);
         ''' + code + '''
-        FFLAGS |= softfloat_exceptionFlags;
         if (softfloat_exceptionFlags) {
+            xc->setMiscReg(MISCREG_FFLAGS_EXE, softfloat_exceptionFlags);
             softfloat_exceptionFlags = 0;
-            xc->setMiscReg(MISCREG_FFLAGS, FFLAGS);
         }
         '''
 }};

--- a/src/arch/riscv/isa/vector/simple/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.isa
@@ -125,13 +125,11 @@ let {{
 
     def fflags_wrapper(code):
         return '''
-        RegVal FFLAGS = xc->readMiscReg(MISCREG_FFLAGS);
         feclearexcept(FE_ALL_EXCEPT);
         ''' + code + '''
-        FFLAGS |= softfloat_exceptionFlags;
         if (softfloat_exceptionFlags) {
+            xc->setMiscReg(MISCREG_FFLAGS_EXE, softfloat_exceptionFlags);
             softfloat_exceptionFlags = 0;
-            xc->setMiscReg(MISCREG_FFLAGS, FFLAGS);
         }
         '''
 }};

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -265,7 +265,9 @@ enum MiscRegIndex
     // non-maskable-interrupt-pending: NMI version of xIP
     MISCREG_NMIP,
 
-    NUM_MISCREGS
+    NUM_MISCREGS,
+    MISCREG_FFLAGS_EXE = NUM_MISCREGS,
+    NUM_MISC_AND_HELPER_REGS
 };
 
 enum CSRIndex


### PR DESCRIPTION
## Motivation

`povray_13677` in the SMT 0.3c perf path exposed a RISC-V difftest mismatch where `fflags` read back as `NX` in gem5 while the reference had `UF|NX`.

The root cause is that FP/vector FP instructions treated sticky `fflags` as a normal misc CSR: they read architectural `MISCREG_FFLAGS` at execute time and recorded a whole-value misc write for commit. On O3, younger FP instructions may execute before older ones, so a younger whole-value `fflags` write can overwrite sticky bits that an older FP instruction committed first.

## Approach

Port the upstream-style helper-register fix from gem5's `arch-riscv: Include FFLAGS O3 CPU fix from #868` direction:

- Add `MISCREG_FFLAGS_EXE` as an execution helper misc register outside the physical misc register file.
- Change scalar FP and vector FP templates to write only the current instruction's `softfloat_exceptionFlags` to `MISCREG_FFLAGS_EXE`.
- Handle `MISCREG_FFLAGS_EXE` in RISC-V ISA `setMiscReg()` by OR-ing the exception bits into architectural `MISCREG_FFLAGS` at commit time.
- Keep CSR writes to `fflags` / `fcsr` as whole-value writes, so explicit software clear/write semantics are unchanged.

## Validation

- `scons build/RISCV/gem5.fast --gold-linker -j64`

Warnings were limited to existing optional dependency warnings for PNG, HDF5, and backtrace support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened floating-point exception flag validation and handling in RISC-V instruction execution.
  * Improved control/status register legality checks to more strictly validate out-of-range values.

* **Refactor**
  * Updated floating-point exception flag capture mechanism for improved accuracy across scalar and vector instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->