### PR TITLE
cpu-o3: Limit store drain for barrier micro-ops

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1689,16 +1689,18 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 "at the head of the ROB, PC %s.\n",
                 tid, head_inst->seqNum, head_inst->pcState());
 
-        // Non-speculative memory-ordering instructions such as sfence.vma must
-        // not execute until older stores are visible; otherwise page-table
-        // updates may race with the TLB invalidation. AMO fence micro-ops are
-        // already ordered by the normal barrier path and should not force a
-        // full store-buffer drain.
+        // Memory-ordering instructions such as sfence.vma and architectural
+        // fence must not execute until older stores are visible. RISC-V AMO
+        // fence micro-ops are already ordered by the normal barrier path and
+        // should not force a full store-buffer drain.
         const bool is_ordering_barrier =
             head_inst->isReadBarrier() || head_inst->isWriteBarrier();
+        const bool is_amo_fence_microop =
+            is_ordering_barrier && head_inst->isMicroop() &&
+            !head_inst->isNonSpeculative();
         const bool needs_store_drain =
             head_inst->isMemRef() || head_inst->isReturn() ||
-            (head_inst->isNonSpeculative() && is_ordering_barrier);
+            (is_ordering_barrier && !is_amo_fence_microop);
         const bool stores_drained =
             !needs_store_drain || iewStage->flushStores(tid, head_inst->seqNum);
         if (needs_store_drain && (inst_num > 0 || !stores_drained)) {

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1689,12 +1689,16 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                 "at the head of the ROB, PC %s.\n",
                 tid, head_inst->seqNum, head_inst->pcState());
 
-        // Memory-ordering instructions such as sfence.vma must not execute
-        // until older stores are visible; otherwise page-table updates may
-        // race with the TLB invalidation.
+        // Non-speculative memory-ordering instructions such as sfence.vma must
+        // not execute until older stores are visible; otherwise page-table
+        // updates may race with the TLB invalidation. AMO fence micro-ops are
+        // already ordered by the normal barrier path and should not force a
+        // full store-buffer drain.
+        const bool is_ordering_barrier =
+            head_inst->isReadBarrier() || head_inst->isWriteBarrier();
         const bool needs_store_drain =
             head_inst->isMemRef() || head_inst->isReturn() ||
-            head_inst->isReadBarrier() || head_inst->isWriteBarrier();
+            (head_inst->isNonSpeculative() && is_ordering_barrier);
         const bool stores_drained =
             !needs_store_drain || iewStage->flushStores(tid, head_inst->seqNum);
         if (needs_store_drain && (inst_num > 0 || !stores_drained)) {


### PR DESCRIPTION
## Motivation

SMT `perlbench_checkspam_24350` regressed into a pathological final measured
region in run88. The slice completed, but final IPC collapsed from the historic
~3 range to `0.183349`, with `34.663M` committed memory barriers and `43.330M`
commit non-spec stalls.

PC sampling showed the first repeated post-warmup barrier stalls were not
kernel `sfence.vma`. They were user-space AMO fence micro-ops at PC `0xe20ec`,
which maps to glibc `_int_free` (`malloc.c:4513`). The architectural instruction
there is `amoswap.w`, used by malloc/free locking.

## Approach

Keep the store-drain requirement for true non-speculative memory-ordering
instructions such as `sfence.vma`, but do not force every read/write barrier
micro-op to drain the store buffer.

This matters because RISC-V AMOs are modeled with strict read/write barrier
micro-ops. Those AMO fence micro-ops are already ordered by the normal barrier
path and should not be upgraded into a full store-buffer drain at commit.

## Validation

Built:

```text
scons build/RISCV/gem5.fast --gold-linker -j64
```

Targeted SMT checkpoint A/B:

```text
perlbench_checkspam_24350
configs/example/smt_idealkmhv3.py
--warmup-insts-no-switch=20000000
```

Run88 final block:

```text
cycles              218.125M
totalIpc            0.183349
membars             34.663M
commitNonSpecStalls 43.330M
```

Patched final block:

```text
cycles              13.547M
totalIpc            2.941605
membars             24.238K
commitNonSpecStalls 30.444K
```

The patched run also reached the expected `SPAM[...]` output before
max-instruction exit; the pathological run reached max instruction count before
that output appeared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction ordering in the simulator around store completion.
  * Memory-ordering barriers now wait for pending stores only for non-speculative cases, while memory references and return instructions continue to require draining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->