### PR TITLE
misc: Keep distributed runs going after missing checkpoints

### DIFF
--- a/util/xs_scripts/distributed_sim.py
+++ b/util/xs_scripts/distributed_sim.py
@@ -859,16 +859,20 @@ def append_launcher_output(job: PendingJob, stdout: bytes, stderr: bytes) -> Non
                 handle.write(b"\n")
 
 
-def mark_launcher_failure(job: PendingJob, message: str) -> None:
-    job.work_dir.mkdir(parents=True, exist_ok=True)
-    (job.work_dir / "running").unlink(missing_ok=True)
-    (job.work_dir / "completed").unlink(missing_ok=True)
-    (job.work_dir / "abort").touch()
-    with (job.work_dir / "log.txt").open("a", encoding="utf-8") as handle:
-        handle.write("\n===== distributed_sim launcher failure =====\n")
+def mark_work_dir_failure(work_dir: Path, header: str, message: str) -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "running").unlink(missing_ok=True)
+    (work_dir / "completed").unlink(missing_ok=True)
+    (work_dir / "abort").touch()
+    with (work_dir / "log.txt").open("a", encoding="utf-8") as handle:
+        handle.write(f"\n===== distributed_sim {header} =====\n")
         handle.write(message)
         if not message.endswith("\n"):
             handle.write("\n")
+
+
+def mark_launcher_failure(job: PendingJob, message: str) -> None:
+    mark_work_dir_failure(job.work_dir, "launcher failure", message)
 
 
 def wait_for_visible_marker(job: PendingJob, timeout: float) -> str:
@@ -1035,22 +1039,38 @@ def run_scheduler(
     launch_interval: float,
     force: bool,
 ) -> int:
-    pending_workloads = [ScheduledWorkload(workload) for workload in workloads]
-    total = len(pending_workloads)
+    total = len(workloads)
     skipped = 0
     first_launches = 0
     launch_attempts = 0
     completed = 0
     failed = 0
     last_launch_at = 0.0
+    pending_workloads: list[ScheduledWorkload] = []
     checkpoint_by_workload: dict[Workload, Path] = {}
     for workload in workloads:
         work_dir = full_work_dir / workload.name
         if (work_dir / "completed").exists() and not force:
+            pending_workloads.append(ScheduledWorkload(workload))
             continue
-        checkpoint_by_workload[workload] = find_checkpoint(
-            cpt_dir, workload.checkpoint_key
-        )
+        try:
+            checkpoint_by_workload[workload] = find_checkpoint(
+                cpt_dir, workload.checkpoint_key
+            )
+        except FileNotFoundError as exc:
+            clear_stale_markers(work_dir, force=force)
+            mark_work_dir_failure(
+                work_dir,
+                "checkpoint failure",
+                (
+                    f"Failed to resolve checkpoint for workload {workload.name!r}: "
+                    f"{exc}"
+                ),
+            )
+            failed += 1
+            print(f"[fail] {workload.name} checkpoint: {exc}", flush=True)
+            continue
+        pending_workloads.append(ScheduledWorkload(workload))
 
     try:
         while pending_workloads or any(server.pending for server in servers):


### PR DESCRIPTION
## Motivation
The weekly SMT SPEC06 1.0c job can fail before launching any GEM5 jobs when the distributed runner pre-resolves every selected checkpoint and one list entry is missing. In run 29038421818, the SMT checkpoint root was missing hmmer_nph3/0 and hmmer_retro/0, while the rest of the workload set was valid.

## Approach
- Treat missing checkpoint preflight failures like other workload failures.
- Write abort/log.txt for the affected workload and continue scheduling the remaining workloads.
- Keep the distributed runner exit status at 0 so workflow check_result remains the authority for failing on aborts.

## Validation
- PYTHONPYCACHEPREFIX=/tmp/gem5-dist-missing-pycache python3 -m py_compile util/xs_scripts/distributed_sim.py
- Fake local runner using /bin/true: one valid checkpoint completed, one missing checkpoint produced abort/log.txt, runner summary reported completed=1 failed=1 and exited 0.
- Confirmed the current SMT 1.0c checkpoint list/root is missing exactly hmmer_nph3_0 and hmmer_retro_0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler resilience when checkpoint files are missing or cannot be resolved.
  * Affected workloads are now marked as failed with clear status and log entries, while remaining workloads continue to be scheduled.
  * Standardized failure status updates and logging for launcher and checkpoint failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->