### PR TITLE
cpu-o3: add opt-in NaiveCpt RAT-checkpoint recovery policy

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -967,6 +967,14 @@ def xiangshan_system_init():
         default="",
         help="Apply a solver overlay JSON before instantiate",
     )
+    parser.add_argument(
+        "--rob-walk-policy",
+        type=str,
+        default="Replay",
+        choices=["Rollback", "Replay", "ConstCycle", "NaiveCpt", "ConfidentCpt"],
+        help="ROB misprediction-recovery walk policy. NaiveCpt enables the "
+              "RAT-checkpoint recovery-cost model.",
+    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -971,7 +971,7 @@ def xiangshan_system_init():
         "--rob-walk-policy",
         type=str,
         default="Replay",
-        choices=["Rollback", "Replay", "ConstCycle", "NaiveCpt", "ConfidentCpt"],
+        choices=["Rollback", "Replay", "ConstCycle", "NaiveCpt"],
         help="ROB misprediction-recovery walk policy. NaiveCpt enables the "
               "RAT-checkpoint recovery-cost model.",
     )

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -72,6 +72,7 @@ def setKmhV3IdealParams(args, system):
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression
         cpu.smtBorrowDonorReserveEntries = args.smtROBDonorEntry
         cpu.smtBorrowBaseReserveEntries = args.smtROBBaseEntry
+        cpu.robWalkPolicy = 'NaiveCpt' # ideal core recovers via RAT checkpoints
 
         # lsu
         cpu.StoreWbStage = 4

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -84,6 +84,7 @@ def setKmhV3Params(args, system):
         cpu.RobCompressPolicy = 'none'
         cpu.numROBEntries = 352
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression
+        cpu.robWalkPolicy = args.rob_walk_policy
 
         # lsu
         cpu.StoreWbStage = 4

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -160,6 +160,13 @@ class BaseO3CPU(BaseCPU):
     squashWidth = Param.Unsigned(8, "Squash width with rollback/redo rob walk")
     ConstSquashCycle = Param.Unsigned(1, "Squash width with redo rob walk")
     robWalkPolicy = Param.ROBWalkPolicy('Replay', "Squash with a specific policy")
+    numMaxRatSnapshot = Param.Unsigned(4,
+        "Number of rename-map (RAT) checkpoints for NaiveCpt recovery")
+    ratSnapshotDistance = Param.Unsigned(32,
+        "Minimum instructions between successive RAT checkpoints")
+    robWalkByDestRegs = Param.Bool(True,
+        "Size the recovery walk by destination-register reclaim, "
+        "not by instruction count")
 
     trapLatency = Param.Cycles(13, "Trap latency")
     fetchTrapLatency = Param.Cycles(1, "Fetch trap latency")

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -220,6 +220,7 @@ class DynInst : public ExecContext, public RefCounted
                                  /// instructions ahead of it
         SerializeAfter,          /// Needs to serialize instructions behind it
         SerializeHandled,        /// Serialization has been handled
+        RatSnapshotted,          /// Instruction owns a RAT checkpoint
         NumStatus
     };
 
@@ -889,6 +890,15 @@ class DynInst : public ExecContext, public RefCounted
      *  serializing state.
      */
     bool isSerializeHandled() { return status[SerializeHandled]; }
