### PR TITLE
arch-riscv: calibrate RVV split rulses

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -386,6 +386,29 @@ IssueQue::isVectorMemInst(const DynInstPtr& inst) const
     return inst && inst->isVector() && inst->isMemRef() && !inst->isSquashed();
 }
 
+bool
+IssueQue::isBlockingVectorSplitInst(const DynInstPtr& inst) const
+{
+    return isVectorMemInst(inst) && inst->opClass() != enums::VectorUnitStrideLoad;
+}
+
+void
+IssueQue::scheduleVectorReadyQEvent()
+{
+    if (!cpu || vectorReadyQEvent.scheduled()) {
+        return;
+    }
+
+    if (!vectorSplitQ.empty() && !vectorSplitQReleaseTicks.empty()) {
+        cpu->schedule(vectorReadyQEvent, vectorSplitQReleaseTicks.front());
+        return;
+    }
+
+    if (!vectorReadyQ.empty()) {
+        cpu->schedule(vectorReadyQEvent, curTick());
+    }
+}
+
 void
 IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
 {
@@ -397,18 +420,55 @@ IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
         return;
     }
 
-    assert(cpu);
-    const Tick releaseTick = cpu->clockEdge(Cycles(3));
-    const bool needSchedule = vectorReadyQ.empty();
     vectorReadyQ.push(inst);
-    vectorReadyQReleaseTicks.push(releaseTick);
     vectorReadyQReplay.push(replay);
     DPRINTF(Schedule,
-            "[sn:%llu] add to vectorReadyQ, replay:%d, release at %llu\n",
-            inst->seqNum, replay, releaseTick);
+            "[sn:%llu] add to vectorReadyQ, replay:%d\n",
+            inst->seqNum, replay);
 
-    if (needSchedule && !vectorReadyQEvent.scheduled()) {
-        cpu->schedule(vectorReadyQEvent, releaseTick);
+    scheduleVectorReadyQEvent();
+}
+
+void
+IssueQue::tryStartVectorMemSplit()
+{
+    assert(vectorReadyQ.size() == vectorReadyQReplay.size());
+
+    while (!vectorReadyQ.empty() && !vectorReadyQReplay.empty()) {
+        auto inst = vectorReadyQ.front();
+        const bool replay = vectorReadyQReplay.front();
+
+        if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
+            vectorReadyQ.pop();
+            vectorReadyQReplay.pop();
+            if (inst) {
+                vectorReadyQSeqs.erase(inst->seqNum);
+                vectorBlockingSplitSeqs.erase(inst->seqNum);
+            }
+            continue;
+        }
+
+        if (!vectorBlockingSplitSeqs.empty()) {
+            return;
+        }
+
+        vectorReadyQ.pop();
+        vectorReadyQReplay.pop();
+
+        assert(cpu);
+        const Tick releaseTick = cpu->clockEdge(Cycles(3));
+        vectorSplitQ.push(inst);
+        vectorSplitQReleaseTicks.push(releaseTick);
+        vectorSplitQReplay.push(replay);
+        if (isBlockingVectorSplitInst(inst)) {
+            vectorBlockingSplitSeqs.insert(inst->seqNum);
+        }
+
+        DPRINTF(Schedule,
+                "[sn:%llu] enter vector split, replay:%d, release at %llu, "
+                "blocking:%d\n",
+                inst->seqNum, replay, releaseTick,
+                isBlockingVectorSplitInst(inst));
     }
 }
 
@@ -425,11 +485,13 @@ IssueQue::releaseVectorDelayedReadyQ()
         if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
+                vectorBlockingSplitSeqs.erase(inst->seqNum);
             }
             continue;
         }
 
         vectorReadyQSeqs.erase(inst->seqNum);
