### PR TITLE
[codex] Add arch DB lifetime dump option

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -223,6 +223,10 @@ def addNoISAOptions(parser, configure_xiangshan=False):
                         default=True,
                         help="start arch database from "
                         "the beginning of the simulation")
+    parser.add_argument("--arch-db-dump-lifetime",
+                        action="store_true",
+                        default=False,
+                        help="dump per-instruction lifetime trace for perfCCT")
     parser.add_argument("--enable-rolling",
                         default=False,
                         help="enable rolling perfcnt "

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -712,7 +712,7 @@ CREATE TABLE LoadLifeTimeCommitTrace(
         test_sys.arch_db.dump_stride_train_trace = False
         test_sys.arch_db.dump_sms_train_trace = False
         test_sys.arch_db.dump_vaddr_trace = False
-        test_sys.arch_db.dump_lifetime = False
+        test_sys.arch_db.dump_lifetime = args.arch_db_dump_lifetime
         test_sys.arch_db.table_cmds = [
             "CREATE TABLE L1MissTrace(" \
             "ID INTEGER PRIMARY KEY AUTOINCREMENT," \


### PR DESCRIPTION
## Motivation

The ArchDB lifetime table schema already exists, but `dump_lifetime` is forced off in the XiangShan config. This makes the per-instruction lifetime trace unavailable from normal config arguments.

## Approach

- Add `--arch-db-dump-lifetime` as an opt-in config argument.
- Wire `ArchDBer.dump_lifetime` to that argument while keeping the default behavior disabled.

## Validation

- `python3 -m py_compile configs/common/Options.py configs/common/xiangshan.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to enable per-instruction lifetime trace dumping for perfCCT.
  * The arch DB lifetime trace setting now follows the selected runtime option instead of being fixed off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->