+
+    /** Returns whether the instruction owns a RAT checkpoint. */
+    bool isRatSnapshotted() const { return status[RatSnapshotted]; }
+    /** Records that the instruction owns a RAT checkpoint. Does not capture
+     *  any alias-table state; it only marks the instruction so the ROB can
+     *  find the nearest checkpoint during a squash. */
+    void setRatSnapshotted() { status.set(RatSnapshotted); }
+    /** Clears the RAT-checkpoint mark. */
+    void clearRatSnapshotted() { status.reset(RatSnapshotted); }
 
     /** Returns the opclass of this instruction. */
     OpClass opClass() const { return staticInst->opClass(); }

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -59,7 +59,10 @@ namespace o3
 {
 
 Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
-    : cpu(_cpu),
+    : ratSnapshotActive(params.robWalkPolicy == ROBWalkPolicy::NaiveCpt),
+      numMaxRatSnapshot(params.numMaxRatSnapshot),
+      ratSnapshotDistance(params.ratSnapshotDistance),
+      cpu(_cpu),
       iewToRenameDelay(params.iewToRenameDelay),
       decodeToRenameDelay(params.decodeToRenameDelay),
       commitToRenameDelay(params.commitToRenameDelay),
@@ -151,7 +154,15 @@ Rename::RenameStats::RenameStats(CPU *cpu, Rename *rename)
       ADD_STAT(stallEvents, statistics::units::Count::get(),
                "count of stall events"),
       ADD_STAT(smtStallEvents, statistics::units::Count::get(),
-               "Number of events the Rename has stalled per thread")
+               "Number of events the Rename has stalled per thread"),
+      ADD_STAT(assignedRatSnapshot, statistics::units::Count::get(),
+               "Number of RAT checkpoints taken"),
+      ADD_STAT(committedRatSnapshot, statistics::units::Count::get(),
+               "Number of RAT checkpoints released at commit"),
+      ADD_STAT(squashedRatSnapshot, statistics::units::Count::get(),
+               "Number of RAT checkpoints discarded on squash"),
+      ADD_STAT(distanceRatSnapshot, statistics::units::Count::get(),
+               "Instruction distance between successive RAT checkpoints")
 {
     squashCycles.prereq(squashCycles);
     idleCycles.prereq(idleCycles);
@@ -204,6 +215,8 @@ Rename::RenameStats::RenameStats(CPU *cpu, Rename *rename)
         stallEvents.subname(i, stall_event_str[static_cast<StallEvent>(i)]);
         smtStallEvents.subname(i, stall_event_str[static_cast<StallEvent>(i)]);
     }
+
+    distanceRatSnapshot.init(10, 100, 5).flags(statistics::pdf);
 }
 
 void
@@ -272,7 +285,11 @@ Rename::resetStage()
         stalls[tid].iew = false;
         finalCommitSeq[tid] = 0;
         releaseSeq[tid] = 0;
+        ratSnapshotBuffer[tid].clear();
     }
+
+    numRatSnapshotInUse = 0;
+    lastRatSnapshotDistance = 0;
 }
 
 void
@@ -306,7 +323,8 @@ Rename::isDrained() const
 {
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         if (!historyBuffer[tid].empty() ||
-            !fixedbuffer[tid].empty())
+            !fixedbuffer[tid].empty() ||
+            !ratSnapshotBuffer[tid].empty())
             return false;
     }
     return true;
@@ -324,6 +342,7 @@ Rename::drainSanityCheck() const
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         assert(historyBuffer[tid].empty());
         assert(fixedbuffer[tid].empty());
+        assert(ratSnapshotBuffer[tid].empty());
     }
 }
 
@@ -477,6 +496,8 @@ Rename::releasePhysRegs()
         }
 
         removeFromHistory(releaseSeq[tid], tid);
+        if (ratSnapshotActive)
+            commitSnapshot(finalCommitSeq[tid], tid);
         // doneSeqNum is also reused as a squash-progress marker while the
         // ROB is walking younger entries. Only real commit progress should
         // release physical registers.
@@ -585,6 +606,14 @@ Rename::renameInsts(ThreadID tid)
         renameSrcRegs(inst, inst->threadNumber);
 
         renameDestRegs(inst, inst->threadNumber);
+
+        if (ratSnapshotActive) {
+            if (ratSnapshotAvailable() && suitableForRatSnapshot(inst)) {
+                takeSnapshot(inst, tid);
+            } else {
+                ++lastRatSnapshotDistance;
+            }
+        }
 
         cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtRename);
 
@@ -742,6 +771,9 @@ Rename::tryFreePReg(PhysRegIdPtr preg)
 void
 Rename::doSquash(const InstSeqNum &squashed_seq_num, ThreadID tid)
 {
+    if (ratSnapshotActive)
+        squashSnapshot(squashed_seq_num, tid);
+
     auto hb_it = historyBuffer[tid].begin();
 
     // After a syscall squashes everything, the history buffer may be empty
@@ -784,6 +816,71 @@ Rename::doSquash(const InstSeqNum &squashed_seq_num, ThreadID tid)
 
         ++stats.undoneMaps;
     }
