### PR TITLE
ext: Zero-init SoftFloat commonNaN macros

### DIFF
--- a/ext/softfloat/specialize.h
+++ b/ext/softfloat/specialize.h
@@ -98,7 +98,11 @@ struct commonNaN { char _unused; };
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f16UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & 0x0200) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f16UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & 0x0200) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 16-bit floating-point
@@ -133,7 +137,11 @@ uint_fast16_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f32UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & 0x00400000) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f32UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & 0x00400000) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 32-bit floating-point
@@ -168,7 +176,11 @@ uint_fast32_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f64UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & UINT64_C( 0x0008000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f64UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & UINT64_C( 0x0008000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 64-bit floating-point
@@ -213,8 +225,12 @@ uint_fast64_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_extF80UIToCommonNaN( uiA64, uiA0, zPtr ) if ( ! ((uiA0) & UINT64_C( 0x4000000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
-
+#define softfloat_extF80UIToCommonNaN( uiA64, uiA0, zPtr ) \
+    do { \
+        if ( ! ((uiA0) & UINT64_C( 0x4000000000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into an 80-bit extended
 | floating-point NaN, and returns the bit pattern of this value as an unsigned
@@ -271,7 +287,12 @@ struct uint128
 | pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid exception
 | is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f128UIToCommonNaN( uiA64, uiA0, zPtr ) if ( ! ((uiA64) & UINT64_C( 0x0000800000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f128UIToCommonNaN( uiA64, uiA0, zPtr ) \
+    do { \
+        if ( ! ((uiA64) & UINT64_C( 0x0000800000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 128-bit floating-point
@@ -320,7 +341,12 @@ struct uint128
 | common NaN at the location pointed to by `zPtr'.  If the NaN is a signaling
 | NaN, the invalid exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_extF80MToCommonNaN( aSPtr, zPtr ) if ( ! ((aSPtr)->signif & UINT64_C( 0x4000000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_extF80MToCommonNaN( aSPtr, zPtr ) \
+    do { \
+        if ( ! ((aSPtr)->signif & UINT64_C( 0x4000000000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into an 80-bit extended
@@ -371,7 +397,12 @@ void
 | four 32-bit elements that concatenate in the platform's normal endian order
 | to form a 128-bit floating-point value.
 *----------------------------------------------------------------------------*/
-#define softfloat_f128MToCommonNaN( aWPtr, zPtr ) if ( ! ((aWPtr)[indexWordHi( 4 )] & UINT64_C( 0x0000800000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f128MToCommonNaN( aWPtr, zPtr ) \
+    do { \
+        if ( ! ((aWPtr)[indexWordHi( 4 )] & UINT64_C( 0x0000800000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 128-bit floating-point


### PR DESCRIPTION
## Motivation

Manual perf builds using clang can fail in ext/softfloat when -Werror promotes -Wuninitialized-const-pointer diagnostics to errors. The failing pattern is SoftFloat ToCommonNaN macros under SOFTFLOAT_FAST_INT64: they may raise the invalid flag, but they do not write the destination commonNaN object before later code passes it by const pointer.

This is cherry-picked from upstream gem5 commit 02da314e96ab6436fcda1ee69a3607639a17dacb.

## Approach

Zero-initialize the destination struct commonNaN in the SoftFloat ToCommonNaN macros. This preserves the default-NaN behavior while satisfying newer clang diagnostics, and avoids broadly suppressing -Wuninitialized.

## Validation

- CC=clang CXX=clang++ scons build/RISCV/ext/softfloat/f16_to_f128.os build/RISCV/ext/softfloat/f32_to_f128.os build/RISCV/ext/softfloat/f64_to_f128.os --gold-linker --pgo-prof -j1
- git diff --check origin/xs-dev...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NaN conversion behavior across multiple floating-point formats.
  * Signaling NaNs still trigger invalid exceptions, and the output NaN value is now consistently initialized, reducing the chance of undefined or stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->