### PR TITLE
misc,util: Simplify SMT perf scoring

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -78,7 +78,7 @@ jobs:
             "gcc12-spec06-smt-0.3c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/spec06_0.3c.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
-              echo "score_script=gem5-score-ci-total-ipc" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/spec06_0.3c.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc12-spec06-smt-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage dual-context SMT spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
@@ -86,7 +86,7 @@ jobs:
             "gcc12-spec06-smt-1.0c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/checkpoint-0-0-0.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
-              echo "score_script=gem5-score-ci-total-ipc" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc12-spec06-smt-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage dual-context SMT spec06 checkpoints" >> $GITHUB_OUTPUT
@@ -285,30 +285,10 @@ jobs:
           export GEM5_HOME=$GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE/gem5_data_proc
           # 使用已有的数据spec_all生成测试报告
-          if [ "${{ steps.config.outputs.score_script }}" = "gem5-score-ci-total-ipc" ]; then
-            SCORE_CSV=results/gem5-score-total-ipc.csv
-            python3 "$GITHUB_WORKSPACE/util/xs_scripts/extract_total_ipc_score_csv.py" \
-              "$PERF_ARCHIVE_DIR/spec_all" \
-              "$SCORE_CSV"
-            DATA_ROWS=$(tail -n +2 "$SCORE_CSV" | wc -l)
-            if [ "$DATA_ROWS" -gt 0 ]; then
-              python3 simpoint_cpt/compute_weighted.py \
-                -r "$SCORE_CSV" \
-                -j ${{ steps.config.outputs.cluster_config }} \
-                --score results/gem5-score-total-ipc-score.csv \
-                > $GITHUB_WORKSPACE/score.txt
-            else
-              {
-                echo "No usable system.cpu.totalIpc rows were found."
-                echo "Check abort files and workload logs under $PERF_ARCHIVE_DIR/spec_all."
-              } > $GITHUB_WORKSPACE/score.txt
-            fi
-          else
-            bash example-scripts/${{ steps.config.outputs.score_script }} \
-              "$PERF_ARCHIVE_DIR/spec_all" \
-              ${{ steps.config.outputs.cluster_config }} \
-              > $GITHUB_WORKSPACE/score.txt
-          fi
+          bash example-scripts/${{ steps.config.outputs.score_script }} \
+            "$PERF_ARCHIVE_DIR/spec_all" \
+            ${{ steps.config.outputs.cluster_config }} \
+            > $GITHUB_WORKSPACE/score.txt
           cp "$GITHUB_WORKSPACE/score.txt" "$PERF_ARCHIVE_DIR/"
           # 提取最后42行score信息
           echo "### performance test result :rocket:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Motivation

SMT perf scoring no longer needs a separate total-IPC extraction path now that the shared gem5_data_proc scoring config reads system.cpu.totalIpc for the normal ipc column.

## Approach

- Use the standard gem5-score-ci.sh script for gcc12 SPEC06 SMT benchmark types.
- Remove the workflow-local gem5-score-ci-total-ipc branch from the performance template.
- Keep the final score grep unchanged by relying on the shared gem5_data_proc output format.

## Validation

Ran the same scoring wrapper used by CI with /nfs/home/yanyue/workspace/gem5_data_proc:

- SMT: bash example-scripts/gem5-score-ci.sh /nfs/home/share/gem5_ci/performance_data/gcc12-spec06-smt-0.3c/20260617_034613_a105ca0fa_smt_idealkmhv3_run3/spec_all /nfs/home/share/gem5_ci/spec06_cpts/spec06_0.3c.json
  - Estimated Int score per GHz: 25.205421497335145
  - Estimated overall score per GHz: 24.591843183600393
- Non-SMT: bash example-scripts/gem5-score-ci.sh /nfs/home/share/gem5_ci/performance_data/gcc12-spec06-0.3c/20260615_175557_4346f9ce79_idealkmhv3_run386/spec_all /nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json
  - Estimated Int score per GHz: 16.877815400846842

Also ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the performance test workflow to use a different scoring script for one benchmark configuration.
  * Simplified how performance results are generated so the selected scoring command runs directly in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->