### PR TITLE
arch-riscv: Fix failing autotest for compressed TLB

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -346,7 +346,7 @@ TLB::lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
             bool sign_used, uint8_t translateMode, bool is_prefetch)
 {
     TlbEntry *entry = trie.lookup(buildKey(vpn, asid, translateMode));
-    if (entry && entry->isCompressed) {
+    if (!hidden && entry && entry->isCompressed) {
         const uint8_t sub_idx = (vpn >> PageShift) & 0x7;
         if (!(entry->validIdx & (1 << sub_idx))) {
             TlbEntry *fallback_entry =


### PR DESCRIPTION
When L1 direct compression is enabled, TLB insertion uses hidden lookup to check whether a trie entry already exists. This lookup is structural and should not apply compressed validIdx filtering, otherwise an existing compressed entry may be treated as absent and trigger duplicate trie insertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted TLB lookup behavior so hidden lookups no longer apply compressed-entry handling.
  * Improved consistency for address translation results when entries are marked hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->