+}
+
+int
+Rename::countRatSnapshots()
+{
+    int total = 0;
+    for (ThreadID tid = 0; tid < numThreads; tid++)
+        total += countRatSnapshots(tid);
+    return total;
+}
+
+size_t
+Rename::countRatSnapshots(ThreadID tid)
+{
+    return ratSnapshotBuffer[tid].size();
+}
+
+void
+Rename::takeSnapshot(const DynInstPtr &inst, ThreadID tid)
+{
+    inst->setRatSnapshotted();
+    numRatSnapshotInUse++;
+    ratSnapshotBuffer[tid].push_front(inst->seqNum);
+    assert(numRatSnapshotInUse <= numMaxRatSnapshot);
+
+    stats.assignedRatSnapshot++;
+    stats.distanceRatSnapshot.sample(lastRatSnapshotDistance);
+    lastRatSnapshotDistance = 0;
+
+    DPRINTF(Rename, "[tid:%i] Took RAT checkpoint at [sn:%llu], inUse %d\n",
+            tid, inst->seqNum, numRatSnapshotInUse);
+}
+
+void
+Rename::commitSnapshot(InstSeqNum commit_seq_num, ThreadID tid)
+{
+    // Oldest checkpoints sit at the back; release those the commit head passed.
+    while (!ratSnapshotBuffer[tid].empty() &&
+           ratSnapshotBuffer[tid].back() <= commit_seq_num) {
+        ratSnapshotBuffer[tid].pop_back();
+        numRatSnapshotInUse--;
+        stats.committedRatSnapshot++;
+    }
+    assert(numRatSnapshotInUse >= 0);
+}
+
+void
+Rename::squashSnapshot(InstSeqNum squash_seq_num, ThreadID tid)
+{
+    // Newest checkpoints sit at the front; release those on the discarded
+    // (younger) path. The checkpoint at the redirect itself survives and is
+    // released later at commit.
+    while (!ratSnapshotBuffer[tid].empty() &&
+           ratSnapshotBuffer[tid].front() > squash_seq_num) {
+        ratSnapshotBuffer[tid].pop_front();
+        numRatSnapshotInUse--;
+        stats.squashedRatSnapshot++;
+    }
+    assert(numRatSnapshotInUse >= 0);
+}
+
+bool
+Rename::suitableForRatSnapshot(const DynInstPtr &inst)
+{
+    return inst->isControl() && lastRatSnapshotDistance >= ratSnapshotDistance;
 }
 
 void

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -54,6 +54,7 @@
 #include "cpu/o3/limits.hh"
 #include "cpu/timebuf.hh"
 #include "cpu/valuepred/valuepred_unit.hh"
+#include "enums/ROBWalkPolicy.hh"
 #include "sim/probe/probe.hh"
 
 namespace gem5
@@ -281,6 +282,40 @@ class Rename
 
     InstSeqNum releaseSeq[MaxThreads] = {};
 
+    /** RAT checkpoint records, per thread: sequence numbers of in-flight
+     *  control-flow instructions that currently own a checkpoint. Newest at
+     *  front, oldest at back (strictly descending by sequence number). */
+    std::list<InstSeqNum> ratSnapshotBuffer[MaxThreads];
+
+    /** True when the active recovery policy consumes RAT checkpoints
+     *  (NaiveCpt). Derived from robWalkPolicy at construction. */
+    bool ratSnapshotActive;
+    /** Maximum number of live checkpoints (slots). */
+    int numMaxRatSnapshot;
+    /** Minimum instructions between successive checkpoints. */
+    unsigned ratSnapshotDistance;
+    /** Live checkpoints across all threads (checkpoints are thread-shared). */
+    int numRatSnapshotInUse{0};
+    /** Instructions renamed since the last checkpoint was taken. */
+    unsigned lastRatSnapshotDistance{0};
+
+    /** Total live checkpoints across threads (invariant check). */
+    int countRatSnapshots();
+    size_t countRatSnapshots(ThreadID tid);
+    /** Whether a free checkpoint slot exists. */
+    bool ratSnapshotAvailable() {
+        assert(numRatSnapshotInUse == countRatSnapshots());
+        return numRatSnapshotInUse < numMaxRatSnapshot;
+    }
+    /** Record a checkpoint on this instruction. */
+    void takeSnapshot(const DynInstPtr &inst, ThreadID tid);
+    /** Release checkpoints at or older than the committed sequence number. */
+    void commitSnapshot(InstSeqNum commit_seq_num, ThreadID tid);
+    /** Release checkpoints strictly younger than the squash point. */
+    void squashSnapshot(InstSeqNum squash_seq_num, ThreadID tid);
+    /** Whether the instruction may carry a checkpoint. */
+    bool suitableForRatSnapshot(const DynInstPtr &inst);
+
     void tryFreePReg(PhysRegIdPtr phys_reg);
 
     /** Pointer to CPU. */
