### PR TITLE
arch-riscv: configurable vector splitting unit

### DIFF
--- a/docs/Gem5_Docs/RVV/vector.md
+++ b/docs/Gem5_Docs/RVV/vector.md
@@ -1,0 +1,74 @@
+# Vector Split Units
+
+## Scope
+
+本文档描述 O3 后端里向量访存的 split 建模，不描述 RVV 宏指令拆 micro-op 的 ISA 语义。
+
+当前实现位置在 `src/cpu/o3/issue_queue.{hh,cc}`，作用对象是：
+
+- `isVector() && isMemRef()` 的向量访存指令
+- 指令在操作数 ready 之后，进入 issue 前的 split 延迟模型
+
+## Current Model
+
+向量访存 ready 后，会经过下面这条路径：
+
+1. 进入 `vectorReadyQ`
+2. 被分配到某个 vector split unit
+3. 在 split unit 中等待固定 `3` 拍
+4. 释放到 `vectorDelayedReadyQ`
+5. 再回到常规 `readyQ`，参与后续 schedule / issue
+
+本次实现后，`IssueQue` 默认有 `2` 个独立的 vector split unit，可通过 `vectorSplitUnits` 参数修改。
+
+## Two-Unit Semantics
+
+两个 split unit 之间没有阻塞关系。
+
+每个 split unit 内部保留原有阻塞语义：
+
+- 如果该 unit 里已经有非 `unit-stride` 的向量访存正在 split，这个 unit 就不再接收新的待拆分指令
+- 另一个 unit 如果没有被这种指令占住，仍然可以继续接收新的待拆分指令
+
+`unit-stride` 指令仍然视为非阻塞型：
+
+- 它们会被送入某个具体 split unit
+- 但不会把该 unit 标记成 blocked
+
+因此，效果上等价于：
+
+- 旧模型：1 套“split 通道 + 全局 blocker”
+- 新模型：2 套彼此独立的“split 通道 + 每通道各自的 blocker”
+
+## Unit Selection
+
+待拆分指令统一先进入全局 `vectorReadyQ`。
+
+当 `IssueQue` 尝试启动 split 时：
+
+1. 按 `vectorReadyQ` 的 FIFO 顺序取最老指令
+2. 在所有未 blocked 的 split unit 中做轮转选择
+3. 将该指令送入选中的 unit
+4. 若该指令是非 `unit-stride`，则只阻塞它所在的那个 unit
+
+如果 2 个 unit 都被非 `unit-stride` 指令占住，则 `vectorReadyQ` 停止继续向前推进，直到至少一个 unit 释放。
+
+## What Stays Unchanged
+
+这次修改没有改变下面这些语义：
+
+- split 延迟仍然是固定 `3` 拍
+- 释放后仍然先进入 `vectorDelayedReadyQ`
+- 后续仍然走原有 `readyQ -> select -> schedule -> toFu` 路径
+- 没有把一个 vector memory micro-op 进一步拆成多个 LSQ 子请求
+- 没有改 RVV ISA 模板里的 macro-op / micro-op 生成方式
+
+## Config Surface
+
+`src/cpu/o3/FuncScheduler.py` 中给 `IssueQue` 新增了：
+
+```python
+vectorSplitUnits = Param.Unsigned(2, "Number of independent vector split units")
+```
+
+默认值是 `2`。如果需要回退到旧行为，可以显式把它设成 `1`。

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -84,6 +84,7 @@ class IssueQue(SimObject):
     size = Param.Int(16, "")
     inports = Param.Int(2, "")
     scheduleToExecDelay = Param.Cycles(2, "")
+    vectorSplitUnits = Param.Unsigned(2, "Number of independent vector split units")
     oports = VectorParam.IssuePort("")
     sel = Param.BaseSelector(BaseSelector(), "Selector for this IQ")
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -197,11 +197,17 @@ IssueQue::IssueQue(const IssueQueParams& params)
       iqsize(params.size),
       scheduleToExecDelay(params.scheduleToExecDelay),
       iqname(params.name),
+      vectorSplitUnits(params.vectorSplitUnits),
+      nextVectorSplitUnit(0),
       inflightIssues(scheduleToExecDelay, 0),
