### PR TITLE
util: Cap perf workload logs

### DIFF
--- a/util/xs_scripts/distributed_sim.py
+++ b/util/xs_scripts/distributed_sim.py
@@ -32,7 +32,22 @@ DEFAULT_MARKER_TIMEOUT_SEC = 30.0
 DEFAULT_LAUNCH_RETRIES = 2
 DEFAULT_LAUNCH_RETRY_DELAY_SEC = 20.0
 DEFAULT_LAUNCH_INTERVAL_SEC = 0.2
+DEFAULT_LOG_LIMIT_BYTES = 64 * 1024 * 1024
 ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def parse_positive_int(value: str) -> int:
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return number
+
+
+def default_log_limit_bytes() -> int:
+    value = os.environ.get("GEM5_PERF_LOG_LIMIT_BYTES")
+    if not value:
+        return DEFAULT_LOG_LIMIT_BYTES
+    return parse_positive_int(value)
 
 
 @dataclass(frozen=True)
@@ -235,6 +250,15 @@ def parse_launcher_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]
         "--extra-gem5-args",
         default="",
         help="Extra GEM5 arguments. Overrides the legacy sixth positional argument when set.",
+    )
+    parser.add_argument(
+        "--log-limit-bytes",
+        type=parse_positive_int,
+        default=default_log_limit_bytes(),
+        help=(
+            "Keep only this many trailing bytes in each workload log.txt. "
+            "Defaults to $GEM5_PERF_LOG_LIMIT_BYTES or 64 MiB."
+        ),
     )
 
     args, rest = parser.parse_known_args(argv)
@@ -494,15 +518,18 @@ def make_job_script(
     checkpoint: Path,
     command: list[str],
     env: dict[str, str],
+    log_limit_bytes: int,
 ) -> str:
     command_text = " ".join(shlex.quote(part) for part in command)
     workload_message = shlex.quote(f"distributed_sim workload: {workload.name}")
     checkpoint_message = shlex.quote(f"checkpoint: {checkpoint}")
     command_message = shlex.quote(f"command: {command_text}")
+    log_path = work_dir / "log.txt"
     return f"""set -u
 mkdir -p {shlex.quote(str(work_dir))}
+log_limit_bytes={log_limit_bytes}
+run_job() {{
 cd {shlex.quote(str(work_dir))}
-exec >{shlex.quote("log.txt")} 2>&1
 printf '%s\\n' {workload_message}
 printf '%s\\n' {checkpoint_message}
 echo "host: $(hostname)"
@@ -522,6 +549,9 @@ fi
 echo "finish: $(date -Is)"
 echo "exit_status: $status"
 exit "$status"
+}}
+run_job 2>&1 | tail -c "$log_limit_bytes" > {shlex.quote(str(log_path))}
+exit "${{PIPESTATUS[0]}}"
 """
 
 
@@ -1034,6 +1064,7 @@ def run_scheduler(
     launch_retry_delay: float,
     launch_interval: float,
     force: bool,
+    log_limit_bytes: int,
 ) -> int:
     pending_workloads = [ScheduledWorkload(workload) for workload in workloads]
     total = len(pending_workloads)
@@ -1104,6 +1135,7 @@ def run_scheduler(
                     checkpoint=checkpoint,
                     command=command,
                     env=env,
+                    log_limit_bytes=log_limit_bytes,
                 )
                 launch_job(
                     server=server,
@@ -1239,6 +1271,7 @@ def main(argv: list[str]) -> int:
         print(f"Benchmark filters: {benchmark_filters}")
     if extra_gem5_args.strip():
         print(f"Extra gem5 args: {extra_gem5_args}")
+    print(f"Log limit bytes: {args.log_limit_bytes}")
 
     if args.dry_run:
         for index, workload in enumerate(workloads, start=1):
@@ -1273,6 +1306,7 @@ def main(argv: list[str]) -> int:
         launch_retry_delay=args.launch_retry_delay,
         launch_interval=args.launch_interval,
         force=args.force,
+        log_limit_bytes=args.log_limit_bytes,
     )
 
 

--- a/util/xs_scripts/parallel_sim.sh
+++ b/util/xs_scripts/parallel_sim.sh
@@ -93,6 +93,7 @@ export cpt_dir=`realpath $3`
 export tag=$4
 
 export log_file='log.txt'
+export GEM5_PERF_LOG_LIMIT_BYTES="${GEM5_PERF_LOG_LIMIT_BYTES:-67108864}"
 
 export ds=$(pwd)  # data storage. It is specific for BOSC machines, you can ignore it
 export full_work_dir=$ds/$tag # work dir wheter stats data stored
@@ -224,7 +225,12 @@ function arg_wrapper() {
     dw=${args[4]}
     sample=${args[5]}
 
-    run $checkpoint $work_dir >$work_dir/$log_file 2>&1
+    if ! [[ "$GEM5_PERF_LOG_LIMIT_BYTES" =~ ^[0-9]+$ ]] || [ "$GEM5_PERF_LOG_LIMIT_BYTES" -lt 1 ]; then
+        echo "Invalid GEM5_PERF_LOG_LIMIT_BYTES='$GEM5_PERF_LOG_LIMIT_BYTES'" >&2
+        exit 1
+    fi
+
+    run $checkpoint $work_dir 2>&1 | tail -c "$GEM5_PERF_LOG_LIMIT_BYTES" >$work_dir/$log_file
 }
 
 


### PR DESCRIPTION
## Motivation
A noisy GEM5 run can write multi-GB `log.txt` files under perf archives and exhaust shared NFS before old-run cleanup runs.

## Approach
- Keep only trailing `GEM5_PERF_LOG_LIMIT_BYTES` bytes for local `parallel_sim.sh` workload logs. The default is 64 MiB.
- Add the same cap to `distributed_sim.py` remote job scripts, with a `--log-limit-bytes` override.
- Preserve the existing `completed` / `abort` marker behavior and keep the log tail so final panic or exit status remains visible.

## Validation
- `bash -n util/xs_scripts/parallel_sim.sh`
- `PYTHONPYCACHEPREFIX=/tmp/gem5_review_pycache python3 -m py_compile util/xs_scripts/distributed_sim.py`
- `git diff --check`
- Local fake workload checks for local cap behavior and distributed success/failure marker behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for how much workload output is saved to logs.
  * Users can now set the log size through an environment variable or a command-line option.

* **Bug Fixes**
  * Log files now keep only the most recent output, helping prevent overly large log files.
  * Job runs still preserve the original exit status after log capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->