### PR TITLE
cpu: Add MicroTAGE S3 teacher update

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -109,7 +109,6 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.tage.tableSizes = [2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048]
             cpu.branchPred.tage.numWays = [2, 2, 4, 2, 2, 2, 2, 2]
             cpu.branchPred.microtage.usingS3Pred = True
-            cpu.branchPred.microtage.enableBankConflict = True
             # cpu.branchPred.microtage.enabled = False
 
         # l1 cache per core

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -108,6 +108,8 @@ def setKmhV3IdealParams(args, system):
             # TAGE table sizes and numWays tunning
             cpu.branchPred.tage.tableSizes = [2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048]
             cpu.branchPred.tage.numWays = [2, 2, 4, 2, 2, 2, 2, 2]
+            cpu.branchPred.microtage.usingS3Pred = True
+            cpu.branchPred.microtage.s3UpdateUseResolveBackpressure = False
             # cpu.branchPred.microtage.enabled = False
 
         # l1 cache per core

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -109,7 +109,7 @@ def setKmhV3IdealParams(args, system):
             cpu.branchPred.tage.tableSizes = [2048, 2048, 8192, 8192, 8192, 8192, 8192, 2048]
             cpu.branchPred.tage.numWays = [2, 2, 4, 2, 2, 2, 2, 2]
             cpu.branchPred.microtage.usingS3Pred = True
-            cpu.branchPred.microtage.s3UpdateUseResolveBackpressure = False
+            cpu.branchPred.microtage.enableBankConflict = True
             # cpu.branchPred.microtage.enabled = False
 
         # l1 cache per core

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -120,7 +120,6 @@ def setKmhV3Params(args, system):
             cpu.branchPred.abtb.enabled = True
             cpu.branchPred.microtage.enabled = True
             cpu.branchPred.microtage.usingS3Pred = True
-            cpu.branchPred.microtage.enableBankConflict = True
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -119,6 +119,8 @@ def setKmhV3Params(args, system):
             cpu.branchPred.ubtb.enabled = True
             cpu.branchPred.abtb.enabled = True
             cpu.branchPred.microtage.enabled = True
+            cpu.branchPred.microtage.usingS3Pred = True
+            cpu.branchPred.microtage.s3UpdateUseResolveBackpressure = False
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -120,7 +120,7 @@ def setKmhV3Params(args, system):
             cpu.branchPred.abtb.enabled = True
             cpu.branchPred.microtage.enabled = True
             cpu.branchPred.microtage.usingS3Pred = True
-            cpu.branchPred.microtage.s3UpdateUseResolveBackpressure = False
+            cpu.branchPred.microtage.enableBankConflict = True
             cpu.branchPred.mbtb.enabled = True
             cpu.branchPred.tage.enabled = True
             cpu.branchPred.ittage.enabled = True

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1084,6 +1084,10 @@ class MicroTAGE(TimedBaseBTBPredictor):
 
     enableSC = Param.Bool(False, "Enable SC or not")
     updateOnRead = Param.Bool(True,"Enable update on read, no need to save tage meta in FTQ")
+    usingS3Pred = Param.Bool(False, "Whether using final-stage prediction to teacher-update MicroTAGE")
+    s3UpdateUseResolveBackpressure = Param.Bool(
+        False,
+        "Whether MicroTAGE S3-update mode still participates in resolved-update conflict backpressure")
     # Keep vector parameters consistent with numPredictors to avoid constructor asserts.
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([512] * 4,"the TAGE T0~Tn length")

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1085,9 +1085,6 @@ class MicroTAGE(TimedBaseBTBPredictor):
     enableSC = Param.Bool(False, "Enable SC or not")
     updateOnRead = Param.Bool(True,"Enable update on read, no need to save tage meta in FTQ")
     usingS3Pred = Param.Bool(False, "Whether using final-stage prediction to teacher-update MicroTAGE")
-    s3UpdateUseResolveBackpressure = Param.Bool(
-        False,
-        "Whether MicroTAGE S3-update mode still participates in resolved-update conflict backpressure")
     # Keep vector parameters consistent with numPredictors to avoid constructor asserts.
     numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
     tableSizes = VectorParam.Unsigned([512] * 4,"the TAGE T0~Tn length")

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -375,6 +375,15 @@ AheadBTB::getPredictionMeta(ThreadID tid)
     return state.meta;
 }
 
+bool
+AheadBTB::lastPredHasEntries(ThreadID tid) const
+{
+    if (tid >= threadStates.size()) {
+        return false;
+    }
+    return !threadState(tid).lastPredEntries.empty();
+}
+
 void
 AheadBTB::recoverState(const FetchTarget &entry)
 {

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -153,6 +153,11 @@ class AheadBTB : public TimedBaseBTBPredictor
      */
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
 
+    /** Returns whether the last AheadBTB prediction produced any native hit
+     *  entries before mixing with uBTB stage-0 output.
+     */
+    bool lastPredHasEntries(ThreadID tid) const;
+
     void recoverState(const FetchTarget &entry);
 
 #ifndef UNIT_TEST

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -44,6 +44,53 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+namespace
+{
+
+constexpr int NumOverrideReasonBuckets = 3;
+constexpr int NumBoolBuckets = 2;
+
+constexpr const char *OverrideReasonLabels[NumOverrideReasonBuckets] = {
+    "fall_thru",
+    "control_addr",
+    "target"
+};
+
+constexpr const char *AbtbHitLabels[NumBoolBuckets] = {
+    "abtb_miss",
+    "abtb_hit"
+};
+
+constexpr const char *AfterSquashLabels[NumBoolBuckets] = {
+    "normal",
+    "after_squash"
+};
+
+int
+overrideReasonBucket(OverrideReason reason)
+{
+    switch (reason) {
+      case OverrideReason::FALL_THRU:
+        return 0;
+      case OverrideReason::CONTROL_ADDR:
+        return 1;
+      case OverrideReason::TARGET:
+        return 2;
+      case OverrideReason::NO_OVERRIDE:
+        break;
+    }
+
+    return -1;
+}
+
+int
+boolBucket(bool value)
+{
+    return value ? 1 : 0;
+}
+
+} // namespace
+
 UBTB::UBTB(const Params &p)
     : TimedBaseBTBPredictor(p),
       lastPred(),
@@ -421,6 +468,23 @@ UBTB::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
     }
 }
 
+void
+UBTB::recordS1OverrideDetail(OverrideReason reason,
+                             bool abtbHit,
+                             bool afterSquash)
+{
+    const int reasonBucket = overrideReasonBucket(reason);
+    if (reasonBucket < 0) {
+        return;
+    }
+
+    ubtbStats.s1OverrideByReason[reasonBucket]++;
+    ubtbStats.s1OverrideByReasonAndAbtbHit
+        [reasonBucket][boolBucket(abtbHit)]++;
+    ubtbStats.s1OverrideByReasonAndAfterSquash
+        [reasonBucket][boolBucket(afterSquash)]++;
+}
+
 // Initialize uBTB statistics
 UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
     : statistics::Group(parent),
@@ -474,8 +538,29 @@ UBTB::UBTBStats::UBTBStats(statistics::Group *parent)
       ADD_STAT(s1Misses3Taken, statistics::units::Count::get(), "s1 misses s3 predicted taken"),
       ADD_STAT(s1Hits3Taken, statistics::units::Count::get(), "s1 hits s3 predicted taken"),
       ADD_STAT(s1Misses3FallThrough, statistics::units::Count::get(), "s1 misses s3 predicted fall through"),
-      ADD_STAT(s1InvalidatedEntries, statistics::units::Count::get(), "s1 invalidated entries")
+      ADD_STAT(s1InvalidatedEntries, statistics::units::Count::get(), "s1 invalidated entries"),
+      ADD_STAT(s1OverrideByReason, statistics::units::Count::get(),
+               "uBTB-sourced S1 override events bucketed by override reason"),
+      ADD_STAT(s1OverrideByReasonAndAbtbHit, statistics::units::Count::get(),
+               "uBTB-sourced S1 override events bucketed by override reason and native aBTB hit"),
+      ADD_STAT(s1OverrideByReasonAndAfterSquash, statistics::units::Count::get(),
+               "uBTB-sourced S1 override events bucketed by override reason "
+               "and whether the prediction is the first one after squash "
+               "recovery")
 {
+    s1OverrideByReason.init(NumOverrideReasonBuckets);
+    s1OverrideByReasonAndAbtbHit.init(NumOverrideReasonBuckets, NumBoolBuckets);
+    s1OverrideByReasonAndAfterSquash.init(NumOverrideReasonBuckets, NumBoolBuckets);
+
+    for (int i = 0; i < NumOverrideReasonBuckets; ++i) {
+        s1OverrideByReason.subname(i, OverrideReasonLabels[i]);
+        s1OverrideByReasonAndAbtbHit.subname(i, OverrideReasonLabels[i]);
+        s1OverrideByReasonAndAfterSquash.subname(i, OverrideReasonLabels[i]);
+    }
+    for (int i = 0; i < NumBoolBuckets; ++i) {
+        s1OverrideByReasonAndAbtbHit.ysubname(i, AbtbHitLabels[i]);
+        s1OverrideByReasonAndAfterSquash.ysubname(i, AfterSquashLabels[i]);
+    }
 }
 
 }  // namespace btb_pred

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -138,6 +138,13 @@ class UBTB : public TimedBaseBTBPredictor
      */
     void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
 
