### PR TITLE
arch-riscv: Limit PTW level parallelism

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -889,6 +889,43 @@ def xiangshan_system_init():
         help="Disable L1 direct one-stage TLB compression for A/B validation",
     )
     parser.add_argument(
+        "--disable-ptw-level-limit",
+        action="store_false",
+        dest="enable_ptw_level_limit",
+        default=True,
+        help="Disable PTW level parallelism limits for A/B validation",
+    )
+    parser.add_argument(
+        "--ptw-level0-limit",
+        type=int,
+        default=6,
+        help="PTW level-0 parallelism limit",
+    )
+    parser.add_argument(
+        "--ptw-level1-limit",
+        type=int,
+        default=1,
+        help="PTW level-1 parallelism limit",
+    )
+    parser.add_argument(
+        "--ptw-level2-limit",
+        type=int,
+        default=1,
+        help="PTW level-2 parallelism limit",
+    )
+    parser.add_argument(
+        "--ptw-level3-limit",
+        type=int,
+        default=1,
+        help="PTW level-3 parallelism limit",
+    )
+    parser.add_argument(
+        "--ptw-miss-queue-size",
+        type=int,
+        default=40,
+        help="PTW MissQueue size",
+    )
+    parser.add_argument(
         "--standalone-sc",
         action="store_true",
         default=False,

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -21,6 +21,14 @@ from common.xiangshan import *
 
 from m5.objects.ValuePredictor import *
 
+def setPtwLevelLimitParams(args, tlb):
+    tlb.walker.enable_ptw_level_limit = args.enable_ptw_level_limit
+    tlb.walker.ptw_level0_limit = args.ptw_level0_limit
+    tlb.walker.ptw_level1_limit = args.ptw_level1_limit
+    tlb.walker.ptw_level2_limit = args.ptw_level2_limit
+    tlb.walker.ptw_level3_limit = args.ptw_level3_limit
+    tlb.walker.ptw_miss_queue_size = args.ptw_miss_queue_size
+
 def setKmhV3IdealParams(args, system):
     for cpu in system.cpu:
 
@@ -28,6 +36,8 @@ def setKmhV3IdealParams(args, system):
         cpu.mmu.itb.size = 96
         #cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
         #cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
+        setPtwLevelLimitParams(args, cpu.mmu.itb)
+        setPtwLevelLimitParams(args, cpu.mmu.dtb)
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4  # maybe we need to change iewToFetchDelay to 4, but now we use commit update bpu

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -20,6 +20,14 @@ from common import Simulation
 from common.Caches import *
 from common.xiangshan import *
 
+def setPtwLevelLimitParams(args, tlb):
+    tlb.walker.enable_ptw_level_limit = args.enable_ptw_level_limit
+    tlb.walker.ptw_level0_limit = args.ptw_level0_limit
+    tlb.walker.ptw_level1_limit = args.ptw_level1_limit
+    tlb.walker.ptw_level2_limit = args.ptw_level2_limit
+    tlb.walker.ptw_level3_limit = args.ptw_level3_limit
+    tlb.walker.ptw_miss_queue_size = args.ptw_miss_queue_size
+
 def setKmhV3Params(args, system):
     for cpu in system.cpu:
 
@@ -27,6 +35,8 @@ def setKmhV3Params(args, system):
         cpu.mmu.itb.size = 96
         cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
         cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
+        setPtwLevelLimitParams(args, cpu.mmu.itb)
+        setPtwLevelLimitParams(args, cpu.mmu.dtb)
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 2

--- a/src/arch/riscv/RiscvTLB.py
+++ b/src/arch/riscv/RiscvTLB.py
@@ -52,6 +52,14 @@ class RiscvPagetableWalker(ClockedObject):
     pma_checker = Param.PMAChecker(Parent.any, "PMA Checker")
     pmp = Param.PMP(Parent.any, "PMP")
     open_nextline = Param.Bool(True, "open nextline pre")
+    enable_ptw_level_limit = Param.Bool(True,
+            "Enable one-stage direct PTW parallelism limits by walk level")
+    ptw_level0_limit = Param.Unsigned(6, "PTW level-0 parallelism limit")
+    ptw_level1_limit = Param.Unsigned(1, "PTW level-1 parallelism limit")
+    ptw_level2_limit = Param.Unsigned(1, "PTW level-2 parallelism limit")
+    ptw_level3_limit = Param.Unsigned(1, "PTW level-3 parallelism limit")
+    ptw_miss_queue_size = Param.Unsigned(40,
+            "Number of pending one-stage direct PTW misses")
 
 class RiscvTLB(BaseTLB):
     type = 'RiscvTLB'

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -819,12 +819,13 @@ Walker::WalkerState::startWalk(Addr ppn, int f_level, bool from_l2tlb,
         nextState = state;
         state = Waiting;
         mainFault = NoFault;
-        if (!walker->reservePtwLevel(this, level)) {
+        const int resource_level = currentPtwResourceLevel();
+        if (!walker->reservePtwLevel(this, resource_level)) {
             waitingForPtwLevel = true;
-            blockedPtwLevel = level;
+            blockedPtwLevel = resource_level;
             DPRINTF(PageTableWalker,
                     "PTW level%d busy, defer initial read for %#lx\n",
-                    level, mainReq->getVaddr());
+                    resource_level, mainReq->getVaddr());
             return fault;
         }
         sendPackets();
@@ -1129,6 +1130,11 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
             if (walker->l2tlb == nullptr)
                 panic("walker->l2tlb is none\n");
             
+            if (deferPtwLevelRead(twoStageLevel, nextRead, oldSize, flags, oldRead)) {
+                read = nullptr;
+                walker->retryPtwLevelBlockedStates();
+                return fault;
+            }
             delete oldRead;
             oldRead = nullptr;
             RequestPtr request = std::make_shared<Request>(nextRead, oldSize, flags, walker->requestorId);
@@ -1297,6 +1303,7 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
                         if (!tlbHit) {
                             delete oldRead;
                             oldRead = nullptr;
+                            read = nullptr;
                             fault = startTwoStageWalk(gPaddr, entry.vaddr);
                             if (fault != NoFault) {
                                 endWalk();
@@ -1384,6 +1391,7 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
                     if (!tlbHit) {
                         delete oldRead;
                         oldRead = nullptr;
+                        read = nullptr;
                         fault = startTwoStageWalk(gPaddr, entry.vaddr);
                         if (fault != NoFault) {
                             endWalk();
@@ -1835,7 +1843,17 @@ Walker::WalkerState::endWalk()
 bool
 Walker::WalkerState::usePtwLevelLimit() const
 {
-    return timing && translateMode == defaultmode && !fromPre && !fromBackPre;
+    return timing && (translateMode == defaultmode ||
+                      translateMode == twoStageMode) &&
+           !fromPre && !fromBackPre;
+}
+
+int
+Walker::WalkerState::currentPtwResourceLevel() const
+{
+    if (translateMode == twoStageMode && inGstage)
+        return twoStageLevel;
+    return level;
 }
 
 bool
@@ -1856,6 +1874,29 @@ Walker::WalkerState::waitForPtwLevel(int target_level, Addr next_read,
     DPRINTF(PageTableWalker,
             "PTW level%d busy, defer read %#lx for vaddr %#lx\n",
             target_level, next_read, mainReq->getVaddr());
+    return true;
+}
+
+bool
+Walker::WalkerState::deferPtwLevelRead(int target_level, Addr next_read,
+                                       unsigned read_size,
+                                       Request::Flags flags,
+                                       PacketPtr old_read)
+{
+    if (walker->reservePtwLevel(this, target_level))
+        return false;
+
+    if (!waitForPtwLevel(target_level, next_read, read_size, flags))
+        return false;
+
+    PacketPtr pending_read = old_read;
+    if (!pending_read && read && read->isResponse())
+        pending_read = read;
+    if (pending_read) {
+        if (read == pending_read)
+            read = nullptr;
+        delete pending_read;
+    }
     return true;
 }
 
@@ -1937,6 +1978,9 @@ Walker::WalkerState::startTwoStageWalkFromTLBNotInG(Addr ppn, Addr vaddr)
     if (nextRead == 0)
         panic("nextread can't be 0\n");
     Request::Flags flags = Request::PHYSICAL;
+    if (deferPtwLevelRead(level, nextRead, 64, flags, nullptr))
+        return NoFault;
+
     RequestPtr request = std::make_shared<Request>(nextRead, 64, flags, walker->requestorId);
     DPRINTF(PageTableWalkerTwoStage, "twoStageStepWalk nextRead %lx vaddr %lx gpaddr %lx level %d twolevel %d\n",
             nextRead, entry.vaddr, gPaddr, level, twoStageLevel);
@@ -1954,6 +1998,9 @@ Walker::WalkerState::startTwoStageWalkFromTLBInG(Addr ppn, Addr vaddr)
     nextRead = (nextRead >> 6) << 6;
     if (nextRead == 0)
         panic("nextread can't be 0\n");
+    if (deferPtwLevelRead(twoStageLevel, nextRead, 64, flags, nullptr))
+        return NoFault;
+
     RequestPtr request = std::make_shared<Request>(nextRead, 64, flags, walker->requestorId);
     read = new Packet(request, MemCmd::ReadReq);
     read->allocate();
@@ -1985,6 +2032,9 @@ Walker::WalkerState::startTwoStageWalk(Addr ppn, Addr vaddr)
         if (TwoLevelTopAddr == 0)
             panic("topAddr can't be 0\n");
         // DPRINTF(PageTableWalker, " sv39 size is %d\n", sizeof(PTE));
+
+        if (deferPtwLevelRead(twoStageLevel, TwoLevelTopAddr, 64, flags, nullptr))
+            return NoFault;
 
         read = new Packet(request, MemCmd::ReadReq);
         read->allocate();

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -115,7 +115,17 @@ Walker::WalkerStats::WalkerStats(statistics::Group *parent)
       ADD_STAT(ptwMissQueueAdmissionRetries, statistics::units::Count::get(),
                "Number of waiting one-stage direct PTW misses admitted to MissQueue"),
       ADD_STAT(ptwMissQueueFullEvents, statistics::units::Count::get(),
-               "Number of one-stage direct PTW miss queue full events")
+               "Number of one-stage direct PTW miss queue full events"),
+      ADD_STAT(ptwMissQueueHintChecks, statistics::units::Count::get(),
+               "Number of MissQueue entries checked by TLB refill hints"),
+      ADD_STAT(ptwMissQueueHintMatches, statistics::units::Count::get(),
+               "Number of MissQueue entries matched by TLB refill hints"),
+      ADD_STAT(ptwMissQueueHintRetries, statistics::units::Count::get(),
+               "Number of MissQueue entries retried by TLB refill hints"),
+      ADD_STAT(ptwMissQueueHintResolved, statistics::units::Count::get(),
+               "Number of hint retried MissQueue entries completed immediately"),
+      ADD_STAT(ptwMissQueueHintDelayed, statistics::units::Count::get(),
+               "Number of hint retried MissQueue entries delayed again")
 {
 }
 
@@ -241,6 +251,61 @@ void
 Walker::recordPtwMissQueueFifoBlocked()
 {
     stats.ptwMissQueueFifoBlocked++;
+}
+
+bool
+Walker::ptwMissQueueHintMatch(const MissQueueEntry &entry,
+                              const TlbEntry &refill_entry,
+                              uint8_t translateMode) const
+{
+    if (!entry.tc || !entry.req)
+        return false;
+    return tlb->refillHintMaySatisfy(entry.req, entry.tc, entry.mode,
+                                     refill_entry, translateMode);
+}
+
+void
+Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
+{
+    if (!enablePtwLevelLimit || translateMode != direct ||
+        retryingPtwMissQueue || processingPtwMissQueueHint ||
+        ptwMissQueue.empty())
+        return;
+
+    std::deque<MissQueueEntry> remaining;
+    std::deque<MissQueueEntry> matched;
+    processingPtwMissQueueHint = true;
+
+    while (!ptwMissQueue.empty()) {
+        MissQueueEntry mq_entry = ptwMissQueue.front();
+        ptwMissQueue.pop_front();
+        stats.ptwMissQueueHintChecks++;
+        if (ptwMissQueueHintMatch(mq_entry, entry, translateMode)) {
+            stats.ptwMissQueueHintMatches++;
+            matched.push_back(mq_entry);
+        } else {
+            remaining.push_back(mq_entry);
+        }
+    }
+
+    ptwMissQueue.swap(remaining);
+
+    while (!matched.empty()) {
+        MissQueueEntry mq_entry = matched.front();
+        matched.pop_front();
+        stats.ptwMissQueueHintRetries++;
+        bool resolved = tlb->retryTimingPtwMiss(mq_entry.tc,
+                                                mq_entry.translation,
+                                                mq_entry.req,
+                                                mq_entry.mode,
+                                                true);
+        if (resolved)
+            stats.ptwMissQueueHintResolved++;
+        else
+            stats.ptwMissQueueHintDelayed++;
+    }
+
+    processingPtwMissQueueHint = false;
 }
 
 bool

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -125,7 +125,27 @@ Walker::WalkerStats::WalkerStats(statistics::Group *parent)
       ADD_STAT(ptwMissQueueHintResolved, statistics::units::Count::get(),
                "Number of hint retried MissQueue entries completed immediately"),
       ADD_STAT(ptwMissQueueHintDelayed, statistics::units::Count::get(),
-               "Number of hint retried MissQueue entries delayed again")
+               "Number of hint retried MissQueue entries delayed again"),
+      ADD_STAT(ptwMissQueueHintDirectChecks, statistics::units::Count::get(),
+               "Number of direct refill hint MissQueue checks"),
+      ADD_STAT(ptwMissQueueHintDirectMatches, statistics::units::Count::get(),
+               "Number of direct refill hint MissQueue matches"),
+      ADD_STAT(ptwMissQueueHintDirectRetries, statistics::units::Count::get(),
+               "Number of direct refill hint MissQueue retries"),
+      ADD_STAT(ptwMissQueueHintDirectResolved, statistics::units::Count::get(),
+               "Number of direct refill hint retries completed immediately"),
+      ADD_STAT(ptwMissQueueHintDirectDelayed, statistics::units::Count::get(),
+               "Number of direct refill hint retries delayed again"),
+      ADD_STAT(ptwMissQueueHintAllstageChecks, statistics::units::Count::get(),
+               "Number of all-stage refill hint MissQueue checks"),
+      ADD_STAT(ptwMissQueueHintAllstageMatches, statistics::units::Count::get(),
+               "Number of all-stage refill hint MissQueue matches"),
+      ADD_STAT(ptwMissQueueHintAllstageRetries, statistics::units::Count::get(),
+               "Number of all-stage refill hint MissQueue retries"),
+      ADD_STAT(ptwMissQueueHintAllstageResolved, statistics::units::Count::get(),
+               "Number of all-stage refill hint retries completed immediately"),
+      ADD_STAT(ptwMissQueueHintAllstageDelayed, statistics::units::Count::get(),
+               "Number of all-stage refill hint retries delayed again")
 {
 }
 
@@ -253,6 +273,81 @@ Walker::recordPtwMissQueueFifoBlocked()
     stats.ptwMissQueueFifoBlocked++;
 }
 
+void
+Walker::recordPtwMissQueueHintCheck(uint8_t translateMode)
+{
+    switch (translateMode) {
+      case direct:
+        stats.ptwMissQueueHintDirectChecks++;
+        break;
+      case allstage:
+        stats.ptwMissQueueHintAllstageChecks++;
+        break;
+      default:
+        break;
+    }
+}
+
+void
+Walker::recordPtwMissQueueHintMatch(uint8_t translateMode)
+{
+    switch (translateMode) {
+      case direct:
+        stats.ptwMissQueueHintDirectMatches++;
+        break;
+      case allstage:
+        stats.ptwMissQueueHintAllstageMatches++;
+        break;
+      default:
+        break;
+    }
+}
+
+void
+Walker::recordPtwMissQueueHintRetry(uint8_t translateMode)
+{
+    switch (translateMode) {
+      case direct:
+        stats.ptwMissQueueHintDirectRetries++;
+        break;
+      case allstage:
+        stats.ptwMissQueueHintAllstageRetries++;
+        break;
+      default:
+        break;
+    }
+}
+
+void
+Walker::recordPtwMissQueueHintResolved(uint8_t translateMode)
+{
+    switch (translateMode) {
+      case direct:
+        stats.ptwMissQueueHintDirectResolved++;
+        break;
+      case allstage:
+        stats.ptwMissQueueHintAllstageResolved++;
+        break;
+      default:
+        break;
+    }
+}
+
+void
+Walker::recordPtwMissQueueHintDelayed(uint8_t translateMode)
+{
+    switch (translateMode) {
+      case direct:
+        stats.ptwMissQueueHintDirectDelayed++;
+        break;
+      case allstage:
+        stats.ptwMissQueueHintAllstageDelayed++;
+        break;
+      default:
+        break;
+    }
+}
+
 bool
 Walker::ptwMissQueueHintMatch(const MissQueueEntry &entry,
                               const TlbEntry &refill_entry,
@@ -267,10 +362,44 @@ Walker::ptwMissQueueHintMatch(const MissQueueEntry &entry,
 void
 Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
 {
-    if (!enablePtwLevelLimit || translateMode != direct ||
-        retryingPtwMissQueue || processingPtwMissQueueHint ||
-        ptwMissQueue.empty())
+    if (translateMode != direct && translateMode != allstage)
         return;
+    if (translateMode == allstage && !entry.pte.r && !entry.pte.x)
+        return;
+
+    if (!enablePtwLevelLimit || retryingPtwMissQueue ||
+        processingPtwMissQueueHint || ptwMissQueue.empty())
+        return;
+
+    if (translateMode == allstage) {
+        MissQueueEntry mq_entry = ptwMissQueue.front();
+        stats.ptwMissQueueHintChecks++;
+        recordPtwMissQueueHintCheck(translateMode);
+        if (!ptwMissQueueHintMatch(mq_entry, entry, translateMode))
+            return;
+
+        ptwMissQueue.pop_front();
+        stats.ptwMissQueueHintMatches++;
+        recordPtwMissQueueHintMatch(translateMode);
+        stats.ptwMissQueueHintRetries++;
+        recordPtwMissQueueHintRetry(translateMode);
+
+        processingPtwMissQueueHint = true;
+        bool resolved = tlb->retryTimingPtwMiss(mq_entry.tc,
+                                                mq_entry.translation,
+                                                mq_entry.req,
+                                                mq_entry.mode,
+                                                true);
+        processingPtwMissQueueHint = false;
+        if (resolved) {
+            stats.ptwMissQueueHintResolved++;
+            recordPtwMissQueueHintResolved(translateMode);
+        } else {
+            stats.ptwMissQueueHintDelayed++;
+            recordPtwMissQueueHintDelayed(translateMode);
+        }
+        return;
+    }
 
     std::deque<MissQueueEntry> remaining;
     std::deque<MissQueueEntry> matched;
@@ -280,8 +409,10 @@ Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
         MissQueueEntry mq_entry = ptwMissQueue.front();
         ptwMissQueue.pop_front();
         stats.ptwMissQueueHintChecks++;
+        recordPtwMissQueueHintCheck(translateMode);
         if (ptwMissQueueHintMatch(mq_entry, entry, translateMode)) {
             stats.ptwMissQueueHintMatches++;
+            recordPtwMissQueueHintMatch(translateMode);
             matched.push_back(mq_entry);
         } else {
             remaining.push_back(mq_entry);
@@ -294,15 +425,19 @@ Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
         MissQueueEntry mq_entry = matched.front();
         matched.pop_front();
         stats.ptwMissQueueHintRetries++;
+        recordPtwMissQueueHintRetry(translateMode);
         bool resolved = tlb->retryTimingPtwMiss(mq_entry.tc,
                                                 mq_entry.translation,
                                                 mq_entry.req,
                                                 mq_entry.mode,
                                                 true);
-        if (resolved)
+        if (resolved) {
             stats.ptwMissQueueHintResolved++;
-        else
+            recordPtwMissQueueHintResolved(translateMode);
+        } else {
             stats.ptwMissQueueHintDelayed++;
+            recordPtwMissQueueHintDelayed(translateMode);
+        }
     }
 
     processingPtwMissQueueHint = false;

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -89,85 +89,8 @@ Walker::WalkerStats::WalkerStats(statistics::Group *parent)
                    statistics::units::Cycle,
                    statistics::units::Count>::get(),
                "Average PTW memory latency",
-               ptwMemCycle / ptwMemCount),
-      ADD_STAT(ptwLevel0ResourceBlocked, statistics::units::Count::get(),
-               "Number of one-stage direct PTW walks blocked by level-0 limit"),
-      ADD_STAT(ptwLevel1ResourceBlocked, statistics::units::Count::get(),
-               "Number of one-stage direct PTW walks blocked by level-1 limit"),
-      ADD_STAT(ptwLevel2ResourceBlocked, statistics::units::Count::get(),
-               "Number of one-stage direct PTW walks blocked by level-2 limit"),
-      ADD_STAT(ptwLevel3ResourceBlocked, statistics::units::Count::get(),
-               "Number of one-stage direct PTW walks blocked by level-3 limit"),
-      ADD_STAT(ptwMissQueueResourceBlocked, statistics::units::Count::get(),
-               "Number of PTW misses enqueued because the target PTW level was busy"),
-      ADD_STAT(ptwMissQueueFifoBlocked, statistics::units::Count::get(),
-               "Number of PTW misses enqueued to preserve MissQueue FIFO order"),
-      ADD_STAT(ptwMissQueueFullBlocked, statistics::units::Count::get(),
-               "Number of PTW misses blocked because MissQueue was full"),
-      ADD_STAT(ptwMissQueueEnqueues, statistics::units::Count::get(),
-               "Number of one-stage direct PTW misses enqueued"),
-      ADD_STAT(ptwMissQueueDequeues, statistics::units::Count::get(),
-               "Number of one-stage direct PTW misses dequeued"),
-      ADD_STAT(ptwMissQueueRequeues, statistics::units::Count::get(),
-               "Number of one-stage direct PTW miss queue head retries"),
-      ADD_STAT(ptwMissQueueAdmissionWaits, statistics::units::Count::get(),
-               "Number of one-stage direct PTW misses waiting for MissQueue space"),
-      ADD_STAT(ptwMissQueueAdmissionRetries, statistics::units::Count::get(),
-               "Number of waiting one-stage direct PTW misses admitted to MissQueue"),
-      ADD_STAT(ptwMissQueueFullEvents, statistics::units::Count::get(),
-               "Number of one-stage direct PTW miss queue full events"),
-      ADD_STAT(ptwMissQueueHintChecks, statistics::units::Count::get(),
-               "Number of MissQueue entries checked by TLB refill hints"),
-      ADD_STAT(ptwMissQueueHintMatches, statistics::units::Count::get(),
-               "Number of MissQueue entries matched by TLB refill hints"),
-      ADD_STAT(ptwMissQueueHintRetries, statistics::units::Count::get(),
-               "Number of MissQueue entries retried by TLB refill hints"),
-      ADD_STAT(ptwMissQueueHintResolved, statistics::units::Count::get(),
-               "Number of hint retried MissQueue entries completed immediately"),
-      ADD_STAT(ptwMissQueueHintDelayed, statistics::units::Count::get(),
-               "Number of hint retried MissQueue entries delayed again"),
-      ADD_STAT(ptwMissQueueHintDirectChecks, statistics::units::Count::get(),
-               "Number of direct refill hint MissQueue checks"),
-      ADD_STAT(ptwMissQueueHintDirectMatches, statistics::units::Count::get(),
-               "Number of direct refill hint MissQueue matches"),
-      ADD_STAT(ptwMissQueueHintDirectRetries, statistics::units::Count::get(),
-               "Number of direct refill hint MissQueue retries"),
-      ADD_STAT(ptwMissQueueHintDirectResolved, statistics::units::Count::get(),
-               "Number of direct refill hint retries completed immediately"),
-      ADD_STAT(ptwMissQueueHintDirectDelayed, statistics::units::Count::get(),
-               "Number of direct refill hint retries delayed again"),
-      ADD_STAT(ptwMissQueueHintAllstageChecks, statistics::units::Count::get(),
-               "Number of all-stage refill hint MissQueue checks"),
-      ADD_STAT(ptwMissQueueHintAllstageMatches, statistics::units::Count::get(),
-               "Number of all-stage refill hint MissQueue matches"),
-      ADD_STAT(ptwMissQueueHintAllstageRetries, statistics::units::Count::get(),
-               "Number of all-stage refill hint MissQueue retries"),
-      ADD_STAT(ptwMissQueueHintAllstageResolved, statistics::units::Count::get(),
-               "Number of all-stage refill hint retries completed immediately"),
-      ADD_STAT(ptwMissQueueHintAllstageDelayed, statistics::units::Count::get(),
-               "Number of all-stage refill hint retries delayed again")
+               ptwMemCycle / ptwMemCount)
 {
-}
-
-void
-Walker::recordPtwLevelBlocked(int level)
-{
-    switch (level) {
-      case 0:
-        stats.ptwLevel0ResourceBlocked++;
-        break;
-      case 1:
-        stats.ptwLevel1ResourceBlocked++;
-        break;
-      case 2:
-        stats.ptwLevel2ResourceBlocked++;
-        break;
-      case 3:
-        stats.ptwLevel3ResourceBlocked++;
-        break;
-      default:
-        panic("Invalid PTW level %d\n", level);
-    }
 }
 
 bool
@@ -199,10 +122,8 @@ Walker::reservePtwLevel(WalkerState *state, int level)
         return true;
 
     releasePtwLevel(state);
-    if (ptwLevelActive[level] >= ptwLevelLimit[level]) {
-        recordPtwLevelBlocked(level);
+    if (ptwLevelActive[level] >= ptwLevelLimit[level])
         return false;
-    }
 
     ptwLevelActive[level]++;
     state->reservedPtwLevel = level;
@@ -238,16 +159,19 @@ Walker::retryPtwLevelBlockedStates()
 
 bool
 Walker::usePtwLevelLimitForStart(bool from_forward_pre_req,
-                                 bool from_back_pre_req) const
+                                 bool from_back_pre_req,
+                                 bool is_prefetch) const
 {
-    return enablePtwLevelLimit && !from_forward_pre_req && !from_back_pre_req;
+    return enablePtwLevelLimit && !from_forward_pre_req &&
+           !from_back_pre_req && !is_prefetch;
 }
 
 bool
 Walker::canStartPtwLevel(int level, bool from_forward_pre_req,
-                         bool from_back_pre_req)
+                         bool from_back_pre_req, bool is_prefetch)
 {
-    if (!usePtwLevelLimitForStart(from_forward_pre_req, from_back_pre_req))
+    if (!usePtwLevelLimitForStart(from_forward_pre_req, from_back_pre_req,
+                                  is_prefetch))
         return true;
 
     panic_if(level < 0 || level >= static_cast<int>(ptwLevelLimit.size()),
@@ -257,95 +181,7 @@ Walker::canStartPtwLevel(int level, bool from_forward_pre_req,
     if (ptwLevelActive[level] < ptwLevelLimit[level])
         return true;
 
-    recordPtwLevelBlocked(level);
     return false;
-}
-
-void
-Walker::recordPtwMissQueueResourceBlocked()
-{
-    stats.ptwMissQueueResourceBlocked++;
-}
-
-void
-Walker::recordPtwMissQueueFifoBlocked()
-{
-    stats.ptwMissQueueFifoBlocked++;
-}
-
-void
-Walker::recordPtwMissQueueHintCheck(uint8_t translateMode)
-{
-    switch (translateMode) {
-      case direct:
-        stats.ptwMissQueueHintDirectChecks++;
-        break;
-      case allstage:
-        stats.ptwMissQueueHintAllstageChecks++;
-        break;
-      default:
-        break;
-    }
-}
-
-void
-Walker::recordPtwMissQueueHintMatch(uint8_t translateMode)
-{
-    switch (translateMode) {
-      case direct:
-        stats.ptwMissQueueHintDirectMatches++;
-        break;
-      case allstage:
-        stats.ptwMissQueueHintAllstageMatches++;
-        break;
-      default:
-        break;
-    }
-}
-
-void
-Walker::recordPtwMissQueueHintRetry(uint8_t translateMode)
-{
-    switch (translateMode) {
-      case direct:
-        stats.ptwMissQueueHintDirectRetries++;
-        break;
-      case allstage:
-        stats.ptwMissQueueHintAllstageRetries++;
-        break;
-      default:
-        break;
-    }
-}
-
-void
-Walker::recordPtwMissQueueHintResolved(uint8_t translateMode)
-{
-    switch (translateMode) {
-      case direct:
-        stats.ptwMissQueueHintDirectResolved++;
-        break;
-      case allstage:
-        stats.ptwMissQueueHintAllstageResolved++;
-        break;
-      default:
-        break;
-    }
-}
-
-void
-Walker::recordPtwMissQueueHintDelayed(uint8_t translateMode)
-{
-    switch (translateMode) {
-      case direct:
-        stats.ptwMissQueueHintDirectDelayed++;
-        break;
-      case allstage:
-        stats.ptwMissQueueHintAllstageDelayed++;
-        break;
-      default:
-        break;
-    }
 }
 
 bool
@@ -373,31 +209,15 @@ Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
 
     if (translateMode == allstage) {
         MissQueueEntry mq_entry = ptwMissQueue.front();
-        stats.ptwMissQueueHintChecks++;
-        recordPtwMissQueueHintCheck(translateMode);
         if (!ptwMissQueueHintMatch(mq_entry, entry, translateMode))
             return;
 
         ptwMissQueue.pop_front();
-        stats.ptwMissQueueHintMatches++;
-        recordPtwMissQueueHintMatch(translateMode);
-        stats.ptwMissQueueHintRetries++;
-        recordPtwMissQueueHintRetry(translateMode);
 
         processingPtwMissQueueHint = true;
-        bool resolved = tlb->retryTimingPtwMiss(mq_entry.tc,
-                                                mq_entry.translation,
-                                                mq_entry.req,
-                                                mq_entry.mode,
-                                                true);
+        tlb->retryTimingPtwMiss(mq_entry.tc, mq_entry.translation,
+                                mq_entry.req, mq_entry.mode, true);
         processingPtwMissQueueHint = false;
-        if (resolved) {
-            stats.ptwMissQueueHintResolved++;
-            recordPtwMissQueueHintResolved(translateMode);
-        } else {
-            stats.ptwMissQueueHintDelayed++;
-            recordPtwMissQueueHintDelayed(translateMode);
-        }
         return;
     }
 
@@ -408,11 +228,7 @@ Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
     while (!ptwMissQueue.empty()) {
         MissQueueEntry mq_entry = ptwMissQueue.front();
         ptwMissQueue.pop_front();
-        stats.ptwMissQueueHintChecks++;
-        recordPtwMissQueueHintCheck(translateMode);
         if (ptwMissQueueHintMatch(mq_entry, entry, translateMode)) {
-            stats.ptwMissQueueHintMatches++;
-            recordPtwMissQueueHintMatch(translateMode);
             matched.push_back(mq_entry);
         } else {
             remaining.push_back(mq_entry);
@@ -424,20 +240,8 @@ Walker::notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode)
     while (!matched.empty()) {
         MissQueueEntry mq_entry = matched.front();
         matched.pop_front();
-        stats.ptwMissQueueHintRetries++;
-        recordPtwMissQueueHintRetry(translateMode);
-        bool resolved = tlb->retryTimingPtwMiss(mq_entry.tc,
-                                                mq_entry.translation,
-                                                mq_entry.req,
-                                                mq_entry.mode,
-                                                true);
-        if (resolved) {
-            stats.ptwMissQueueHintResolved++;
-            recordPtwMissQueueHintResolved(translateMode);
-        } else {
-            stats.ptwMissQueueHintDelayed++;
-            recordPtwMissQueueHintDelayed(translateMode);
-        }
+        tlb->retryTimingPtwMiss(mq_entry.tc, mq_entry.translation,
+                                mq_entry.req, mq_entry.mode, true);
     }
 
     processingPtwMissQueueHint = false;
@@ -457,10 +261,7 @@ Walker::enqueuePtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
     entry.mode = mode;
 
     if (!front && ptwMissQueue.size() >= ptwMissQueueSize) {
-        stats.ptwMissQueueFullEvents++;
-        stats.ptwMissQueueFullBlocked++;
         ptwMissQueueWaiters.push_back(entry);
-        stats.ptwMissQueueAdmissionWaits++;
         DPRINTF(PageTableWalker,
                 "PTW MissQueue full, hold vaddr %#lx waiter size %u\n",
                 req->getVaddr(), ptwMissQueueWaiters.size());
@@ -473,10 +274,6 @@ Walker::enqueuePtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
     } else {
         ptwMissQueue.push_back(entry);
     }
-    if (front)
-        stats.ptwMissQueueRequeues++;
-    else
-        stats.ptwMissQueueEnqueues++;
     DPRINTF(PageTableWalker,
             "Enqueue PTW miss vaddr %#lx queue size %u\n",
             req->getVaddr(), ptwMissQueue.size());
@@ -493,7 +290,6 @@ Walker::retryPtwMissQueue()
            ptwMissQueue.size() < ptwMissQueueSize) {
         ptwMissQueue.push_back(ptwMissQueueWaiters.front());
         ptwMissQueueWaiters.pop_front();
-        stats.ptwMissQueueAdmissionRetries++;
     }
     if (ptwMissQueue.empty())
         return;
@@ -504,7 +300,6 @@ Walker::retryPtwMissQueue()
         ptwMissQueueHeadRequeued = false;
         MissQueueEntry entry = ptwMissQueue.front();
         ptwMissQueue.pop_front();
-        stats.ptwMissQueueDequeues++;
         DPRINTF(PageTableWalker,
                 "Dequeue PTW miss vaddr %#lx queue size %u\n",
                 entry.req->getVaddr(), ptwMissQueue.size());
@@ -516,7 +311,6 @@ Walker::retryPtwMissQueue()
                ptwMissQueue.size() < ptwMissQueueSize) {
             ptwMissQueue.push_back(ptwMissQueueWaiters.front());
             ptwMissQueueWaiters.pop_front();
-            stats.ptwMissQueueAdmissionRetries++;
         }
     }
     retryingPtwMissQueue = false;
@@ -2045,7 +1839,8 @@ Walker::WalkerState::usePtwLevelLimit() const
 {
     return timing && (translateMode == defaultmode ||
                       translateMode == twoStageMode) &&
-           !fromPre && !fromBackPre;
+           !fromPre && !fromBackPre &&
+           mainReq && !mainReq->isPrefetch();
 }
 
 int

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -89,8 +89,237 @@ Walker::WalkerStats::WalkerStats(statistics::Group *parent)
                    statistics::units::Cycle,
                    statistics::units::Count>::get(),
                "Average PTW memory latency",
-               ptwMemCycle / ptwMemCount)
+               ptwMemCycle / ptwMemCount),
+      ADD_STAT(ptwLevel0ResourceBlocked, statistics::units::Count::get(),
+               "Number of one-stage direct PTW walks blocked by level-0 limit"),
+      ADD_STAT(ptwLevel1ResourceBlocked, statistics::units::Count::get(),
+               "Number of one-stage direct PTW walks blocked by level-1 limit"),
+      ADD_STAT(ptwLevel2ResourceBlocked, statistics::units::Count::get(),
+               "Number of one-stage direct PTW walks blocked by level-2 limit"),
+      ADD_STAT(ptwLevel3ResourceBlocked, statistics::units::Count::get(),
+               "Number of one-stage direct PTW walks blocked by level-3 limit"),
+      ADD_STAT(ptwMissQueueResourceBlocked, statistics::units::Count::get(),
+               "Number of PTW misses enqueued because the target PTW level was busy"),
+      ADD_STAT(ptwMissQueueFifoBlocked, statistics::units::Count::get(),
+               "Number of PTW misses enqueued to preserve MissQueue FIFO order"),
+      ADD_STAT(ptwMissQueueFullBlocked, statistics::units::Count::get(),
+               "Number of PTW misses blocked because MissQueue was full"),
+      ADD_STAT(ptwMissQueueEnqueues, statistics::units::Count::get(),
+               "Number of one-stage direct PTW misses enqueued"),
+      ADD_STAT(ptwMissQueueDequeues, statistics::units::Count::get(),
+               "Number of one-stage direct PTW misses dequeued"),
+      ADD_STAT(ptwMissQueueRequeues, statistics::units::Count::get(),
+               "Number of one-stage direct PTW miss queue head retries"),
+      ADD_STAT(ptwMissQueueAdmissionWaits, statistics::units::Count::get(),
+               "Number of one-stage direct PTW misses waiting for MissQueue space"),
+      ADD_STAT(ptwMissQueueAdmissionRetries, statistics::units::Count::get(),
+               "Number of waiting one-stage direct PTW misses admitted to MissQueue"),
+      ADD_STAT(ptwMissQueueFullEvents, statistics::units::Count::get(),
+               "Number of one-stage direct PTW miss queue full events")
 {
+}
+
+void
+Walker::recordPtwLevelBlocked(int level)
+{
+    switch (level) {
+      case 0:
+        stats.ptwLevel0ResourceBlocked++;
+        break;
+      case 1:
+        stats.ptwLevel1ResourceBlocked++;
+        break;
+      case 2:
+        stats.ptwLevel2ResourceBlocked++;
+        break;
+      case 3:
+        stats.ptwLevel3ResourceBlocked++;
+        break;
+      default:
+        panic("Invalid PTW level %d\n", level);
+    }
+}
+
+bool
+Walker::ptwLevelAvailable(WalkerState *state, int level) const
+{
+    if (!enablePtwLevelLimit || !state->usePtwLevelLimit())
+        return true;
+
+    panic_if(level < 0 || level >= static_cast<int>(ptwLevelLimit.size()),
+             "Invalid PTW level %d\n", level);
+    panic_if(ptwLevelLimit[level] == 0,
+             "PTW level %d limit must be positive when enabled\n", level);
+    return state->reservedPtwLevel == level ||
+           ptwLevelActive[level] < ptwLevelLimit[level];
+}
+
+bool
+Walker::reservePtwLevel(WalkerState *state, int level)
+{
+    if (!enablePtwLevelLimit || !state->usePtwLevelLimit())
+        return true;
+
+    panic_if(level < 0 || level >= static_cast<int>(ptwLevelLimit.size()),
+             "Invalid PTW level %d\n", level);
+    panic_if(ptwLevelLimit[level] == 0,
+             "PTW level %d limit must be positive when enabled\n", level);
+
+    if (state->reservedPtwLevel == level)
+        return true;
+
+    releasePtwLevel(state);
+    if (ptwLevelActive[level] >= ptwLevelLimit[level]) {
+        recordPtwLevelBlocked(level);
+        return false;
+    }
+
+    ptwLevelActive[level]++;
+    state->reservedPtwLevel = level;
+    return true;
+}
+
+void
+Walker::releasePtwLevel(WalkerState *state)
+{
+    if (!enablePtwLevelLimit || state->reservedPtwLevel < 0)
+        return;
+
+    const int level = state->reservedPtwLevel;
+    panic_if(level >= static_cast<int>(ptwLevelActive.size()),
+             "Invalid reserved PTW level %d\n", level);
+    panic_if(ptwLevelActive[level] == 0,
+             "PTW level %d active counter underflow\n", level);
+    ptwLevelActive[level]--;
+    state->reservedPtwLevel = -1;
+}
+
+void
+Walker::retryPtwLevelBlockedStates()
+{
+    if (!enablePtwLevelLimit)
+        return;
+
+    for (auto *walker_state : currStates) {
+        if (walker_state->retryBlockedPtwLevel())
+            break;
+    }
+}
+
+bool
+Walker::usePtwLevelLimitForStart(bool from_forward_pre_req,
+                                 bool from_back_pre_req) const
+{
+    return enablePtwLevelLimit && !from_forward_pre_req && !from_back_pre_req;
+}
+
+bool
+Walker::canStartPtwLevel(int level, bool from_forward_pre_req,
+                         bool from_back_pre_req)
+{
+    if (!usePtwLevelLimitForStart(from_forward_pre_req, from_back_pre_req))
+        return true;
+
+    panic_if(level < 0 || level >= static_cast<int>(ptwLevelLimit.size()),
+             "Invalid PTW level %d\n", level);
+    panic_if(ptwLevelLimit[level] == 0,
+             "PTW level %d limit must be positive when enabled\n", level);
+    if (ptwLevelActive[level] < ptwLevelLimit[level])
+        return true;
+
+    recordPtwLevelBlocked(level);
+    return false;
+}
+
+void
+Walker::recordPtwMissQueueResourceBlocked()
+{
+    stats.ptwMissQueueResourceBlocked++;
+}
+
+void
+Walker::recordPtwMissQueueFifoBlocked()
+{
+    stats.ptwMissQueueFifoBlocked++;
+}
+
+bool
+Walker::enqueuePtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
+                       const RequestPtr &req, BaseMMU::Mode mode, bool front)
+{
+    if (!enablePtwLevelLimit)
+        return false;
+
+    MissQueueEntry entry;
+    entry.tc = tc;
+    entry.translation = translation;
+    entry.req = req;
+    entry.mode = mode;
+
+    if (!front && ptwMissQueue.size() >= ptwMissQueueSize) {
+        stats.ptwMissQueueFullEvents++;
+        stats.ptwMissQueueFullBlocked++;
+        ptwMissQueueWaiters.push_back(entry);
+        stats.ptwMissQueueAdmissionWaits++;
+        DPRINTF(PageTableWalker,
+                "PTW MissQueue full, hold vaddr %#lx waiter size %u\n",
+                req->getVaddr(), ptwMissQueueWaiters.size());
+        return true;
+    }
+
+    if (front) {
+        ptwMissQueue.push_front(entry);
+        ptwMissQueueHeadRequeued = true;
+    } else {
+        ptwMissQueue.push_back(entry);
+    }
+    if (front)
+        stats.ptwMissQueueRequeues++;
+    else
+        stats.ptwMissQueueEnqueues++;
+    DPRINTF(PageTableWalker,
+            "Enqueue PTW miss vaddr %#lx queue size %u\n",
+            req->getVaddr(), ptwMissQueue.size());
+    return true;
+}
+
+void
+Walker::retryPtwMissQueue()
+{
+    if (!enablePtwLevelLimit || retryingPtwMissQueue)
+        return;
+
+    while (!ptwMissQueueWaiters.empty() &&
+           ptwMissQueue.size() < ptwMissQueueSize) {
+        ptwMissQueue.push_back(ptwMissQueueWaiters.front());
+        ptwMissQueueWaiters.pop_front();
+        stats.ptwMissQueueAdmissionRetries++;
+    }
+    if (ptwMissQueue.empty())
+        return;
+
+    retryingPtwMissQueue = true;
+    while (!ptwMissQueue.empty()) {
+        const size_t size_before = ptwMissQueue.size();
+        ptwMissQueueHeadRequeued = false;
+        MissQueueEntry entry = ptwMissQueue.front();
+        ptwMissQueue.pop_front();
+        stats.ptwMissQueueDequeues++;
+        DPRINTF(PageTableWalker,
+                "Dequeue PTW miss vaddr %#lx queue size %u\n",
+                entry.req->getVaddr(), ptwMissQueue.size());
+        tlb->retryTimingPtwMiss(entry.tc, entry.translation, entry.req, entry.mode);
+        if (ptwMissQueueHeadRequeued ||
+            ptwMissQueue.size() >= size_before)
+            break;
+        while (!ptwMissQueueWaiters.empty() &&
+               ptwMissQueue.size() < ptwMissQueueSize) {
+            ptwMissQueue.push_back(ptwMissQueueWaiters.front());
+            ptwMissQueueWaiters.pop_front();
+            stats.ptwMissQueueAdmissionRetries++;
+        }
+    }
+    retryingPtwMissQueue = false;
 }
 
 void
