### PR TITLE
cpu-o3: Make badSpecBound stats per-thread for SMT

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -322,7 +322,10 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
 
     commitSquashedInsts.prereq(commitSquashedInsts);
     commitNonSpecStalls.prereq(commitNonSpecStalls);
-    branchMispredicts.prereq(branchMispredicts);
+
+    branchMispredicts
+        .init(cpu->numThreads)
+        .flags(total);
 
     numCommittedDist
         .init(0,commit->commitWidth * 8,1)
@@ -397,6 +400,34 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
         .flags(total | pdf | dist);
 
     committedInstType.ysubnames(enums::OpClassStrings);
+
+    recovery_bubble
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToBranch
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToOrderViolation
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToValuePrediction
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToTrap
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToTC
+        .init(cpu->numThreads)
+        .flags(total);
+
+    squashDueToSquashAfter
+        .init(cpu->numThreads)
+        .flags(total);
 
     totalSquash = squashDueToBranch + squashDueToOrderViolation + \
         squashDueToTrap + squashDueToTC + squashDueToSquashAfter;
@@ -763,7 +794,7 @@ Commit::squashFromTrap(ThreadID tid)
     trapSquash[tid] = false;
 
     commitStatus[tid] = ROBSquashing;
-    stats.squashDueToTrap++;
+    stats.squashDueToTrap[tid]++;
     cpu->activityThisCycle();
 }
 
@@ -783,7 +814,7 @@ Commit::squashFromTC(ThreadID tid)
     assert(!thread[tid]->trapPending);
 
     commitStatus[tid] = ROBSquashing;
-    stats.squashDueToTC++;
+    stats.squashDueToTC[tid]++;
     cpu->activityThisCycle();
 
     tcSquash[tid] = false;
@@ -815,7 +846,7 @@ Commit::squashFromSquashAfter(ThreadID tid)
     squashAfterInst[tid] = NULL;
 
     commitStatus[tid] = ROBSquashing;
-    stats.squashDueToSquashAfter++;
+    stats.squashDueToSquashAfter[tid]++;
     cpu->activityThisCycle();
 }
 
@@ -1069,17 +1100,17 @@ Commit::commit()
                     tid,
                     fromIEW->mispredictInst[tid]->pcState().instAddr(),
                     fromIEW->squashedSeqNum[tid]);
-                stats.squashDueToBranch++;
+                stats.squashDueToBranch[tid]++;
             } else if (fromIEW->valuePredictionError[tid]) {
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to value prediction error [sn:%llu]\n",
                     tid, fromIEW->squashedSeqNum[tid]);
-                stats.squashDueToValuePrediction++;
+                stats.squashDueToValuePrediction[tid]++;
             } else {
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to order violation [sn:%llu]\n",
                     tid, fromIEW->squashedSeqNum[tid]);
-                stats.squashDueToOrderViolation++;
+                stats.squashDueToOrderViolation[tid]++;
             }
 
             DPRINTF(Commit, "[tid:%i] Redirecting to PC %#x\n",
@@ -1132,7 +1163,7 @@ Commit::commit()
                 if (toIEW->commitInfo[tid].mispredictInst->isUncondCtrl()) {
                      toIEW->commitInfo[tid].branchTaken = true;
                 }
-                ++stats.branchMispredicts;
+                ++stats.branchMispredicts[tid];
             }
 
             set(toIEW->commitInfo[tid].pc, fromIEW->pc[tid]);
@@ -1325,7 +1356,7 @@ Commit::commitInsts()
 
                     if (ismispred) {
                         ismispred = false;
-                        stats.recovery_bubble +=
+                        stats.recovery_bubble[tid] +=
                             (cpu->curCycle() - lastCommitCycle[tid]) *
                             renameWidth;
                     }

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -430,7 +430,8 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
         .flags(total);
 
     totalSquash = squashDueToBranch + squashDueToOrderViolation + \
-        squashDueToTrap + squashDueToTC + squashDueToSquashAfter;
+        squashDueToValuePrediction + squashDueToTrap + squashDueToTC + \
+        squashDueToSquashAfter;
 }
 
 void
