### PR TITLE
[codex] Fix H checkpoint autotest inputs

### DIFF
--- a/.github/workflows/autotest/gem5-h.cfg
+++ b/.github/workflows/autotest/gem5-h.cfg
@@ -17,56 +17,59 @@ compile_thread = 70
 set_var = export GCBH_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so" && \
           export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
 
+# H-extension checkpoint root. Keep archive moves to one line.
+h_cpt_root = /nfs/home/share/jiaxiaoyu/checkpoint_move/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46
+
 #checkpoints 搜索路径
 #格式: <path1 level> ; <path2 level>
 #可以这样写:binpath = checkpoints.paths ;test-diff/*/*.bin 2 
 #他会自动在paths文件中对每一行路径搜索,也会搜索test-diff/*/*.bin
 #每个glob路径后可以带一个数字,代表分类级数,比如home/a/b/c.txt,c.txt被分类了3次(a/b/c),因此填3
 #如果不带数字,则默认为1,即使用文件名作为分类
-ck_path = /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/astar_biglakes/563/_563_0.210733_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/astar_rivers/6526/_6526_0.232639_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/bwaves/11547/_11547_0.705661_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/bzip2_chicken/2381/_2381_0.252364_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/bzip2_combined/8555/_8555_0.255870_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/bzip2_html/6405/_6405_0.272950_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/bzip2_liberty/14642/_14642_0.330396_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/cactusADM/34611/_34611_0.645230_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/calculix/106537/_106537_0.242045_.zstd 4;
-    # /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/dealII/31900/_31900_0.124368_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gamess_cytosine/32442/_32442_0.140280_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gamess_gradient/21599/_21599_0.142400_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_166/2882/_2882_0.153946_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_200/5353/_5353_0.176711_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_cpdecl/980/_980_0.165296_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_expr/1595/_1595_0.167314_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_g23/9388/_9388_0.155191_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_s04/2064/_2064_0.199712_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_scilab/2750/_2750_0.194858_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gcc_typeck/5174/_5174_0.233650_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/GemsFDTD/14687/_14687_0.203339_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gobmk_13x13/7053/_7053_0.177736_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/zeusmp/80042/_80042_0.098310_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gobmk_nngs/6637/_6637_0.228579_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gobmk_score2/10643/_10643_0.153254_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gobmk_trevorc/6872/_6872_0.224235_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/gromacs/1013/_1013_0.217974_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/h264ref_foreman.baseline/20409/_20409_0.175944_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/h264ref_foreman.main/17362/_17362_0.160952_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/h264ref_sss/117206/_117206_0.137445_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/hmmer_nph3/10449/_10449_0.265110_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/leslie3d/23860/_23860_0.164700_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/libquantum/32364/_32364_0.141293_.zstd 4;
-    # /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/milc/32828/_32828_0.107332_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/omnetpp/12773/_12773_0.069781_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/perlbench_checkspam/34931/_34931_0.120246_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/perlbench_diffmail/16667/_16667_0.153475_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/perlbench_splitmail/29377/_29377_0.556450_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/povray/13919/_13919_0.096337_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/sjeng/99801/_99801_0.129843_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/soplex_pds-50/7832/_7832_0.188026_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/soplex_ref/4677/_4677_0.340354_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/tonto/85933/_85933_0.099321_.zstd 4;
-    /nfs/home/share/jiaxiaoyu/checkpoint/h_v_checkpoint_1203/checkpoint_scripts/checkpoint_scripts/archive/spec06_gcc15.0.0_rv64gcbv_base_intFppOff_for_H_V_sv39_NEMU_archgroup_2025-01-23-14-46/checkpoint-0-0-0/wrf/6348/_6348_0.173583_.zstd 4;
+ck_path = {h_cpt_root}/checkpoint-0-0-0/astar_biglakes/563/_563_0.210733_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/astar_rivers/6526/_6526_0.232639_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/bwaves/11547/_11547_0.705661_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/bzip2_chicken/2381/_2381_0.252364_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/bzip2_combined/8555/_8555_0.255870_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/bzip2_html/6405/_6405_0.272950_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/bzip2_liberty/14642/_14642_0.330396_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/cactusADM/34611/_34611_0.645230_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/calculix/106537/_106537_0.242045_.zstd 4;
+    # {h_cpt_root}/checkpoint-0-0-0/dealII/31900/_31900_0.124368_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gamess_cytosine/32442/_32442_0.140280_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gamess_gradient/21599/_21599_0.142400_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_166/2882/_2882_0.153946_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_200/5353/_5353_0.176711_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_cpdecl/980/_980_0.165296_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_expr/1595/_1595_0.167314_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_g23/9388/_9388_0.155191_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_s04/2064/_2064_0.199712_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_scilab/2750/_2750_0.194858_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gcc_typeck/5174/_5174_0.233650_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/GemsFDTD/14687/_14687_0.203339_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gobmk_13x13/7053/_7053_0.177736_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/zeusmp/80042/_80042_0.098310_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gobmk_nngs/6637/_6637_0.228579_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gobmk_score2/10643/_10643_0.153254_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gobmk_trevorc/6872/_6872_0.224235_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/gromacs/1013/_1013_0.217974_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/h264ref_foreman.baseline/20409/_20409_0.175944_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/h264ref_foreman.main/17362/_17362_0.160952_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/h264ref_sss/117206/_117206_0.137445_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/hmmer_nph3/10449/_10449_0.265110_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/leslie3d/23860/_23860_0.164700_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/libquantum/32364/_32364_0.141293_.zstd 4;
+    # {h_cpt_root}/checkpoint-0-0-0/milc/32828/_32828_0.107332_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/omnetpp/12773/_12773_0.069781_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/perlbench_checkspam/34931/_34931_0.120246_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/perlbench_diffmail/16667/_16667_0.153475_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/perlbench_splitmail/29377/_29377_0.556450_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/povray/13919/_13919_0.096337_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/sjeng/99801/_99801_0.129843_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/soplex_pds-50/7832/_7832_0.188026_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/soplex_ref/4677/_4677_0.340354_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/tonto/85933/_85933_0.099321_.zstd 4;
+    {h_cpt_root}/checkpoint-0-0-0/wrf/6348/_6348_0.173583_.zstd 4;
 
 
 [iteration]