@@ -446,7 +481,12 @@ class Rename
         statistics::Vector stallEvents;
 
         statistics::VectorDistribution smtStallEvents;
-        
+
+        statistics::Scalar assignedRatSnapshot;
+        statistics::Scalar committedRatSnapshot;
+        statistics::Scalar squashedRatSnapshot;
+        statistics::Distribution distanceRatSnapshot;
+
     } stats;
 
     std::vector<StallReason> renameStalls;

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -191,7 +191,7 @@ ROB::ROB(CPU *_cpu, const BaseO3CPUParams &params)
     assert((robWalkPolicy == ROBWalkPolicy::Rollback && rollbackWidth > 0)
            || (robWalkPolicy == ROBWalkPolicy::Replay && replayWidth > 0)
            || (robWalkPolicy == ROBWalkPolicy::ConstCycle && constSquashCycle > 0)
-        //    || robWalkPolicy == ROBWalkPolicy::NaiveCpt
+           || (robWalkPolicy == ROBWalkPolicy::NaiveCpt && replayWidth > 0)
         //    || robWalkPolicy == ROBWalkPolicy::ConfidentCpt
            );
 
@@ -889,6 +889,15 @@ ROB::computeDynSquashWidth(unsigned uncommitted_insts, unsigned to_squash)
                 ROB,
                 "Recovery with replay, walk ROB with width %u in %f cycles\n",
                 dyn_squash_width, expected_cycles);
+            break;
+
+        case ROBWalkPolicy::NaiveCpt:
+            // Checkpoints are recorded in rename but not yet consumed here;
+            // recover like Replay until the snapshot-aware model (Task 4).
+            expected_cycles =
+                std::max(2.0, ((double)uncommitted_insts / replayWidth));
+            dyn_squash_width = ceil((double)to_squash / expected_cycles);
+            dyn_squash_width = std::max(dyn_squash_width, 1u);
             break;
 
         case ROBWalkPolicy::ConstCycle:

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -142,6 +142,7 @@ ROB::ROB(CPU *_cpu, const BaseO3CPUParams &params)
       rollbackWidth(params.squashWidth),
       replayWidth(params.squashWidth),
       constSquashCycle(params.ConstSquashCycle),
+      robWalkByDestRegs(params.robWalkByDestRegs),
       numInstsInROB(0),
       numThreads(params.numThreads),
       stats(_cpu)
@@ -847,17 +848,21 @@ ROB::squash(InstSeqNum squash_num, ThreadID tid)
 
     squashedSeqNum[tid] = squash_num;
 
-    // TODO: find the number of instructions to squash and
-    // the number of uncommited instructions
-    unsigned total_inst_to_squash = 0;
-    for (auto it = instList[tid].begin(); it != instList[tid].end(); ++it) {
-        if ((*it)->seqNum > squash_num) {
-            total_inst_to_squash++;
+    if (robWalkPolicy == ROBWalkPolicy::NaiveCpt) {
+        dynSquashWidth = computeSnapshotSquashWidth(squash_num, tid);
+    } else {
+        unsigned total_inst_to_squash = 0;
+        for (auto it = instList[tid].begin(); it != instList[tid].end(); ++it) {
+            if ((*it)->seqNum > squash_num) {
+                total_inst_to_squash++;
+            }
         }
-    }
-    unsigned num_uncommited_inst = instList[tid].size() - total_inst_to_squash;
+        unsigned num_uncommited_inst =
+            instList[tid].size() - total_inst_to_squash;
 
-    dynSquashWidth = computeDynSquashWidth(num_uncommited_inst, total_inst_to_squash);
+        dynSquashWidth =
+            computeDynSquashWidth(num_uncommited_inst, total_inst_to_squash);
+    }
 
     if (!instList[tid].empty()) {
         InstIt tail_thread = instList[tid].end();
@@ -891,15 +896,6 @@ ROB::computeDynSquashWidth(unsigned uncommitted_insts, unsigned to_squash)
                 dyn_squash_width, expected_cycles);
             break;
 
-        case ROBWalkPolicy::NaiveCpt:
-            // Checkpoints are recorded in rename but not yet consumed here;
-            // recover like Replay until the snapshot-aware model (Task 4).
-            expected_cycles =
-                std::max(2.0, ((double)uncommitted_insts / replayWidth));
-            dyn_squash_width = ceil((double)to_squash / expected_cycles);
-            dyn_squash_width = std::max(dyn_squash_width, 1u);
-            break;
-
         case ROBWalkPolicy::ConstCycle:
             dyn_squash_width = ceil((double) to_squash / (double) constSquashCycle);
             dyn_squash_width = std::max(dyn_squash_width, rollbackWidth);
@@ -909,6 +905,42 @@ ROB::computeDynSquashWidth(unsigned uncommitted_insts, unsigned to_squash)
         default:
             break;
     }
