### PR TITLE
configs: Tune ideal KMHv3 params align with RTL

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -53,8 +53,8 @@ def setKmhV3IdealParams(args, system):
         cpu.scheduler = KMHV3Scheduler()
 
         # rob
-        cpu.commitWidth = 12
-        cpu.squashWidth = 12
+        cpu.commitWidth = 8
+        cpu.squashWidth = 8
         cpu.phyregReleaseWidth = 8
         cpu.RobCompressPolicy = 'kmhv3'
         cpu.numROBEntries = 160
@@ -72,7 +72,7 @@ def setKmhV3IdealParams(args, system):
         cpu.valuePred = IdealConstantLVP()
 
         # lsq
-        cpu.LQEntries = 128
+        cpu.LQEntries = 120
         cpu.SQEntries = 64
         cpu.RARQEntries = 96
         cpu.RAWQEntries = 56
@@ -80,8 +80,8 @@ def setKmhV3IdealParams(args, system):
         cpu.StoreCompletionWidth = 4
         cpu.RARDequeuePerCycle = 4
         cpu.RAWDequeuePerCycle = 4
-        cpu.SbufferEntries = 24
-        cpu.SbufferEvictThreshold = 16
+        cpu.SbufferEntries = 16
+        cpu.SbufferEvictThreshold = 8
         cpu.store_prefetch_train = False
 
         # branch predictor
@@ -106,14 +106,16 @@ def setKmhV3IdealParams(args, system):
     if args.l2cache:
         for i in range(args.num_cpus):
             if args.classic_l2:
+                system.l2_caches[i].wpu = NULL
                 system.l2_caches[i].slice_num = 0 # 4 -> 0, no slice
             else:
                 l2_wrapper = system.l2_wrappers[i]
                 l2_wrapper.data_sram_banks = 2
                 l2_wrapper.dir_sram_banks = 2
-                l2_wrapper.pipe_dir_write_stage = 4
-                l2_wrapper.dir_read_bypass = True
+                l2_wrapper.pipe_dir_write_stage = 3
+                l2_wrapper.dir_read_bypass = False
                 for j in range(args.l2_slices):
+                    l2_wrapper.slices[j].inner_cache.wpu = NULL
                     # Configure XSDRRIP replacement policy (DRRIP mode)
                     # Each slice: 2MB/4 = 512KB, 8-way, 64B line → 1024 sets
                     l2_wrapper.slices[j].inner_cache.replacement_policy = XSDRRIPRP(mode=2, num_sets=1024)
@@ -131,7 +133,8 @@ def setKmhV3IdealParams(args, system):
 
     # l3 cache
     if args.l3cache:
-        system.l3.mshrs = 128
+        system.l3.mshrs = 64
+        system.l3.num_slices = 4
 
 if __name__ == '__m5_main__':
     FutureClass = None


### PR DESCRIPTION
## Motivation

Tune the ideal KMHv3 configuration to better match RTL behavior.

## Changes

- ~~Increase `commitToFetchDelay` from 2 to 3, adding one cycle to the commit-driven flush penalty.~~
- Set `commitWidth` and `squashWidth` back to 8.
- Reduce `LQEntries` from 128 to 120.
- Reduce SBuffer capacity from 24 to 16 entries and the eviction threshold from 16 to 8.
- Disable L2 WPU for both classic L2 and L2 wrapper inner caches.
- Adjust L2 wrapper directory timing by setting `pipe_dir_write_stage` to 3 and disabling `dir_read_bypass`.
- Reduce L3 MSHRs from 128 to 64 and set the L3 slice count to 4.

## Validation

- Ran `git diff --check` for `configs/example/idealkmhv3.py`.
- Confirmed the commit only changes `configs/example/idealkmhv3.py`.