### PR TITLE
mem: add vtage value predictor

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -82,10 +82,11 @@ def setKmhV3IdealParams(args, system):
         cpu.valuePred = CompositeValuePredictor(
                             predictors=[
                                 IdealConstantLVP(),
-                                # ExampleValuePredictor(),
+                                # VTAGE()
+                                # ExampleValuePredictor()
                                 # EStride(logMaxConfidence=13, thresholdPercent=0.35)
                             ],
-                            arb=CVPConfidenceArb(counterBits=6)
+                            arb=CVPFixedPriorityArb()
                         )
 
         # lsq

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -68,6 +68,7 @@
 #include "cpu/timebuf.hh"
 #include "cpu/valuepred/es_metadata.hh"
 #include "cpu/valuepred/example_value_predictor_metadata.hh"
+#include "cpu/valuepred/vtage_metadata.hh"
 #include "debug/Activity.hh"
 #include "debug/Commit.hh"
 #include "debug/CommitRate.hh"
@@ -1958,6 +1959,13 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 head_inst->effAddrValid(),
                 head_inst->effAddr,
                 head_inst->physEffAddr);
+        updateInfo.emplaceExt<valuepred::LoadTrainInfoExt>(
+                head_inst->vpObservedCacheHit,
+                head_inst->vpObservedLoadLatencyCycles,
+                head_inst->vpTrainInfoValid,
+                static_cast<uint8_t>(head_inst->numSrcRegs()),
+                head_inst->opClass(),
+                head_inst->vpCriticalLoad);
 
         // additional auxiliary info for the value predictor
         valuepred::VPFeedback feedback;
@@ -1968,6 +1976,9 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         feedback.predictedValue = head_inst->vpRecord ?
             head_inst->vpRecord->predictedValue : 0;
         feedback.wouldHaveBeenCorrect = feedback.applied &&
+            !head_inst->vpMisprediction;
+        feedback.overallPredictionMade = head_inst->vpApplied;
+        feedback.overallPredictionCorrect = head_inst->vpApplied &&
             !head_inst->vpMisprediction;
 
         valuePred->update(updateInfo, head_inst->vpRecord.get(), feedback);

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -1744,6 +1744,16 @@ class DynInst : public ExecContext, public RefCounted
     /** get golden */
     uint8_t *getGolden() { return goldenData; }
 
+    void
+    recordVPObservedLoadResult(uint32_t latency_cycles, bool cache_hit,
+            bool critical_load = false)
+    {
+        vpObservedLoadLatencyCycles = latency_cycles;
+        vpObservedCacheHit = cache_hit;
+        vpCriticalLoad = critical_load;
+        vpTrainInfoValid = true;
+    }
+
     /** value prediction */
     valuepred::VPResult vpResult = {false, 0xdeadbeefULL};
     std::unique_ptr<valuepred::VPPredictionRecord> vpRecord = nullptr;
@@ -1752,6 +1762,10 @@ class DynInst : public ExecContext, public RefCounted
     RegVal actualValue = 0xdeadbeefULL;
     bool vpMisprediction = false;
     bool vpSupported = false;
+    uint32_t vpObservedLoadLatencyCycles = 0;
+    bool vpObservedCacheHit = false;
+    bool vpTrainInfoValid = false;
+    bool vpCriticalLoad = false;
 
     bool canLVP(){
         return isLoad() && !isVector() && !isLoadReserved();

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -63,6 +63,7 @@
 #include "cpu/o3/trace/TraceFetch.hh"
 #include "cpu/pred/btb/decoupled_bpred.hh"
 #include "cpu/valuepred/example_value_predictor_metadata.hh"
+#include "cpu/valuepred/vtage_metadata.hh"
 #include "debug/Activity.hh"
 #include "debug/Drain.hh"
 #include "debug/Fetch.hh"
@@ -2105,6 +2106,10 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
         // request with extra fetch-time inputs without changing core fields.
         predictRequest.emplaceExt<valuepred::ExamplePredictRequestExt>(
                 curTick(), instruction->opClass());
+        if (dbpbtb && dbpbtb->ftqHasFetching(tid)) {
+            predictRequest.emplaceExt<valuepred::VPHistoryRequestExt>(
+                    &dbpbtb->ftqFetchingTarget(tid));
+        }
         instruction->vpResult =
             valuePred->valuePredict(predictRequest, instruction->vpRecord);
     }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -3201,7 +3201,14 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
     bool isNormalLd = this->isNormalLd();
     bool enableLdMissReplay = lsq->enableLdMissReplay();
     // All responses received in 1 cycle are cache hit.
