### PR TITLE
[codex] Extend SMT weekly timeout

### DIFF
--- a/.github/workflows/gem5-ideal-btb-perf-weekly.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-weekly.yml
@@ -38,3 +38,4 @@ jobs:
       config_path: configs/example/smt_idealkmhv3.py
       benchmark_type: "gcc12-spec06-smt-1.0c"
       check_result: false
+      timeout_minutes: 720

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         description: "Specific commit SHA to checkout (takes precedence)"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 360
+        description: "Job timeout in minutes"
 
 permissions:
   contents: read
@@ -41,6 +46,7 @@ permissions:
 jobs:
   run_performance_test:
     runs-on: [self-hosted, node]
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     continue-on-error: false
     name: XS-GEM5 - Run performance test (${{ inputs.benchmark_type }})
     steps:


### PR DESCRIPTION
## Motivation

The weekly SMT SPEC2006 1.0c performance job can exceed the default GitHub Actions job timeout. The referenced run `28190405323` had `smt_test_spec06 / XS-GEM5 - Run performance test (gcc12-spec06-smt-1.0c)` cancelled after about 6 hours, before result checking could run.

## Approach

Add a `timeout_minutes` input to the shared performance workflow template and apply it to the actual self-hosted runner job. The default remains 360 minutes so existing callers keep their current behavior.

Set only the weekly `smt_test_spec06` caller to `720` minutes, giving the SMT 1.0c job a 12-hour limit without widening the timeout for the other weekly performance jobs.

## Scope of Impact

This is limited to GitHub Actions workflow configuration. It does not change simulator code, benchmark selection, scoring, or archive layout.

## Validation

- Confirmed the referenced job was cancelled after roughly 6 hours on the `smt_test_spec06` reusable workflow job.
- Ran `git diff --check`.
- Parsed the modified workflow YAML files with Ruby `YAML.load_file`.

`actionlint` is not installed in the local environment, so schema-level Actions linting was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the runtime limit for a long-running performance test to reduce the chance of premature timeouts.
  * Added a configurable timeout option for performance test runs, with a sensible default for easier use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->