### PR TITLE
arch-riscv: Add missing zbkb instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1118,6 +1118,9 @@ decode QUADRANT {
                             Rd_sd = Rs1_sd/Rs2_sd;
                         }
                     }}, IntDivOp);
+                    0x4: pack({{
+                        Rd = (bits(Rs2, 31, 0) << 32) | bits(Rs1, 31, 0);
+                    }});
                     0x5: min({{
                         Rd = (((int64_t) Rs1) < ((int64_t) Rs2)) ? Rs1 : Rs2;
                     }});
@@ -1196,6 +1199,10 @@ decode QUADRANT {
                             Rd = Rs1%Rs2;
                         }
                     }}, IntDivOp);
+                    0x4: packh({{
+                        // It doesn't need to sign ext as MSB is always 0
+                        Rd = (Rs2_ub << 8) | Rs1_ub;
+                    }});
                     0x5: maxu({{
                         Rd = Rs1 > Rs2 ? Rs1 : Rs2;
                     }});
@@ -1254,9 +1261,17 @@ decode QUADRANT {
                             Rd_sd = Rs1_sw/Rs2_sw;
                         }
                     }}, IntDivOp);
-                    0x4: zext_h({{
-                        Rd = Rs1_uh;
-                    }});
+                    0x4: decode RS2 {
+                        0x0: zext_h({{
+                            Rd = Rs1_uh;
+                        }});
+                        // In terms of functionality, we can execute zext.h like packw (Rs2_uh = 0).
+                        // However, instruction fusion relies on zext.h, so we do a 'decode RS2' to distinct them.
+                        // refer to src/arch/riscv/insts/fusion.cc.
+                        default: packw({{
+                            Rd_sd = sext<32>((Rs2_uh << 16) | Rs1_uh);
+                        }});
+                    }
                     0x10: sh2add_uw({{
                         Rd = (((uint64_t)Rs1_uw) << 2) + Rs2;
                     }});


### PR DESCRIPTION
Port upstream patch

Including:
- pack (without rv32 support)
- packh
- packw

Link: https://github.com/gem5/gem5/commit/331ef9e82bf0a0c73854b3e29725a26ac8e0a068
Change-Id: I1153f476002fc0354acf2763c022231dc97d6381

Supersede #957 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for new RISC-V packing decode behaviors that combine register portions into 64-bit results.
  * Added support for additional packing variants at byte and word granularity.

* **Bug Fixes**
  * Corrected extension and packing interactions to ensure the expected zero-/sign-extension semantics are preserved when related packing instructions are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->