+        vectorBlockingSplitSeqs.erase(inst->seqNum);
         if (replay) {
             replayQ.push(inst);
             DPRINTF(Schedule, "[sn:%llu] released to replayQ after vector delay\n",
@@ -449,20 +511,23 @@ IssueQue::releaseVectorDelayedReadyQ()
 void
 IssueQue::processVectorReadyQ()
 {
-    assert(vectorReadyQ.size() == vectorReadyQReleaseTicks.size());
-    assert(vectorReadyQ.size() == vectorReadyQReplay.size());
-    while (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty() &&
-           !vectorReadyQReplay.empty() &&
-           vectorReadyQReleaseTicks.front() <= curTick()) {
-        auto inst = vectorReadyQ.front();
-        const bool replay = vectorReadyQReplay.front();
-        vectorReadyQ.pop();
-        vectorReadyQReleaseTicks.pop();
-        vectorReadyQReplay.pop();
+    tryStartVectorMemSplit();
+
+    assert(vectorSplitQ.size() == vectorSplitQReleaseTicks.size());
+    assert(vectorSplitQ.size() == vectorSplitQReplay.size());
+    while (!vectorSplitQ.empty() && !vectorSplitQReleaseTicks.empty() &&
+           !vectorSplitQReplay.empty() &&
+           vectorSplitQReleaseTicks.front() <= curTick()) {
+        auto inst = vectorSplitQ.front();
+        const bool replay = vectorSplitQReplay.front();
+        vectorSplitQ.pop();
+        vectorSplitQReleaseTicks.pop();
+        vectorSplitQReplay.pop();
 
         if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
+                vectorBlockingSplitSeqs.erase(inst->seqNum);
             }
             continue;
         }
@@ -473,12 +538,9 @@ IssueQue::processVectorReadyQ()
                 inst->seqNum, replay);
     }
 
-    if (!vectorReadyQ.empty() && !vectorReadyQReleaseTicks.empty() &&
-        !vectorReadyQEvent.scheduled()) {
-        cpu->schedule(vectorReadyQEvent, vectorReadyQReleaseTicks.front());
-    }
-
     releaseVectorDelayedReadyQ();
+    tryStartVectorMemSplit();
+    scheduleVectorReadyQEvent();
 }
 
 void
@@ -605,6 +667,7 @@ IssueQue::idle()
     }
     idle |= replayQ.size() > 0;
     idle |= vectorReadyQ.size() > 0;
+    idle |= vectorSplitQ.size() > 0;
     idle |= vectorDelayedReadyQ.size() > 0;
     return idle;
 }
@@ -928,9 +991,11 @@ IssueQue::popReadyVectorInst()
             continue;
         }
 
+        scheduleVectorReadyQEvent();
         return inst;
     }
 
+    scheduleVectorReadyQEvent();
     return nullptr;
 }
 
@@ -942,6 +1007,7 @@ IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
         if (inst->threadNumber == tid && inst->seqNum <= seqNum) {
             assert(inst->isIssued());
             vectorReadyQSeqs.erase(inst->seqNum);
+            vectorBlockingSplitSeqs.erase(inst->seqNum);
             it = instList.erase(it);
         } else {
             ++it;
@@ -975,6 +1041,7 @@ IssueQue::doSquash(SquashInfo squashInfo)
             (*it)->clearScheduled();
             (*it)->setCancel();
             vectorReadyQSeqs.erase((*it)->seqNum);
+            vectorBlockingSplitSeqs.erase((*it)->seqNum);
             it = instList.erase(it);
             assert(instList.size() >= instNum);
         } else {

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -170,11 +170,14 @@ class IssueQue : public SimObject
 
     std::queue<DynInstPtr> replayQ;  // only for mem
     std::queue<DynInstPtr> vectorReadyQ;
-    std::queue<Tick> vectorReadyQReleaseTicks;
     std::queue<bool> vectorReadyQReplay;
+    std::queue<DynInstPtr> vectorSplitQ;
+    std::queue<Tick> vectorSplitQReleaseTicks;
+    std::queue<bool> vectorSplitQReplay;
     std::queue<DynInstPtr> vectorDelayedReadyQ;
     std::queue<bool> vectorDelayedReadyQReplay;
     std::unordered_set<InstSeqNum> vectorReadyQSeqs;
+    std::unordered_set<InstSeqNum> vectorBlockingSplitSeqs;
     EventFunctionWrapper vectorReadyQEvent;
 
     CPU* cpu = nullptr;
@@ -205,7 +208,10 @@ class IssueQue : public SimObject
     void addToFu(const DynInstPtr& inst);
     bool checkScoreboard(const DynInstPtr& inst);
     bool isVectorMemInst(const DynInstPtr& inst) const;
+    bool isBlockingVectorSplitInst(const DynInstPtr& inst) const;
     void enqueueVectorMemDelay(const DynInstPtr& inst, bool replay);
+    void tryStartVectorMemSplit();
+    void scheduleVectorReadyQEvent();
     void releaseVectorDelayedReadyQ();
     void issueToFu();
     void wakeUpDependents(const DynInstPtr& inst, bool speculative);


### PR DESCRIPTION
1. If a vector instruction other than `VectorUnitStrideLoadOp` is currently being split, all subsequent vector instructions must be stalled and cannot be issued.
2. If the vector instruction currently being split is a `VectorUnitStrideLoadOp`, other vector instructions may continue to enter the vector split unit without being blocked.
3. The issue behavior of non-vector instructions must not be inadvertently affected by this rule.

Change-Id: I3972e6b8191e2bb45007060d6492b741d93ec205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling for vector memory operations so they become ready and issue more reliably.
  * Fixed cases where vector instructions could be delayed, duplicated, or left waiting incorrectly after completion, squashes, or commits.
  * Enhanced handling of vector split work so outstanding operations no longer interfere with new ones.
  * The issue queue now better reflects active vector split activity, improving overall readiness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->