### PR TITLE
configs: should not define another `numDelay` in MicroTAGE[skip ci]

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1101,7 +1101,7 @@ class MicroTAGE(TimedBaseBTBPredictor):
     useAltOnNaWidth = Param.Unsigned(7,"Width of the useAltOnNa table")
     numBanks = Param.Unsigned(4,"Number of banks for bank conflict simulation")
     enableBankConflict = Param.Bool(False,"Enable bank conflict simulation")
-    numDelay = Param.Unsigned(0,"Prediction latency in cycles")
+    numDelay = 0
 
 class BTBITTAGE(TimedBaseBTBPredictor):
     type = 'BTBITTAGE'


### PR DESCRIPTION
Change-Id: I001b62f5a2e990f2354b6a292aed48db6e9dc7ac