### PR TITLE
cpu-o3: Split redirect to fetch delay

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -31,10 +31,11 @@ def setKmhV3IdealParams(args, system):
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
+        cpu.redirectToFetchDelay = 4
         cpu.fetchQueueSize = 64
 
         # decode
-        cpu.fetchToDecodeDelay = 5
+        cpu.fetchToDecodeDelay = 3
         cpu.decodeWidth = 8
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -30,6 +30,7 @@ def setKmhV3Params(args, system):
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
+        cpu.redirectToFetchDelay = 4
         cpu.fetchQueueSize = 64
 
         # decode

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -123,6 +123,9 @@ class BaseO3CPU(BaseCPU):
     iewToFetchDelay = Param.Cycles(1, "Issue/Execute/Writeback to fetch "
                                    "delay")
     commitToFetchDelay = Param.Cycles(3, "Commit to fetch delay")
+    redirectToFetchDelay = Param.Cycles(
+        Self.commitToFetchDelay,
+        "Backend redirect to fetch/BPU delay")
     fetchWidth = Param.Unsigned(16, "Fetch width")
     fetchBufferSize = Param.Unsigned(66, "Fetch buffer size in bytes")
     fetchQueueSize = Param.Unsigned(48, "Fetch queue size in micro-ops "

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -95,6 +95,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       renameToFetchDelay(params.renameToFetchDelay),
       iewToFetchDelay(params.iewToFetchDelay),
       commitToFetchDelay(params.commitToFetchDelay),
+      redirectToFetchDelay(params.redirectToFetchDelay),
       fetchWidth(params.fetchWidth),
       decodeWidth(params.decodeWidth),
       retryPkt(),
@@ -399,6 +400,7 @@ Fetch::setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer)
     fromRename = timeBuffer->getWire(-renameToFetchDelay);
     fromIEW = timeBuffer->getWire(-iewToFetchDelay);
     fromCommit = timeBuffer->getWire(-commitToFetchDelay);
+    fromCommitRedirect = timeBuffer->getWire(-redirectToFetchDelay);
 }
 
 void
@@ -1576,7 +1578,8 @@ Fetch::measureFrontendBubbles(unsigned insts_to_decode, ThreadID tid)
     // For N-wide machine, if frontend supplies 0 instructions:
     // - fetchBubbles += N (count total empty slots)
     // - fetchBubbles_max += 1 (count occurrence of all slots being empty)