--- a/.github/workflows/autotest/script/autotest.py
+++ b/.github/workflows/autotest/script/autotest.py
@@ -165,9 +165,24 @@ def Wrun_single(log_dir, etcArg):
     work_items = list(works.items())
     cnt = 0
     names = []
+    runErr_works = []
     for work in work_items:
-        files, sublog = utils.get_file_list(
+        files, sublog, missing_patterns = utils.get_file_list(
             cfgfile['work-'+work[0]]['binpath'])
+        if missing_patterns:
+            sample = '\n'.join(missing_patterns[:5])
+            if len(missing_patterns) > 5:
+                sample += '\n... {0} more'.format(len(missing_patterns) - 5)
+            msg = """error in:[work:{0}][{1} binpath entries matched no files]\n{2}""".format(
+                work[0], len(missing_patterns), sample)
+            SendMsg(msg)
+            runErr_works.append(work[0])
+            continue
+        if len(files) == 0:
+            msg = """error in:[work:{0}][binpath has no matched files]""".format(work[0])
+            SendMsg(msg)
+            runErr_works.append(work[0])
+            continue
         for i in range(len(files)):
             names.append(sublog[i])
             random_int = random.randint(0, 10000)
@@ -183,8 +198,9 @@ def Wrun_single(log_dir, etcArg):
             time.sleep(0.5)
     pool.close()
     pool.join()
-    finished = True
-    runErr_works = []
+    finished = len(results) > 0 and len(runErr_works) == 0
+    if len(results) == 0:
+        SendMsg("error: no single-mode work item was scheduled")
     for cnt in range(len(results)):
         if not results[cnt].get():
             runErr_works.append(names[cnt])

--- a/.github/workflows/autotest/script/utils.py
+++ b/.github/workflows/autotest/script/utils.py
@@ -168,6 +168,7 @@ def get_file_list(path: str):
     subpaths = path.split(';')
     sargs = []
     sublogs = []
+    missing_patterns = []
     # 获取所有的文件行
     lines: list[str] = []
     for subpath in subpaths:
@@ -199,7 +200,11 @@ def get_file_list(path: str):
         if idx > 0 and dual[idx+1:].isdigit():
             info = dual[0:idx]
             ser = int(dual[idx+1:])
-        for file in glob.glob(info):
+        matched_files = glob.glob(info)
+        if not matched_files:
+            warning("can't find any file matching:" + info)
+            missing_patterns.append(info)
+        for file in matched_files:
             if os.path.exists(file):
                 sargs.append(file)
             else:
@@ -208,7 +213,7 @@ def get_file_list(path: str):
             # 去掉后缀名
             name = os.path.splitext(name)[0]
             sublogs.append(name)
-    return sargs, sublogs
+    return sargs, sublogs, missing_patterns
 
 
 def free_numa_cores(n):


### PR DESCRIPTION
## Motivation

The H-extension checkpoint archive used by `.github/workflows/autotest/gem5-h.cfg` was moved from the old `checkpoint/h_v_checkpoint_1203` path to `checkpoint_move/h_v_checkpoint_1203`. Because the autotest helper only warned when a `binpath` matched no files, the H checkpoint CI could pass without scheduling any checkpoint work.

## Approach

- Update `gem5-h.cfg` to use the new H checkpoint archive root.
- Factor the archive root into `h_cpt_root` so future archive moves only touch one line.
- Make single-mode autotest fail when any configured `binpath` entry or glob matches no files.
- Add a manual `workflow_dispatch` input to `gem5.yml` so maintainers can dispatch only `paralel_cpt_h_test` instead of the full Tier 2 workflow.

## Scope of Impact

This is CI/autotest plumbing only. Normal `push` runs on `xs-dev` still run all `gem5.yml` jobs. Manual dispatch can now choose `all` or `paralel_cpt_h_test`.

## Validation

- `git diff --check`
- `python3 -m py_compile .github/workflows/autotest/script/autotest.py .github/workflows/autotest/script/utils.py`
- YAML parse of `.github/workflows/gem5.yml`
- On `open10`, verified the refactored H cfg expands to the new `checkpoint_move` root with `matched=42`, `missing=0`.
- Autotest dry-runs:
  - all-missing `binpath` returns 255
  - partially missing `binpath` returns 255
  - existing single input returns 0

## Follow-up

After this PR branch exists on GitHub, dispatch `gem5 Full Test (Tier 2 - Post-Merge)` manually on `codex/h-ci-checkpoint-path` with `job=paralel_cpt_h_test` to run only the H checkpoint job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autotest handling when file patterns don’t match any files, with clearer error messages and no longer attempting to schedule invalid jobs.
  * Single-run scheduling now stops reporting success when nothing was actually scheduled.
  * Checkpoint paths in the H-extension autotest configuration are now built from a shared base path, reducing duplication while keeping the same targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->