@@ -259,11 +488,11 @@ Walker::recvTimingResp(PacketPtr pkt)
                 break;
             }
         }
+        releasePtwLevel(senderWalk);
         delete senderWalk;
-        // Since we block requests when another is outstanding, we
-        // need to check if there is a waiting request to be serviced
-
     }
+    retryPtwLevelBlockedStates();
+    retryPtwMissQueue();
     return true;
 }
 
@@ -590,6 +819,14 @@ Walker::WalkerState::startWalk(Addr ppn, int f_level, bool from_l2tlb,
         nextState = state;
         state = Waiting;
         mainFault = NoFault;
+        if (!walker->reservePtwLevel(this, level)) {
+            waitingForPtwLevel = true;
+            blockedPtwLevel = level;
+            DPRINTF(PageTableWalker,
+                    "PTW level%d busy, defer initial read for %#lx\n",
+                    level, mainReq->getVaddr());
+            return fault;
+        }
         sendPackets();
     } else {
         if (translateMode == twoStageMode)
@@ -1556,6 +1793,17 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         endWalk();
     } else {
         //If we didn't return, we're setting up another read.
+        if (!walker->reservePtwLevel(this, level)) {
+            if (waitForPtwLevel(level, nextRead, oldRead->getSize(), flags)) {
+                delete oldRead;
+                oldRead = nullptr;
+                read = nullptr;
+                walker->retryPtwLevelBlockedStates();
+                return fault;
+            }
+        }
+        walker->retryPtwLevelBlockedStates();
+        walker->retryPtwMissQueue();
         RequestPtr request = std::make_shared<Request>(
             nextRead, oldRead->getSize(), flags, walker->requestorId);
         if (nextRead == 0)
@@ -1581,6 +1829,70 @@ Walker::WalkerState::endWalk()
     nextState = Ready;
     delete read;
     read = NULL;
+    walker->releasePtwLevel(this);
+}
+
+bool
+Walker::WalkerState::usePtwLevelLimit() const
+{
+    return timing && translateMode == defaultmode && !fromPre && !fromBackPre;
+}
+
+bool
+Walker::WalkerState::waitForPtwLevel(int target_level, Addr next_read,
+                                     unsigned read_size,
+                                     Request::Flags flags)
+{
+    if (!usePtwLevelLimit())
+        return false;
+
+    waitingForPtwLevel = true;
+    blockedPtwLevel = target_level;
+    blockedPtwRead = next_read;
+    blockedPtwReadSize = read_size;
+    blockedPtwFlags = flags;
+    state = Waiting;
+    nextState = Translate;
+    DPRINTF(PageTableWalker,
+            "PTW level%d busy, defer read %#lx for vaddr %#lx\n",
+            target_level, next_read, mainReq->getVaddr());
+    return true;
+}
+
+bool
+Walker::WalkerState::retryBlockedPtwLevel()
+{
+    if (!waitingForPtwLevel)
+        return false;
+
+    if (!walker->ptwLevelAvailable(this, blockedPtwLevel))
+        return false;
+    if (!walker->reservePtwLevel(this, blockedPtwLevel))
+        return false;
+
+    panic_if(inflight != 0,
+             "Blocked PTW state has in-flight packet when retried\n");
+    if (!read) {
+        panic_if(blockedPtwRead == 0,
+                 "Blocked PTW read address should not be zero\n");
+        RequestPtr request = std::make_shared<Request>(
+            blockedPtwRead, blockedPtwReadSize, blockedPtwFlags,
+            walker->requestorId);
+        read = new Packet(request, MemCmd::ReadReq);
+        read->allocate();
+    }
+
+    DPRINTF(PageTableWalker,
+            "Resume blocked PTW level%d read %#lx for vaddr %#lx\n",
+            blockedPtwLevel, read->getAddr(), mainReq->getVaddr());
+
+    waitingForPtwLevel = false;
+    blockedPtwLevel = -1;
+    blockedPtwRead = 0;
+    blockedPtwReadSize = 0;
+    blockedPtwFlags = Request::PHYSICAL;
+    sendPackets();
+    return true;
 }
 Fault
 Walker::WalkerState::endGstageWalk()
