### PR TITLE
Revert "cpu-o3: Split redirect to fetch delay"

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -31,11 +31,10 @@ def setKmhV3IdealParams(args, system):
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
-        cpu.redirectToFetchDelay = 4
         cpu.fetchQueueSize = 64
 
         # decode
-        cpu.fetchToDecodeDelay = 3
+        cpu.fetchToDecodeDelay = 5
         cpu.decodeWidth = 8
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -30,7 +30,6 @@ def setKmhV3Params(args, system):
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2
-        cpu.redirectToFetchDelay = 4
         cpu.fetchQueueSize = 64
 
         # decode

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -123,9 +123,6 @@ class BaseO3CPU(BaseCPU):
     iewToFetchDelay = Param.Cycles(1, "Issue/Execute/Writeback to fetch "
                                    "delay")
     commitToFetchDelay = Param.Cycles(3, "Commit to fetch delay")
-    redirectToFetchDelay = Param.Cycles(
-        Self.commitToFetchDelay,
-        "Backend redirect to fetch/BPU delay")
     fetchWidth = Param.Unsigned(16, "Fetch width")
     fetchBufferSize = Param.Unsigned(66, "Fetch buffer size in bytes")
     fetchQueueSize = Param.Unsigned(48, "Fetch queue size in micro-ops "

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -95,7 +95,6 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       renameToFetchDelay(params.renameToFetchDelay),
       iewToFetchDelay(params.iewToFetchDelay),
       commitToFetchDelay(params.commitToFetchDelay),
-      redirectToFetchDelay(params.redirectToFetchDelay),
       fetchWidth(params.fetchWidth),
       decodeWidth(params.decodeWidth),
       retryPkt(),
@@ -400,7 +399,6 @@ Fetch::setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer)
     fromRename = timeBuffer->getWire(-renameToFetchDelay);
     fromIEW = timeBuffer->getWire(-iewToFetchDelay);
     fromCommit = timeBuffer->getWire(-commitToFetchDelay);
-    fromCommitRedirect = timeBuffer->getWire(-redirectToFetchDelay);
 }
 
 void
@@ -1578,8 +1576,7 @@ Fetch::measureFrontendBubbles(unsigned insts_to_decode, ThreadID tid)
     // For N-wide machine, if frontend supplies 0 instructions:
     // - fetchBubbles += N (count total empty slots)
     // - fetchBubbles_max += 1 (count occurrence of all slots being empty)
