### PR TITLE
util: fix checkpoint path prefix matching in parallel_sim.sh

### DIFF
--- a/util/xs_scripts/parallel_sim.sh
+++ b/util/xs_scripts/parallel_sim.sh
@@ -201,7 +201,7 @@ function prepare_env() {
     suffixes=("gz" "zstd")
     checkpoint=""
     for suffix in "${suffixes[@]}"; do
-        checkpoint=$(find -L "$cpt_dir" -wholename "*${task_path}*.$suffix" | head -n 1)
+        checkpoint=$(find -L "$cpt_dir" -wholename "*${task_path}/*.$suffix" | head -n 1)
         if [ -n "$checkpoint" ]; then
             break
         fi


### PR DESCRIPTION
* The find pattern `*${task_path}*.$suffix` causes prefix collision: task_path "bmk/31" incorrectly matches "bmk/314/_314_0.xxx.gz".

* Change to `*${task_path}/*.$suffix` to enforce exact directory boundary matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint file selection during environment preparation.
  * Prevented similarly named checkpoint files from being selected incorrectly when multiple candidates are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->