-    if (!stallSig->blockFetch[tid] && !fromCommit->commitInfo[tid].robSquashing) {
+    if (!stallSig->blockFetch[tid] &&
+        !fromCommitRedirect->commitInfo[tid].robSquashing) {
         // backend not stalled
         int unused_slots = decodeWidth - insts_to_decode;
         if (unused_slots > 0) {
@@ -1711,65 +1714,71 @@ Fetch::handleIEWSignals()
 bool
 Fetch::handleCommitSignals(ThreadID tid)
 {
-    // Check squash signals from commit.
-    if (!fromCommit->commitInfo[tid].squash) {
-        if (fromCommit->commitInfo[tid].doneFtqId) {
-            DPRINTF(DecoupleBP, "Commit stream Id: %lu\n", fromCommit->commitInfo[tid].doneFtqId);
-            assert(dbpbtb);
-            dbpbtb->commit(fromCommit->commitInfo[tid].doneFtqId, tid);
-        }
+    const auto &commit_info = fromCommit->commitInfo[tid];
+
+    if (!commit_info.squash && commit_info.doneFtqId) {
+        DPRINTF(DecoupleBP, "Commit stream Id: %lu\n",
+                commit_info.doneFtqId);
+        assert(dbpbtb);
+        dbpbtb->commit(commit_info.doneFtqId, tid);
+    }
+
+    const auto &redirect_info = fromCommitRedirect->commitInfo[tid];
+
+    if (!redirect_info.squash) {
         return false;
     }
 
-    // Check squash signals from commit.
+    // Check backend redirect/squash signals.
     DPRINTF(Fetch,
             "[tid:%i] Squashing instructions due to squash "
-            "from commit.\n",
+            "from backend redirect.\n",
             tid);
 
-        InstSeqNum squash_seq = fromCommit->commitInfo[tid].doneSeqNum;
-        DynInstPtr squash_inst = fromCommit->commitInfo[tid].squashInst;
-        if (fromCommit->commitInfo[tid].isTrapSquash &&
-            fromCommit->commitInfo[tid].traceTrapSkipInst) {
-            squash_seq = fromCommit->commitInfo[tid].traceTrapSeqNum;
-            squash_inst = nullptr;
-            DPRINTF(Fetch,
-                    "[tid:%i] Trap squash with trace ctrl-flow fault: rollback seq=%llu (skip head)\n",
-                    tid, static_cast<unsigned long long>(squash_seq));
-        }
+    InstSeqNum squash_seq = redirect_info.doneSeqNum;
+    DynInstPtr squash_inst = redirect_info.squashInst;
+    if (redirect_info.isTrapSquash &&
+        redirect_info.traceTrapSkipInst) {
+        squash_seq = redirect_info.traceTrapSeqNum;
+        squash_inst = nullptr;
+        DPRINTF(Fetch,
+                "[tid:%i] Trap squash with trace ctrl-flow fault: rollback seq=%llu (skip head)\n",
+                tid, static_cast<unsigned long long>(squash_seq));
+    }
 
     // In any case, squash.
-    squash(*fromCommit->commitInfo[tid].pc, squash_seq,
+    squash(*redirect_info.pc, squash_seq,
            squash_inst, tid);
 
     localSquashVer[tid].update(
-        fromCommit->commitInfo[tid].squashVersion.getVersion());
+        redirect_info.squashVersion.getVersion());
     DPRINTF(Fetch, "Updating squash version to %u\n",
             localSquashVer[tid].getVersion());
 
-    auto mispred_inst = fromCommit->commitInfo[tid].mispredictInst;
+    auto mispred_inst = redirect_info.mispredictInst;
 
     if (mispred_inst) {
         DPRINTF(Fetch, "Use mispred inst to redirect, treating as control squash\n");
-        const auto corr_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
+        const auto corr_pc = redirect_info.pc->as<RiscvISA::PCState>();
         assert(dbpbtb);
         dbpbtb->controlSquash(mispred_inst->getFtqId(), mispred_inst->pcState(),
                               corr_pc, mispred_inst->staticInst,
-                              mispred_inst->getInstBytes(), fromCommit->commitInfo[tid].branchTaken,
+                              mispred_inst->getInstBytes(), redirect_info.branchTaken,
                               mispred_inst->seqNum, tid, mispred_inst->getLoopIteration(), true);
-    } else if (fromCommit->commitInfo[tid].isTrapSquash) {
+    } else if (redirect_info.isTrapSquash) {
         DPRINTF(Fetch, "Treating as trap squash\n", tid);
-        const auto trap_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
+        const auto trap_pc = redirect_info.pc->as<RiscvISA::PCState>();
         assert(dbpbtb);
-        dbpbtb->trapSquash(fromCommit->commitInfo[tid].squashedTargetId, fromCommit->commitInfo[tid].committedPC,
-                           trap_pc, tid, fromCommit->commitInfo[tid].squashedLoopIter);
+        dbpbtb->trapSquash(redirect_info.squashedTargetId,
+                           redirect_info.committedPC, trap_pc, tid,
+                           redirect_info.squashedLoopIter);
     } else {
-        if (fromCommit->commitInfo[tid].pc && fromCommit->commitInfo[tid].squashedTargetId != 0) {
+        if (redirect_info.pc && redirect_info.squashedTargetId != 0) {
             DPRINTF(Fetch, "Squash with stream id and target id from IEW\n");
-            const auto nc_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
+            const auto nc_pc = redirect_info.pc->as<RiscvISA::PCState>();
             assert(dbpbtb);
-            dbpbtb->nonControlSquash(fromCommit->commitInfo[tid].squashedTargetId, nc_pc,
-                                     0, tid, fromCommit->commitInfo[tid].squashedLoopIter);
+            dbpbtb->nonControlSquash(redirect_info.squashedTargetId, nc_pc,
+                                     0, tid, redirect_info.squashedLoopIter);
         } else {
             DPRINTF(Fetch, "Dont squash dbq because no meaningful stream\n");
         }

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -486,7 +486,7 @@ class Fetch
      */
     bool checkSignalsAndUpdate(ThreadID tid);
 
-    /** Handles commit signals including squash and update operations.
+    /** Handles commit feedback and backend redirect signals.
      *  @return: Returns true if squash occurred and immediate return needed.
      */
     bool handleCommitSignals(ThreadID tid);
@@ -617,6 +617,9 @@ class Fetch
     /** Wire to get commit's information from backwards time buffer. */
     TimeBuffer<TimeStruct>::wire fromCommit;
 
+    /** Wire to get redirect information from backwards time buffer. */
+    TimeBuffer<TimeStruct>::wire fromCommitRedirect;
+
     //Might be annoying how this name is different than the queue.
     /** Wire used to write any information heading to decode. */
     TimeBuffer<FetchStruct>::wire toDecode;
@@ -673,6 +676,9 @@ class Fetch
 
     /** Commit to fetch delay. */
     Cycles commitToFetchDelay;
+
+    /** Backend redirect to fetch/BPU delay. */
+    Cycles redirectToFetchDelay;
 
     /** The width of fetch in instructions. */
     unsigned fetchWidth;


### PR DESCRIPTION
## Motivation

`commitToFetchDelay` currently has two meanings in the O3 frontend path:

- retire/commit feedback that Fetch consumes, such as decoupled BPU/FTQ commit release via `doneFtqId`, empty ROB notification, and interrupt feedback
- backend redirect/squash feedback that Fetch consumes before calling the BPU squash/restart path

That makes it easy to tune flush penalty by increasing `commitToFetchDelay`, but the model then also delays non-redirect commit feedback. RTL keeps the backend redirect path separate from FTQ commit release, so this patch splits the simulator parameter surface in the same direction.

## Approach

- Add `redirectToFetchDelay`, defaulting to `commitToFetchDelay` for compatibility with existing configs.
- Add a separate Fetch time-buffer wire for backend redirect feedback.
- Keep `doneFtqId` commit release on `commitToFetchDelay`.
- Consume squash/redirect payloads, `squashVersion`, and `robSquashing` through `redirectToFetchDelay`.
- Set KMHV3 and ideal-KMHV3 to `commitToFetchDelay = 2` and `redirectToFetchDelay = 4`.
- Restore ideal-KMHV3 `fetchToDecodeDelay` from 5 to 3 so fetch-to-decode latency is no longer used to carry extra flush penalty.

## Validation

- `python3 -m py_compile src/cpu/o3/BaseO3CPU.py configs/example/kmhv3.py configs/example/idealkmhv3.py`
- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`
- `flush_penalty_small` with ideal-KMHV3 and commit-update predictors:
  - default config: `commitToFetchDelay=2`, `fetchToDecodeDelay=3`, `redirectToFetchDelay=4`
  - output: `measured_cycles=3406`, `branch_count=200`, about 17.03 cycles/miss
  - override `-P system.cpu[0].redirectToFetchDelay=2`
  - output: `measured_cycles=3006`, `branch_count=200`, exactly 2 cycles/miss lower

Follow-up cross-check:

- KMHV3 was initially much less sensitive to `redirectToFetchDelay` (`3010` vs `3006` cycles for 4 vs 2).
- That difference is explained by predictor update timing: current KMHV3 explicitly enables `resolvedUpdate` for MBTB/TAGE/ITTAGE, while this branch's ideal-KMHV3 still inherits commit-update defaults.
- Enabling `resolvedUpdate` in ideal-KMHV3 makes it behave like KMHV3 (`3010` vs `3006` cycles for 4 vs 2).
- Disabling `resolvedUpdate` in KMHV3 makes it behave like the commit-update ideal run (`3406` vs `3006` cycles for 4 vs 2).

So the new delay split behaves as expected; the microbench's apparent sensitivity also depends on whether the BPU learns from the resolve path before the measured B-chain redirect would otherwise be consumed.