+    return dyn_squash_width;
+}
+
+unsigned
+ROB::computeSnapshotSquashWidth(InstSeqNum squash_num, ThreadID tid)
+{
+    unsigned younger_before_squash = 0;   // work to squash (younger)
+    unsigned older_after_snapshot = 0;    // residual walk from nearest older cp
+    bool hit = false;
+
+    for (auto it = instList[tid].begin(); it != instList[tid].end(); ++it) {
+        unsigned w = robWalkByDestRegs ? (*it)->numDestRegs() : 1;
+        if ((*it)->seqNum > squash_num) {
+            younger_before_squash += w;
+        } else if ((*it)->seqNum < squash_num) {
+            older_after_snapshot =
+                (*it)->isRatSnapshotted() ? 0 : older_after_snapshot + w;
+        } else if ((*it)->isRatSnapshotted()) {
+            hit = true;
+        }
+    }
+
+    if (hit) {
+        older_after_snapshot = 0;
+        stats.hittedRobRatSnapshot++;
+    }
+
+    double expected_cycles =
+        std::max(2.0, ((double)older_after_snapshot / replayWidth));
+    unsigned dyn_squash_width = std::max(1u,
+        (unsigned)ceil((double)younger_before_squash / expected_cycles));
+
+    stats.snapshotSquashWidth.sample(dyn_squash_width);
+    DPRINTF(ROB, "NaiveCpt squash [sn:%llu] hit=%d residual=%u toSquash=%u "
+            "width=%u\n", squash_num, hit, older_after_snapshot,
+            younger_before_squash, dyn_squash_width);
     return dyn_squash_width;
 }
 
@@ -942,9 +974,14 @@ ROB::ROBStats::ROBStats(statistics::Group *parent)
         "The number of ROB reads"),
     ADD_STAT(writes, statistics::units::Count::get(),
         "The number of ROB writes"),
-    ADD_STAT(instPergroup, statistics::units::Count::get())
+    ADD_STAT(instPergroup, statistics::units::Count::get()),
+    ADD_STAT(hittedRobRatSnapshot, statistics::units::Count::get(),
+        "Squashes that landed exactly on a RAT checkpoint (NaiveCpt)"),
+    ADD_STAT(snapshotSquashWidth, statistics::units::Count::get(),
+        "Distribution of NaiveCpt dynamic squash width")
 {
     instPergroup.init(0, 8, 1).flags(statistics::nozero);
+    snapshotSquashWidth.init(0, 256, 6).flags(statistics::pdf);
 }
 
 DynInstPtr

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -857,11 +857,11 @@ ROB::squash(InstSeqNum squash_num, ThreadID tid)
                 total_inst_to_squash++;
             }
         }
-        unsigned num_uncommited_inst =
+        unsigned num_uncommitted_inst =
             instList[tid].size() - total_inst_to_squash;
 
         dynSquashWidth =