@@ -1921,6 +2233,9 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
 
         sendPackets();
     }
+    if (waitingForPtwLevel)
+        return false;
+
     if ((inflight == 0 && read == NULL && writes.size() == 0) && (translateMode == twoStageMode)) {
         state = Ready;
         nextState = Waiting;
@@ -2092,6 +2407,9 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
 void
 Walker::WalkerState::sendPackets()
 {
+    if (waitingForPtwLevel)
+        return;
+
     //If we're already waiting for the port to become available, just return.
     if (retrying)
         return;

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -336,6 +336,16 @@ namespace RiscvISA
             statistics::Scalar ptwMissQueueHintRetries;
             statistics::Scalar ptwMissQueueHintResolved;
             statistics::Scalar ptwMissQueueHintDelayed;
+            statistics::Scalar ptwMissQueueHintDirectChecks;
+            statistics::Scalar ptwMissQueueHintDirectMatches;
+            statistics::Scalar ptwMissQueueHintDirectRetries;
+            statistics::Scalar ptwMissQueueHintDirectResolved;
+            statistics::Scalar ptwMissQueueHintDirectDelayed;
+            statistics::Scalar ptwMissQueueHintAllstageChecks;
+            statistics::Scalar ptwMissQueueHintAllstageMatches;
+            statistics::Scalar ptwMissQueueHintAllstageRetries;
+            statistics::Scalar ptwMissQueueHintAllstageResolved;
+            statistics::Scalar ptwMissQueueHintAllstageDelayed;
         } stats;
 
         struct WalkerSenderState : public Packet::SenderState
@@ -409,6 +419,11 @@ namespace RiscvISA
         void releasePtwLevel(WalkerState *state);
         void retryPtwLevelBlockedStates();
         void recordPtwLevelBlocked(int level);
+        void recordPtwMissQueueHintCheck(uint8_t translateMode);
+        void recordPtwMissQueueHintMatch(uint8_t translateMode);
+        void recordPtwMissQueueHintRetry(uint8_t translateMode);
+        void recordPtwMissQueueHintResolved(uint8_t translateMode);
+        void recordPtwMissQueueHintDelayed(uint8_t translateMode);
         bool ptwMissQueueHintMatch(const MissQueueEntry &entry,
                                    const TlbEntry &refill_entry,
                                    uint8_t translateMode) const;

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -39,6 +39,8 @@
 #ifndef __ARCH_RISCV_TABLE_WALKER_HH__
 #define __ARCH_RISCV_TABLE_WALKER_HH__
 
+#include <array>
+#include <deque>
 #include <vector>
 
 #include "arch/generic/mmu.hh"
@@ -188,6 +190,12 @@ namespace RiscvISA
             bool tlbHit;
             PTESv39 tlbHitPte;
             Request::Flags tlbflags;
+            bool waitingForPtwLevel;
+            int reservedPtwLevel;
+            int blockedPtwLevel;
+            Addr blockedPtwRead;
+            unsigned blockedPtwReadSize;
+            Request::Flags blockedPtwFlags;
 
 
           public:
@@ -204,7 +212,10 @@ namespace RiscvISA
                 finishDefaultTranslate(false), preHitInPtw(false), fromPre(false),
                 fromBackPre(false),virt(0),translateMode(0),inGstage(false),finishGVA(false),
                 gpaddrMode(0),finishGPA(false),GstageFault(false),
-                tlbHit(false),tlbHitPte(0),tlbflags(Request::PHYSICAL)
+                tlbHit(false),tlbHitPte(0),tlbflags(Request::PHYSICAL),
+                waitingForPtwLevel(false), reservedPtwLevel(-1),
+                blockedPtwLevel(-1), blockedPtwRead(0), blockedPtwReadSize(0),
+                blockedPtwFlags(Request::PHYSICAL)
             {
                 requestors.emplace_back(nullptr, _req, _translation);
             }
@@ -250,6 +261,10 @@ namespace RiscvISA
             Fault stepWalk(PacketPtr &write);
             void sendPackets();
             void endWalk();
+            bool usePtwLevelLimit() const;
+            bool waitForPtwLevel(int target_level, Addr next_read,
+                                 unsigned read_size, Request::Flags flags);
+            bool retryBlockedPtwLevel();
             Fault endGstageWalk();
             Fault pageFault(bool present, bool G);
             Fault pageFaultOnRequestor(RequestorState &requestor, bool G);
@@ -272,6 +287,14 @@ namespace RiscvISA
         };
         std::list<L2TlbState> L2TLBrequestors;
 
