### PR TITLE
misc: Extend manual perf timeout

### DIFF
--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -92,3 +92,4 @@ jobs:
       extra_args: ${{ github.event.inputs.extra_args }}
       pr_sha: ${{ needs.setup.outputs.pr_sha }}
       check_result: true
+      timeout_minutes: 720


### PR DESCRIPTION
## Motivation
Manual performance runs can cover SMT or other long-running benchmark sets. The reusable perf workflow already supports a configurable timeout, but manual-perf did not pass an override.

## Approach
Pass `timeout_minutes: 720` from `manual-perf.yml` to the reusable perf template, raising manual performance runs to a 12 hour limit while leaving the template default unchanged.

## Validation
- `git diff --check -- .github/workflows/manual-perf.yml .github/workflows/gem5-perf-template.yml`
- Ruby YAML parse for `.github/workflows/manual-perf.yml` and `.github/workflows/gem5-perf-template.yml`

Note: `actionlint` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the maximum runtime for the manual performance test workflow, allowing longer performance runs to complete without timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->