### PR TITLE
arch-riscv: Implement pack instruction

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1118,6 +1118,10 @@ decode QUADRANT {
                             Rd_sd = Rs1_sd/Rs2_sd;
                         }
                     }}, IntDivOp);
+                    0x4: pack({{
+                        Rd = (Rs1 & UINT64_C(0xffffffff)) |
+                             ((Rs2 & UINT64_C(0xffffffff)) << 32);
+                    }});
                     0x5: min({{
                         Rd = (((int64_t) Rs1) < ((int64_t) Rs2)) ? Rs1 : Rs2;
                     }});


### PR DESCRIPTION
Change-Id: I112c198e3edf54b10f745b39fb7379be748f11cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the RISC-V `pack` instruction, combining 32-bit values from two source registers into a 64-bit destination result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->