### PR TITLE
Add extra args2

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -25,11 +25,6 @@ on:
         required: false
         type: string
         description: "Benchmark type: base, simple"
-      ddr_config:
-        required: false
-        type: string
-        description: "DRAMsim3 DDR config: 2ch or 8ch. Empty/default maps to 2ch."
-        default: "2ch"
       check_result:
         required: false
         type: boolean
@@ -228,7 +223,9 @@ jobs:
           echo "run_number: $RUN_NUMBER" >> "$TARGET_DIR/metadata.txt"
           echo "benchmark_type: ${{ inputs.benchmark_type }}" >> "$TARGET_DIR/metadata.txt"
           echo "specific_benchmarks: ${{ inputs.specific_benchmarks }}" >> "$TARGET_DIR/metadata.txt"
-          echo "ddr_config: ${{ inputs.ddr_config }}" >> "$TARGET_DIR/metadata.txt"
+          cat >> "$TARGET_DIR/metadata.txt" <<'EOF'
+          extra_args: ${{ inputs.extra_args }}
+          EOF
           echo "workflow_run_id: ${{ github.run_id }}" >> "$TARGET_DIR/metadata.txt"
 
           {
@@ -264,18 +261,6 @@ jobs:
           fi
 
           extra_args="${{ inputs.extra_args }}"
-          case "${{ inputs.ddr_config }}" in
-            default|""|2ch)
-              extra_args="${extra_args} --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_2ch.ini"
-              ;;
-            8ch)
-              extra_args="${extra_args} --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"
-              ;;
-            *)
-              echo "Error: Invalid ddr_config '${{ inputs.ddr_config }}'. Must be one of: 2ch, 8ch"
-              exit 1
-              ;;
-          esac
           extra_args="$(echo "$extra_args" | xargs)"
           echo "Resolved extra gem5 args: $extra_args"
 

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -57,6 +57,12 @@ on:
         options:
           - 2ch
           - 8ch
+      extra_args:
+        description: 'Extra arguments for gem5'
+        required: false
+        type: string
+        default: ''
+        description: "Extra arguments for gem5 (e.g., --disable-mgsc). Only works with .py config files."
       branch:
         description: 'Branch, tag or SHA to test (leave empty for current branch)'
         required: false

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5} - {6}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.ddr_config) }}
+run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}{6}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.extra_args && format(' - {0}', github.event.inputs.extra_args) || '') }}
 
 on:
   workflow_dispatch:
@@ -49,20 +49,11 @@ on:
         options:
           - base
           - simple
-      ddr_config:
-        description: 'DRAMsim3 DDR config'
-        required: false
-        type: choice
-        default: '2ch'
-        options:
-          - 2ch
-          - 8ch
       extra_args:
-        description: 'Extra arguments for gem5'
+        description: 'Extra gem5 args appended to config runs, e.g. --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini'
         required: false
         type: string
         default: ''
-        description: "Extra arguments for gem5 (e.g., --disable-mgsc). Only works with .py config files."
       branch:
         description: 'Branch, tag or SHA to test (leave empty for current branch)'
         required: false
@@ -98,7 +89,6 @@ jobs:
       benchmark_type: ${{ github.event.inputs.benchmark_type }}
       specific_benchmarks: ${{ github.event.inputs.specific_benchmarks }}
       vector_type: ${{ github.event.inputs.vector_type }}
-      ddr_config: ${{ github.event.inputs.ddr_config }}
       extra_args: ${{ github.event.inputs.extra_args }}
       pr_sha: ${{ needs.setup.outputs.pr_sha }}
       check_result: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `extra_args` input to the manual performance workflow, letting you pass additional gem5 arguments when running `.py` configs.
  * The new input is now included in the performance test workflow call alongside existing benchmark, vector, and memory configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->