@@ -1354,14 +1355,14 @@ Commit::commitInsts()
                             head_inst->threadNumber,
                             head_inst->genDisassembly());
 
-                    if (ismispred) {
-                        ismispred = false;
+                    if (ismispred[tid]) {
+                        ismispred[tid] = false;
                         stats.recovery_bubble[tid] +=
                             (cpu->curCycle() - lastCommitCycle[tid]) *
                             renameWidth;
                     }
                     if (head_inst->mispredicted()) {
-                        ismispred = true;
+                        ismispred[tid] = true;
                     }
 
                     lastCommitCycle[tid] = cpu->curCycle();

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -651,7 +651,7 @@ class Commit
         statistics::Formula totalSquash;
     } stats;
 
-    bool ismispred = false;
+    bool ismispred[MaxThreads] = {false};
 
     Tick lastCommitTick;
 

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -588,11 +588,11 @@ class Commit
          */
         statistics::Scalar commitNonSpecStalls;
 
-        statistics::Scalar recovery_bubble;
+        statistics::Vector recovery_bubble;
         /** Stat for the total number of branch mispredicts that caused a
          * squash.
          */
-        statistics::Scalar branchMispredicts;
+        statistics::Vector branchMispredicts;
         /** Distribution of the number of committed instructions each cycle. */
         statistics::Distribution numCommittedDist;
 
@@ -642,12 +642,12 @@ class Commit
         statistics::Scalar vectorVta;
         statistics::Scalar vectorVtu;
 
-        statistics::Scalar squashDueToBranch;
-        statistics::Scalar squashDueToOrderViolation;
-        statistics::Scalar squashDueToValuePrediction;
-        statistics::Scalar squashDueToTrap;
-        statistics::Scalar squashDueToTC;
-        statistics::Scalar squashDueToSquashAfter;
+        statistics::Vector squashDueToBranch;
+        statistics::Vector squashDueToOrderViolation;
+        statistics::Vector squashDueToValuePrediction;
+        statistics::Vector squashDueToTrap;
+        statistics::Vector squashDueToTC;
+        statistics::Vector squashDueToSquashAfter;
         statistics::Formula totalSquash;
     } stats;
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -234,6 +234,10 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         .init(cpu->numThreads)
         .flags(statistics::total);
 
+    dispatchedInsts
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
     wbRate
         .flags(statistics::total);
     wbRate = writebackCount / cpu->baseStats.numCycles;
@@ -1178,7 +1182,7 @@ IEW::dispatchInstFromRename(ThreadID tid)
         }
         ppDispatch->notify(inst);
 
-        ++iewStats.dispatchedInsts;
+        ++iewStats.dispatchedInsts[tid];
 
         insts_to_dispatch.pop_front();
         dispatched++;
@@ -1279,7 +1283,7 @@ IEW::classifyInstToDispQue(ThreadID tid)
                     ++iewStats.dispNonSpecInsts;
                 }
             }