-    bool cacheHit = LSQRequest::_inst->getCpuPtr()->ticksToCycles(curTick() - pkt->sendTick) <= 1;
+    const auto observedLatencyCycles =
+        static_cast<uint32_t>(LSQRequest::_inst->getCpuPtr()->ticksToCycles(
+                curTick() - pkt->sendTick));
+    bool cacheHit = observedLatencyCycles <= 1;
+    if (isLoad() && instruction()->canLVP()) {
+        instruction()->recordVPObservedLoadResult(
+                observedLatencyCycles, cacheHit);
+    }
     // Dump inst num, request addr, and packet addr
     if (debug::LSQ) {
         char buffer[8];
@@ -3265,6 +3272,14 @@ LSQ::SplitDataRequest::recvTimingResp(PacketPtr pkt)
     assert(pktIdx < _packets.size());
     numReceivedPackets++;
     if (numReceivedPackets == _packets.size()) {
+        const auto observedLatencyCycles =
+            static_cast<uint32_t>(LSQRequest::_inst->getCpuPtr()->ticksToCycles(
+                    curTick() - pkt->sendTick));
+        const bool cacheHit = observedLatencyCycles <= 1;
+        if (isLoad() && instruction()->canLVP()) {
+            instruction()->recordVPObservedLoadResult(
+                    observedLatencyCycles, cacheHit);
+        }
         flags.set(Flag::Complete);
         assemblePackets();
         _hasStaleTranslation = false;

--- a/src/cpu/valuepred/SConscript
+++ b/src/cpu/valuepred/SConscript
@@ -9,6 +9,7 @@ SimObject('ValuePredictor.py',
             'CVPRRArb',
             'CVPConfidenceArb',
             'EStride',
+            'VTAGE',
             'ExampleValuePredictor',
             'CompositeValuePredictor',
             'MemoryRenaming',
@@ -20,13 +21,15 @@ Source('valuepred_unit.cc')
 Source('composite_value_predictor_arb.cc')
 Source('composite_value_predictor.cc')
 Source('enhanced_stride.cc')
+Source('vtage.cc')
 Source('example_value_predictor.cc')
 Source('memory_renaming.cc')
 Source('ideal_constant_lvp.cc')
 
 DebugFlag('VPCOMMON')
 DebugFlag('EStride')
+DebugFlag('VTAGE')
 DebugFlag('MemoryRenaming')
 
 
-CompoundFlag('VP', ['VPCOMMON', 'EStride', 'MemoryRenaming'])
+CompoundFlag('VP', ['VPCOMMON', 'EStride', 'VTAGE', 'MemoryRenaming'])

--- a/src/cpu/valuepred/ValuePredictor.py
+++ b/src/cpu/valuepred/ValuePredictor.py
@@ -5,7 +5,7 @@ from m5.SimObject import *
 
 class ValuePredType(ScopedEnum):
     # vals will contains value predictor type
-    vals = ["EStride", "MemoryRenaming", "IdealConstantLVP",
+    vals = ["EStride", "VTAGE", "MemoryRenaming", "IdealConstantLVP",
             "ExampleValuePredictor", "CompositeValuePredictor"]
 
 class ValuePredictor(SimObject):
@@ -45,6 +45,74 @@ class ExampleValuePredictor(ValuePredictor):
     cxx_class = "gem5::valuepred::ExampleValuePredictor"
     cxx_header = "cpu/valuepred/example_value_predictor.hh"
     abstract = False
+
+class VTAGE(ValuePredictor):
+    type = "VTAGE"
+    cxx_class = "gem5::valuepred::VTAGE"
+    cxx_header = "cpu/valuepred/vtage.hh"
+    abstract = False
+
+    numHistories = Param.Unsigned(8,
+        "Number of VTAGE history banks excluding the base bank")
+    numBanks = Param.Unsigned(9,
+        "Total VTAGE banks including the base bank")
+    histLengths = VectorParam.Unsigned(
+        [0, 0, 3, 7, 15, 31, 63, 90, 127],
+        "History length per VTAGE bank, including the base bank")
+    requireHistoryExt = Param.Bool(
+        False,
+        "Fatal if the predict request does not provide FetchTarget history")
+    logBankSize = Param.Unsigned(9, "Log2 entries per VTAGE bank")
+    tagBits = Param.Unsigned(11, "VTAGE tag width")
+    confBits = Param.Unsigned(11, "VTAGE confidence-counter width")
+    usefulBits = Param.Unsigned(2, "VTAGE usefulness-counter width")
+    logValueArrayEntries = Param.Unsigned(9,
+        "Log2 entries per VTAGE value-array way")
+
+    predictConfThreshold = Param.Unsigned(1024,
+        "Minimum confidence needed to issue a VTAGE prediction")
+    hashOnlyUpgradeThreshold = Param.Unsigned(1023,
+        "Minimum confidence before trying to upgrade hash-only entries")
+    mispredBackoffDistance = Param.Unsigned(128,
+        "Number of dynamic instructions to suppress VTAGE after a selected misprediction")
+    agingTickMax = Param.Unsigned(1024,
+        "Threshold for triggering global usefulness aging")
+    agingPenaltyOnAlloc = Param.Unsigned(1,
+        "Aging-tick increment after a successful VTAGE allocation")
+    agingPenaltyOnNoAlloc = Param.Unsigned(5,
+        "Aging-tick increment after a non-allocating VTAGE update")
+
+    l1HitMaxCycles = Param.Unsigned(4,
+        "Observed latency upper bound for L1-like loads")
+    l2HitMaxCycles = Param.Unsigned(20,
+        "Observed latency upper bound for L2-like loads")
+    llcHitMaxCycles = Param.Unsigned(50,
+        "Observed latency upper bound for LLC-like loads")
+    fastInstCycles = Param.Unsigned(1,
+        "Observed latency upper bound for fast loads")
+    mfastInstCycles = Param.Unsigned(14,
+        "Observed latency upper bound for medium-fast loads")
+
+    enableStochasticTraining = Param.Bool(
+        True,
+        "Use probabilistic VTAGE training helpers instead of deterministic always-on updates")
+    rngSeed = Param.Unsigned(1, "VTAGE RNG seed")
+    allocProbLoadL1Hit = Param.Float(
+        0.25, "Allocation probability for fast/L1-like loads")
+    allocProbLoadMiss = Param.Float(
+        1.0, "Allocation probability for slower loads")
+    confIncProbLowValue = Param.Float(
+        1.0, "Confidence increment probability when the actual value is small or sign-extended")
+    confIncProbFastLoad = Param.Float(
+        1.0, "Confidence increment probability for fast loads")
+    uIncProbFastLoad = Param.Float(
+        0.5, "Usefulness increment probability for medium-fast loads")
+    valueArrayUpgradeProb = Param.Float(
+        0.25, "Probability of promoting a hash-only entry into the value array")
+    shortHistoryAllocBias = Param.Float(
+        0.125, "Bias toward allocating from shorter-history banks")
+    deepAllocExtraHopProb = Param.Float(
+        0.125, "Probability of skipping one extra bank toward deeper history on allocation")
 
 class CVPArb(SimObject):
     type = "CVPArb"

--- a/src/cpu/valuepred/composite_value_predictor.cc
+++ b/src/cpu/valuepred/composite_value_predictor.cc
@@ -123,6 +123,9 @@ CompositeValuePredictor::update(const VPUpdateInfo &updateInfo,
         childFeedback.wouldHaveBeenCorrect =
             childFeedback.offeredPrediction &&
             childFeedback.predictedValue == updateInfo.actualValue;
+        childFeedback.overallPredictionMade = feedback.overallPredictionMade;
+        childFeedback.overallPredictionCorrect =
+            feedback.overallPredictionCorrect;
         if (childFeedback.offeredPrediction) {
             offeredChildren++;
             compositeStats.childOffered[i]++;
@@ -159,7 +162,7 @@ CompositeValuePredictor::update(const VPUpdateInfo &updateInfo,
         }
     }
 
-    if (offeredChildren) {
+    if (offeredChildren > 1) {
         compositeStats.multiCandidatePredictions++;
     }
 

--- a/src/cpu/valuepred/valuepred_metadata.hh
+++ b/src/cpu/valuepred/valuepred_metadata.hh
@@ -212,6 +212,8 @@ class VPFeedback
     bool offeredPrediction = false;
     RegVal predictedValue = 0;
     bool wouldHaveBeenCorrect = false;
+    bool overallPredictionMade = false;
+    bool overallPredictionCorrect = false;
 };
 
 class VPChooserFeedback

--- a/src/cpu/valuepred/vtage.cc
+++ b/src/cpu/valuepred/vtage.cc
@@ -1,0 +1,643 @@
+/*
+ * VTAGE is largely based on the open-source implementation of the
+ * 1st-place Championship Value Prediction (CVP-1) submission.
+ *
+ * The version in this codebase is adapted and modified for our environment.
+ * It is not intended to be a bit-exact copy of the original code.
+ *
+ * For detailed background and reference material:
+ * Paper: https://microarch.org/cvp1/papers/Seznec.pdf
+ * Open-source implementation: https://www.microarch.org/cvp1/code/Seznec.tar.gz
+ * Official website: https://www.microarch.org/cvp1/
+ */
+
+#include "cpu/valuepred/vtage.hh"
+
+#include <algorithm>
+#include <limits>
+
+#include "base/logging.hh"
+#include "cpu/pred/btb/common.hh"
+#include "cpu/valuepred/vtage_metadata.hh"
+#include "debug/VTAGE.hh"
+
+namespace gem5
+{
+
+namespace valuepred
+{
+
+using branch_prediction::btb_pred::FetchTarget;
+
+VTAGE::VTAGE(const Params &params)
+    : VPUnit(params),
+      numHistories(params.numHistories),
+      numBanks(params.numBanks),
+      histLengths(params.histLengths.begin(), params.histLengths.end()),
+      requireHistoryExt(params.requireHistoryExt),
+      logBankSize(params.logBankSize),
+      bankSize(1u << params.logBankSize),
+      tagBits(params.tagBits),
+      confBits(params.confBits),
+      usefulBits(params.usefulBits),
+      logValueArrayEntries(params.logValueArrayEntries),
+      valueEntriesPerWay(1u << params.logValueArrayEntries),
+      totalValueEntries(ValueWays * (1u << params.logValueArrayEntries)),
+      predictConfThreshold(params.predictConfThreshold),
+      hashOnlyUpgradeThreshold(params.hashOnlyUpgradeThreshold),
+      mispredBackoffDistance(params.mispredBackoffDistance),
+      agingTickMax(params.agingTickMax),
+      agingPenaltyOnAlloc(params.agingPenaltyOnAlloc),
+      agingPenaltyOnNoAlloc(params.agingPenaltyOnNoAlloc),
+      l1HitMaxCycles(params.l1HitMaxCycles),
+      l2HitMaxCycles(params.l2HitMaxCycles),
+      llcHitMaxCycles(params.llcHitMaxCycles),
+      fastInstCycles(params.fastInstCycles),
+      mfastInstCycles(params.mfastInstCycles),
+      enableStochasticTraining(params.enableStochasticTraining),
+      rngSeed(params.rngSeed),
+      allocProbLoadL1Hit(params.allocProbLoadL1Hit),
+      allocProbLoadMiss(params.allocProbLoadMiss),
+      confIncProbLowValue(params.confIncProbLowValue),
+      confIncProbFastLoad(params.confIncProbFastLoad),
+      uIncProbFastLoad(params.uIncProbFastLoad),
+      valueArrayUpgradeProb(params.valueArrayUpgradeProb),
+      shortHistoryAllocBias(params.shortHistoryAllocBias),
+      deepAllocExtraHopProb(params.deepAllocExtraHopProb),
+      rng(),
+      tables(numThreads),
+      valueArrays(numThreads),
+      agingTicks(numThreads, 0),
+      lastSelectedMispredictSeq(numThreads, 0),
+      hasSelectedMispredictSeq(numThreads, false),
+      vtageStats(this)
+{
+    gem5_assert(numBanks > 0, "VTAGE needs at least one bank");
+    gem5_assert(numBanks == numHistories + 1,
+            "VTAGE expects numBanks == numHistories + 1");
+    gem5_assert(histLengths.size() == numBanks,
+            "VTAGE histLengths must cover every bank, including the base bank");
+    gem5_assert(tagBits > 0, "VTAGE tagBits must be non-zero");
+    gem5_assert(confBits > 0, "VTAGE confBits must be non-zero");
+    gem5_assert(usefulBits > 0, "VTAGE usefulBits must be non-zero");
+    gem5_assert(logBankSize > 0, "VTAGE logBankSize must be non-zero");
+    gem5_assert(logValueArrayEntries > 0,
+            "VTAGE logValueArrayEntries must be non-zero");
+    gem5_assert(predictConfThreshold <= maxConf(),
+            "VTAGE predictConfThreshold exceeds the confidence range");
+    gem5_assert(hashOnlyUpgradeThreshold <= maxConf(),
+            "VTAGE hashOnlyUpgradeThreshold exceeds the confidence range");
+    gem5_assert(fastInstCycles <= mfastInstCycles,
+            "VTAGE fastInstCycles must not exceed mfastInstCycles");
+    gem5_assert(l1HitMaxCycles <= l2HitMaxCycles,
+            "VTAGE l1HitMaxCycles must not exceed l2HitMaxCycles");
+    gem5_assert(l2HitMaxCycles <= llcHitMaxCycles,
+            "VTAGE l2HitMaxCycles must not exceed llcHitMaxCycles");
+
+    rng.init(rngSeed);
+
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        tables[tid].resize(numBanks);
+        for (auto &bank : tables[tid]) {
+            bank.resize(bankSize);
+        }
+        valueArrays[tid].resize(totalValueEntries);
+    }
+
+    vtageStats.predictHitBank.init(numBanks).flags(statistics::nozero);
+    for (unsigned bank = 0; bank < numBanks; ++bank) {
+        vtageStats.predictHitBank.subname(bank,
+                "bank" + std::to_string(bank) + "_hist" +
+                std::to_string(histLengths[bank]));
+    }
+}
+
+uint32_t
+VTAGE::bitMask(unsigned bits) const
+{
+    if (bits >= 32) {
+        return std::numeric_limits<uint32_t>::max();
+    }
+    return (1u << bits) - 1;
+}
+
+uint32_t
+VTAGE::maxConf() const
+{
+    return bitMask(confBits);
+}
+
+uint32_t
+VTAGE::maxUseful() const
+{
+    return bitMask(usefulBits);
+}
+
+uint64_t
+VTAGE::mix64(uint64_t value) const
+{
+    value ^= value >> 30;
+    value *= 0xbf58476d1ce4e5b9ULL;
+    value ^= value >> 27;
+    value *= 0x94d049bb133111ebULL;
+    value ^= value >> 31;
+    return value;
+}
+
+bool
+VTAGE::chance(double probability)
+{
+    if (!enableStochasticTraining) {
+        return true;
+    }
+
+    if (probability <= 0.0) {
+        return false;
+    }
+    if (probability >= 1.0) {
+        return true;
+    }
+    return rng.random<double>() < probability;
+}
+
+bool
+VTAGE::isFastLoad(const TrainInfo &train_info) const
+{
+    return train_info.latencyValid &&
+        train_info.observedLatencyCycles <= fastInstCycles;
+}
+
+bool
+VTAGE::isMFastLoad(const TrainInfo &train_info) const
+{
+    return train_info.latencyValid &&
+        train_info.observedLatencyCycles <= mfastInstCycles;
+}
+
+bool
+VTAGE::isLowValue(RegVal value) const
+{
+    const auto upper = static_cast<uint64_t>(value) >> 32;
+    return upper == 0 || upper == std::numeric_limits<uint32_t>::max();
+}
+
+uint32_t
+VTAGE::foldHistory(const boost::dynamic_bitset<> &history, unsigned length,
+        unsigned out_bits, uint64_t salt) const
+{
+    const auto limit = std::min<size_t>(length, history.size());
+    uint64_t accum = mix64(salt ^ limit);
+
+    for (size_t bit = 0; bit < limit; ++bit) {
+        if (!history.test(bit)) {
+            continue;
+        }
+        accum ^= mix64((static_cast<uint64_t>(bit) + 1) *
+                0x9e3779b97f4a7c15ULL ^ salt);
+        accum = (accum << 7) | (accum >> (64 - 7));
+    }
+
+    return static_cast<uint32_t>(accum) & bitMask(out_bits);
+}
+
+void
+VTAGE::fillIndicesAndTags(const FetchTarget &fetch_target, Addr pc,
+        std::vector<uint32_t> &indices, std::vector<uint32_t> &tags) const
+{
+    indices.resize(numBanks);
+    tags.resize(numBanks);
+
+    for (unsigned bank = 0; bank < numBanks; ++bank) {
+        const unsigned hist_len = histLengths[bank];
+        const auto history_fold = foldHistory(fetch_target.history, hist_len,
+                logBankSize, 0x1000ULL + bank * 0x51ULL);
+        const auto path_fold = foldHistory(fetch_target.phistory,
+                std::min<unsigned>(hist_len,
+                    static_cast<unsigned>(fetch_target.phistory.size())),
+                logBankSize, 0x2000ULL + bank * 0x63ULL);
+        const auto tag_history_fold = foldHistory(fetch_target.history,
+                hist_len, tagBits, 0x3000ULL + bank * 0x77ULL);
+        const auto tag_path_fold = foldHistory(fetch_target.phistory,
+                std::min<unsigned>(hist_len,
+                    static_cast<unsigned>(fetch_target.phistory.size())),
+                tagBits, 0x4000ULL + bank * 0x8bULL);
+
+        const uint64_t index_mix = mix64(pc ^ history_fold ^
+                (static_cast<uint64_t>(path_fold) << 11) ^
+                (static_cast<uint64_t>(fetch_target.asidHash) << 3) ^
+                (bank * 0x9e3779b9ULL));
+        const uint64_t tag_mix = mix64((pc >> 2) ^
+                (static_cast<uint64_t>(tag_history_fold) << 7) ^
+                (static_cast<uint64_t>(tag_path_fold) << 17) ^
+                (static_cast<uint64_t>(fetch_target.asidHash) << 1) ^
+                (bank * 0xc2b2ae35ULL));
+
+        indices[bank] = static_cast<uint32_t>(index_mix) & bitMask(logBankSize);
+        tags[bank] = static_cast<uint32_t>(tag_mix) & bitMask(tagBits);
+    }
+}
+
+uint32_t
+VTAGE::hashActualValue(RegVal value) const
+{
+    return static_cast<uint32_t>(mix64(static_cast<uint64_t>(value))) &
+        bitMask(logValueArrayEntries);
+}
+
+uint32_t
+VTAGE::makeHashToken(RegVal value) const
+{
+    return totalValueEntries + hashActualValue(value);
+}
+
+bool
+VTAGE::entryMatchesActualValue(ThreadID tid, const VTAGEEntry &entry,
+        RegVal actual_value) const
+{
+    if (!entry.valid) {
+        return false;
+    }
+
+    if (entry.hashOrValue < totalValueEntries) {
+        const auto &value_entry = valueArrays[tid][entry.hashOrValue];
+        return value_entry.valid && value_entry.data == actual_value;
+    }
+
+    return entry.hashOrValue == makeHashToken(actual_value);
+}
+
+std::array<uint32_t, VTAGE::ValueWays>
+VTAGE::valueArrayIndices(RegVal actual_value) const
+{
+    std::array<uint32_t, ValueWays> indices = {};
+    for (unsigned way = 0; way < ValueWays; ++way) {
+        const uint64_t mixed = mix64(static_cast<uint64_t>(actual_value) ^
+                (0x9e3779b97f4a7c15ULL * (way + 1)) ^
+                (static_cast<uint64_t>(actual_value) >> (7 * (way + 1))));
+        indices[way] = (static_cast<uint32_t>(mixed) &
+                bitMask(logValueArrayEntries)) +
+            way * valueEntriesPerWay;
+    }
+    return indices;
+}
+
+VTAGE::TrainInfo
+VTAGE::decodeTrainInfo(const VPUpdateInfo &update_info) const
+{
+    TrainInfo train_info;
+    if (const auto *ext = update_info.getExt<LoadTrainInfoExt>()) {
+        train_info.cacheHit = ext->cacheHit;
+        train_info.observedLatencyCycles = ext->observedLatencyCycles;
+        train_info.latencyValid = ext->latencyValid;
+        train_info.numSrcRegs = ext->numSrcRegs;
+        train_info.opClass = ext->opClass;
+        train_info.criticalLoad = ext->criticalLoad;
+    }
+    return train_info;
+}
+
+bool
+VTAGE::shouldIncreaseConfidence(const TrainInfo &train_info, RegVal actual_value)
+{
+    double probability = 1.0;
+    if (enableStochasticTraining) {
+        probability = 0.5;
+        if (isLowValue(actual_value)) {
+            probability = std::max(probability, confIncProbLowValue);
+        }
+        if (isFastLoad(train_info)) {
+            probability = std::max(probability, confIncProbFastLoad);
+        }
+        if (train_info.criticalLoad) {
+            probability = 1.0;
+        }
+    }
+    return chance(probability);
+}
+
+bool
+VTAGE::shouldIncreaseUseful(const TrainInfo &train_info)
+{
+    double probability = 1.0;
+    if (enableStochasticTraining) {
+        probability = isMFastLoad(train_info) ? uIncProbFastLoad : 0.5;
+        if (train_info.criticalLoad) {
+            probability = 1.0;
+        }
+    }
+    return chance(probability);
+}
+
+bool
+VTAGE::shouldAllocateEntry(const TrainInfo &train_info)
+{
+    const bool l1_like = train_info.cacheHit ||
+        (train_info.latencyValid &&
+         train_info.observedLatencyCycles <= l1HitMaxCycles);
+    return chance(l1_like ? allocProbLoadL1Hit : allocProbLoadMiss);
+}
+
+bool
+VTAGE::shouldUpgradeValueArray(const TrainInfo &train_info)
+{
+    double probability = valueArrayUpgradeProb;
+    if (train_info.criticalLoad) {
+        probability = 1.0;
+    }
+    return chance(probability);
+}
+
+unsigned
+VTAGE::chooseAllocationStartBank(int hit_bank)
+{
+    unsigned start_bank = 1;
+    if (hit_bank >= 0) {
+        start_bank = std::min<unsigned>(static_cast<unsigned>(hit_bank + 1),
+                numBanks - 1);
+        if (hit_bank == 0 && start_bank + 1 < numBanks) {
+            ++start_bank;
+        }
+    }
+
+    if (enableStochasticTraining && start_bank > 1 &&
+            chance(shortHistoryAllocBias)) {
+        start_bank = 1;
+    }
+    if (enableStochasticTraining && start_bank + 1 < numBanks &&
+            chance(deepAllocExtraHopProb)) {
+        ++start_bank;
+    }
+
+    return std::min(start_bank, numBanks - 1);
+}
+
+bool
+VTAGE::tryUpgradeToPointer(ThreadID tid, VTAGEEntry &entry, RegVal actual_value,
+        const TrainInfo &train_info)
+{
+    if (!shouldUpgradeValueArray(train_info)) {
+        return false;
+    }
+
+    const auto value_indices = valueArrayIndices(actual_value);
+    auto &thread_values = valueArrays[tid];
+    for (const auto index : value_indices) {
+        auto &value_entry = thread_values[index];
+        if (value_entry.valid && value_entry.data == actual_value) {
+            entry.hashOrValue = index;
+            value_entry.useful = std::min(maxUseful(), value_entry.useful + 1);
+            vtageStats.valueArrayHit++;
+            vtageStats.upgradeToPointer++;
+            return true;
+        }
+    }
+
+    unsigned begin = rng.random<unsigned>(0, ValueWays - 1);
+    for (unsigned offset = 0; offset < ValueWays; ++offset) {
+        const auto index = value_indices[(begin + offset) % ValueWays];
+        auto &value_entry = thread_values[index];
+        if (!value_entry.valid || value_entry.useful == 0) {
+            value_entry.data = actual_value;
+            value_entry.useful = 1;
+            value_entry.valid = true;
+            entry.hashOrValue = index;
+            vtageStats.valueArraySteal++;
+            vtageStats.upgradeToPointer++;
+            return true;
+        }
+    }
+
+    if (enableStochasticTraining) {
+        auto &value_entry = thread_values[value_indices[begin]];
+        if (value_entry.useful > 0) {
+            --value_entry.useful;
+        }
+    }
+    return false;
+}
+
+void
+VTAGE::ageEntries(ThreadID tid)
+{
+    for (auto &bank : tables[tid]) {
+        for (auto &entry : bank) {
+            if (entry.useful > 0) {
+                --entry.useful;
+            }
+        }
+    }
+    for (auto &value_entry : valueArrays[tid]) {
+        if (value_entry.useful > 0) {
+            --value_entry.useful;
+        }
+    }
+    vtageStats.agingPasses++;
+}
+
+void
+VTAGE::advanceAging(ThreadID tid, unsigned delta)
+{
+    if (agingTickMax == 0) {
+        return;
+    }
+
+    agingTicks[tid] += delta;
+    while (agingTicks[tid] >= agingTickMax) {
+        agingTicks[tid] -= agingTickMax;
+        ageEntries(tid);
+    }
+}
+
+bool
+VTAGE::backoffActive(ThreadID tid, uint64_t seq_no) const
+{
+    if (!hasSelectedMispredictSeq[tid]) {
+        return false;
+    }
+    return seq_no - lastSelectedMispredictSeq[tid] < mispredBackoffDistance;
+}
+
+VPPredictionCandidate
+VTAGE::predict(const VPPredictRequest &request)
+{
+    assertValidTid(request.tid);
+
+    VPPredictionCandidate candidate;
+    auto record = std::make_unique<VTAGEPredictionRecord>();
+    record->indices.resize(numBanks);
+    record->tags.resize(numBanks);
+
+    const auto *history_ext = request.getExt<VPHistoryRequestExt>();
+    if (!history_ext || !history_ext->fetchTarget) {
+        vtageStats.missingHistoryReq++;
+        if (requireHistoryExt) {
+            fatal("VTAGE requires VPHistoryRequestExt when requireHistoryExt is true");
+        }
+        candidate.record = std::move(record);
+        return candidate;
+    }
+
+    record->historyAvailable = true;
+    fillIndicesAndTags(*history_ext->fetchTarget, request.pc, record->indices,
+            record->tags);
+
+    auto &thread_tables = tables[request.tid];
+    for (int bank = static_cast<int>(numBanks) - 1; bank >= 0; --bank) {
+        const auto &entry = thread_tables[bank][record->indices[bank]];
+        if (entry.valid && entry.tag == record->tags[bank]) {
+            record->hitBank = bank;
+            break;
+        }
+    }
+
+    if (record->hitBank >= 0) {
+        const auto &entry = thread_tables[record->hitBank]
+            [record->indices[record->hitBank]];
+        vtageStats.predictHitBank[record->hitBank]++;
+        if (entry.hashOrValue < totalValueEntries) {
+            record->pointerHit = true;
+            vtageStats.predictPointerHit++;
+        } else {
+            record->hashOnlyHit = true;
+            vtageStats.predictHashOnlyHit++;
+        }
+
+        record->backoffBlocked = backoffActive(request.tid, request.seqNo);
+        if (record->pointerHit &&
+                valueArrays[request.tid][entry.hashOrValue].valid &&
+                entry.conf >= predictConfThreshold &&
+                !record->backoffBlocked) {
+            candidate.result.speculative = true;
+            candidate.result.value =
+                valueArrays[request.tid][entry.hashOrValue].data;
+            candidate.score = static_cast<uint64_t>(entry.conf) * numBanks +
+                static_cast<uint64_t>(record->hitBank);
+            record->offeredPrediction = true;
+            record->predictedValue = candidate.result.value;
+        } else if (record->pointerHit && entry.conf >= predictConfThreshold &&
+                record->backoffBlocked) {
+            vtageStats.predictBackoffBlocked++;
+        }
+    }
+
+    candidate.record = std::move(record);
+    return candidate;
+}
+
+void
+VTAGE::update(const VPUpdateInfo &update_info, const VPPredictionRecord *record,
+        const VPFeedback &feedback)
+{
+    assertValidTid(update_info.tid);
+
+    const auto *vtage_record =
+        dynamic_cast<const VTAGEPredictionRecord *>(record);
+    gem5_assert(vtage_record,
+            "VTAGE expects VTAGEPredictionRecord on update");
+    if (!vtage_record->historyAvailable) {
+        return;
+    }
+
+    const auto train_info = decodeTrainInfo(update_info);
+    const auto actual_hash = makeHashToken(update_info.actualValue);
+    bool allocated = false;
+    bool should_allocate = !feedback.overallPredictionCorrect;
+
+    if (vtage_record->hitBank >= 0) {
+        const auto bank = static_cast<unsigned>(vtage_record->hitBank);
+        auto &entry = tables[update_info.tid][bank][vtage_record->indices[bank]];
+        if (entry.valid && entry.tag == vtage_record->tags[bank]) {
+            const bool satisfied = entryMatchesActualValue(update_info.tid,
+                    entry, update_info.actualValue);
+            if (satisfied) {
+                vtageStats.commitSatisfiedHit++;
+                should_allocate = false;
+
+                if (entry.conf < maxConf() &&
+                        shouldIncreaseConfidence(train_info,
+                            update_info.actualValue)) {
+                    ++entry.conf;
+                }
+                if (entry.useful < maxUseful() &&
+                        shouldIncreaseUseful(train_info)) {
+                    ++entry.useful;
+                }
+                if (entry.hashOrValue < totalValueEntries) {
+                    auto &value_entry =
+                        valueArrays[update_info.tid][entry.hashOrValue];
+                    if (value_entry.valid && entry.conf >= predictConfThreshold &&
+                            value_entry.useful < maxUseful()) {
+                        ++value_entry.useful;
+                    }
+                } else if (entry.conf >= hashOnlyUpgradeThreshold) {
+                    tryUpgradeToPointer(update_info.tid, entry,
+                            update_info.actualValue, train_info);
+                }
+            } else {
+                vtageStats.commitMismatchedHit++;
+                if (feedback.applied && !feedback.overallPredictionCorrect) {
+                    lastSelectedMispredictSeq[update_info.tid] =
+                        update_info.seqNo;
+                    hasSelectedMispredictSeq[update_info.tid] = true;
+                }
+
+                entry.hashOrValue = actual_hash;
+                if (entry.conf > maxConf() / 2) {
+                    entry.conf = std::max<uint32_t>(1, entry.conf / 2);
+                } else {
+                    entry.conf = 0;
+                }
+                if (entry.useful > 0) {
+                    --entry.useful;
+                }
+            }
+        } else {
+            vtageStats.commitMismatchedHit++;
+        }
+    }
+
+    if (should_allocate && numBanks > 1 && shouldAllocateEntry(train_info)) {
+        const auto start_bank = chooseAllocationStartBank(vtage_record->hitBank);
+        for (unsigned bank = start_bank; bank < numBanks; ++bank) {
+            auto &entry =
+                tables[update_info.tid][bank][vtage_record->indices[bank]];
+            if (!entry.valid || entry.useful == 0 || entry.conf <= 1) {
+                entry.valid = true;
+                entry.hashOrValue = actual_hash;
+                entry.conf = std::max<uint32_t>(1, maxConf() / 2);
+                entry.tag = vtage_record->tags[bank];
+                entry.useful = 0;
+                allocated = true;
+                vtageStats.allocHashOnly++;
+                if (vtage_record->hitBank < 0 ||
+                        bank > static_cast<unsigned>(vtage_record->hitBank)) {
+                    vtageStats.allocLongHistory++;
+                }
+                break;
+            }
+            if (entry.useful > 0) {
+                --entry.useful;
+            }
+        }
+    }
+
+    advanceAging(update_info.tid,
+            allocated ? agingPenaltyOnAlloc : agingPenaltyOnNoAlloc);
+}
+
+void
+VTAGE::specUpdate(const VPSpecUpdateInfo &spec_update_info)
+{
+    (void)spec_update_info;
+}
+
+void
+VTAGE::squash(ThreadID tid, const uint64_t seq_no)
+{
+    (void)tid;
+    (void)seq_no;
+}
+
+} // namespace valuepred
+
+} // namespace gem5

--- a/src/cpu/valuepred/vtage.hh
+++ b/src/cpu/valuepred/vtage.hh
@@ -1,0 +1,240 @@
+/*
+ * VTAGE is largely based on the open-source implementation of the
+ * 1st-place Championship Value Prediction (CVP-1) submission.
+ *
+ * The version in this codebase is adapted and modified for our environment.
+ * It is not intended to be a bit-exact copy of the original code.
+ *
+ * For detailed background and reference material:
+ * Paper: https://microarch.org/cvp1/papers/Seznec.pdf
+ * Open-source implementation: https://www.microarch.org/cvp1/code/Seznec.tar.gz
+ * Official website: https://www.microarch.org/cvp1/
+ */
+
+#ifndef __CPU_VALUEPRED_VTAGE_HH__
+#define __CPU_VALUEPRED_VTAGE_HH__
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "base/random.hh"
+#include "base/types.hh"
+#include "cpu/op_class.hh"
+#include "cpu/valuepred/valuepred_unit.hh"
+#include "params/VTAGE.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+struct FetchTarget;
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+namespace valuepred
+{
+
+class LoadTrainInfoExt;
+
+class VTAGE : public VPUnit
+{
+  private:
+    using Params = VTAGEParams;
+    static constexpr unsigned ValueWays = 3;
+
+    struct VTAGEEntry
+    {
+        uint32_t hashOrValue = 0;
+        uint32_t conf = 0;
+        uint32_t tag = 0;
+        uint32_t useful = 0;
+        bool valid = false;
+    };
+
+    struct ValueEntry
+    {
+        RegVal data = 0;
+        uint32_t useful = 0;
+        bool valid = false;
+    };
+
+    struct TrainInfo
+    {
+        bool cacheHit = false;
+        uint32_t observedLatencyCycles = 0;
+        bool latencyValid = false;
+        uint8_t numSrcRegs = 0;
+        OpClass opClass = No_OpClass;
+        bool criticalLoad = false;
+    };
+
+    class VTAGEPredictionRecord : public VPPredictionRecord
+    {
+      public:
+        std::vector<uint32_t> indices;
+        std::vector<uint32_t> tags;
+        int hitBank = -1;
+        bool historyAvailable = false;
+        bool pointerHit = false;
+        bool hashOnlyHit = false;
+        bool backoffBlocked = false;
+    };
+
+    const unsigned numHistories;
+    const unsigned numBanks;
+    const std::vector<unsigned> histLengths;
+    const bool requireHistoryExt;
+    const unsigned logBankSize;
+    const unsigned bankSize;
+    const unsigned tagBits;
+    const unsigned confBits;
+    const unsigned usefulBits;
+    const unsigned logValueArrayEntries;
+    const unsigned valueEntriesPerWay;
+    const unsigned totalValueEntries;
+    const unsigned predictConfThreshold;
+    const unsigned hashOnlyUpgradeThreshold;
+    const uint64_t mispredBackoffDistance;
+    const unsigned agingTickMax;
+    const unsigned agingPenaltyOnAlloc;
+    const unsigned agingPenaltyOnNoAlloc;
+    const uint32_t l1HitMaxCycles;
+    const uint32_t l2HitMaxCycles;
+    const uint32_t llcHitMaxCycles;
+    const uint32_t fastInstCycles;
+    const uint32_t mfastInstCycles;
+    const bool enableStochasticTraining;
+    const uint32_t rngSeed;
+    const double allocProbLoadL1Hit;
+    const double allocProbLoadMiss;
+    const double confIncProbLowValue;
+    const double confIncProbFastLoad;
+    const double uIncProbFastLoad;
+    const double valueArrayUpgradeProb;
+    const double shortHistoryAllocBias;
+    const double deepAllocExtraHopProb;
+
+    Random rng;
+
+    std::vector<std::vector<std::vector<VTAGEEntry>>> tables;
+    std::vector<std::vector<ValueEntry>> valueArrays;
+    std::vector<unsigned> agingTicks;
+    std::vector<uint64_t> lastSelectedMispredictSeq;
+    std::vector<bool> hasSelectedMispredictSeq;
+
+    struct VTAGEStats : public statistics::Group
+    {
+        statistics::Vector predictHitBank;
+        statistics::Scalar predictPointerHit;
+        statistics::Scalar predictHashOnlyHit;
+        statistics::Scalar predictBackoffBlocked;
+        statistics::Scalar commitSatisfiedHit;
+        statistics::Scalar commitMismatchedHit;
+        statistics::Scalar allocHashOnly;
+        statistics::Scalar allocLongHistory;
+        statistics::Scalar upgradeToPointer;
+        statistics::Scalar valueArrayHit;
+        statistics::Scalar valueArraySteal;
+        statistics::Scalar agingPasses;
+        statistics::Scalar missingHistoryReq;
+
+        explicit VTAGEStats(statistics::Group *parent)
+            : statistics::Group(parent),
+              ADD_STAT(predictHitBank, statistics::units::Count::get(),
+                       "Per-bank tagged hits seen at predict time"),
+              ADD_STAT(predictPointerHit, statistics::units::Count::get(),
+                       "Predict-time hits on pointer-backed entries"),
+              ADD_STAT(predictHashOnlyHit, statistics::units::Count::get(),
+                       "Predict-time hits on hash-only entries"),
+              ADD_STAT(predictBackoffBlocked, statistics::units::Count::get(),
+                       "Predictions suppressed by the VTAGE backoff window"),
+              ADD_STAT(commitSatisfiedHit, statistics::units::Count::get(),
+                       "Commit-time hits whose value/hash matched the actual load result"),
+              ADD_STAT(commitMismatchedHit, statistics::units::Count::get(),
+                       "Commit-time hits whose value/hash mismatched the actual load result"),
+              ADD_STAT(allocHashOnly, statistics::units::Count::get(),
+                       "New hash-only VTAGE allocations"),
+              ADD_STAT(allocLongHistory, statistics::units::Count::get(),
+                       "Allocations placed in a bank longer than the previous hit bank"),
+              ADD_STAT(upgradeToPointer, statistics::units::Count::get(),
+                       "Hash-only entries upgraded to point at the value array"),
+              ADD_STAT(valueArrayHit, statistics::units::Count::get(),
+                       "Value-array lookups that found an existing matching value"),
+              ADD_STAT(valueArraySteal, statistics::units::Count::get(),
+                       "Value-array insertions that claimed a replacement slot"),
+              ADD_STAT(agingPasses, statistics::units::Count::get(),
+                       "Global usefulness-aging passes"),
+              ADD_STAT(missingHistoryReq, statistics::units::Count::get(),
+                       "Predict requests that did not provide FetchTarget history")
+        {
+        }
+    } vtageStats;
+
+  private:
+    uint32_t bitMask(unsigned bits) const;
+    uint32_t maxConf() const;
+    uint32_t maxUseful() const;
+    uint64_t mix64(uint64_t value) const;
+    bool chance(double probability);
+    bool isFastLoad(const TrainInfo &train_info) const;
+    bool isMFastLoad(const TrainInfo &train_info) const;
+    bool isLowValue(RegVal value) const;
+    uint32_t foldHistory(const boost::dynamic_bitset<> &history,
+            unsigned length, unsigned out_bits, uint64_t salt) const;
+    void fillIndicesAndTags(const branch_prediction::btb_pred::FetchTarget &fetch_target,
+            Addr pc, std::vector<uint32_t> &indices,
+            std::vector<uint32_t> &tags) const;
+    uint32_t hashActualValue(RegVal value) const;
+    uint32_t makeHashToken(RegVal value) const;
+    bool entryMatchesActualValue(ThreadID tid, const VTAGEEntry &entry,
+            RegVal actual_value) const;
+    std::array<uint32_t, ValueWays> valueArrayIndices(RegVal actual_value) const;
+    TrainInfo decodeTrainInfo(const VPUpdateInfo &update_info) const;
+    bool shouldIncreaseConfidence(const TrainInfo &train_info,
+            RegVal actual_value);
+    bool shouldIncreaseUseful(const TrainInfo &train_info);
+    bool shouldAllocateEntry(const TrainInfo &train_info);
+    bool shouldUpgradeValueArray(const TrainInfo &train_info);
+    unsigned chooseAllocationStartBank(int hit_bank);
+    bool tryUpgradeToPointer(ThreadID tid, VTAGEEntry &entry,
+            RegVal actual_value, const TrainInfo &train_info);
+    void ageEntries(ThreadID tid);
+    void advanceAging(ThreadID tid, unsigned delta);
+    bool backoffActive(ThreadID tid, uint64_t seq_no) const;
+
+  public:
+    explicit VTAGE(const Params &params);
+
+    std::string name() const override { return "VTAGE"; }
+
+    VPPredictionCandidate predict(const VPPredictRequest &request) override;
+
+    void update(const VPUpdateInfo &update_info,
+            const VPPredictionRecord *record,
+            const VPFeedback &feedback) override;
+
+    void specUpdate(const VPSpecUpdateInfo &spec_update_info) override;
+
+    void squash(ThreadID tid, const uint64_t seq_no) override;
+
+    ValuePredType getValuePredictorType() override
+    {
+        return ValuePredType::VTAGE;
+    }
+};
+
+} // namespace valuepred
+
+} // namespace gem5
+
+#endif // __CPU_VALUEPRED_VTAGE_HH__

--- a/src/cpu/valuepred/vtage_metadata.hh
+++ b/src/cpu/valuepred/vtage_metadata.hh
@@ -1,0 +1,80 @@
+/*
+ * VTAGE is largely based on the open-source implementation of the
+ * 1st-place Championship Value Prediction (CVP-1) submission.
+ *
+ * The version in this codebase is adapted and modified for our environment.
+ * It is not intended to be a bit-exact copy of the original code.
+ *
+ * For detailed background and reference material:
+ * Paper: https://microarch.org/cvp1/papers/Seznec.pdf
+ * Open-source implementation: https://www.microarch.org/cvp1/code/Seznec.tar.gz
+ * Official website: https://www.microarch.org/cvp1/
+ */
+
+#ifndef __CPU_VALUEPRED_VTAGE_METADATA_HH__
+#define __CPU_VALUEPRED_VTAGE_METADATA_HH__
+
+#include <cstdint>
+
+#include "base/types.hh"
+#include "cpu/op_class.hh"
+#include "cpu/valuepred/valuepred_metadata.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+struct FetchTarget;
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+namespace valuepred
+{
+
+class VPHistoryRequestExt : public VPPredictRequestExtension
+{
+  public:
+    explicit VPHistoryRequestExt(
+            const branch_prediction::btb_pred::FetchTarget *fetch_target)
+        : fetchTarget(fetch_target)
+    {
+    }
+
+    const branch_prediction::btb_pred::FetchTarget *fetchTarget = nullptr;
+};
+
+class LoadTrainInfoExt : public VPUpdateInfoExtension
+{
+  public:
+    LoadTrainInfoExt(bool cache_hit, uint32_t observed_latency_cycles,
+            bool latency_valid, uint8_t num_src_regs, OpClass op_class,
+            bool critical_load)
+        : cacheHit(cache_hit),
+          observedLatencyCycles(observed_latency_cycles),
+          latencyValid(latency_valid),
+          numSrcRegs(num_src_regs),
+          opClass(op_class),
+          criticalLoad(critical_load)
+    {
+    }
+
+    bool cacheHit = false;
+    uint32_t observedLatencyCycles = 0;
+    bool latencyValid = false;
+    uint8_t numSrcRegs = 0;
+    OpClass opClass = No_OpClass;
+    bool criticalLoad = false;
+};
+
+} // namespace valuepred
+
+} // namespace gem5
+
+#endif // __CPU_VALUEPRED_VTAGE_METADATA_HH__


### PR DESCRIPTION
The idea of ​​using VTAGE (or E-VTAGE) for value prediction was first proposed in the 1st-place Championship Value Prediction (CVP-1) submission.

VTAGE implementation in this PR is adapted from the CVP1 Open-source implementation and modified for our environment. It is not intended to be a bit-exact copy of the original code.

The parameters in the current implementation have not been finely tuned; this task is left to interested parties for further optimization. 

The VTAGE algorithm was ported to provide a state-of-the-art baseline for research into value prediction — specifically, the [EVES predictor](https://www.microarch.org/cvp1/cvp1online/contestants.html) (comprising EStride and EVTAGE) proposed in the CVP1.

For detailed background and reference material:
+ Paper: https://microarch.org/cvp1/papers/Seznec.pdf
+ Open-source implementation: https://www.microarch.org/cvp1/code/Seznec.tar.gz
+ Official website: https://www.microarch.org/cvp1/

**Note: Since the VTAGE algorithm in this PR has not been thoroughly optimized for SPEC06, using the default parameters will cause a significant performance drop in SPEC06. Therefore, it is not enabled in the current configuration.**

Change-Id: If6bbd218061b2836690390ca1e3f06788df30100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VTAGE value predictor support with configurable parameters.
  * Extended value-prediction requests and load-training metadata with optional BTB fetch-target context and richer observed load fields.
* **Bug Fixes**
  * Improved load value-prediction training by recording observed latency, cache-hit status, and criticality/validity.
  * Ensured composite value-prediction feedback propagates overall correctness/made signals consistently and refined multi-candidate stats.
* **Chores**
  * Updated example value-prediction configuration to use an Ideal-constant ensemble with fixed-priority arbitration.
  * Added safer PGO fallback to non-PGO rebuild when profiling or profile merging fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->