-    if (!stallSig->blockFetch[tid] &&
-        !fromCommitRedirect->commitInfo[tid].robSquashing) {
+    if (!stallSig->blockFetch[tid] && !fromCommit->commitInfo[tid].robSquashing) {
         // backend not stalled
         int unused_slots = decodeWidth - insts_to_decode;
         if (unused_slots > 0) {
@@ -1714,71 +1711,65 @@ Fetch::handleIEWSignals()
 bool
 Fetch::handleCommitSignals(ThreadID tid)
 {
-    const auto &commit_info = fromCommit->commitInfo[tid];
-
-    if (!commit_info.squash && commit_info.doneFtqId) {
-        DPRINTF(DecoupleBP, "Commit stream Id: %lu\n",
-                commit_info.doneFtqId);
-        assert(dbpbtb);
-        dbpbtb->commit(commit_info.doneFtqId, tid);
-    }
-
-    const auto &redirect_info = fromCommitRedirect->commitInfo[tid];
-
-    if (!redirect_info.squash) {
+    // Check squash signals from commit.
+    if (!fromCommit->commitInfo[tid].squash) {
+        if (fromCommit->commitInfo[tid].doneFtqId) {
+            DPRINTF(DecoupleBP, "Commit stream Id: %lu\n", fromCommit->commitInfo[tid].doneFtqId);
+            assert(dbpbtb);
+            dbpbtb->commit(fromCommit->commitInfo[tid].doneFtqId, tid);
+        }
         return false;
     }
 
-    // Check backend redirect/squash signals.
+    // Check squash signals from commit.
     DPRINTF(Fetch,
             "[tid:%i] Squashing instructions due to squash "
-            "from backend redirect.\n",
+            "from commit.\n",
             tid);
 
-    InstSeqNum squash_seq = redirect_info.doneSeqNum;
-    DynInstPtr squash_inst = redirect_info.squashInst;
-    if (redirect_info.isTrapSquash &&
-        redirect_info.traceTrapSkipInst) {
-        squash_seq = redirect_info.traceTrapSeqNum;
-        squash_inst = nullptr;
-        DPRINTF(Fetch,
-                "[tid:%i] Trap squash with trace ctrl-flow fault: rollback seq=%llu (skip head)\n",
-                tid, static_cast<unsigned long long>(squash_seq));
-    }
+        InstSeqNum squash_seq = fromCommit->commitInfo[tid].doneSeqNum;
+        DynInstPtr squash_inst = fromCommit->commitInfo[tid].squashInst;
+        if (fromCommit->commitInfo[tid].isTrapSquash &&
+            fromCommit->commitInfo[tid].traceTrapSkipInst) {
+            squash_seq = fromCommit->commitInfo[tid].traceTrapSeqNum;
+            squash_inst = nullptr;
+            DPRINTF(Fetch,
+                    "[tid:%i] Trap squash with trace ctrl-flow fault: rollback seq=%llu (skip head)\n",
+                    tid, static_cast<unsigned long long>(squash_seq));
+        }
 
     // In any case, squash.
-    squash(*redirect_info.pc, squash_seq,
+    squash(*fromCommit->commitInfo[tid].pc, squash_seq,
            squash_inst, tid);
 
     localSquashVer[tid].update(
-        redirect_info.squashVersion.getVersion());
+        fromCommit->commitInfo[tid].squashVersion.getVersion());
     DPRINTF(Fetch, "Updating squash version to %u\n",
             localSquashVer[tid].getVersion());
 
-    auto mispred_inst = redirect_info.mispredictInst;
+    auto mispred_inst = fromCommit->commitInfo[tid].mispredictInst;
 
     if (mispred_inst) {
         DPRINTF(Fetch, "Use mispred inst to redirect, treating as control squash\n");
-        const auto corr_pc = redirect_info.pc->as<RiscvISA::PCState>();
+        const auto corr_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
         assert(dbpbtb);
         dbpbtb->controlSquash(mispred_inst->getFtqId(), mispred_inst->pcState(),
                               corr_pc, mispred_inst->staticInst,
-                              mispred_inst->getInstBytes(), redirect_info.branchTaken,
+                              mispred_inst->getInstBytes(), fromCommit->commitInfo[tid].branchTaken,
                               mispred_inst->seqNum, tid, mispred_inst->getLoopIteration(), true);
-    } else if (redirect_info.isTrapSquash) {
+    } else if (fromCommit->commitInfo[tid].isTrapSquash) {
         DPRINTF(Fetch, "Treating as trap squash\n", tid);
-        const auto trap_pc = redirect_info.pc->as<RiscvISA::PCState>();
+        const auto trap_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
         assert(dbpbtb);
-        dbpbtb->trapSquash(redirect_info.squashedTargetId,
-                           redirect_info.committedPC, trap_pc, tid,
-                           redirect_info.squashedLoopIter);
+        dbpbtb->trapSquash(fromCommit->commitInfo[tid].squashedTargetId, fromCommit->commitInfo[tid].committedPC,
+                           trap_pc, tid, fromCommit->commitInfo[tid].squashedLoopIter);
     } else {
-        if (redirect_info.pc && redirect_info.squashedTargetId != 0) {
+        if (fromCommit->commitInfo[tid].pc && fromCommit->commitInfo[tid].squashedTargetId != 0) {
             DPRINTF(Fetch, "Squash with stream id and target id from IEW\n");
-            const auto nc_pc = redirect_info.pc->as<RiscvISA::PCState>();
+            const auto nc_pc = fromCommit->commitInfo[tid].pc->as<RiscvISA::PCState>();
             assert(dbpbtb);
-            dbpbtb->nonControlSquash(redirect_info.squashedTargetId, nc_pc,
-                                     0, tid, redirect_info.squashedLoopIter);
+            dbpbtb->nonControlSquash(fromCommit->commitInfo[tid].squashedTargetId, nc_pc,
+                                     0, tid, fromCommit->commitInfo[tid].squashedLoopIter);
         } else {
             DPRINTF(Fetch, "Dont squash dbq because no meaningful stream\n");
         }

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -486,7 +486,7 @@ class Fetch
      */
     bool checkSignalsAndUpdate(ThreadID tid);
 
-    /** Handles commit feedback and backend redirect signals.
+    /** Handles commit signals including squash and update operations.
      *  @return: Returns true if squash occurred and immediate return needed.
      */
     bool handleCommitSignals(ThreadID tid);
@@ -617,9 +617,6 @@ class Fetch
     /** Wire to get commit's information from backwards time buffer. */
     TimeBuffer<TimeStruct>::wire fromCommit;
 
-    /** Wire to get redirect information from backwards time buffer. */
-    TimeBuffer<TimeStruct>::wire fromCommitRedirect;
-
     //Might be annoying how this name is different than the queue.
     /** Wire used to write any information heading to decode. */
     TimeBuffer<FetchStruct>::wire toDecode;
@@ -676,9 +673,6 @@ class Fetch
 
     /** Commit to fetch delay. */
     Cycles commitToFetchDelay;
-
-    /** Backend redirect to fetch/BPU delay. */
-    Cycles redirectToFetchDelay;
 
     /** The width of fetch in instructions. */
     unsigned fetchWidth;


### PR DESCRIPTION
Reverts OpenXiangShan/GEM5#934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified frontend redirect and squash handling, which should make fetch behavior more consistent during branch redirects and commit-time squashes.
  * Updated default timing settings in example configurations to reflect the new fetch/decode pipeline behavior.

* **Refactor**
  * Removed an exposed redirect-to-fetch timing setting and consolidated commit signal handling around a single commit path.
  * Cleaned up related fetch-stage wiring and timing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->