-            ++iewStats.dispatchedInsts;
+            ++iewStats.dispatchedInsts[tid];
             dispQue[id].push_back(inst);
 
             if (!inst->isNop() && !inst->isEliminated()) {

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -507,7 +507,7 @@ class IEW
         /** Stat for total number of unblocking cycles. */
         statistics::Scalar unblockCycles;
         /** Stat for total number of instructions dispatched. */
-        statistics::Scalar dispatchedInsts;
+        statistics::Vector dispatchedInsts;
         /** Stat for total number of squashed instructions dispatch skips. */
         statistics::Scalar dispSquashedInsts;
         /** Stat for total number of dispatched load instructions. */


### PR DESCRIPTION
# cpu-o3: Make badSpecBound stats per-thread for SMT

## Motivation

Analyzing an SMT dhrystone checkpoint slice
(`checkpoints/dhrystone_dual/.../dhrystone/1184049`) showed the real-test-phase
`badSpecBound` pegged at ~35% for both SMT threads even though
`totalSquash == 0` and `recovery_bubble == 0` for both threads — i.e. no
misspeculation actually happened in that window. The warmup phase also showed
nearly identical `badSpecBound` for both threads (0.121 vs 0.126) despite very
different real squash counts (146 vs 82), which should not happen for a
genuinely per-thread metric.

## Root cause

`CPU::CPUStats::badSpecBound` (`src/cpu/o3/cpu.cc`) is:

```cpp
badSpecBound = (dispatchedInsts - committedInsts + recovery_bubble) /
               (issueWidth * numCycles);
```

`committedInsts` is a per-thread `Vector`, but `dispatchedInsts` (`iew.hh`) and
`recovery_bubble` / `branchMispredicts` / `squashDueTo*` (`commit.hh`) were
plain `Scalar`s shared across both SMT threads. Subtracting a per-thread
vector from a shared scalar broadcasts the *combined* dispatch/recovery/squash
count into every thread's formula, so each thread's `badSpecBound` absorbs the
other thread's activity as if it were its own bad speculation.

## Changes

- `src/cpu/o3/iew.hh` / `iew.cc`: make `dispatchedInsts` a per-thread `Vector`;
  update both increment sites (`dispatchInstFromRename`,
  `classifyInstToDispQue`) to index by `tid`.
- `src/cpu/o3/commit.hh` / `commit.cc`: make `recovery_bubble`,
  `branchMispredicts`, and the
  `squashDueTo{Branch,OrderViolation,ValuePrediction,Trap,TC,SquashAfter}`
  counters per-thread `Vector`s; update all increment sites to index by `tid`.
  `totalSquash` (a `Formula` summing these) becomes per-thread automatically
  since gem5 sums same-size vectors element-wise.
- Dropped the now-stale `branchMispredicts.prereq(branchMispredicts)`
  self-suppression: `VectorBase::zero()` (`src/base/statistics.hh`) returns
  true only when *every* per-thread element is non-zero — the opposite of
  what a "hide when zero" prereq needs — so combined with the Vector
  conversion it was hiding the stat exactly when it had real, non-zero data.
  Other per-thread counters in `commit.cc` (`loads`, `stores`, `memRefs`, ...)
  already print unconditionally without a prereq, so this just brings
  `branchMispredicts` in line with them.
- `src/cpu/o3/cpu.cc`'s topdown formula itself is unchanged — it is correct
  once its operands are properly sized per-thread vectors.

## Scope

SMT (2-thread) topdown stats only. Non-SMT single-thread runs are numerically
unaffected, since a 1-element vector is equivalent to the old scalar.
`committedInsts`, IPC, cycle counts and all other functional behavior are
bit-identical before/after; only the derived `badSpecBound` /
`branchMissPrediction` / `machineClears` topdown stats and the raw
`dispatchedInsts` / `recovery_bubble` / `branchMispredicts` / `squashDueTo*` /
`totalSquash` counters change from combined to per-thread values.

## Validation

Built:

```text
scons build/RISCV/gem5.opt --gold-linker -j64
```

Re-ran the same checkpoint slice
(`checkpoints/dhrystone_dual/.../dhrystone/1184049`,
`configs/example/smt_idealkmhv3.py --warmup-insts=100000 --maxinsts=500000`):

Real-test phase (`totalSquash::0/1 == 0`, `branchMispredicts::0/1 == 0` — no
actual misspeculation occurred):

| | before | after |
|---|---|---|
| badSpecBound::0 | 0.353309 | 0 |
| badSpecBound::1 | 0.353318 | 0.000002 |

Warmup phase (real squash activity, `totalSquash::0=146`, `totalSquash::1=82`):

| | before | after |
|---|---|---|
| badSpecBound::0 | 0.121131 | 0.021136 |
| badSpecBound::1 | 0.126478 | 0.041488 |
| branchMispredicts | 222 (shared scalar) | 142 / 80 (per-thread) |

`branchMissPrediction` / `machineClears` derived stats now cross-check exactly
against the raw per-thread `branchMispredicts` / `totalSquash` /
`badSpecBound` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Performance statistics are now reported separately for each thread.
  * Dispatch, branch misprediction, recovery bubble, and instruction squash metrics provide more detailed per-thread visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->