### PR TITLE
cpu-o3: Fix incorrect rob borrowing limit calculation

### DIFF
--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -350,9 +350,7 @@ ROB::borrowingLimit(ThreadID tid) const
         const unsigned reserve =
             borrowingDonor[other] ? donor_resume_quota : base;
         const unsigned used = threadGroups[other].size();
-        if (used < reserve) {
-            reserved += reserve - used;
-        }
+        reserved += std::max(reserve, used);
     }
 
     if (reserved >= numEntries) {


### PR DESCRIPTION
#### Problem Description
The `ROB::borrowingLimit()` function incorrectly calculates the number of available ROB entries for a borrowing thread. 

In the original implementation, when calculating the total reserved entries, the code only subtracted the usage that exceeded the reserved quota (`reserve - used` when `used < reserve`). This logic fundamentally ignored the protected quota (`reserve`) itself, resulting in an overestimation of the borrowable entries and violating the resource isolation policy.

#### Root Cause Analysis
The core issue lies in the loop calculating the `reserved` count:
```cpp
// Original buggy code
if (used < reserve) {
    reserved += reserve - used;
}
```
By only adding the *difference* to `reserved`, the base `reserve` amount is effectively left unreserved in the global pool. Since `numEntries` is the total capacity, the correct approach is to deduct the maximum of the protected quota and the actual usage for each thread.

#### Solution
This PR fixes the calculation logic by replacing the conditional subtraction with `std::max(reserve, used)`. This guarantees that the protected quota for each thread is always accounted for in the reserved pool.

**Code Changes:**
```cpp
// Before:
const unsigned used = threadGroups[other].size();
if (used < reserve) {
    reserved += reserve - used;
}

// After:
const unsigned used = threadGroups[other].size();
reserved += std::max(reserve, used);
```

#### Impact
This fix strictly enforces the SMT resource borrowing limits. It prevents a borrowing thread from over-allocating ROB entries at the expense of other threads' guaranteed minimum quotas, thereby avoiding potential performance degradation or deadlocks caused by resource starvation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource borrowing calculations to more accurately determine available entries under dynamic borrowing policies.
  * Helps ensure borrowing limits reflect current usage and reserved capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->