+        struct MissQueueEntry
+        {
+            ThreadContext *tc;
+            BaseMMU::Translation *translation;
+            RequestPtr req;
+            BaseMMU::Mode mode;
+        };
+
         friend class WalkerState;
         // State for timing and atomic accesses (need multiple per walker in
         // the case of multiple outstanding requests in timing mode)
@@ -291,6 +314,19 @@ namespace RiscvISA
             statistics::Scalar ptwMemCount;
             statistics::Scalar ptwMemCycle;
             statistics::Formula ptwAvgMemLatency;
+            statistics::Scalar ptwLevel0ResourceBlocked;
+            statistics::Scalar ptwLevel1ResourceBlocked;
+            statistics::Scalar ptwLevel2ResourceBlocked;
+            statistics::Scalar ptwLevel3ResourceBlocked;
+            statistics::Scalar ptwMissQueueResourceBlocked;
+            statistics::Scalar ptwMissQueueFifoBlocked;
+            statistics::Scalar ptwMissQueueFullBlocked;
+            statistics::Scalar ptwMissQueueEnqueues;
+            statistics::Scalar ptwMissQueueDequeues;
+            statistics::Scalar ptwMissQueueRequeues;
+            statistics::Scalar ptwMissQueueAdmissionWaits;
+            statistics::Scalar ptwMissQueueAdmissionRetries;
+            statistics::Scalar ptwMissQueueFullEvents;
         } stats;
 
         struct WalkerSenderState : public Packet::SenderState