-            computeDynSquashWidth(num_uncommited_inst, total_inst_to_squash);
+            computeDynSquashWidth(num_uncommitted_inst, total_inst_to_squash);
     }
 
     if (!instList[tid].empty()) {
@@ -929,7 +929,7 @@ ROB::computeSnapshotSquashWidth(InstSeqNum squash_num, ThreadID tid)
 
     if (hit) {
         older_after_snapshot = 0;
-        stats.hittedRobRatSnapshot++;
+        stats.robRatSnapshotHits++;
     }
 
     double expected_cycles =
@@ -975,7 +975,7 @@ ROB::ROBStats::ROBStats(statistics::Group *parent)
     ADD_STAT(writes, statistics::units::Count::get(),
         "The number of ROB writes"),
     ADD_STAT(instPergroup, statistics::units::Count::get()),
-    ADD_STAT(hittedRobRatSnapshot, statistics::units::Count::get(),
+    ADD_STAT(robRatSnapshotHits, statistics::units::Count::get(),
         "Squashes that landed exactly on a RAT checkpoint (NaiveCpt)"),
     ADD_STAT(snapshotSquashWidth, statistics::units::Count::get(),
         "Distribution of NaiveCpt dynamic squash width")

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -407,7 +407,7 @@ class ROB
 
         statistics::Distribution instPergroup;
 
-        statistics::Scalar hittedRobRatSnapshot;
+        statistics::Scalar robRatSnapshotHits;
         statistics::Distribution snapshotSquashWidth;
     } stats;
 };

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -349,7 +349,13 @@ class ROB
 
     unsigned constSquashCycle{1};
 
+    bool robWalkByDestRegs{false};
+
     unsigned computeDynSquashWidth(unsigned uncommitted_insts, unsigned to_squash);
+
+    /** NaiveCpt recovery width: walk from the nearest checkpoint older than
+     *  the redirect, counted in destination-register reclaim work. */
+    unsigned computeSnapshotSquashWidth(InstSeqNum squash_num, ThreadID tid);
 
   public:
     /** Iterator pointing to the instruction which is the last instruction
@@ -400,6 +406,9 @@ class ROB
         statistics::Scalar writes;
 
         statistics::Distribution instPergroup;
+
+        statistics::Scalar hittedRobRatSnapshot;
+        statistics::Distribution snapshotSquashWidth;
     } stats;
 };
 


### PR DESCRIPTION
Adds an opt-in NaiveCpt ROB-walk recovery policy that grounds misprediction-recovery latency in Xiangshan's RAT-checkpoint mechanism. Today the default Replay policy charges every misprediction the full commit-head-to-redirect walk. NaiveCpt instead sizes the recovery walk by the distance from the nearest rename-table checkpoint older than the redirect, matching how the hardware restores the register alias table from a nearby snapshot and walks only the short residual.

  This is a recovery-cost (timing) model, not a change to functional recovery: gem5 already restores the rename map correctly via the history buffer on every squash. The checkpoint records position only (a sequence number + a per-instruction flag) and feeds ROB::computeDynSquashWidth — it does not copy alias-table state.

  Ported from the upstream internal/rat-snapshot work (original author ZhangZifei), adapted to current xs-dev and made opt-in.

## What changed

  - dyn_inst.hh: a RatSnapshotted status flag + accessors.
  - BaseO3CPU.py: params numMaxRatSnapshot (default 4), ratSnapshotDistance (default 32), robWalkByDestRegs (default true).
  - configs/: a --rob-walk-policy command-line option, applied per-CPU in kmhv3.
  - rename.{hh,cc}: a per-thread checkpoint buffer with take/commit/squash lifecycle, activated only under NaiveCpt, plus stats.
  - rob.{hh,cc}: computeSnapshotSquashWidth, which sizes the walk by destination-register reclaim from the nearest older checkpoint (a checkpoint at the redirect ⇒ zero residual), and the NaiveCpt branch in ROB::squash.

## Design notes

  - Opt-in and baseline-preserving. Wired into the reserved NaiveCpt enum slot; the Rollback/Replay/ConstCycle branches and their inputs are unchanged.
  - Activation is derived from robWalkPolicy (active if NaiveCpt), no separate enable flag.
  - Defaults match current Xiangshan RTL: 4 checkpoint slots, control-flow instructions spaced ≥32 apart, and walk cost counted by destination registers reclaimed (robWalkByDestRegs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--rob-walk-policy` CLI option (default: `Replay`) with new `NaiveCpt` checkpoint-based ROB misprediction recovery mode.
  * Introduced new O3 recovery/snapshot tuning parameters for RAT checkpoint snapshot sizing and behavior.
  * Integrated RAT checkpoint snapshot lifecycle into the rename stage, including assignment, commit, and squash tracking plus distance distribution stats.
  * Added NaiveCpt snapshot-aware dynamic squash-width calculation and new ROB snapshot-hit and squash-width distribution statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->