+    /** Records fine-grained attribution for S1 override events whose source is
+     *  uBTB. The counters are updated at override time rather than commit time.
+     */
+    void recordS1OverrideDetail(OverrideReason reason,
+                                bool abtbHit,
+                                bool afterSquash);
+
     /** Get prediction BTBMeta
      *  @return Returns the prediction meta
      */
@@ -325,6 +332,9 @@ class UBTB : public TimedBaseBTBPredictor
         statistics::Scalar s1Hits3Taken;
         statistics::Scalar s1Misses3FallThrough;
         statistics::Scalar s1InvalidatedEntries;
+        statistics::Vector s1OverrideByReason;
+        statistics::Vector2d s1OverrideByReasonAndAbtbHit;
+        statistics::Vector2d s1OverrideByReasonAndAfterSquash;
 
         UBTBStats(statistics::Group* parent);
     } ubtbStats;

--- a/src/cpu/pred/btb/common.hh
+++ b/src/cpu/pred/btb/common.hh
@@ -98,9 +98,7 @@ enum class OverrideReason
     NO_OVERRIDE,
     FALL_THRU,
     CONTROL_ADDR,
-    TARGET,
-    END,
-    HIST_INFO
+    TARGET
 };
 
 enum class HistoryType

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -265,6 +265,7 @@ DecoupledBPUWithBTB::tick()
             }
             threads[tid].validprediction = false;
             threads[tid].numOverrideBubbles = 0;
+            threads[tid].nextPredictionAfterSquash = true;
             tage->dryRunCycle(threads[tid].s0PC);
             DPRINTF(Override, "Squashing, BPU state updated.\n");
             threads[tid].squashing = false;
@@ -450,6 +451,11 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
     // 4. Record override bubbles and update statistics
     if (first_hit_stage > 0) {
         dbpBtbStats.overrideCount++;
+        if (finalPred.s1Source == ubtb->getComponentIdx()) {
+            ubtb->recordS1OverrideDetail(overrideReason,
+                                         abtb->lastPredHasEntries(tid),
+                                         threads[tid].nextPredictionAfterSquash);
+        }
     }
 
     // 5. Finalize prediction process
@@ -521,6 +527,7 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
 
     // 5. Add entry to fetch target queue
     ftq.insert(entry);
+    threads[tid].nextPredictionAfterSquash = false;
     threads[tid].validprediction = false;
 
     // 6. Debug output and update statistics

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -442,6 +442,9 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
         } else if (abtb->isEnabled()) {
             abtb->updateUsingS3Pred(predsOfEachStage[numStages - 1], 0);
         }
+        if (microtage->isEnabled()) {
+            microtage->updateUsingS3Pred(predsOfEachStage[numStages - 1]);
+        }
     }
 
     // 4. Record override bubbles and update statistics

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -273,8 +273,6 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar overrideFallThruMismatch;
         statistics::Scalar overrideControlAddrMismatch;
         statistics::Scalar overrideTargetMismatch;
-        statistics::Scalar overrideEndMismatch;
-        statistics::Scalar overrideHistInfoMismatch;
 
         statistics::Distribution fsqEntryDist;
         statistics::Scalar fsqEntryEnqueued;
@@ -311,6 +309,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar s1PredWrongFallthrough;
         statistics::Scalar s1PredWrongUbtb;
         statistics::Scalar s1PredWrongAbtb;
+        statistics::Vector2d s1PredWrongBySourceAndReason;
         statistics::Scalar s3PredWrongMbtb;
         statistics::Scalar s3PredWrongTage;
         statistics::Scalar s3PredWrongIttage;

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -141,6 +141,7 @@ class DecoupledBPUWithBTB : public BPredUnit
         unsigned numOverrideBubbles{0};
         bool validprediction{false};
         bool squashing{false};
+        bool nextPredictionAfterSquash{false};
         bool blockPredictionPending{false};
     } threads[MaxThreads];
 

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -16,6 +16,44 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+namespace
+{
+
+constexpr int NumS1SourceBuckets = 3;
+constexpr int NumOverrideReasonBuckets = 4;
+
+constexpr const char *S1SourceLabels[NumS1SourceBuckets] = {
+    "fallthrough",
+    "ubtb",
+    "abtb"
+};
+
+constexpr const char *OverrideReasonLabels[NumOverrideReasonBuckets] = {
+    "no_override",
+    "fall_thru",
+    "control_addr",
+    "target"
+};
+
+int
+overrideReasonBucket(OverrideReason reason)
+{
+    switch (reason) {
+      case OverrideReason::NO_OVERRIDE:
+        return 0;
+      case OverrideReason::FALL_THRU:
+        return 1;
+      case OverrideReason::CONTROL_ADDR:
+        return 2;
+      case OverrideReason::TARGET:
+        return 3;
+    }
+
+    return 0;
+}
+
+} // namespace
+
 void
 DecoupledBPUWithBTB::initDB()
 {
@@ -431,10 +469,6 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     "Number of overrides due to control address mismatches, on commit path"),
     ADD_STAT(overrideTargetMismatch, statistics::units::Count::get(),
     "Number of overrides due to target mismatches, on commit path"),
-    ADD_STAT(overrideEndMismatch, statistics::units::Count::get(),
-    "Number of overrides due to end address mismatches, on commit path"),
-    ADD_STAT(overrideHistInfoMismatch, statistics::units::Count::get(),
-    "Number of overrides due to history info mismatches, on commit path"),
     ADD_STAT(fsqEntryDist, statistics::units::Count::get(), "the distribution of number of entries in fsq"),
     ADD_STAT(fsqEntryEnqueued, statistics::units::Count::get(), "the number of fsq entries enqueued"),
     ADD_STAT(fsqEntryCommitted, statistics::units::Count::get(), "the number of fsq entries committed at last"),
@@ -461,6 +495,8 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     ADD_STAT(s1PredWrongFallthrough, statistics::units::Count::get(), "S1pred wrong full throughs"),
     ADD_STAT(s1PredWrongUbtb, statistics::units::Count::get(),"S1pred wrong using ubtb "),
     ADD_STAT(s1PredWrongAbtb, statistics::units::Count::get(), "S1pred wrong using abtb "),
+    ADD_STAT(s1PredWrongBySourceAndReason, statistics::units::Count::get(),
+             "committed S1 mispredictions bucketed by S1 source and override reason"),
     ADD_STAT(s3PredWrongMbtb, statistics::units::Count::get(), "S3pred wrong blame mbtb "),
     ADD_STAT(s3PredWrongTage, statistics::units::Count::get(), "S3pred wrong blame tage "),
     ADD_STAT(s3PredWrongIttage, statistics::units::Count::get(), "S3pred wrong blame ittage "),
@@ -474,9 +510,16 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     fsqEntryDist.init(0, fsqSize, 20).flags(statistics::total);
     commitFsqEntryHasInsts.init(0, maxInstsNum >> 1, 1);
     commitFsqEntryFetchedInsts.init(0, maxInstsNum >> 1, 1);
+    s1PredWrongBySourceAndReason.init(NumS1SourceBuckets, NumOverrideReasonBuckets);
     branchClassCounts.init(NumBranchClasses);
     branchClassMisses.init(NumBranchClasses);
     controlSquashByClass.init(NumBranchClasses);