+      vectorSplitStates(params.vectorSplitUnits),
       vectorReadyQEvent([this]() { processVectorReadyQ(); },
                         csprintf("%s.vectorReadyQEvent", params.name)),
       selector(params.sel)
 {
+    panic_if(vectorSplitUnits == 0,
+             "%s: vectorSplitUnits must be greater than 0\n", iqname);
+
     // TODO: keep this in sync with the current load IQ naming convention.
     // This should become an explicit IssueQue parameter when the config grows
     // more load pipes or renames the queues.
@@ -392,20 +398,81 @@ IssueQue::isBlockingVectorSplitInst(const DynInstPtr& inst) const
     return isVectorMemInst(inst) && inst->opClass() != enums::VectorUnitStrideLoad;
 }
 
+bool
+IssueQue::hasAvailableVectorSplitUnit() const
+{
+    for (const auto& unit : vectorSplitStates) {
+        if (!unit.blocked()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+int
+IssueQue::selectVectorSplitUnit()
+{
+    if (vectorSplitStates.empty()) {
+        return -1;
+    }
+
+    for (unsigned offset = 0; offset < vectorSplitStates.size(); ++offset) {
+        const unsigned idx = (nextVectorSplitUnit + offset) %
+                             vectorSplitStates.size();
+        if (!vectorSplitStates[idx].blocked()) {
+            nextVectorSplitUnit = (idx + 1) % vectorSplitStates.size();
+            return idx;
+        }
+    }
+
+    return -1;
+}
+
+Tick
+IssueQue::nextVectorSplitReleaseTick() const
+{
+    Tick next_tick = MaxTick;
+
+    for (const auto& unit : vectorSplitStates) {
+        if (!unit.splitQ.empty() && !unit.splitQReleaseTicks.empty()) {
+            next_tick = std::min(next_tick, unit.splitQReleaseTicks.front());
+        }
+    }
+
+    return next_tick;
+}
+
+void
+IssueQue::eraseVectorSplitBlocker(InstSeqNum seq_num)
+{
+    for (auto& unit : vectorSplitStates) {
+        unit.blockingSeqs.erase(seq_num);
+    }
+}
+
 void
 IssueQue::scheduleVectorReadyQEvent()
 {
-    if (!cpu || vectorReadyQEvent.scheduled()) {
+    if (!cpu) {
         return;
     }
 
-    if (!vectorSplitQ.empty() && !vectorSplitQReleaseTicks.empty()) {
-        cpu->schedule(vectorReadyQEvent, vectorSplitQReleaseTicks.front());
+    Tick next_tick = MaxTick;
+    if (!vectorReadyQ.empty() && hasAvailableVectorSplitUnit()) {
+        next_tick = curTick();
+    } else {
+        next_tick = nextVectorSplitReleaseTick();
+    }
+
+    if (next_tick == MaxTick) {
         return;
     }
 
-    if (!vectorReadyQ.empty()) {
-        cpu->schedule(vectorReadyQEvent, curTick());
+    if (vectorReadyQEvent.scheduled()) {
+        cpu->reschedule(vectorReadyQEvent, next_tick, true);
+    } else {
+        cpu->schedule(vectorReadyQEvent, next_tick);
     }
 }
 
@@ -443,12 +510,13 @@ IssueQue::tryStartVectorMemSplit()
             vectorReadyQReplay.pop();
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
-                vectorBlockingSplitSeqs.erase(inst->seqNum);
+                eraseVectorSplitBlocker(inst->seqNum);
             }
             continue;
         }
 
-        if (!vectorBlockingSplitSeqs.empty()) {
+        const int split_unit = selectVectorSplitUnit();
+        if (split_unit < 0) {
             return;
         }
 
@@ -457,17 +525,18 @@ IssueQue::tryStartVectorMemSplit()
 
         assert(cpu);
         const Tick releaseTick = cpu->clockEdge(Cycles(3));
-        vectorSplitQ.push(inst);
-        vectorSplitQReleaseTicks.push(releaseTick);
-        vectorSplitQReplay.push(replay);
+        auto& unit = vectorSplitStates[split_unit];
+        unit.splitQ.push(inst);
+        unit.splitQReleaseTicks.push(releaseTick);
+        unit.splitQReplay.push(replay);
         if (isBlockingVectorSplitInst(inst)) {
-            vectorBlockingSplitSeqs.insert(inst->seqNum);
+            unit.blockingSeqs.insert(inst->seqNum);
         }
 
         DPRINTF(Schedule,
-                "[sn:%llu] enter vector split, replay:%d, release at %llu, "
-                "blocking:%d\n",
-                inst->seqNum, replay, releaseTick,
+                "[sn:%llu] enter vector split unit %d, replay:%d, release at "
+                "%llu, blocking:%d\n",
+                inst->seqNum, split_unit, replay, releaseTick,
                 isBlockingVectorSplitInst(inst));
     }
 }
@@ -485,13 +554,13 @@ IssueQue::releaseVectorDelayedReadyQ()
         if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
-                vectorBlockingSplitSeqs.erase(inst->seqNum);
+                eraseVectorSplitBlocker(inst->seqNum);
             }
             continue;
         }
 
         vectorReadyQSeqs.erase(inst->seqNum);
-        vectorBlockingSplitSeqs.erase(inst->seqNum);
+        eraseVectorSplitBlocker(inst->seqNum);
         if (replay) {
             replayQ.push(inst);
             DPRINTF(Schedule, "[sn:%llu] released to replayQ after vector delay\n",
@@ -513,29 +582,32 @@ IssueQue::processVectorReadyQ()
 {
     tryStartVectorMemSplit();
 
-    assert(vectorSplitQ.size() == vectorSplitQReleaseTicks.size());
-    assert(vectorSplitQ.size() == vectorSplitQReplay.size());
-    while (!vectorSplitQ.empty() && !vectorSplitQReleaseTicks.empty() &&
-           !vectorSplitQReplay.empty() &&
-           vectorSplitQReleaseTicks.front() <= curTick()) {
-        auto inst = vectorSplitQ.front();
-        const bool replay = vectorSplitQReplay.front();
-        vectorSplitQ.pop();
-        vectorSplitQReleaseTicks.pop();
-        vectorSplitQReplay.pop();
+    for (auto& unit : vectorSplitStates) {
+        assert(unit.splitQ.size() == unit.splitQReleaseTicks.size());
+        assert(unit.splitQ.size() == unit.splitQReplay.size());
+        while (!unit.splitQ.empty() && !unit.splitQReleaseTicks.empty() &&
+               !unit.splitQReplay.empty() &&
+               unit.splitQReleaseTicks.front() <= curTick()) {
+            auto inst = unit.splitQ.front();
+            const bool replay = unit.splitQReplay.front();
+            unit.splitQ.pop();
+            unit.splitQReleaseTicks.pop();
+            unit.splitQReplay.pop();
 
-        if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
-            if (inst) {
-                vectorReadyQSeqs.erase(inst->seqNum);
-                vectorBlockingSplitSeqs.erase(inst->seqNum);
+            if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
+                if (inst) {
+                    vectorReadyQSeqs.erase(inst->seqNum);
+                    eraseVectorSplitBlocker(inst->seqNum);
+                }
+                continue;
             }
-            continue;
-        }
 
-        vectorDelayedReadyQ.push(inst);
-        vectorDelayedReadyQReplay.push(replay);
-        DPRINTF(Schedule, "[sn:%llu] moved to vectorDelayedReadyQ, replay:%d\n",
-                inst->seqNum, replay);
+            vectorDelayedReadyQ.push(inst);
+            vectorDelayedReadyQReplay.push(replay);
+            DPRINTF(Schedule,
+                    "[sn:%llu] moved to vectorDelayedReadyQ, replay:%d\n",
+                    inst->seqNum, replay);
+        }
     }
 
     releaseVectorDelayedReadyQ();
@@ -668,7 +740,9 @@ IssueQue::idle()
     }
     idle |= replayQ.size() > 0;
     idle |= vectorReadyQ.size() > 0;
-    idle |= vectorSplitQ.size() > 0;
+    for (const auto& unit : vectorSplitStates) {
+        idle |= unit.splitQ.size() > 0;
+    }
     idle |= vectorDelayedReadyQ.size() > 0;
     return idle;
 }
@@ -1008,7 +1082,7 @@ IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
         if (inst->threadNumber == tid && inst->seqNum <= seqNum) {
             assert(inst->isIssued());
             vectorReadyQSeqs.erase(inst->seqNum);
-            vectorBlockingSplitSeqs.erase(inst->seqNum);
+            eraseVectorSplitBlocker(inst->seqNum);
             it = instList.erase(it);
         } else {
             ++it;
@@ -1042,7 +1116,7 @@ IssueQue::doSquash(SquashInfo squashInfo)
             (*it)->clearScheduled();
             (*it)->setCancel();
             vectorReadyQSeqs.erase((*it)->seqNum);
-            vectorBlockingSplitSeqs.erase((*it)->seqNum);
+            eraseVectorSplitBlocker((*it)->seqNum);
             it = instList.erase(it);
             assert(instList.size() >= instNum);
         } else {
@@ -1070,6 +1144,8 @@ IssueQue::doSquash(SquashInfo squashInfo)
             }
         }
     }
