### PR TITLE
cpu-o3: use another way to add 2 cycle flush penalty

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -30,11 +30,11 @@ def setKmhV3IdealParams(args, system):
         #cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
         cpu.fetchWidth = 32
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
-        cpu.commitToFetchDelay = 2
+        cpu.commitToFetchDelay = 4  # maybe we need to change iewToFetchDelay to 4, but now we use commit update bpu
         cpu.fetchQueueSize = 64
 
         # decode
-        cpu.fetchToDecodeDelay = 5
+        cpu.fetchToDecodeDelay = 3
         cpu.decodeWidth = 8
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False


### PR DESCRIPTION
since fetchToDecodeDelay will impact SMT seriously, we need to align RTL, now after exec BpWrong, squash arbitration need more cycles

Change-Id: I8bfe090d71e06a51b485e412e33c503e39d3f669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the example ideal timing configuration with revised pipeline delay values for more accurate simulation defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->