+    for (int i = 0; i < NumS1SourceBuckets; ++i) {
+        s1PredWrongBySourceAndReason.subname(i, S1SourceLabels[i]);
+    }
+    for (int i = 0; i < NumOverrideReasonBuckets; ++i) {
+        s1PredWrongBySourceAndReason.ysubname(i, OverrideReasonLabels[i]);
+    }
     for (size_t i = 0; i < NumBranchClasses; ++i) {
         branchClassCounts.subname(i, BranchClassLabels[i]);
         branchClassMisses.subname(i, BranchClassLabels[i]);
@@ -497,12 +540,6 @@ void DecoupledBPUWithBTB::overrideStats(OverrideReason overrideReason)
                 break;
             case OverrideReason::TARGET:
                 dbpBtbStats.overrideTargetMismatch++;
-                break;
-            case OverrideReason::END:
-                dbpBtbStats.overrideEndMismatch++;
-                break;
-            case OverrideReason::HIST_INFO:
-                dbpBtbStats.overrideHistInfoMismatch++;
                 break;
             default:
                 break;
@@ -850,15 +887,21 @@ DecoupledBPUWithBTB::commitPredWrongSource(const FetchTarget &entry)
     auto exeBranchInfo = entry.exeBranchInfo;
 
     bool onlyDirectionWrong = entry.exeTaken != entry.predTaken;
+    int s1SourceBucket = 0;
 
     assert(s1PredSource < mbtbid);
     if (s1PredSource == ubtbid) {
         dbpBtbStats.s1PredWrongUbtb++;
+        s1SourceBucket = 1;
     } else if (s1PredSource == abtbid) {
         dbpBtbStats.s1PredWrongAbtb++;
+        s1SourceBucket = 2;
     }else {
         dbpBtbStats.s1PredWrongFallthrough++;
     }
+
+    dbpBtbStats.s1PredWrongBySourceAndReason
+        [s1SourceBucket][overrideReasonBucket(entry.overrideReason)]++;
 
     if (s3PredSource == rasid) {
         if (exeBranchInfo.isCond) {

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -40,6 +40,8 @@ MicroTAGE::MicroTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSiz
       numWays(numWays),
       maxBranchPositions(32),
       updateOnRead(false),
+      usingS3Pred(false),
+      s3UpdateUseResolveBackpressure(false),
       numBanks(numBanks),
       bankIdWidth(ceilLog2(numBanks)),
       bankBaseShift(instShiftAmt),
@@ -48,7 +50,7 @@ MicroTAGE::MicroTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSiz
       lastPredBankId(0),
       predBankValid(false)
 {
-    setNumDelay(1);
+    setNumDelay(0);
 
     // Initialize with default parameters for testing
     tableSizes.resize(numPredictors, tableSize);
@@ -69,12 +71,14 @@ tableTagBits(p.TTagBitSizes),
 tablePcShifts(p.TTagPcShifts),
 histLengths(p.histLengths),
 maxHistLen(p.maxHistLen),
-numWays(p.numWays),
-maxBranchPositions(p.maxBranchPositions),
-updateOnRead(p.updateOnRead),
-numBanks(p.numBanks),
-bankIdWidth(ceilLog2(p.numBanks)),
-bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
+    numWays(p.numWays),
+    maxBranchPositions(p.maxBranchPositions),
+    updateOnRead(p.updateOnRead),
+    usingS3Pred(p.usingS3Pred),
+    s3UpdateUseResolveBackpressure(p.s3UpdateUseResolveBackpressure),
+    numBanks(p.numBanks),
+    bankIdWidth(ceilLog2(p.numBanks)),
+    bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
 indexShift(bankBaseShift + ceilLog2(p.numBanks)),
 enableBankConflict(p.enableBankConflict),
 lastPredBankId(0),
@@ -418,6 +422,40 @@ MicroTAGE::prepareUpdateEntries(const FetchTarget &stream) {
     return all_entries;
 }
 
+std::vector<BTBEntry>
+MicroTAGE::prepareS3UpdateEntries(const FullBTBPrediction &s3Pred)
+{
+    std::vector<BTBEntry> entries;
+    for (const auto &entry : s3Pred.btbEntries) {
+        if (!entry.valid) {
+            continue;
+        }
+
+        if (!entry.isCond) {
+            if (entry.isDirect || entry.isIndirect || entry.isReturn || entry.isCall ||
+                entry.isUncond()) {
+                break;
+            }
+            continue;
+        }
+
+        Addr branch_pc = entry.pc;
+        auto teacher_it = CondTakens_find(s3Pred.condTakens, branch_pc);
+        // Stop at the first control transfer the S3 teacher says is taken.
+        bool teacher_taken = entry.alwaysTaken ||
+            (teacher_it != s3Pred.condTakens.end() && teacher_it->second);
+
+        if (!entry.alwaysTaken) {
+            entries.push_back(entry);
+        }
+
+        if (teacher_taken) {
+            break;
+        }
+    }
+    return entries;
+}
+
 /**
  * @brief Update predictor state for a single entry
  *
@@ -523,6 +561,94 @@ MicroTAGE::updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
     return true;
 }
 
+bool
+MicroTAGE::updatePredictorStateAndCheckAllocationS3(const BTBEntry &entry,
+                             bool actual_taken,
+                             const TagePrediction &pred) {
+    // Mirror the normal update path, but interpret mismatch against the S3 teacher
+    // instead of a resolved squash/commit outcome.
+    if (pred.mainprovided) {
+        tageStats.s3UpdateUseAlt++;
+    } else {
+        tageStats.s3UpdateNoHitUseBim++;
+    }
+
+    auto &main_info = pred.mainInfo;
+    bool used_base = !pred.mainprovided;
+    bool base_taken = entry.ctr >= 0;
+
+    if (main_info.found) {
+        bool main_weak = (main_info.entry.counter == 0 || main_info.entry.counter == -1);
+        if (main_weak) {
+            tageStats.s3UpdateProviderNa++;
+            bool base_correct = (base_taken == actual_taken);
+            tageStats.s3UpdateUseAltOnNaUpdated++;
+            if (base_correct) {
+                tageStats.s3UpdateUseAltOnNaCorrect++;
+            } else {
+                tageStats.s3UpdateUseAltOnNaWrong++;
+            }
+        }
+    }
+
+    if (main_info.found) {
+        DPRINTF(UTAGE, "S3 teacher-update provided by table %d, idx %lu, way %u\n",
+            main_info.table, main_info.index, main_info.way);
+
+        auto &way = tageTable[main_info.table][main_info.index][main_info.way];
+        updateCounter(actual_taken, 3, way.counter);
+
+        bool main_is_correct = main_info.taken() == actual_taken;
+        bool base_is_correct_and_strong =
+                                     (base_taken == actual_taken) &&
+                                     (abs(2 * entry.ctr + 1) == 5);
+
+        if (base_is_correct_and_strong && main_is_correct) {
+            way.useful = 0;
+            DPRINTF(TAGEUseful, "useful bit reset to 0 due to humility rule\n");
+        } else if (main_info.taken() != base_taken) {
+            if (main_is_correct) {
+                way.useful = 1;
+            }
+        }
+
+        if (way.counter == 0 || way.counter == -1) {
+            way.useful = 0;
+            DPRINTF(TAGEUseful, "useful bit reset to 0 due to weak counter\n");
+        }
+        DPRINTF(UTAGE, "useful bit is now %d\n", way.useful);
+
+        if (!main_is_correct) {
+            tageStats.s3UpdateUtageHitWrong++;
+        }
+    }
+
+    if (used_base) {
+        bool base_correct = base_taken == actual_taken;
+        if (base_correct) {
+            tageStats.s3UpdateUseAltCorrect++;
+        } else {
+            tageStats.s3UpdateUseAltWrong++;
+        }
+        if (main_info.found && main_info.taken() != base_taken) {
+            tageStats.s3UpdateAltDiffers++;
+        }
+    }
+
+    bool teacher_mismatch = pred.taken != actual_taken;
+    if (!teacher_mismatch) {
+        return false;
+    }
+
+    tageStats.s3UpdateMispred++;
+
+    if (main_info.found && main_info.table == numPredictors - 1) {
+        return false;
+    }
+
+    return true;
+}
+
 /**
  * @brief Handle allocation of new entries
  *
@@ -540,6 +666,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  unsigned start_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
+                                 TageStats *stats,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way) {
@@ -570,6 +697,9 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                         ti, newIndex, way, newTag, position, newCounter, entry.pc);
                 cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
                 tageStats.updateAllocSuccess++;
+                if (stats) {
+                    stats->s3UpdateAllocSuccess++;
+                }
                 allocated_table = ti;
                 allocated_index = newIndex;
                 allocated_way = way;
@@ -591,12 +721,18 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
         }
 
         tageStats.updateAllocFailure++;
+        if (stats) {
+            stats->s3UpdateAllocFailure++;
+        }
         usefulResetCnt++;
     }
 
     if (usefulResetCnt >= 256) {
         usefulResetCnt = 0;
         tageStats.updateResetU++;
+        if (stats) {
+            stats->s3UpdateResetU++;
+        }
         DPRINTF(UTAGE, "reset useful bit of all entries\n");
         for (auto &table : tageTable) {
             for (auto &set : table) {
@@ -609,6 +745,9 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
 
     DPRINTF(UTAGE, "no eligible way found for allocation starting from table %d\n", start_table);
     tageStats.updateAllocFailureNoValidTable++;
+    if (stats) {
+        stats->s3UpdateAllocFailureNoValidTable++;
+    }
     return false;
 }
 
@@ -618,6 +757,11 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
  */
 bool
 MicroTAGE::canResolveUpdate(const FetchTarget &stream) {
+    if (usingS3Pred && !s3UpdateUseResolveBackpressure) {
+        tageStats.s3UpdateResolvedBypass++;
+        return true;
+    }
+
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -647,6 +791,13 @@ MicroTAGE::canResolveUpdate(const FetchTarget &stream) {
  */
 void
 MicroTAGE::doResolveUpdate(const FetchTarget &stream) {
+    if (usingS3Pred) {
+        tageStats.s3UpdateResolvedBackpressure++;
+        if (enableBankConflict && predBankValid && s3UpdateUseResolveBackpressure) {
+            predBankValid = false;
+        }
+        return;
+    }
     if (enableBankConflict && predBankValid) {
         // Prediction consumed; clear bank tag for next cycle
         predBankValid = false;
@@ -661,6 +812,11 @@ MicroTAGE::doResolveUpdate(const FetchTarget &stream) {
  */
 void
 MicroTAGE::update(const FetchTarget &stream) {
+    if (usingS3Pred) {
+        DPRINTF(UTAGE, "update bypassed because usingS3Pred is enabled\n");
+        return;
+    }
+
     Addr startAddr = stream.getRealStartPC();
     unsigned updateBank = getBankId(startAddr);
 
@@ -717,7 +873,7 @@ MicroTAGE::update(const FetchTarget &stream) {
                 start_table = main_info.table + 1; // start from the table after the main prediction table
             }
             alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
-                                   start_table, predMeta, stream.asidHash,
+                                   start_table, predMeta, stream.asidHash, nullptr,
                                    allocated_table, allocated_index, allocated_way);
         }
 
@@ -746,6 +902,86 @@ MicroTAGE::update(const FetchTarget &stream) {
     }
     checkUtageUpdateMisspred(stream);
     DPRINTF(UTAGE, "end update\n");
+}
+
+void
+MicroTAGE::updateUsingS3Pred(FullBTBPrediction &s3Pred)
+{
+    if (!usingS3Pred) {
+        return;
+    }
+
+    const ThreadID tid = s3Pred.tid;
+    if (tid >= threadMeta.size()) {
+        DPRINTF(UTAGE, "S3 teacher-update: invalid tid %u\n", tid);
+        return;
+    }
+
+    auto predMeta = threadMeta[tid];
+    if (!predMeta) {
+        DPRINTF(UTAGE, "S3 teacher-update: no prediction meta for tid %u, skip\n", tid);
+        tageStats.s3UpdateNoMeta++;
+        return;
+    }
+
+    const Addr startAddr = s3Pred.bbStart;
+    // Only train the conditional prefix that remains reachable under the
+    // final-stage teacher prediction for this fetch block.
+    auto entries_to_update = prepareS3UpdateEntries(s3Pred);
+    bool utage_hit = false;
+
+    for (const auto &btb_entry : entries_to_update) {
+        tageStats.s3UpdateEntries++;
+        bool actual_taken = false;
+        Addr branch_pc = btb_entry.pc;
+        auto teacher_it = CondTakens_find(s3Pred.condTakens, branch_pc);
+        if (teacher_it != s3Pred.condTakens.end()) {
+            actual_taken = teacher_it->second;
+        }
+
+        TagePrediction recomputed;
+        if (updateOnRead) {
+            recomputed = generateSinglePrediction(
+                btb_entry, startAddr, predMeta, tid, s3Pred.asidHash);
+        } else {
+            auto pred_it = predMeta->preds.find(btb_entry.pc);
+            if (pred_it != predMeta->preds.end()) {
+                recomputed = pred_it->second;
+            } else {
+                DPRINTF(UTAGE,
+                        "S3 teacher-update: missing predMeta entry for pc %#lx, recompute with snapshot\n",
+                        btb_entry.pc);
+                recomputed = generateSinglePrediction(
+                    btb_entry, startAddr, predMeta, tid, s3Pred.asidHash);
+            }
+        }
+
+        if (recomputed.mainprovided) {
+            utage_hit = true;
+        }
+
+        bool need_allocate = updatePredictorStateAndCheckAllocationS3(
+            btb_entry, actual_taken, recomputed);
+
+        if (need_allocate) {
+            uint64_t allocated_table = 0;
+            uint64_t allocated_index = 0;
+            uint64_t allocated_way = 0;
+            unsigned start_table = 0;
+            auto &main_info = recomputed.mainInfo;
+            if (main_info.found) {
+                start_table = main_info.table + 1;
+            }
+            handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
+                                     start_table, predMeta, s3Pred.asidHash, &tageStats,
+                                     allocated_table, allocated_index,
+                                     allocated_way);
+        }
+    }
+
+    if (utage_hit) {
+        tageStats.s3UpdateUtageHit++;
+    }
 }
 
 void
@@ -1079,6 +1315,47 @@ MicroTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, in
 
     ADD_STAT(updateUtageHit, statistics::units::Count::get(), "number of updates where utage provided the main prediction"),
     ADD_STAT(updateUtageHitWrong, statistics::units::Count::get(), "number of updates where utage prediction was wrong"),
+
+    ADD_STAT(s3UpdateEntries, statistics::units::Count::get(),
+             "number of conditional entries trained by S3 teacher update"),
+    ADD_STAT(s3UpdateNoMeta, statistics::units::Count::get(),
+             "number of S3 teacher updates skipped due to missing prediction metadata"),
+    ADD_STAT(s3UpdateNoHitUseBim, statistics::units::Count::get(),
+             "use bimodal when no hit on S3 teacher update"),
+    ADD_STAT(s3UpdateUseAlt, statistics::units::Count::get(),
+             "use alt on S3 teacher update"),
+    ADD_STAT(s3UpdateUseAltCorrect, statistics::units::Count::get(),
+             "use alt on S3 teacher update and correct"),
+    ADD_STAT(s3UpdateUseAltWrong, statistics::units::Count::get(),
+             "use alt on S3 teacher update and wrong"),
+    ADD_STAT(s3UpdateAltDiffers, statistics::units::Count::get(),
+             "alt differs on S3 teacher update"),
+    ADD_STAT(s3UpdateUseAltOnNaUpdated, statistics::units::Count::get(),
+             "use alt on na ctr updated during S3 teacher update"),
+    ADD_STAT(s3UpdateProviderNa, statistics::units::Count::get(),
+             "provider weak during S3 teacher update"),
+    ADD_STAT(s3UpdateUseAltOnNaCorrect, statistics::units::Count::get(),
+             "use alt on na correct during S3 teacher update"),
+    ADD_STAT(s3UpdateUseAltOnNaWrong, statistics::units::Count::get(),
+             "use alt on na wrong during S3 teacher update"),
+    ADD_STAT(s3UpdateAllocFailure, statistics::units::Count::get(),
+             "alloc failure during S3 teacher update"),
+    ADD_STAT(s3UpdateAllocFailureNoValidTable, statistics::units::Count::get(),
+             "alloc failure with no valid table during S3 teacher update"),
+    ADD_STAT(s3UpdateAllocSuccess, statistics::units::Count::get(),
+             "alloc success during S3 teacher update"),
+    ADD_STAT(s3UpdateMispred, statistics::units::Count::get(),
+             "teacher mismatch during S3 teacher update"),
+    ADD_STAT(s3UpdateResetU, statistics::units::Count::get(),
+             "reset u during S3 teacher update"),
+    ADD_STAT(s3UpdateUtageHit, statistics::units::Count::get(),
+             "number of S3 teacher updates where utage provided the main prediction"),
+    ADD_STAT(s3UpdateUtageHitWrong, statistics::units::Count::get(),
+             "number of S3 teacher updates where utage prediction disagreed with the S3 teacher"),
+    ADD_STAT(s3UpdateResolvedBypass, statistics::units::Count::get(),
+             "number of resolved-update probes bypassed in S3 teacher-update mode"),
+    ADD_STAT(s3UpdateResolvedBackpressure, statistics::units::Count::get(),
+             "number of resolved-update callbacks observed while S3 teacher-update mode keeps backpressure enabled"),
 
     ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
     ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(), "number of updates deferred due to bank conflict (retried later)"),

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -63,26 +63,26 @@ MicroTAGE::MicroTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSiz
     maxHistLen = histLengths[numPredictors-1];
 #else
 // Constructor: Initialize TAGE predictor with given parameters
-MicroTAGE::MicroTAGE(const Params& p):
-TimedBaseBTBPredictor(p),
-numPredictors(p.numPredictors),
-tableSizes(p.tableSizes),
-tableTagBits(p.TTagBitSizes),
-tablePcShifts(p.TTagPcShifts),
-histLengths(p.histLengths),
-maxHistLen(p.maxHistLen),
-    numWays(p.numWays),
-    maxBranchPositions(p.maxBranchPositions),
-    updateOnRead(p.updateOnRead),
-    usingS3Pred(p.usingS3Pred),
-    numBanks(p.numBanks),
-    bankIdWidth(ceilLog2(p.numBanks)),
-    bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
-indexShift(bankBaseShift + ceilLog2(p.numBanks)),
-enableBankConflict(p.enableBankConflict),
-lastPredBankId(0),
-predBankValid(false),
-tageStats(this, p.numPredictors, p.numBanks)
+MicroTAGE::MicroTAGE(const Params& p)
+    : TimedBaseBTBPredictor(p),
+      numPredictors(p.numPredictors),
+      tableSizes(p.tableSizes),
+      tableTagBits(p.TTagBitSizes),
+      tablePcShifts(p.TTagPcShifts),
+      histLengths(p.histLengths),
+      maxHistLen(p.maxHistLen),
+      numWays(p.numWays),
+      maxBranchPositions(p.maxBranchPositions),
+      updateOnRead(p.updateOnRead),
+      usingS3Pred(p.usingS3Pred),
+      numBanks(p.numBanks),
+      bankIdWidth(ceilLog2(p.numBanks)),
+      bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
+      indexShift(bankBaseShift + ceilLog2(p.numBanks)),
+      enableBankConflict(p.enableBankConflict),
+      lastPredBankId(0),
+      predBankValid(false),
+      tageStats(this, p.numPredictors, p.numBanks)
 {
     // Warn if updateOnRead is disabled (bank simulation works better with it enabled)
     if (!p.updateOnRead) {
@@ -665,7 +665,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  unsigned start_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
-                                 TageStats *stats,
+                                 TrainingMode mode,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way) {
@@ -673,30 +673,31 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
     // - For each table from start_table upward, check the set at computed index.
     // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
     // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
+    const bool isS3Update = mode == TrainingMode::S3Update;
     auto count_alloc_success = [&]() {
-        if (stats) {
-            stats->s3UpdateAllocSuccess++;
+        if (isS3Update) {
+            tageStats.s3UpdateAllocSuccess++;
         } else {
             tageStats.updateAllocSuccess++;
         }
     };
     auto count_alloc_failure = [&]() {
-        if (stats) {
-            stats->s3UpdateAllocFailure++;
+        if (isS3Update) {
+            tageStats.s3UpdateAllocFailure++;
         } else {
             tageStats.updateAllocFailure++;
         }
     };
     auto count_reset_u = [&]() {
-        if (stats) {
-            stats->s3UpdateResetU++;
+        if (isS3Update) {
+            tageStats.s3UpdateResetU++;
         } else {
             tageStats.updateResetU++;
         }
     };
     auto count_no_valid_table = [&]() {
-        if (stats) {
-            stats->s3UpdateAllocFailureNoValidTable++;
+        if (isS3Update) {
+            tageStats.s3UpdateAllocFailureNoValidTable++;
         } else {
             tageStats.updateAllocFailureNoValidTable++;
         }
@@ -848,73 +849,8 @@ MicroTAGE::update(const FetchTarget &stream) {
         return;
     }
 
-    bool utage_hit = false;
-    // Process each BTB entry
-    for (auto &btb_entry : entries_to_update) {
-        bool actual_taken = stream.exeTaken && stream.exeBranchInfo == btb_entry;
-        TagePrediction recomputed;
-        if (updateOnRead) { // if update on read is enabled, re-read providers using snapshot
-            // Re-read providers using snapshot (do not rely on prediction-time main/alt)
-            recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta,
-                                                 stream.tid, stream.asidHash);
-        } else { // otherwise, use the prediction from the prediction-time main/alt
-            auto pred_it = predMeta->preds.find(btb_entry.pc);
-            if (pred_it != predMeta->preds.end()) {
-                recomputed = pred_it->second;
-            } else {
-                DPRINTF(UTAGE, "update: missing predMeta entry for pc %#lx, recompute with snapshot\n",
-                        btb_entry.pc);
-                recomputed = generateSinglePrediction(btb_entry, startAddr, predMeta,
-                                                     stream.tid, stream.asidHash);
-            }
-        }
-        if (recomputed.mainprovided) {
-            utage_hit = true;
-        }
-        // Update predictor state and check if need to allocate new entry
-        bool need_allocate = updatePredictorStateAndCheckAllocation(btb_entry, actual_taken, recomputed, stream);
-
-        // Handle new entry allocation if needed
-        bool alloc_success = false;
-        uint64_t allocated_table = 0;
-        uint64_t allocated_index = 0;
-        uint64_t allocated_way = 0;
-        if (need_allocate) {
-
-            // Handle allocation of new entries
-            uint start_table = 0;
-            auto &main_info = recomputed.mainInfo;
-            if (main_info.found) {
-                start_table = main_info.table + 1; // start from the table after the main prediction table
-            }
-            alloc_success = handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
-                                   start_table, predMeta, stream.asidHash, nullptr,
-                                   allocated_table, allocated_index, allocated_way);
-        }
-
-#ifndef UNIT_TEST
-        // if (enableDB) {
-        //     TageMissTrace t;
-        //     std::string history_str;
-        //     boost::dynamic_bitset<> history_low50 = predMeta->history;
-        //     if (history_low50.size() > 50) {
-        //         history_low50.resize(50);  // get the lower 50 bits of history
-        //     }
-        //     boost::to_string(history_low50, history_str);
-        //     auto main_info = recomputed.mainInfo;
-        //     t.set(startAddr, btb_entry.pc, main_info.way,
-        //         main_info.found, main_info.entry.counter, main_info.entry.useful,
-        //         main_info.table, main_info.index,
-        //         recomputed.useAlt, recomputed.taken, actual_taken, alloc_success,
-        //         allocated_table, allocated_index, allocated_way,
-        //         history_str, predMeta->indexFoldedHist[main_info.table].get());
-        //     tageMissTrace->write_record(t);
-        // }
-#endif
-    }
-    if (utage_hit){
-        tageStats.updateUtageHit++;//for RTL align pred Accuracy
-    }
+    trainEntries(entries_to_update, predMeta, startAddr, stream.tid, stream.asidHash,
+                 TrainingMode::Resolved, &stream, nullptr);
     checkUtageUpdateMisspred(stream);
     DPRINTF(UTAGE, "end update\n");
 }
@@ -943,59 +879,119 @@ MicroTAGE::updateUsingS3Pred(FullBTBPrediction &s3Pred)
     // Only train the conditional prefix that remains reachable under the
     // final-stage teacher prediction for this fetch block.
     auto entries_to_update = prepareS3UpdateEntries(s3Pred);
+    trainEntries(entries_to_update, predMeta, startAddr, tid, s3Pred.asidHash,
+                 TrainingMode::S3Update, nullptr, &s3Pred.condTakens);
+}
+
+void
+MicroTAGE::trainEntries(const std::vector<BTBEntry> &entries_to_update,
+                        const std::shared_ptr<TageMeta> &predMeta,
+                        const Addr &startPC,
+                        ThreadID tid,
+                        uint8_t asidHash,
+                        TrainingMode mode,
+                        const FetchTarget *stream,
+                        const CondTakens *teacherCondTakens)
+{
+    const bool isS3Update = mode == TrainingMode::S3Update;
     bool utage_hit = false;
+    const char *context = isS3Update ? "S3 teacher-update" : "update";
+    auto get_prediction_for_training =
+        [&](const BTBEntry &btb_entry) -> TagePrediction {
+            if (updateOnRead) {
+                return generateSinglePrediction(
+                    btb_entry, startPC, predMeta, tid, asidHash);
+            }
 
-    for (const auto &btb_entry : entries_to_update) {
-        tageStats.s3UpdateEntries++;
-        bool actual_taken = false;
-        Addr branch_pc = btb_entry.pc;
-        auto teacher_it = CondTakens_find(s3Pred.condTakens, branch_pc);
-        if (teacher_it != s3Pred.condTakens.end()) {
-            actual_taken = teacher_it->second;
-        }
-
-        TagePrediction recomputed;
-        if (updateOnRead) {
-            recomputed = generateSinglePrediction(
-                btb_entry, startAddr, predMeta, tid, s3Pred.asidHash);
-        } else {
             auto pred_it = predMeta->preds.find(btb_entry.pc);
             if (pred_it != predMeta->preds.end()) {
-                recomputed = pred_it->second;
-            } else {
-                DPRINTF(UTAGE,
-                        "S3 teacher-update: missing predMeta entry for pc %#lx, recompute with snapshot\n",
-                        btb_entry.pc);
-                recomputed = generateSinglePrediction(
-                    btb_entry, startAddr, predMeta, tid, s3Pred.asidHash);
+                return pred_it->second;
             }
+
+            DPRINTF(UTAGE,
+                    "%s: missing predMeta entry for pc %#lx, recompute with snapshot\n",
+                    context, btb_entry.pc);
+            return generateSinglePrediction(
+                btb_entry, startPC, predMeta, tid, asidHash);
+        };
+
+    for (const auto &btb_entry : entries_to_update) {
+        if (isS3Update) {
+            tageStats.s3UpdateEntries++;
         }
+
+        bool actual_taken = false;
+        if (isS3Update) {
+            assert(teacherCondTakens != nullptr);
+            const auto &teacher_cond_takens = *teacherCondTakens;
+            Addr branch_pc = btb_entry.pc;
+            auto teacher_it = CondTakens_find(teacher_cond_takens, branch_pc);
+            if (teacher_it != teacher_cond_takens.end()) {
+                actual_taken = teacher_it->second;
+            }
+        } else {
+            assert(stream != nullptr);
+            actual_taken = stream->exeTaken && stream->exeBranchInfo == btb_entry;
+        }
+
+        auto recomputed = get_prediction_for_training(btb_entry);
 
         if (recomputed.mainprovided) {
             utage_hit = true;
         }
 
-        bool need_allocate = updatePredictorStateAndCheckAllocationS3(
-            btb_entry, actual_taken, recomputed);
+        bool need_allocate = isS3Update
+            ? updatePredictorStateAndCheckAllocationS3(btb_entry, actual_taken, recomputed)
+            : updatePredictorStateAndCheckAllocation(btb_entry, actual_taken, recomputed, *stream);
 
-        if (need_allocate) {
-            uint64_t allocated_table = 0;
-            uint64_t allocated_index = 0;
-            uint64_t allocated_way = 0;
-            unsigned start_table = 0;
-            auto &main_info = recomputed.mainInfo;
-            if (main_info.found) {
-                start_table = main_info.table + 1;
-            }
-            handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
-                                     start_table, predMeta, s3Pred.asidHash, &tageStats,
-                                     allocated_table, allocated_index,
-                                     allocated_way);
+        if (!need_allocate) {
+            continue;
         }
+
+        uint64_t allocated_table = 0;
+        uint64_t allocated_index = 0;
+        uint64_t allocated_way = 0;
+        unsigned start_table = 0;
+        auto &main_info = recomputed.mainInfo;
+        if (main_info.found) {
+            start_table = main_info.table + 1;
+        }
+
+        handleNewEntryAllocation(startPC, btb_entry, actual_taken,
+                                 start_table, predMeta, asidHash, mode,
+                                 allocated_table, allocated_index,
+                                 allocated_way);
+
+#ifndef UNIT_TEST
+        // Optional per-entry miss tracing is only kept for the resolved update path.
+        // The S3 teacher-update path shares the same provider/allocation mechanics,
+        // but does not currently feed the miss-trace database.
+        // if (!isS3Update && enableDB) {
+        //     TageMissTrace t;
+        //     std::string history_str;
+        //     boost::dynamic_bitset<> history_low50 = predMeta->history;
+        //     if (history_low50.size() > 50) {
+        //         history_low50.resize(50);  // get the lower 50 bits of history
+        //     }
+        //     boost::to_string(history_low50, history_str);
+        //     auto main_info = recomputed.mainInfo;
+        //     t.set(startPC, btb_entry.pc, main_info.way,
+        //         main_info.found, main_info.entry.counter, main_info.entry.useful,
+        //         main_info.table, main_info.index,
+        //         recomputed.useAlt, recomputed.taken, actual_taken, alloc_success,
+        //         allocated_table, allocated_index, allocated_way,
+        //         history_str, predMeta->indexFoldedHist[main_info.table].get());
+        //     tageMissTrace->write_record(t);
+        // }
+#endif
     }
 
     if (utage_hit) {
-        tageStats.s3UpdateUtageHit++;
+        if (isS3Update) {
+            tageStats.s3UpdateUtageHit++;
+        } else {
+            tageStats.updateUtageHit++;
+        }
     }
 }
 

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -47,7 +47,8 @@ MicroTAGE::MicroTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSiz
       indexShift(bankBaseShift + ceilLog2(numBanks)),
       enableBankConflict(false),
       lastPredBankId(0),
-      predBankValid(false)
+      predBankValid(false),
+      tageStats()
 {
     setNumDelay(0);
 
@@ -565,14 +566,14 @@ MicroTAGE::updatePredictorStateAndCheckAllocationS3(const BTBEntry &entry,
                              const TagePrediction &pred) {
     // Mirror the normal update path, but interpret mismatch against the S3 teacher
     // instead of a resolved squash/commit outcome.
-    if (pred.mainprovided) {
-        tageStats.s3UpdateUseAlt++;
-    } else {
-        tageStats.s3UpdateNoHitUseBim++;
-    }
-
     auto &main_info = pred.mainInfo;
     bool used_base = !pred.mainprovided;
+    if (!main_info.found) {
+        tageStats.s3UpdateNoHitUseBim++;
+    }
+    if (!main_info.found || used_base) {
+        tageStats.s3UpdateUseAlt++;
+    }
     bool base_taken = entry.ctr >= 0;
 
     if (main_info.found) {
@@ -672,6 +673,34 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
     // - For each table from start_table upward, check the set at computed index.
     // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
     // - If none, apply a one-step age penalty to a strong, not-useful way (no allocation).
+    auto count_alloc_success = [&]() {
+        if (stats) {
+            stats->s3UpdateAllocSuccess++;
+        } else {
+            tageStats.updateAllocSuccess++;
+        }
+    };
+    auto count_alloc_failure = [&]() {
+        if (stats) {
+            stats->s3UpdateAllocFailure++;
+        } else {
+            tageStats.updateAllocFailure++;
+        }
+    };
+    auto count_reset_u = [&]() {
+        if (stats) {
+            stats->s3UpdateResetU++;
+        } else {
+            tageStats.updateResetU++;
+        }
+    };
+    auto count_no_valid_table = [&]() {
+        if (stats) {
+            stats->s3UpdateAllocFailureNoValidTable++;
+        } else {
+            tageStats.updateAllocFailureNoValidTable++;
+        }
+    };
 
     // Calculate branch position within the block (like RTL's cfiPosition)
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
@@ -694,10 +723,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                 DPRINTF(UTAGE, "allocating entry in table %d[%lu][%u], tag %lu (with pos %u), counter %d, pc %#lx\n",
                         ti, newIndex, way, newTag, position, newCounter, entry.pc);
                 cand = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
-                tageStats.updateAllocSuccess++;
-                if (stats) {
-                    stats->s3UpdateAllocSuccess++;
-                }
+                count_alloc_success();
                 allocated_table = ti;
                 allocated_index = newIndex;
                 allocated_way = way;
@@ -718,19 +744,13 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
             }
         }
 
-        tageStats.updateAllocFailure++;
-        if (stats) {
-            stats->s3UpdateAllocFailure++;
-        }
+        count_alloc_failure();
         usefulResetCnt++;
     }
 
     if (usefulResetCnt >= 256) {
         usefulResetCnt = 0;
-        tageStats.updateResetU++;
-        if (stats) {
-            stats->s3UpdateResetU++;
-        }
+        count_reset_u();
         DPRINTF(UTAGE, "reset useful bit of all entries\n");
         for (auto &table : tageTable) {
             for (auto &set : table) {
@@ -742,10 +762,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
     }
 
     DPRINTF(UTAGE, "no eligible way found for allocation starting from table %d\n", start_table);
-    tageStats.updateAllocFailureNoValidTable++;
-    if (stats) {
-        stats->s3UpdateAllocFailureNoValidTable++;
-    }
+    count_no_valid_table();
     return false;
 }
 

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -41,7 +41,6 @@ MicroTAGE::MicroTAGE(unsigned numPredictors, unsigned numWays, unsigned tableSiz
       maxBranchPositions(32),
       updateOnRead(false),
       usingS3Pred(false),
-      s3UpdateUseResolveBackpressure(false),
       numBanks(numBanks),
       bankIdWidth(ceilLog2(numBanks)),
       bankBaseShift(instShiftAmt),
@@ -75,7 +74,6 @@ maxHistLen(p.maxHistLen),
     maxBranchPositions(p.maxBranchPositions),
     updateOnRead(p.updateOnRead),
     usingS3Pred(p.usingS3Pred),
-    s3UpdateUseResolveBackpressure(p.s3UpdateUseResolveBackpressure),
     numBanks(p.numBanks),
     bankIdWidth(ceilLog2(p.numBanks)),
     bankBaseShift(instShiftAmt), // strip instruction alignment bits before indexing
@@ -752,13 +750,14 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
 }
 
 /**
- * @brief Probe resolved update for bank conflicts without mutating state.
- * Returns false if the update cannot proceed due to a bank conflict.
+ * @brief Probe whether the resolved-update path may proceed this cycle.
+ *
+ * In S3 teacher-update mode, MicroTAGE no longer participates in resolved
+ * update backpressure and always lets the caller proceed.
  */
 bool
 MicroTAGE::canResolveUpdate(const FetchTarget &stream) {
-    if (usingS3Pred && !s3UpdateUseResolveBackpressure) {
-        tageStats.s3UpdateResolvedBypass++;
+    if (usingS3Pred) {
         return true;
     }
 
@@ -788,14 +787,13 @@ MicroTAGE::canResolveUpdate(const FetchTarget &stream) {
 
 /**
  * @brief Perform resolved update after probe success.
+ *
+ * In S3 teacher-update mode this callback becomes a no-op because functional
+ * predictor state is updated by updateUsingS3Pred().
  */
 void
 MicroTAGE::doResolveUpdate(const FetchTarget &stream) {
     if (usingS3Pred) {
-        tageStats.s3UpdateResolvedBackpressure++;
-        if (enableBankConflict && predBankValid && s3UpdateUseResolveBackpressure) {
-            predBankValid = false;
-        }
         return;
     }
     if (enableBankConflict && predBankValid) {
@@ -1352,10 +1350,6 @@ MicroTAGE::TageStats::TageStats(statistics::Group* parent, int numPredictors, in
              "number of S3 teacher updates where utage provided the main prediction"),
     ADD_STAT(s3UpdateUtageHitWrong, statistics::units::Count::get(),
              "number of S3 teacher updates where utage prediction disagreed with the S3 teacher"),
-    ADD_STAT(s3UpdateResolvedBypass, statistics::units::Count::get(),
-             "number of resolved-update probes bypassed in S3 teacher-update mode"),
-    ADD_STAT(s3UpdateResolvedBackpressure, statistics::units::Count::get(),
-             "number of resolved-update callbacks observed while S3 teacher-update mode keeps backpressure enabled"),
 
     ADD_STAT(updateBankConflict, statistics::units::Count::get(), "number of bank conflicts detected"),
     ADD_STAT(updateDeferredDueToConflict, statistics::units::Count::get(), "number of updates deferred due to bank conflict (retried later)"),

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -359,6 +359,21 @@ public:
         TageMeta() : aheadIndexFoldedHistValid(false) {}
     } TageMeta;
 
+    enum class TrainingMode
+    {
+        Resolved,
+        S3Update
+    };
+
+    void trainEntries(const std::vector<BTBEntry> &entries_to_update,
+                      const std::shared_ptr<TageMeta> &predMeta,
+                      const Addr &startPC,
+                      ThreadID tid,
+                      uint8_t asidHash,
+                      TrainingMode mode,
+                      const FetchTarget *stream,
+                      const CondTakens *teacherCondTakens);
+
 #ifdef UNIT_TEST
   public:
 #else
@@ -396,7 +411,7 @@ public:
                                  unsigned main_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
-                                 TageStats *stats,
+                                 TrainingMode mode,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way);

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -243,7 +243,6 @@ class MicroTAGE : public TimedBaseBTBPredictor
     // Whether to update on read
     bool updateOnRead;
     bool usingS3Pred;
-    bool s3UpdateUseResolveBackpressure;
 
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
@@ -310,8 +309,6 @@ class MicroTAGE : public TimedBaseBTBPredictor
         Scalar s3UpdateResetU;
         Scalar s3UpdateUtageHit;
         Scalar s3UpdateUtageHitWrong;
-        Scalar s3UpdateResolvedBypass;
-        Scalar s3UpdateResolvedBackpressure;
 
         // Bank conflict statistics
         Scalar updateBankConflict;           // Number of bank conflicts detected

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -140,6 +140,8 @@ class MicroTAGE : public TimedBaseBTBPredictor
     void update(const FetchTarget &entry) override;
     bool canResolveUpdate(const FetchTarget &entry) override;
     void doResolveUpdate(const FetchTarget &entry) override;
+    // Train MicroTAGE from the final-stage teacher prediction instead of commit-time truth.
+    void updateUsingS3Pred(FullBTBPrediction &s3Pred);
 
 #ifndef UNIT_TEST
     void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
@@ -240,6 +242,8 @@ class MicroTAGE : public TimedBaseBTBPredictor
 
     // Whether to update on read
     bool updateOnRead;
+    bool usingS3Pred;
+    bool s3UpdateUseResolveBackpressure;
 
     // ========== Bank Configuration ==========
     // Bank mechanism to simulate hardware bank conflicts
@@ -287,6 +291,27 @@ class MicroTAGE : public TimedBaseBTBPredictor
 
         Scalar updateUtageHit;
         Scalar updateUtageHitWrong;
+
+        Scalar s3UpdateEntries;
+        Scalar s3UpdateNoMeta;
+        Scalar s3UpdateNoHitUseBim;
+        Scalar s3UpdateUseAlt;
+        Scalar s3UpdateUseAltCorrect;
+        Scalar s3UpdateUseAltWrong;
+        Scalar s3UpdateAltDiffers;
+        Scalar s3UpdateUseAltOnNaUpdated;
+        Scalar s3UpdateProviderNa;
+        Scalar s3UpdateUseAltOnNaCorrect;
+        Scalar s3UpdateUseAltOnNaWrong;
+        Scalar s3UpdateAllocFailure;
+        Scalar s3UpdateAllocFailureNoValidTable;
+        Scalar s3UpdateAllocSuccess;
+        Scalar s3UpdateMispred;
+        Scalar s3UpdateResetU;
+        Scalar s3UpdateUtageHit;
+        Scalar s3UpdateUtageHitWrong;
+        Scalar s3UpdateResolvedBypass;
+        Scalar s3UpdateResolvedBackpressure;
 
         // Bank conflict statistics
         Scalar updateBankConflict;           // Number of bank conflicts detected
@@ -350,12 +375,18 @@ private:
 
     // Helper method to prepare BTB entries for update
     std::vector<BTBEntry> prepareUpdateEntries(const FetchTarget &stream);
+    // Build the reachable conditional prefix for S3 teacher update.
+    std::vector<BTBEntry> prepareS3UpdateEntries(const FullBTBPrediction &s3Pred);
 
     // Helper method to update predictor state for a single entry
     bool updatePredictorStateAndCheckAllocation(const BTBEntry &entry,
                                  bool actual_taken,
                                  const TagePrediction &pred,
                                  const FetchTarget &stream);
+    // Reuse the provider/allocation policy under an S3-teacher mismatch definition.
+    bool updatePredictorStateAndCheckAllocationS3(const BTBEntry &entry,
+                                 bool actual_taken,
+                                 const TagePrediction &pred);
 
     // Helper method to handle new entry allocation
     bool handleNewEntryAllocation(const Addr &startPC,
@@ -364,6 +395,7 @@ private:
                                  unsigned main_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
+                                 TageStats *stats,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
                                  uint64_t &allocated_way);

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -359,7 +359,11 @@ public:
         TageMeta() : aheadIndexFoldedHistValid(false) {}
     } TageMeta;
 
-private:
+#ifdef UNIT_TEST
+  public:
+#else
+  private:
+#endif
 
     // Helper method to generate prediction for a single BTB entry
     // If predMeta is provided, use snapshot folded history for index/tag calculation (update path)

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -36,6 +36,13 @@ GTest('mgsc.test',
     '../timed_base_pred.cc',
 )
 
+GTest('microtage.test',
+    '../microtage.cc',
+    'microtage.test.cc',
+    '../folded_hist.cc',
+    '../timed_base_pred.cc',
+)
+
 GTest('folded_hist.test',
     'folded_hist.test.cc',
     '../folded_hist.cc',
@@ -58,6 +65,7 @@ env.Append(UNITTESTS=['uras.test',
         'btb.test',
         'tage.test',
         'mgsc.test',
+        'microtage.test',
         'folded_hist.test',
         'history_manager.test',
         'jump_ahead.test',

--- a/src/cpu/pred/btb/test/microtage.test.cc
+++ b/src/cpu/pred/btb/test/microtage.test.cc
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/microtage.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+namespace btb_pred
+{
+
+namespace test
+{
+
+namespace
+{
+
+BTBEntry
+makeCondEntry(Addr pc, int ctr = -1, bool always_taken = false)
+{
+    BTBEntry entry;
+    entry.valid = true;
+    entry.pc = pc;
+    entry.target = pc + 4;
+    entry.size = 4;
+    entry.isCond = true;
+    entry.ctr = ctr;
+    entry.alwaysTaken = always_taken;
+    return entry;
+}
+
+FullBTBPrediction
+makeStagePred(Addr start_pc, const std::vector<BTBEntry> &entries,
+              const CondTakens &cond_takens)
+{
+    FullBTBPrediction pred;
+    pred.tid = 0;
+    pred.bbStart = start_pc;
+    pred.btbEntries = entries;
+    pred.condTakens = cond_takens;
+    return pred;
+}
+
+} // namespace
+
+class MicroTAGES3UpdateTest : public ::testing::Test
+{
+  protected:
+    void
+    SetUp() override
+    {
+        tage = std::make_unique<MicroTAGE>(4, 1, 32, 4);
+        tage->usingS3Pred = true;
+        tage->s3UpdateUseResolveBackpressure = false;
+    }
+
+    void
+    primePrediction(MicroTAGE *tage, const FullBTBPrediction &seed)
+    {
+        auto copied = seed;
+        std::vector<FullBTBPrediction> stage_preds(1);
+        stage_preds[0] = copied;
+        tage->putPCHistory(seed.bbStart, boost::dynamic_bitset<>(64), stage_preds);
+    }
+
+    bool
+    predictTaken(MicroTAGE *predictor, Addr start_pc, const BTBEntry &entry)
+    {
+        std::vector<FullBTBPrediction> stage_preds(1);
+        stage_preds[0].tid = 0;
+        stage_preds[0].bbStart = start_pc;
+        stage_preds[0].btbEntries = {entry};
+        predictor->putPCHistory(start_pc, boost::dynamic_bitset<>(64), stage_preds);
+        Addr branch_pc = entry.pc;
+        auto it = CondTakens_find(stage_preds[0].condTakens, branch_pc);
+        return it != stage_preds[0].condTakens.end() && it->second;
+    }
+
+    std::unique_ptr<MicroTAGE> tage;
+};
+
+TEST_F(MicroTAGES3UpdateTest, FunctionalUpdateBypassedWhenUsingS3Pred)
+{
+    BTBEntry entry = makeCondEntry(0x1000, -1);
+    FullBTBPrediction seed = makeStagePred(0x1000, {entry}, {{entry.pc, false}});
+    primePrediction(tage.get(), seed);
+
+    FetchTarget stream;
+    stream.startPC = 0x1000;
+    stream.updateBTBEntries = {entry};
+    stream.exeTaken = true;
+    stream.exeBranchInfo = entry;
+
+    tage->update(stream);
+    EXPECT_FALSE(predictTaken(tage.get(), 0x1000, entry));
+}
+
+TEST_F(MicroTAGES3UpdateTest, LearnsFromS3TeacherDirection)
+{
+    BTBEntry entry = makeCondEntry(0x1000, -1);
+    FullBTBPrediction seed = makeStagePred(0x1000, {entry}, {{entry.pc, false}});
+    primePrediction(tage.get(), seed);
+    bool before = predictTaken(tage.get(), 0x1000, entry);
+
+    FullBTBPrediction teacher = makeStagePred(0x1000, {entry}, {{entry.pc, true}});
+    tage->updateUsingS3Pred(teacher);
+
+    bool after = predictTaken(tage.get(), 0x1000, entry);
+    EXPECT_FALSE(before);
+    EXPECT_TRUE(after);
+}
+
+TEST_F(MicroTAGES3UpdateTest, StopsTrainingAfterFirstTakenControl)
+{
+    BTBEntry first = makeCondEntry(0x1000, -1);
+    BTBEntry second = makeCondEntry(0x1004, -1);
+    FullBTBPrediction seed = makeStagePred(0x1000, {first, second},
+                                           {{first.pc, false}, {second.pc, false}});
+    primePrediction(tage.get(), seed);
+
+    FullBTBPrediction teacher = makeStagePred(0x1000, {first, second},
+                                              {{first.pc, true}, {second.pc, true}});
+    tage->updateUsingS3Pred(teacher);
+
+    EXPECT_TRUE(predictTaken(tage.get(), 0x1000, first));
+    EXPECT_FALSE(predictTaken(tage.get(), 0x1000, second));
+}
+
+TEST_F(MicroTAGES3UpdateTest, MissingPredictionMetaSkipsSafely)
+{
+    FullBTBPrediction teacher = makeStagePred(0x2000, {makeCondEntry(0x2000)},
+                                              {{0x2000, true}});
+    EXPECT_NO_THROW(tage->updateUsingS3Pred(teacher));
+}
+
+} // namespace test
+
+} // namespace btb_pred
+
+} // namespace branch_prediction
+
+} // namespace gem5

--- a/src/cpu/pred/btb/test/microtage.test.cc
+++ b/src/cpu/pred/btb/test/microtage.test.cc
@@ -56,7 +56,6 @@ class MicroTAGES3UpdateTest : public ::testing::Test
     {
         tage = std::make_unique<MicroTAGE>(4, 1, 32, 4);
         tage->usingS3Pred = true;
-        tage->s3UpdateUseResolveBackpressure = false;
     }
 
     void

--- a/src/cpu/pred/btb/test/microtage.test.cc
+++ b/src/cpu/pred/btb/test/microtage.test.cc
@@ -40,6 +40,7 @@ makeStagePred(Addr start_pc, const std::vector<BTBEntry> &entries,
 {
     FullBTBPrediction pred;
     pred.tid = 0;
+    pred.asidHash = 0;
     pred.bbStart = start_pc;
     pred.btbEntries = entries;
     pred.condTakens = cond_takens;
@@ -114,6 +115,22 @@ TEST_F(MicroTAGES3UpdateTest, LearnsFromS3TeacherDirection)
     EXPECT_TRUE(after);
 }
 
+TEST_F(MicroTAGES3UpdateTest, S3NoHitStatsMirrorPredictionAccounting)
+{
+    BTBEntry entry = makeCondEntry(0x1800, -1);
+    FullBTBPrediction seed = makeStagePred(0x1800, {entry}, {{entry.pc, false}});
+    primePrediction(tage.get(), seed);
+
+    FullBTBPrediction teacher = makeStagePred(0x1800, {entry}, {{entry.pc, true}});
+    tage->updateUsingS3Pred(teacher);
+
+    EXPECT_EQ(tage->tageStats.s3UpdateEntries, 1ULL);
+    EXPECT_EQ(tage->tageStats.s3UpdateNoHitUseBim, 1ULL);
+    EXPECT_EQ(tage->tageStats.s3UpdateUseAlt, 1ULL);
+    EXPECT_EQ(tage->tageStats.updateNoHitUseBim, 0ULL);
+    EXPECT_EQ(tage->tageStats.updateUseAlt, 0ULL);
+}
+
 TEST_F(MicroTAGES3UpdateTest, StopsTrainingAfterFirstTakenControl)
 {
     BTBEntry first = makeCondEntry(0x1000, -1);
@@ -135,6 +152,62 @@ TEST_F(MicroTAGES3UpdateTest, MissingPredictionMetaSkipsSafely)
     FullBTBPrediction teacher = makeStagePred(0x2000, {makeCondEntry(0x2000)},
                                               {{0x2000, true}});
     EXPECT_NO_THROW(tage->updateUsingS3Pred(teacher));
+}
+
+TEST_F(MicroTAGES3UpdateTest, S3AllocationCountersStaySplitFromNormalUpdateCounters)
+{
+    BTBEntry entry = makeCondEntry(0x3000, -1);
+    FullBTBPrediction seed = makeStagePred(0x3000, {entry}, {{entry.pc, false}});
+    primePrediction(tage.get(), seed);
+
+    auto meta = tage->threadMeta[0];
+    ASSERT_NE(meta, nullptr);
+
+    uint64_t allocated_table = 0;
+    uint64_t allocated_index = 0;
+    uint64_t allocated_way = 0;
+    bool allocated = tage->handleNewEntryAllocation(
+        seed.bbStart, entry, true, 0, meta, seed.asidHash, &tage->tageStats,
+        allocated_table, allocated_index, allocated_way);
+
+    EXPECT_TRUE(allocated);
+    EXPECT_EQ(tage->tageStats.s3UpdateAllocSuccess, 1ULL);
+    EXPECT_EQ(tage->tageStats.updateAllocSuccess, 0ULL);
+}
+
+TEST_F(MicroTAGES3UpdateTest, S3AllocationFailureAndResetCountersStaySplit)
+{
+    BTBEntry entry = makeCondEntry(0x3800, -1);
+    FullBTBPrediction seed = makeStagePred(0x3800, {entry}, {{entry.pc, false}});
+    primePrediction(tage.get(), seed);
+
+    auto meta = tage->threadMeta[0];
+    ASSERT_NE(meta, nullptr);
+
+    const unsigned blocked_table = tage->numPredictors - 1;
+    Addr blocked_index = tage->getTageIndex(
+        seed.bbStart, blocked_table, meta->indexFoldedHist[blocked_table].get(),
+        seed.asidHash);
+    auto &blocked_way = tage->tageTable[blocked_table][blocked_index][0];
+    blocked_way = MicroTAGE::TageEntry(0x55, 3, entry.pc);
+    blocked_way.useful = true;
+
+    tage->usefulResetCnt = 255;
+
+    uint64_t allocated_table = 0;
+    uint64_t allocated_index = 0;
+    uint64_t allocated_way = 0;
+    bool allocated = tage->handleNewEntryAllocation(
+        seed.bbStart, entry, true, blocked_table, meta, seed.asidHash,
+        &tage->tageStats, allocated_table, allocated_index, allocated_way);
+
+    EXPECT_FALSE(allocated);
+    EXPECT_EQ(tage->tageStats.s3UpdateAllocFailure, 1ULL);
+    EXPECT_EQ(tage->tageStats.updateAllocFailure, 0ULL);
+    EXPECT_EQ(tage->tageStats.s3UpdateResetU, 1ULL);
+    EXPECT_EQ(tage->tageStats.updateResetU, 0ULL);
+    EXPECT_EQ(tage->tageStats.s3UpdateAllocFailureNoValidTable, 1ULL);
+    EXPECT_EQ(tage->tageStats.updateAllocFailureNoValidTable, 0ULL);
 }
 
 } // namespace test

--- a/src/cpu/pred/btb/test/microtage.test.cc
+++ b/src/cpu/pred/btb/test/microtage.test.cc
@@ -167,7 +167,8 @@ TEST_F(MicroTAGES3UpdateTest, S3AllocationCountersStaySplitFromNormalUpdateCount
     uint64_t allocated_index = 0;
     uint64_t allocated_way = 0;
     bool allocated = tage->handleNewEntryAllocation(
-        seed.bbStart, entry, true, 0, meta, seed.asidHash, &tage->tageStats,
+        seed.bbStart, entry, true, 0, meta, seed.asidHash,
+        MicroTAGE::TrainingMode::S3Update,
         allocated_table, allocated_index, allocated_way);
 
     EXPECT_TRUE(allocated);
@@ -199,7 +200,8 @@ TEST_F(MicroTAGES3UpdateTest, S3AllocationFailureAndResetCountersStaySplit)
     uint64_t allocated_way = 0;
     bool allocated = tage->handleNewEntryAllocation(
         seed.bbStart, entry, true, blocked_table, meta, seed.asidHash,
-        &tage->tageStats, allocated_table, allocated_index, allocated_way);
+        MicroTAGE::TrainingMode::S3Update,
+        allocated_table, allocated_index, allocated_way);
 
     EXPECT_FALSE(allocated);
     EXPECT_EQ(tage->tageStats.s3UpdateAllocFailure, 1ULL);


### PR DESCRIPTION
Change-Id: I46663d8e37d225a543c5b1d8db0cf7f28f415528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an S3 teacher-update mode for MicroTAGE branch prediction and enabled it in the decoupled BPU example configurations.
  * Extended MicroTAGE/UTAGE telemetry with S3-specific update, allocation, and no-hit statistics.
* **Bug Fixes**
  * Updated the decoupled BPU final S3 prediction flow so MicroTAGE now receives and learns from S3 teacher updates when enabled.
* **Tests**
  * Added new MicroTAGE unit tests covering S3 learning, early-stop after the first taken, allocation counter behavior, and robustness with missing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->