### PR TITLE
util: Add DDR channel selection to manual perf [skip ci]

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         description: "Benchmark type: base, simple"
+      ddr_config:
+        required: false
+        type: string
+        description: "DRAMsim3 DDR config: 2ch or 8ch. Empty/default maps to 2ch."
+        default: "2ch"
       check_result:
         required: false
         type: boolean
@@ -217,6 +222,7 @@ jobs:
           echo "run_number: $RUN_NUMBER" >> "$TARGET_DIR/metadata.txt"
           echo "benchmark_type: ${{ inputs.benchmark_type }}" >> "$TARGET_DIR/metadata.txt"
           echo "specific_benchmarks: ${{ inputs.specific_benchmarks }}" >> "$TARGET_DIR/metadata.txt"
+          echo "ddr_config: ${{ inputs.ddr_config }}" >> "$TARGET_DIR/metadata.txt"
           echo "workflow_run_id: ${{ github.run_id }}" >> "$TARGET_DIR/metadata.txt"
 
           {
@@ -251,12 +257,28 @@ jobs:
             export GCB_MULTI_CORE_RESTORER=""
           fi
 
+          extra_args="${{ inputs.extra_args }}"
+          case "${{ inputs.ddr_config }}" in
+            default|""|2ch)
+              extra_args="${extra_args} --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_2ch.ini"
+              ;;
+            8ch)
+              extra_args="${extra_args} --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"
+              ;;
+            *)
+              echo "Error: Invalid ddr_config '${{ inputs.ddr_config }}'. Must be one of: 2ch, 8ch"
+              exit 1
+              ;;
+          esac
+          extra_args="$(echo "$extra_args" | xargs)"
+          echo "Resolved extra gem5 args: $extra_args"
+
           bash "$GEM5_HOME/util/xs_scripts/parallel_sim.sh" "$(realpath "$CONFIG_PATH")" \
             ${{ steps.config.outputs.checkpoint_list }} \
             ${{ steps.config.outputs.checkpoint_root_node}} \
             spec_all \
             "${{ inputs.specific_benchmarks }}" \
-            "${{ inputs.extra_args }}"
+            "$extra_args"
       - name: Setup gem5_data_proc environment
         run: |
           # 使用本地数据处理仓库，避免GitHub网络问题

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type) }}
+run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5} - {6}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.ddr_config) }}
 
 on:
   workflow_dispatch:
@@ -49,6 +49,14 @@ on:
         options:
           - base
           - simple
+      ddr_config:
+        description: 'DRAMsim3 DDR config'
+        required: false
+        type: choice
+        default: '2ch'
+        options:
+          - 2ch
+          - 8ch
       branch:
         description: 'Branch, tag or SHA to test (leave empty for current branch)'
         required: false
@@ -59,7 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       config_path: ${{ steps.resolve.outputs.config_path }}
-      extra_args: ${{ steps.resolve.outputs.extra_args }}
       pr_sha: ${{ steps.resolve.outputs.pr_sha }}
     steps:
       - name: Resolve parameters
@@ -67,10 +74,8 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.benchmark_type }}" == gcc12-spec06-smt-* ]]; then
             echo "config_path=configs/example/smt_idealkmhv3.py" >> $GITHUB_OUTPUT
-            echo "extra_args=" >> $GITHUB_OUTPUT
           else
             echo "config_path=configs/example/${{ github.event.inputs.configuration }}" >> $GITHUB_OUTPUT
-            echo "extra_args=" >> $GITHUB_OUTPUT
           fi
           
           if [ -n "${{ github.event.inputs.branch }}" ]; then
@@ -84,9 +89,9 @@ jobs:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: ${{ needs.setup.outputs.config_path }}
-      extra_args: ${{ needs.setup.outputs.extra_args }}
       benchmark_type: ${{ github.event.inputs.benchmark_type }}
       specific_benchmarks: ${{ github.event.inputs.specific_benchmarks }}
       vector_type: ${{ github.event.inputs.vector_type }}
+      ddr_config: ${{ github.event.inputs.ddr_config }}
       pr_sha: ${{ needs.setup.outputs.pr_sha }}
       check_result: true


### PR DESCRIPTION
Add a manual perf workflow input for selecting the DRAMSim3 DDR configuration. The manual workflow now exposes 2ch and 8ch choices, with 2ch as the default, and includes the selected DDR config in the workflow run name.

Change-Id: I0f62d752730ab9678e7ab341f27e66da21c87a67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a DDR configuration option for performance runs, with support for selecting between 2-channel and 8-channel setups.
  * Run names now include the selected DDR configuration for easier identification.

* **Behavior Changes**
  * Performance jobs now automatically apply the matching DRAMSim3 configuration based on the selected DDR option.
  * Run metadata now records the chosen DDR configuration.
  * Manual runs now pass the DDR setting directly into the shared performance workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->