### PR TITLE
Rvv 1.0c fix DiffTest Failed duxy

### DIFF
--- a/src/arch/riscv/isa/vector/base/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.isa
@@ -1024,10 +1024,18 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = """
+        (_microIdx + 1 == (vflmul < 1 ? 1 : vflmul))
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
-    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    old_dest_reg_id = """
+        (_microIdx == 0)
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
@@ -1074,10 +1082,18 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = """
+        (_microIdx + 1 == (vflmul < 1 ? 1 : vflmul))
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
-    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    old_dest_reg_id = """
+        (_microIdx == 0)
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
@@ -1120,10 +1136,18 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = """
+        (_microIdx + 1 == (vflmul < 1 ? 1 : vflmul))
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
-    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    old_dest_reg_id = """
+        (_microIdx == 0)
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
@@ -1220,10 +1244,18 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = """
+        (_microIdx + 1 == (vflmul < 1 ? 1 : vflmul))
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
-    old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    old_dest_reg_id = """
+        (_microIdx == 0)
+            ? RegId(VecRegClass, _machInst.vd)
+            : RegId(VecRegClass, VecTempReg0)
+    """
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)

--- a/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
@@ -1409,7 +1409,7 @@ Fault
                 for (uint32_t i = 0; i < micro_vlmax; i++) {
                     uint32_t ei = i + micro_vlmax * this->microIdx;
                     if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                        tmp_val = f(tmp_val, Vs2[i]).v;
+                        tmp_val = f(tmp_val, vs2[i]).v;
                     }
                 }
                 return tmp_val;

--- a/src/arch/riscv/isa/vector/base/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/base/vector_conf.isa
@@ -113,6 +113,7 @@ def template VConfExecute {{
             float vflmul = getVflmul(new_vtype.vlmul);
             uint32_t sew = getSew(new_vtype.vsew);
             uint32_t new_vill =
+                bits(requested_vtype, 63, 63) != 0 ||
                 !(vflmul >= 0.125 && vflmul <= 8) ||
                 sew > std::min(vflmul, 1.0f) * ELEN ||
                 bits(requested_vtype, 30, 8) != 0;

--- a/src/arch/riscv/isa/vector/base/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/base/vector_conf.isa
@@ -95,6 +95,20 @@ def template VConfExecute {{
     {
         auto tc = xc->tcBase();
 
+        STATUS status = xc->readMiscReg(MISCREG_STATUS);
+        if (status.vs == 0) {
+            return std::make_shared<IllegalInstFault>(
+                    "Vector instruction with VS off\n", machInst);
+        }
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+            if (vsstatus.vs == 0) {
+                return std::make_shared<IllegalInstFault>(
+                        "Vector instruction with VS off in virtual mode\n",
+                        machInst);
+            }
+        }
+
         %(op_decl)s;
         %(op_rd)s;
         %(code)s;

--- a/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
@@ -426,7 +426,6 @@ def template VlWholeConstructor {{
     %(set_reg_idx_arr)s;
 
     size_t NFIELDS = machInst.nf + 1;
-    eew = 8;
     StaticInstPtr microop;
     VectorMicroInfo vmi;
     for (int i = 0; i < NFIELDS; ++i) {

--- a/src/arch/riscv/isa/vector/simple/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_conf.isa
@@ -95,6 +95,20 @@ def template VConfExecute {{
     {
         auto tc = xc->tcBase();
 
+        STATUS status = xc->readMiscReg(MISCREG_STATUS);
+        if (status.vs == 0) {
+            return std::make_shared<IllegalInstFault>(
+                    "Vector instruction with VS off\n", machInst);
+        }
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+            if (vsstatus.vs == 0) {
+                return std::make_shared<IllegalInstFault>(
+                        "Vector instruction with VS off in virtual mode\n",
+                        machInst);
+            }
+        }
+
         %(op_decl)s;
         %(op_rd)s;
         %(code)s;

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1496,6 +1496,17 @@ Commit::commitInsts()
                             RiscvISA::MiscRegIndex::MISCREG_STATUS,
                             (RegVal)status, tid);
                     }
+                    if (head_inst->isVector() &&
+                        (head_inst->numDestRegs() > 0 ||
+                         head_inst->staticInst->isVectorConfig())) {
+                        RiscvISA::STATUS status = cpu->readMiscRegNoEffect(
+                            RiscvISA::MiscRegIndex::MISCREG_STATUS, tid);
+                        status.sd = 1;
+                        status.vs = 3;
+                        cpu->setMiscRegNoEffect(
+                            RiscvISA::MiscRegIndex::MISCREG_STATUS,
+                            (RegVal)status, tid);
+                    }
                     if (head_inst->isUpdateVsstatusSd()) {
                         auto v = cpu->readMiscRegNoEffect(
                             RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -424,6 +424,17 @@ BaseSimpleCPU::postExecute(const Fault &fault)
     if (curStaticInst->isVector()){
         t_info.execContextStats.numVecAluAccesses++;
         t_info.execContextStats.numVecInsts++;
+        if (fault == NoFault &&
+            (curStaticInst->numDestRegs() > 0 ||
+             curStaticInst->isVectorConfig())) {
+            RiscvISA::STATUS status =
+                threadContexts[curThread]->readMiscRegNoEffect(
+                    RiscvISA::MiscRegIndex::MISCREG_STATUS);
+            status.sd = 1;
+            status.vs = 3;
+            threadContexts[curThread]->setMiscRegNoEffect(
+                RiscvISA::MiscRegIndex::MISCREG_STATUS, (RegVal)status);
+        }
     }
 
     //number of function calls/returns to get window accesses


### PR DESCRIPTION
This PR fixes several RVV correctness issues found while running SPEC06 RVV 1.0c checkpoints and CI workloads.

**What Changed**
- Fix vsetvl/vsetvli/vsetivli handling when requested_vtype.vill=1prevent inconsistent VTYPE/VL state from being committed.

- Fix VS=Off handling for RVV config instructionsmake vsetvl/vsetvli/vsetivli raise illegal instruction faults when mstatus.VS is off apply the corresponding vsstatus.VS check in virtual mode.

- Fix whole-register vector load handlinguse the instruction-selected EEW instead of a hard-coded 8-bit width.

- Fix mstatus.VS dirty trackingmark VS=Dirty after committed vector instructions that modify vector state.

- Fix RVV reduction micro-op dependency handlingroute intermediate partial sums through VecTempReg0 avoid vd/vs2 overlap hazards in multi-micro-op reductions such as vfredosum/vred*.

**Validation**
These fixes resolved the previously observed failures in:
gamess_cytosine_7
tonto_953486
cactusADM_0
hmmer_nph3_0
hmmer_retro_0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RISC-V vector reduction operations, including multi-step and widening reductions.
  - Corrected floating-point vector reduction operand handling.
  - Vector configuration instructions now fault correctly when vector processing is disabled or invalid settings are requested.
  - Vector state is updated correctly after applicable vector instructions execute.
  - Improved handling of whole-vector memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->