+
+    scheduleVectorReadyQEvent();
 }
 
 void

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -122,6 +122,8 @@ class IssueQue : public SimObject
     int numLoadPipe = 0;
     int numStorePipe = 0;
     int loadPipeId = -1;
+    const unsigned vectorSplitUnits;
+    unsigned nextVectorSplitUnit = 0;
 
     struct select_policy
     {
@@ -168,16 +170,23 @@ class IssueQue : public SimObject
     // srcIdx : inst
     std::vector<std::vector<std::pair<uint8_t, DynInstPtr>>> subDepGraph;
 
+    struct VectorSplitUnitState
+    {
+        std::queue<DynInstPtr> splitQ;
+        std::queue<Tick> splitQReleaseTicks;
+        std::queue<bool> splitQReplay;
+        std::unordered_set<InstSeqNum> blockingSeqs;
+
+        bool blocked() const { return !blockingSeqs.empty(); }
+    };
+
     std::queue<DynInstPtr> replayQ;  // only for mem
     std::queue<DynInstPtr> vectorReadyQ;
     std::queue<bool> vectorReadyQReplay;
-    std::queue<DynInstPtr> vectorSplitQ;
-    std::queue<Tick> vectorSplitQReleaseTicks;
-    std::queue<bool> vectorSplitQReplay;
+    std::vector<VectorSplitUnitState> vectorSplitStates;
     std::queue<DynInstPtr> vectorDelayedReadyQ;
     std::queue<bool> vectorDelayedReadyQReplay;
     std::unordered_set<InstSeqNum> vectorReadyQSeqs;
-    std::unordered_set<InstSeqNum> vectorBlockingSplitSeqs;
     EventFunctionWrapper vectorReadyQEvent;
 
     CPU* cpu = nullptr;
@@ -209,6 +218,10 @@ class IssueQue : public SimObject
     bool checkScoreboard(const DynInstPtr& inst);
     bool isVectorMemInst(const DynInstPtr& inst) const;
     bool isBlockingVectorSplitInst(const DynInstPtr& inst) const;
+    bool hasAvailableVectorSplitUnit() const;
+    int selectVectorSplitUnit();
+    Tick nextVectorSplitReleaseTick() const;
+    void eraseVectorSplitBlocker(InstSeqNum seq_num);
     void enqueueVectorMemDelay(const DynInstPtr& inst, bool replay);
     void tryStartVectorMemSplit();
     void scheduleVectorReadyQEvent();

--- a/src/cpu/pred/ftb/decoupled_bpred.cc
+++ b/src/cpu/pred/ftb/decoupled_bpred.cc
@@ -1107,7 +1107,7 @@ DecoupledBPUWithFTB::controlSquash(unsigned target_id, unsigned stream_id,
     }
 
     auto pc = stream.startPC;
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (pc == ObservingPC) {
         debugFlagOn = true;
     }
@@ -1443,7 +1443,7 @@ void DecoupledBPUWithFTB::update(unsigned stream_id, ThreadID tid)
     if (fetchStreamQueue.empty())
         return;
     auto it = fetchStreamQueue.begin();
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     while (it != fetchStreamQueue.end() && stream_id >= it->first) {
         auto &stream = it->second;
         // dequeue
@@ -2162,7 +2162,7 @@ DecoupledBPUWithFTB::dumpFsq(const char *when)
 void
 DecoupledBPUWithFTB::tryEnqFetchStream()
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (s0PC == ObservingPC) {
         debugFlagOn = true;
     }
@@ -2414,7 +2414,7 @@ DecoupledBPUWithFTB::generateAndSetNewFetchStream()
     auto &entry = entry_new;
     entry.startPC = s0PC;
     entry.predMetas.resize(numComponents);
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (s0PC == ObservingPC) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/loop_predictor.cc
+++ b/src/cpu/pred/loop_predictor.cc
@@ -278,7 +278,7 @@ bool
 LoopPredictor::loopPredict(ThreadID tid, Addr branch_pc, bool cond_branch,
                    BranchInfo* bi, bool prev_pred_taken, unsigned instShiftAmt)
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branch_pc == ObservingPC) {
         debugFlagOn = true;
     }
@@ -339,7 +339,7 @@ LoopPredictor::condBranchUpdate(ThreadID tid, Addr branch_pc, bool taken,
                                 unsigned instShiftAmt)
 {
 
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branch_pc == ObservingPC) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/ltage.cc
+++ b/src/cpu/pred/ltage.cc
@@ -66,7 +66,7 @@ LTAGE::init()
 bool
 LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branch_pc == ObservingPC) {
         debugFlagOn = true;
     }
