### PR TITLE
configs: Fix difftest init bug in single-thread Sim

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -410,8 +410,8 @@ def config_difftest(cpu_list, args, sys):
                 cpu.enable_difftest = True
                 cpu.difftest_ref_so = args.difftest_ref_so
         else:
-            # sys.enable_mem_dedup = True
-            # cpu_list[0].enable_mem_dedup = True
+            sys.enable_mem_dedup = True
+            cpu_list[0].enable_mem_dedup = True
             cpu_list[0].enable_difftest = True
             cpu_list[0].difftest_ref_so = args.difftest_ref_so
 


### PR DESCRIPTION
#### Problem Description
When running GEM5 simulation with `--enable-difftest` in **single-core mode**, the simulation aborts immediately with a memory access error.

**Error Log:**
```text
**** REAL SIMULATION ****
build/RISCV/sim/simulate.cc:194: info: Entering event queue @ 0.  Starting simulation...
gem5.opt: src/cpu/difftest/ref.c:78: difftest_memcpy: Assertion `guest_to_host(nemu_addr) != NULL' failed.
Program aborted at tick 66267
```

#### Root Cause Analysis
The issue stems from a configuration mismatch between GEM5 and the NEMU reference model regarding memory deduplication (`mem_dedup`).

1. **NEMU Side**: The NEMU reference library is compiled with `CONFIG_ENABLE_MEM_DEDUP=1`. This configuration requires the memory to be passed from the DUT (GEM5) rather than allocated internally by NEMU.
2. **GEM5 Side**: In `configs/common/xiangshan.py`, the `config_difftest()` function handles configuration differently for multi-core/SMT and single-core modes:
   - **Multi-core/SMT**: Correctly sets `sys.enable_mem_dedup = True` and `cpu.enable_mem_dedup = True`.
   - **Single-core**: The lines enabling `mem_dedup` were commented out.

Because `enable_mem_dedup` was disabled in single-core mode, GEM5 did not pass the memory pointer to NEMU as expected. Consequently, NEMU failed to map the guest address, leading to the `difftest_memcpy` assertion failure.

#### Solution
Uncomment the `enable_mem_dedup` settings in the single-core branch of `config_difftest()` to ensure consistency with the multi-core configuration and the NEMU build flags.

**Code Changes in `configs/common/xiangshan.py`:**
```python
# Before:
        else:
            # sys.enable_mem_dedup = True
            # cpu_list[0].enable_mem_dedup = True
            cpu_list[0].enable_difftest = True
            ...

# After:
        else:
            sys.enable_mem_dedup = True
            cpu_list[0].enable_mem_dedup = True
            cpu_list[0].enable_difftest = True
            ...
```

#### Verification
After applying this fix, single-core simulations with `--enable-difftest` start successfully without triggering the `guest_to_host` assertion failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled memory deduplication for single-core, non-SMT configurations, improving consistency with multi-core setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->