@@ -344,12 +380,25 @@ namespace RiscvISA
         bool ptwSquash;
         bool openNextLine;
         bool autoOpenNextLine;
+        bool enablePtwLevelLimit;
+        std::array<unsigned, 4> ptwLevelLimit;
+        std::array<unsigned, 4> ptwLevelActive;
+        unsigned ptwMissQueueSize;
+        std::deque<MissQueueEntry> ptwMissQueue;
+        std::deque<MissQueueEntry> ptwMissQueueWaiters;
+        bool retryingPtwMissQueue;
+        bool ptwMissQueueHeadRequeued;
         /** Last tick at which PTW in-flight time accounting was updated. */
         Tick lastPtwMemCycleTick;
         /** Number of PTW memory requests currently in flight. */
         unsigned outstandingPtwMemReqs;
 
         void updatePtwMemCycleStats();
+        bool ptwLevelAvailable(WalkerState *state, int level) const;
+        bool reservePtwLevel(WalkerState *state, int level);
+        void releasePtwLevel(WalkerState *state);
+        void retryPtwLevelBlockedStates();
+        void recordPtwLevelBlocked(int level);
       public:
         bool is_from_pre_req;
 
@@ -376,6 +425,19 @@ namespace RiscvISA
         bool recvTimingResp(PacketPtr pkt);
         void recvReqRetry();
         bool sendTiming(WalkerState * sendingState, PacketPtr pkt);