@@ -103,7 +103,7 @@ void
 LTAGE::update(ThreadID tid, Addr branch_pc, bool taken, void* bp_history,
               bool squashed, const StaticInstPtr & inst, Addr corrTarget)
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branch_pc == ObservingPC) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/stream/decoupled_bpred.cc
+++ b/src/cpu/pred/stream/decoupled_bpred.cc
@@ -340,7 +340,7 @@ DecoupledStreamBPU::controlSquash(unsigned target_id, unsigned stream_id,
     auto &stream = squashing_stream_it->second;
 
     auto pc = stream.streamStart;
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (pc == ObservingPC) {
         debugFlagOn = true;
     }
@@ -681,7 +681,7 @@ void DecoupledStreamBPU::update(unsigned stream_id, ThreadID tid)
     if (fetchStreamQueue.empty())
         return;
     auto it = fetchStreamQueue.begin();
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     while (it != fetchStreamQueue.end() && stream_id >= it->first) {
         auto &stream = it->second;
         storeLoopInfo(it->first, stream);
@@ -842,7 +842,7 @@ DecoupledStreamBPU::dumpFsq(const char *when)
 void
 DecoupledStreamBPU::tryEnqFetchStream()
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (s0StreamStartPC == ObservingPC) {
         debugFlagOn = true;
     }
@@ -1117,7 +1117,7 @@ DecoupledStreamBPU::processNewPrediction(bool create_new_stream)
     auto back = fetchStreamQueue.rbegin();
     auto &entry = create_new_stream ? entry_new : back->second;
     entry.streamStart = s0StreamStartPC;
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (s0StreamStartPC == ObservingPC) {
         debugFlagOn = true;
     }
@@ -1302,7 +1302,7 @@ DecoupledStreamBPU::pushRAS(FetchStreamId stream_id, const char *when, Addr ra)
 void
 DecoupledStreamBPU::updateTAGE(FetchStream &stream)
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (stream.streamStart == ObservingPC) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/stream/loop_detector.cc
+++ b/src/cpu/pred/stream/loop_detector.cc
@@ -75,7 +75,7 @@ StreamLoopDetector::adjustLoopEntry(bool taken_backward, DetectorEntry &entry, A
 
 void
 StreamLoopDetector::insertEntry(Addr branchAddr, DetectorEntry loopEntry) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -98,7 +98,7 @@ StreamLoopDetector::insertEntry(Addr branchAddr, DetectorEntry loopEntry) {
 
 void
 StreamLoopDetector::update(Addr branchAddr, Addr targetAddr, Addr fallThruPC) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/stream/modify_tage.cc
+++ b/src/cpu/pred/stream/modify_tage.cc
@@ -220,7 +220,7 @@ void
 StreamTAGE::putPCHistory(Addr cur_chunk_start, Addr stream_start, const bitset &history) {
     DPRINTF(Override, "In tage.putPCHistory().\n");
 
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     TickedStreamStorage *target = nullptr;
     TickedStreamStorage *alt_target = nullptr;
     int main_table = -1;

--- a/src/cpu/pred/stream/stream_loop_predictor.cc
+++ b/src/cpu/pred/stream/stream_loop_predictor.cc
@@ -15,7 +15,7 @@ StreamLoopPredictor::StreamLoopPredictor(const Params &params)
 
 void
 StreamLoopPredictor::insertEntry(Addr branchAddr, LoopEntry loopEntry) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC) {
         debugFlagOn = true;
     }
@@ -38,7 +38,7 @@ StreamLoopPredictor::insertEntry(Addr branchAddr, LoopEntry loopEntry) {
 void
 StreamLoopPredictor::updateTripCount(unsigned fsqId, Addr branchAddr)
 {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -74,7 +74,7 @@ StreamLoopPredictor::updateTripCount(unsigned fsqId, Addr branchAddr)
 
 std::pair<bool, Addr>
 StreamLoopPredictor::makeLoopPrediction(Addr branchAddr) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -101,7 +101,7 @@ StreamLoopPredictor::makeLoopPrediction(Addr branchAddr) {
 
 void
 StreamLoopPredictor::updateEntry(Addr branchAddr, Addr targetAddr, Addr outTarget, Addr fallThruPC, int detectedCount, bool intraTaken) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -125,7 +125,7 @@ StreamLoopPredictor::updateEntry(Addr branchAddr, Addr targetAddr, Addr outTarge
 
 void
 StreamLoopPredictor::updateMRULoop(Addr branchAddr) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC) {
         debugFlagOn = true;
     }
@@ -163,7 +163,7 @@ StreamLoopPredictor::restoreLoopTable(std::list<std::pair<Addr, unsigned int>> m
 
 void
 StreamLoopPredictor::controlSquash(unsigned fsqId, FetchStream stream, Addr branchAddr, Addr targetAddr) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -196,7 +196,7 @@ StreamLoopPredictor::controlSquash(unsigned fsqId, FetchStream stream, Addr bran
 
 std::pair<bool, std::vector<DivideEntry> >
 StreamLoopPredictor::updateTAGE(Addr streamStart, Addr branchAddr, Addr targetAddr) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (streamStart == ObservingPC || branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }
@@ -239,7 +239,7 @@ StreamLoopPredictor::updateTAGE(Addr streamStart, Addr branchAddr, Addr targetAd
 
 void
 StreamLoopPredictor::deleteEntry(Addr branchAddr) {
-    defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+    defer _(nullptr, [this](void *) { debugFlagOn = false; });
     if (branchAddr == ObservingPC2) {
         debugFlagOn = true;
     }

--- a/src/cpu/pred/stream/stream_loop_predictor.hh
+++ b/src/cpu/pred/stream/stream_loop_predictor.hh
@@ -64,7 +64,7 @@ public:
     void updateTripCount(unsigned fsqId, Addr branchAddr);
 
     bool getLoopPredValid(Addr branchAddr) {
-        defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+        defer _(nullptr, [this](void *) { debugFlagOn = false; });
         if (branchAddr == ObservingPC) {
             debugFlagOn = true;
         }
@@ -78,7 +78,7 @@ public:
     }
 
     int getTripCount(Addr branchAddr) {
-        defer _(nullptr, std::bind([this]{ debugFlagOn = false; }));
+        defer _(nullptr, [this](void *) { debugFlagOn = false; });
         if (branchAddr == ObservingPC) {
             debugFlagOn = true;
         }

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -57,8 +57,10 @@ main(int argc, char **argv)
         &PyMem_RawFree);
 
     // This can help python find libraries at run time relative to this binary.
-    // It's probably not necessary, but is mostly harmless and might be useful.
+    // Python 3.11 deprecated Py_SetProgramName(), so skip it there.
+#if PY_VERSION_HEX < 0x030B0000
     Py_SetProgramName(program.get());
+#endif
 
     py::scoped_interpreter guard(true, argc, argv);
 


### PR DESCRIPTION
Implement multiple configurable vector split units, with no blocking between different split units.

Change-Id: I7d2487187f3d45f76ebc7eec44c845c8aa87d666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable support for modeling vector memory splits with multiple independent split units.
  * Vector-ready operations now enter a staged delay before rejoining the standard scheduling pipeline.
* **Bug Fixes**
  * Improved vector split scheduling to better handle blocked vs non-blocked cases and reschedule work when split units become available.
* **Documentation**
  * Added a new/updated guide describing the vector memory split behavior and the “two-unit semantics.”
* **Chores**
  * Avoided deprecated Python behavior on Python 3.11+ when setting the program name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->