### PR TITLE
[codex] configs,cpu: Fix aligned L2 defaults and mip diff noise

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -147,7 +147,9 @@ def config_aligned_l2(options, system, l2_cache_class):
     for i in range(options.num_cpus):
         l2_wrapper = system.l2_wrappers[i]
         xbar = l2_wrapper.xbar
-        if not options.no_pf:
+        if options.no_pf:
+            l2_wrapper.prefetcher = NULL
+        else:
             l2_wrapper.prefetcher = create_prefetcher(system.cpu[i], 'l2_wrapper', options)
         for j in range(num_l2_slices):
             # Apply original per-L2-cache configurations to each slice's inner cache

--- a/configs/example/se.py
+++ b/configs/example/se.py
@@ -142,7 +142,7 @@ def setDefaultArgs(args):
         'l2cache': True,
         'l2_size': '1MB',
         'l2_assoc': 8,
-        'l2_hwp_type': 'WorkerPrefetcher',
+        'l2_hwp_type': 'PrefetcherForwarder',
         'l3cache': True,
         'l3_size': '16MB',
         'l3_assoc': 16,
@@ -303,7 +303,6 @@ def setKmhV3IdealParams(args, system):
         cpu.renameWidth = 8
         cpu.commitWidth = 12
         cpu.squashWidth = 12
-        cpu.replayWidth = 12
         cpu.LQEntries = 128
         cpu.SQEntries = 64
         cpu.SbufferEntries = 24
@@ -340,8 +339,15 @@ def setKmhV3IdealParams(args, system):
 
     if args.l2cache:
         for i in range(args.num_cpus):
-            system.l2_caches[i].size = '2MB'
-            system.l2_caches[i].num_slices = 0   # 4 -> 0, no slice
+            if args.classic_l2:
+                system.l2_caches[i].size = '2MB'
+                system.l2_caches[i].slice_num = 0   # 4 -> 0, no slice
+            else:
+                l2_wrapper = system.l2_wrappers[i]
+                l2_wrapper.data_sram_banks = 2
+                l2_wrapper.dir_sram_banks = 2
+                l2_wrapper.pipe_dir_write_stage = 4
+                l2_wrapper.dir_read_bypass = True
             system.tol2bus_list[i].forward_latency = 0  # 3->0
             system.tol2bus_list[i].response_latency = 0  # 3->0
             system.tol2bus_list[i].hint_wakeup_ahead_cycles = 0  # 2->0

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -1216,8 +1216,10 @@ BaseCPU::diffWithNEMU(ThreadID tid, InstSeqNum seq)
         gem5_val = readMiscReg(RiscvISA::MiscRegIndex::MISCREG_IP, tid);
         diffAllStates->gem5RegFile.mip = gem5_val;
         ref_val = diffAllStates->referenceRegFile.mip;
-        if (gem5_val != ref_val) {
-            warn("mip:\tGEM5: %#lx,\tREF: %#lx\n", gem5_val, ref_val);
+        const RegVal mip_diff_mask = RiscvISA::NEMU_MIP_MASK;
+        if ((gem5_val & mip_diff_mask) != (ref_val & mip_diff_mask)) {
+            warn("mip:\tGEM5: %#lx,\tREF: %#lx,\tMASK: %#lx\n",
+                 gem5_val, ref_val, mip_diff_mask);
             diffMsg <<
                 csprintf("%s at \033[31m%s\033[0m Ref value: \033[31m%#lx\033[0m, GEM5 value: \033[31m%#lx\033[0m\n",
                     gem5_val == ref_val ? "match" : "diff", "mip", ref_val, gem5_val);


### PR DESCRIPTION
## Motivation

This small cleanup fixes two config/default issues found while working with the current XiangShan flows, and reduces noisy difftest logging for asynchronous `mip` bits.

## Changes

- Set the aligned L2 wrapper prefetcher to `NULL` when `--no-pf` is used, instead of leaving the wrapper's default prefetcher object alive.
- Align SE-mode L2 defaults with the aligned-L2 plumbing by using `PrefetcherForwarder` at the L2 cache level and configuring wrapper-side ideal L2 parameters when `classic_l2` is disabled.
- Compare difftest `mip` warnings using `NEMU_MIP_MASK`, so locally injected/asynchronous bits outside the NEMU-synchronized mask do not flood logs while masked `mip` mismatches still report normally.

## Validation

- `python3 -m py_compile configs/common/CacheConfig.py configs/example/se.py`
- `git diff --check`
- `scons build/RISCV/gem5.fast --gold-linker -j64`

The build completed successfully. Warnings were limited to existing optional dependency warnings for PNG, HDF5, and backtrace support, plus existing Python SyntaxWarnings from generated/config parsing paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added L2 cache configuration option for classic mode selection

* **Bug Fixes**
  * Enhanced MIP register comparison logic in CPU debugging output
  * Improved L2 prefetcher assignment consistency

* **Chores**
  * Updated default prefetcher type for cache configuration
  * Refined L2 wrapper prefetcher handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->