+        bool usePtwLevelLimitForStart(bool from_forward_pre_req,
+                                      bool from_back_pre_req) const;
+        bool canStartPtwLevel(int level, bool from_forward_pre_req,
+                              bool from_back_pre_req);
+        void recordPtwMissQueueResourceBlocked();
+        void recordPtwMissQueueFifoBlocked();
+        bool enqueuePtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
+                            const RequestPtr &req, BaseMMU::Mode mode, bool front = false);
+        bool hasPendingPtwMiss() const
+        {
+            return !ptwMissQueue.empty() || !ptwMissQueueWaiters.empty();
+        }
+        void retryPtwMissQueue();
         //bool pre_ptw;
 
       public:
@@ -403,6 +465,17 @@ namespace RiscvISA
             ptwSquash(params.ptw_squash),
             openNextLine(params.open_nextline),
             autoOpenNextLine(true),
+            enablePtwLevelLimit(params.enable_ptw_level_limit),
+            ptwLevelLimit({{
+                params.ptw_level0_limit,
+                params.ptw_level1_limit,
+                params.ptw_level2_limit,
+                params.ptw_level3_limit
+            }}),
+            ptwLevelActive({{0, 0, 0, 0}}),
+            ptwMissQueueSize(params.ptw_miss_queue_size),
+            retryingPtwMissQueue(false),
+            ptwMissQueueHeadRequeued(false),
             lastPtwMemCycleTick(0),
             outstandingPtwMemReqs(0),
             doL2TLBHitEvent([this]{dol2TLBHit();},name())

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -331,6 +331,11 @@ namespace RiscvISA
             statistics::Scalar ptwMissQueueAdmissionWaits;
             statistics::Scalar ptwMissQueueAdmissionRetries;
             statistics::Scalar ptwMissQueueFullEvents;
+            statistics::Scalar ptwMissQueueHintChecks;
+            statistics::Scalar ptwMissQueueHintMatches;
+            statistics::Scalar ptwMissQueueHintRetries;
+            statistics::Scalar ptwMissQueueHintResolved;
+            statistics::Scalar ptwMissQueueHintDelayed;
         } stats;
 
         struct WalkerSenderState : public Packet::SenderState
@@ -391,6 +396,7 @@ namespace RiscvISA
         std::deque<MissQueueEntry> ptwMissQueue;
         std::deque<MissQueueEntry> ptwMissQueueWaiters;
         bool retryingPtwMissQueue;
+        bool processingPtwMissQueueHint;
         bool ptwMissQueueHeadRequeued;
         /** Last tick at which PTW in-flight time accounting was updated. */
         Tick lastPtwMemCycleTick;
@@ -403,6 +409,9 @@ namespace RiscvISA
         void releasePtwLevel(WalkerState *state);
         void retryPtwLevelBlockedStates();
         void recordPtwLevelBlocked(int level);
+        bool ptwMissQueueHintMatch(const MissQueueEntry &entry,
+                                   const TlbEntry &refill_entry,
+                                   uint8_t translateMode) const;
       public:
         bool is_from_pre_req;
 
@@ -441,6 +450,7 @@ namespace RiscvISA
         {
             return !ptwMissQueue.empty() || !ptwMissQueueWaiters.empty();
         }
+        void notifyTlbRefillHint(const TlbEntry &entry, uint8_t translateMode);
         void retryPtwMissQueue();
         //bool pre_ptw;
 
@@ -479,6 +489,7 @@ namespace RiscvISA
             ptwLevelActive({{0, 0, 0, 0}}),
             ptwMissQueueSize(params.ptw_miss_queue_size),
             retryingPtwMissQueue(false),
+            processingPtwMissQueueHint(false),
             ptwMissQueueHeadRequeued(false),
             lastPtwMemCycleTick(0),
             outstandingPtwMemReqs(0),

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -318,34 +318,6 @@ namespace RiscvISA
             statistics::Scalar ptwMemCount;
             statistics::Scalar ptwMemCycle;
             statistics::Formula ptwAvgMemLatency;
-            statistics::Scalar ptwLevel0ResourceBlocked;
-            statistics::Scalar ptwLevel1ResourceBlocked;
-            statistics::Scalar ptwLevel2ResourceBlocked;
-            statistics::Scalar ptwLevel3ResourceBlocked;
-            statistics::Scalar ptwMissQueueResourceBlocked;
-            statistics::Scalar ptwMissQueueFifoBlocked;
-            statistics::Scalar ptwMissQueueFullBlocked;
-            statistics::Scalar ptwMissQueueEnqueues;
-            statistics::Scalar ptwMissQueueDequeues;
-            statistics::Scalar ptwMissQueueRequeues;
-            statistics::Scalar ptwMissQueueAdmissionWaits;
-            statistics::Scalar ptwMissQueueAdmissionRetries;
-            statistics::Scalar ptwMissQueueFullEvents;
-            statistics::Scalar ptwMissQueueHintChecks;
-            statistics::Scalar ptwMissQueueHintMatches;
-            statistics::Scalar ptwMissQueueHintRetries;
-            statistics::Scalar ptwMissQueueHintResolved;
-            statistics::Scalar ptwMissQueueHintDelayed;
-            statistics::Scalar ptwMissQueueHintDirectChecks;
-            statistics::Scalar ptwMissQueueHintDirectMatches;
-            statistics::Scalar ptwMissQueueHintDirectRetries;
-            statistics::Scalar ptwMissQueueHintDirectResolved;
-            statistics::Scalar ptwMissQueueHintDirectDelayed;
-            statistics::Scalar ptwMissQueueHintAllstageChecks;
-            statistics::Scalar ptwMissQueueHintAllstageMatches;
-            statistics::Scalar ptwMissQueueHintAllstageRetries;
-            statistics::Scalar ptwMissQueueHintAllstageResolved;
-            statistics::Scalar ptwMissQueueHintAllstageDelayed;
         } stats;
 
         struct WalkerSenderState : public Packet::SenderState
@@ -418,12 +390,6 @@ namespace RiscvISA
         bool reservePtwLevel(WalkerState *state, int level);
         void releasePtwLevel(WalkerState *state);
         void retryPtwLevelBlockedStates();
-        void recordPtwLevelBlocked(int level);
-        void recordPtwMissQueueHintCheck(uint8_t translateMode);
-        void recordPtwMissQueueHintMatch(uint8_t translateMode);
-        void recordPtwMissQueueHintRetry(uint8_t translateMode);
-        void recordPtwMissQueueHintResolved(uint8_t translateMode);
-        void recordPtwMissQueueHintDelayed(uint8_t translateMode);
         bool ptwMissQueueHintMatch(const MissQueueEntry &entry,
                                    const TlbEntry &refill_entry,
                                    uint8_t translateMode) const;
@@ -454,11 +420,11 @@ namespace RiscvISA
         void recvReqRetry();
         bool sendTiming(WalkerState * sendingState, PacketPtr pkt);
         bool usePtwLevelLimitForStart(bool from_forward_pre_req,
-                                      bool from_back_pre_req) const;
+                                      bool from_back_pre_req,
+                                      bool is_prefetch) const;
         bool canStartPtwLevel(int level, bool from_forward_pre_req,
-                              bool from_back_pre_req);
-        void recordPtwMissQueueResourceBlocked();
-        void recordPtwMissQueueFifoBlocked();
+                              bool from_back_pre_req,
+                              bool is_prefetch);
         bool enqueuePtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
                             const RequestPtr &req, BaseMMU::Mode mode, bool front = false);
         bool hasPendingPtwMiss() const

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -262,8 +262,12 @@ namespace RiscvISA
             void sendPackets();
             void endWalk();
             bool usePtwLevelLimit() const;
+            int currentPtwResourceLevel() const;
             bool waitForPtwLevel(int target_level, Addr next_read,
                                  unsigned read_size, Request::Flags flags);
+            bool deferPtwLevelRead(int target_level, Addr next_read,
+                                   unsigned read_size, Request::Flags flags,
+                                   PacketPtr old_read);
             bool retryBlockedPtwLevel();
             Fault endGstageWalk();
             Fault pageFault(bool present, bool G);

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -691,7 +691,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
         TlbEntry *merged_entry = prepareL1CompressedInsert(
             entry, translateMode);
         if (merged_entry) {
-            if (translateMode == direct && walker)
+            if (walker)
                 walker->notifyTlbRefillHint(*merged_entry, translateMode);
             return merged_entry;
         }
@@ -739,6 +739,8 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
             DPRINTF(TLBGPre, "l1 newEntry->vaddr %#x vpn %#x \n", newEntry->vaddr, vpn);
         }
 
+        if (walker)
+            walker->notifyTlbRefillHint(*newEntry, translateMode);
         return newEntry;
     }
 
@@ -762,7 +764,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     // stats all insert number
     stats.ALLInsert++;
     allUsed++;
-    if (translateMode == direct && walker)
+    if (walker)
         walker->notifyTlbRefillHint(*newEntry, translateMode);
     return newEntry;
 }
@@ -1317,26 +1319,53 @@ TLB::refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
 {
     (void)mode;
 
-    if (translateMode != direct || req->get_two_stage_state())
-        return false;
-
-    SATP satp = tc->readMiscReg(MISCREG_SATP);
-    if (satp.mode != AddrXlateMode::SV39 &&
-        satp.mode != AddrXlateMode::SV48)
-        return false;
-    if (entry.asid != satp.asid)
-        return false;
-
-    Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
-    if ((vaddr & ~mask(entry.logBytes)) != entry.vaddr)
-        return false;
+    auto covers = [&entry](Addr addr, Addr base) {
+        return (addr & ~mask(entry.logBytes)) == base;
+    };
 
     if (entry.isCompressed) {
+        if (translateMode != direct || req->get_two_stage_state())
+            return false;
+        SATP satp = tc->readMiscReg(MISCREG_SATP);
+        if (satp.mode != AddrXlateMode::SV39 &&
+            satp.mode != AddrXlateMode::SV48)
+            return false;
+        Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
         const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
-        return entry.validIdx & (1 << sub_idx);
+        return entry.asid == satp.asid && covers(vaddr, entry.vaddr) &&
+               (entry.validIdx & (1 << sub_idx));
     }
 
-    return true;
+    if (translateMode == direct) {
+        if (req->get_two_stage_state())
+            return false;
+
+        SATP satp = tc->readMiscReg(MISCREG_SATP);
+        if (satp.mode != AddrXlateMode::SV39 &&
+            satp.mode != AddrXlateMode::SV48)
+            return false;
+        Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
+        return entry.asid == satp.asid && covers(vaddr, entry.vaddr);
+    }
+
+    if (!req->get_two_stage_state())
+        return false;
+
+    SATP vsatp = tc->readMiscReg(MISCREG_VSATP);
+    HGATP hgatp = tc->readMiscReg(MISCREG_HGATP);
+    Addr vaddr = VADDR_SEXT(hgatp.mode, req->getVaddr());
+
+    switch (translateMode) {
+      case allstage:
+        return vsatp.mode != 0 && entry.asid == vsatp.asid &&
+               entry.vmid == hgatp.vmid && covers(vaddr, entry.vaddr);
+      case vsstage:
+        return false;
+      case gstage:
+        return false;
+      default:
+        return false;
+    }
 }
 
 TlbEntry *

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1809,7 +1809,7 @@ TLB::retryTimingPtwMiss(ThreadContext *tc,
                         bool from_miss_queue)
 {
     bool delayed = false;
-    Fault fault = doTranslate(req, tc, translation, mode, delayed, from_miss_queue);
+    Fault fault = translate(req, tc, translation, mode, delayed, from_miss_queue);
     if (!delayed) {
         translation->finish(fault, req, tc, mode);
     } else if (fault != NoFault) {
@@ -2199,7 +2199,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
 Fault
 TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                  BaseMMU::Translation *translation, BaseMMU::Mode mode,
-                 bool &delayed)
+                 bool &delayed, bool from_miss_queue)
 {
     SATP vsatp = tc->readMiscReg(MISCREG_VSATP);
     HGATP hgatp = tc->readMiscReg(MISCREG_HGATP);
@@ -2280,6 +2280,23 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                         code = ExceptionCode::INST_ACCESS;
                     }
                     return std::make_shared<AddressFault>(req->getVaddr(), 0, code);
+                }
+                if (translation != nullptr && !from_miss_queue &&
+                    walker->hasPendingPtwMiss()) {
+                    walker->recordPtwMissQueueFifoBlocked();
+                    walker->enqueuePtwMiss(tc, translation, req, mode, false);
+                    delayed = true;
+                    return fault;
+                }
+                int walk_level = req->get_h_gstage() ?
+                    req->get_two_stage_level() : req->get_level();
+                if (translation != nullptr &&
+                    !walker->canStartPtwLevel(walk_level, false, false)) {
+                    walker->recordPtwMissQueueResourceBlocked();
+                    walker->enqueuePtwMiss(tc, translation, req, mode,
+                                           from_miss_queue);
+                    delayed = true;
+                    return fault;
                 }
                 DPRINTFR(TLB, "doTwoStageTranslate: walker start\n");
                 fault = walker->start(0, tc, translation, req, mode, false, false, 0, false, 0);
@@ -2674,7 +2691,7 @@ TLB::isaMMUCheck(ThreadContext *tc, Addr vaddr, BaseMMU::Mode mode)
 Fault
 TLB::translate(const RequestPtr &req, ThreadContext *tc,
                BaseMMU::Translation *translation, BaseMMU::Mode mode,
-               bool &delayed)
+               bool &delayed, bool from_miss_queue)
 {
     delayed = false;
 
@@ -2701,7 +2718,8 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
             if ((hgatp.mode == NEMU_SATP_SV39 || vsatp.mode == NEMU_SATP_SV39
                 || hgatp.mode == NEMU_SATP_SV48 || vsatp.mode == NEMU_SATP_SV48)
                 && (pmode < PrivilegeMode::PRV_M)) {
-                fault = doTwoStageTranslate(req, tc, translation, mode, delayed);
+                fault = doTwoStageTranslate(req, tc, translation, mode, delayed,
+                                             from_miss_queue);
             } else {
                 req->setPaddr(req->getVaddr());
                 fault = NoFault;
@@ -2712,11 +2730,13 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
             if (two_stage_translation) {
                 assert((vsatp.mode == NEMU_SATP_SV39) || (hgatp.mode == NEMU_SATP_SV39)
                        || (vsatp.mode == NEMU_SATP_SV48) || (hgatp.mode == NEMU_SATP_SV48));
-                fault = doTwoStageTranslate(req, tc, translation, mode, delayed);
+                fault = doTwoStageTranslate(req, tc, translation, mode, delayed,
+                                             from_miss_queue);
             } else {
                 req->setTwoStageState(false, 0, 0);
                 controlNum++;
-                fault = doTranslate(req, tc, translation, mode, delayed);
+                fault = doTranslate(req, tc, translation, mode, delayed,
+                                    from_miss_queue);
             }
         }
 

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -690,8 +690,11 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
         translateMode == direct) {
         TlbEntry *merged_entry = prepareL1CompressedInsert(
             entry, translateMode);
-        if (merged_entry)
+        if (merged_entry) {
+            if (translateMode == direct && walker)
+                walker->notifyTlbRefillHint(*merged_entry, translateMode);
             return merged_entry;
+        }
     }
 
     // If somebody beat us to it, just use that existing entry.
@@ -759,6 +762,8 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     // stats all insert number
     stats.ALLInsert++;
     allUsed++;
+    if (translateMode == direct && walker)
+        walker->notifyTlbRefillHint(*newEntry, translateMode);
     return newEntry;
 }
 
@@ -1305,6 +1310,35 @@ TLB::getEntryPaddr(const TlbEntry *entry, Addr vaddr) const
     return (ppn << PageShift) | (vaddr & mask(PageShift));
 }
 
+bool
+TLB::refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
+                          BaseMMU::Mode mode, const TlbEntry &entry,
+                          uint8_t translateMode) const
+{
+    (void)mode;
+
+    if (translateMode != direct || req->get_two_stage_state())
+        return false;
+
+    SATP satp = tc->readMiscReg(MISCREG_SATP);
+    if (satp.mode != AddrXlateMode::SV39 &&
+        satp.mode != AddrXlateMode::SV48)
+        return false;
+    if (entry.asid != satp.asid)
+        return false;
+
+    Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
+    if ((vaddr & ~mask(entry.logBytes)) != entry.vaddr)
+        return false;
+
+    if (entry.isCompressed) {
+        const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+        return entry.validIdx & (1 << sub_idx);
+    }
+
+    return true;
+}
+
 TlbEntry *
 TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
                                 uint8_t translateMode,
@@ -1802,7 +1836,7 @@ TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req,
     return std::make_pair(false, fault);
 }
 
-void
+bool
 TLB::retryTimingPtwMiss(ThreadContext *tc,
                         BaseMMU::Translation *translation,
                         const RequestPtr &req, BaseMMU::Mode mode,
@@ -1812,9 +1846,12 @@ TLB::retryTimingPtwMiss(ThreadContext *tc,
     Fault fault = translate(req, tc, translation, mode, delayed, from_miss_queue);
     if (!delayed) {
         translation->finish(fault, req, tc, mode);
+        return true;
     } else if (fault != NoFault) {
         translation->finish(fault, req, tc, mode);
+        return true;
     }
+    return false;
 }
 
 std::pair<int,Fault>

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1832,6 +1832,7 @@ TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req,
     Addr paddr;
     TlbEntry *e_l2tlbVsstage = nullptr;
     TlbEntry *e_l2tlbGstage = nullptr;
+    const bool is_prefetch = req->isPrefetch();
 
     if (hitInSp) {  //hit sp,obtain PA direatly
         if (fault == NoFault) {
@@ -1841,16 +1842,14 @@ TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req,
             return std::make_pair(true, fault);
         }
     } else {    //hit l2l1/l2/l3,trigger PTW
-        if (translation != nullptr && !from_miss_queue &&
+        if (translation != nullptr && !from_miss_queue && !is_prefetch &&
             walker->hasPendingPtwMiss()) {
-            walker->recordPtwMissQueueFifoBlocked();
             walker->enqueuePtwMiss(tc, translation, req, mode, false);
             delayed = true;
             return std::make_pair(true, fault);
         }
         if (translation != nullptr &&
-            !walker->canStartPtwLevel(level, false, false)) {
-            walker->recordPtwMissQueueResourceBlocked();
+            !walker->canStartPtwLevel(level, false, false, is_prefetch)) {
             walker->enqueuePtwMiss(tc, translation, req, mode, from_miss_queue);
             delayed = true;
             return std::make_pair(true, fault);
@@ -2278,7 +2277,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
     PrivilegeMode pmode = getMemPriv(tc, mode);
     bool continuePtw = false;
     int l1tlbtype = H_L1miss;
-
+    const bool is_prefetch = req->isPrefetch();
 
     TLB *l2tlb;
     if (isStage2) {
@@ -2348,8 +2347,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                     return std::make_shared<AddressFault>(req->getVaddr(), 0, code);
                 }
                 if (translation != nullptr && !from_miss_queue &&
-                    walker->hasPendingPtwMiss()) {
-                    walker->recordPtwMissQueueFifoBlocked();
+                    !is_prefetch && walker->hasPendingPtwMiss()) {
                     walker->enqueuePtwMiss(tc, translation, req, mode, false);
                     delayed = true;
                     return fault;
@@ -2357,8 +2355,8 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                 int walk_level = req->get_h_gstage() ?
                     req->get_two_stage_level() : req->get_level();
                 if (translation != nullptr &&
-                    !walker->canStartPtwLevel(walk_level, false, false)) {
-                    walker->recordPtwMissQueueResourceBlocked();
+                    !walker->canStartPtwLevel(walk_level, false, false,
+                                              is_prefetch)) {
                     walker->enqueuePtwMiss(tc, translation, req, mode,
                                            from_miss_queue);
                     delayed = true;
@@ -2608,16 +2606,15 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (traceFlag)
                 DPRINTF(TLBtrace, "tlb miss vaddr %#x pc %#x\n", vaddr_trace, req->getPC());
             int walk_level = satp.mode == AddrXlateMode::SV48 ? 3 : 2;
-            if (translation != nullptr && !from_miss_queue &&
+            if (translation != nullptr && !from_miss_queue && !is_prefetch &&
                 walker->hasPendingPtwMiss()) {
-                walker->recordPtwMissQueueFifoBlocked();
                 walker->enqueuePtwMiss(tc, translation, req, mode, false);
                 delayed = true;
                 return fault;
             }
             if (translation != nullptr &&
-                !walker->canStartPtwLevel(walk_level, false, false)) {
-                walker->recordPtwMissQueueResourceBlocked();
+                !walker->canStartPtwLevel(walk_level, false, false,
+                                          is_prefetch)) {
                 walker->enqueuePtwMiss(tc, translation, req, mode, from_miss_queue);
                 delayed = true;
                 return fault;

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1761,8 +1761,10 @@ TLB::sendPreHitOnHitRequest(TlbEntry *e_pre_1, TlbEntry *e_pre_2, const RequestP
     }
 }
 std::pair<bool, Fault>
-TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req, ThreadContext *tc,
-                      BaseMMU::Translation *translation, BaseMMU::Mode mode, Addr vaddr, bool &delayed, int level)
+TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req,
+                      ThreadContext *tc, BaseMMU::Translation *translation,
+                      BaseMMU::Mode mode, Addr vaddr, bool &delayed, int level,
+                      bool from_miss_queue)
 {
     Addr paddr;
     TlbEntry *e_l2tlbVsstage = nullptr;
@@ -1776,13 +1778,43 @@ TLB::L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req, Thr
             return std::make_pair(true, fault);
         }
     } else {    //hit l2l1/l2/l3,trigger PTW
-        fault = walker->start(e_l2tlb->pte.ppn, tc, translation, req, mode, false, false, level, true, e_l2tlb->asid);
+        if (translation != nullptr && !from_miss_queue &&
+            walker->hasPendingPtwMiss()) {
+            walker->recordPtwMissQueueFifoBlocked();
+            walker->enqueuePtwMiss(tc, translation, req, mode, false);
+            delayed = true;
+            return std::make_pair(true, fault);
+        }
+        if (translation != nullptr &&
+            !walker->canStartPtwLevel(level, false, false)) {
+            walker->recordPtwMissQueueResourceBlocked();
+            walker->enqueuePtwMiss(tc, translation, req, mode, from_miss_queue);
+            delayed = true;
+            return std::make_pair(true, fault);
+        }
+        fault = walker->start(e_l2tlb->pte.ppn, tc, translation, req, mode,
+                              false, false, level, true, e_l2tlb->asid);
         if (translation != nullptr || fault != NoFault) {
             delayed = true;
             return std::make_pair(true, fault);
         }
     }
     return std::make_pair(false, fault);
+}
+
+void
+TLB::retryTimingPtwMiss(ThreadContext *tc,
+                        BaseMMU::Translation *translation,
+                        const RequestPtr &req, BaseMMU::Mode mode,
+                        bool from_miss_queue)
+{
+    bool delayed = false;
+    Fault fault = doTranslate(req, tc, translation, mode, delayed, from_miss_queue);
+    if (!delayed) {
+        translation->finish(fault, req, tc, mode);
+    } else if (fault != NoFault) {
+        translation->finish(fault, req, tc, mode);
+    }
 }
 
 std::pair<int,Fault>
@@ -2274,7 +2306,7 @@ TLB::doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
 Fault
 TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
                  BaseMMU::Translation *translation, BaseMMU::Mode mode,
-                 bool &delayed)
+                 bool &delayed, bool from_miss_queue)
 {
     delayed = false;
     SATP satp = tc->readMiscReg(MISCREG_SATP);
@@ -2429,7 +2461,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2sp1];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2sp1], req, tc, translation, mode, vaddr, delayed, L2L1CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2sp1], req, tc, translation, mode, vaddr, delayed,
+                                  L2L1CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else if (e[L_L2sp2] && e[L_L2sp2]->pte.v) {
@@ -2438,7 +2471,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2sp2];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2sp2], req, tc, translation, mode, vaddr, delayed, L2L2CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2sp2], req, tc, translation, mode, vaddr, delayed,
+                                  L2L2CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2sp3] && e[L_L2sp3]->pte.v) {
@@ -2447,7 +2481,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2sp3];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2sp3], req, tc, translation, mode, vaddr, delayed, L2L3CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2sp3], req, tc, translation, mode, vaddr, delayed,
+                                  L2L3CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else if (e[L_L2L1] && e[L_L2L1]->pte.v) {
@@ -2457,7 +2492,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2L1];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2L1], req, tc, translation, mode, vaddr, delayed, L2L1CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2L1], req, tc, translation, mode, vaddr, delayed,
+                                  L2L1CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else if (e[L_L2L2] && e[L_L2L2]->pte.v) {
@@ -2467,7 +2503,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2L2];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2L2], req, tc, translation, mode, vaddr, delayed, L2L2CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2L2], req, tc, translation, mode, vaddr, delayed,
+                                  L2L2CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else if (satp.mode == AddrXlateMode::SV48 && e[L_L2L3] && e[L_L2L3]->pte.v) {
@@ -2476,7 +2513,8 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (hitInSp)
                 e[0] = e[L_L2L3];
             auto [return_flag, fault_return] =
-                L2TLBSendRequest(fault, e[L_L2L3], req, tc, translation, mode, vaddr, delayed, L2L3CheckLevel - 1);
+                L2TLBSendRequest(fault, e[L_L2L3], req, tc, translation, mode, vaddr, delayed,
+                                  L2L3CheckLevel - 1, from_miss_queue);
             if (return_flag)
                 return fault_return;
         } else {
@@ -2487,6 +2525,20 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             if (traceFlag)
                 DPRINTF(TLBtrace, "tlb miss vaddr %#x pc %#x\n", vaddr_trace, req->getPC());
             int walk_level = satp.mode == AddrXlateMode::SV48 ? 3 : 2;
+            if (translation != nullptr && !from_miss_queue &&
+                walker->hasPendingPtwMiss()) {
+                walker->recordPtwMissQueueFifoBlocked();
+                walker->enqueuePtwMiss(tc, translation, req, mode, false);
+                delayed = true;
+                return fault;
+            }
+            if (translation != nullptr &&
+                !walker->canStartPtwLevel(walk_level, false, false)) {
+                walker->recordPtwMissQueueResourceBlocked();
+                walker->enqueuePtwMiss(tc, translation, req, mode, from_miss_queue);
+                delayed = true;
+                return fault;
+            }
             fault = walker->start(0, tc, translation, req, mode, false, false, walk_level, false, 0);
             DPRINTF(TLB, "finish start\n");
             if (translation != nullptr || fault != NoFault) {

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -243,6 +243,9 @@ class TLB : public BaseTLB
     Port *getTableWalkerPort() override;
 
     Addr getEntryPaddr(const TlbEntry *entry, Addr vaddr) const;
+    bool refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
+                              BaseMMU::Mode mode, const TlbEntry &entry,
+                              uint8_t translateMode) const;
     TlbEntry *lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
                                          uint8_t translateMode,
                                          const TlbEntry *missed_entry);
@@ -274,7 +277,7 @@ class TLB : public BaseTLB
                                             ThreadContext *tc, BaseMMU::Translation *translation,
                                             BaseMMU::Mode mode, Addr vaddr, bool &delayed, int level,
                                             bool from_miss_queue = false);
-    void retryTimingPtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
+    bool retryTimingPtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
                             const RequestPtr &req, BaseMMU::Mode mode,
                             bool from_miss_queue = true);
 

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -270,9 +270,13 @@ class TLB : public BaseTLB
     void sendPreHitOnHitRequest(TlbEntry *e_pre_1, TlbEntry *e_pre_2, const RequestPtr &req, Addr pre_block,
                                 uint16_t asid, bool forward, int check_level, STATUS status, PrivilegeMode pmode,
                                 BaseMMU::Mode mode, ThreadContext *tc, BaseMMU::Translation *translation);
-    std::pair<bool, Fault> L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req, ThreadContext *tc,
-                                            BaseMMU::Translation *translation, BaseMMU::Mode mode, Addr vaddr,
-                                            bool &delayed, int level);
+    std::pair<bool, Fault> L2TLBSendRequest(Fault fault, TlbEntry *e_l2tlb, const RequestPtr &req,
+                                            ThreadContext *tc, BaseMMU::Translation *translation,
+                                            BaseMMU::Mode mode, Addr vaddr, bool &delayed, int level,
+                                            bool from_miss_queue = false);
+    void retryTimingPtwMiss(ThreadContext *tc, BaseMMU::Translation *translation,
+                            const RequestPtr &req, BaseMMU::Mode mode,
+                            bool from_miss_queue = true);
 
     Fault translateAtomic(const RequestPtr &req,
                           ThreadContext *tc, BaseMMU::Mode mode) override;
@@ -373,7 +377,7 @@ class TLB : public BaseTLB
                                       BaseMMU::Mode mode, int l1tlbtype);
     Fault doTranslate(const RequestPtr &req, ThreadContext *tc,
                       BaseMMU::Translation *translation, BaseMMU::Mode mode,
-                      bool &delayed);
+                      bool &delayed, bool from_miss_queue = false);
 
 };
 

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -367,10 +367,10 @@ class TLB : public BaseTLB
 
     Fault translate(const RequestPtr &req, ThreadContext *tc,
                     BaseMMU::Translation *translation, BaseMMU::Mode mode,
-                    bool &delayed);
+                    bool &delayed, bool from_miss_queue = false);
     Fault doTwoStageTranslate(const RequestPtr &req, ThreadContext *tc,
                       BaseMMU::Translation *translation, BaseMMU::Mode mode,
-                      bool &delayed);
+                      bool &delayed, bool from_miss_queue = false);
     std::pair<int, Fault> checkHL1Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation *translation,
                                       BaseMMU::Mode mode);
     std::pair<int, Fault> checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation *translation,


### PR DESCRIPTION
This PR adds a parameterized PTW level parallelism limit model for RISC-V one-stage direct translation.

Changes:
- Add PTW level parallelism parameters to RiscvPagetableWalker.
- Default limits are level0=6, level1=1, level2=1, level3=1.
- Add a 40-entry PTW MissQueue with FIFO ordering and full-queue wait handling.
- Enable the limit by default to match hardware resource constraints.
- Add --disable-ptw-level-limit for A/B validation.
- Apply the limit only to timing, one-stage direct, non-prefetch PTW requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line/config controls for one-stage PTW level limiting (levels 0–3), including an option to disable enforcement, plus PTW miss-queue sizing.
  * Extended the RISC-V page table walker to enforce per-level PTW resources and manage a bounded miss queue with retrying.
* **Bug Fixes**
  * Improved timing translation behavior when PTW resources are constrained by deferring and retrying PTW misses.
  * Avoided updating fallback/miss statistics for hidden compressed lookups and refined refill-hint eligibility.
* **Config Updates**
  * Updated example configurations to apply the PTW level-limit and miss-queue settings to both instruction and data paths; enabled L1 direct compression in the “ideal” example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->