### PR TITLE
Add CI support for SPEC 26

### DIFF
--- a/.github/workflows/gem5-ideal-btb-perf-weekly.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-weekly.yml
@@ -20,6 +20,15 @@ jobs:
       config_path: configs/example/kmhv3.py
       benchmark_type: "spec17-1.0c"
 
+  align_test_spec26:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      config_path: configs/example/kmhv3.py
+      benchmark_type: "gcc15-spec26-1.0c"
+      distributed_servers: "default"
+      distributed_jobs_per_server: 32
+      timeout_minutes: 720
+
   perf_test_spec06:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
@@ -31,6 +40,15 @@ jobs:
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "spec17-1.0c"
+
+  perf_test_spec26:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      config_path: configs/example/idealkmhv3.py
+      benchmark_type: "gcc15-spec26-1.0c"
+      distributed_servers: "default"
+      distributed_jobs_per_server: 32
+      timeout_minutes: 720
 
   smt_test_spec06:
     uses: ./.github/workflows/gem5-perf-template.yml

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -168,7 +168,7 @@ jobs:
             "gcc15-spec26-0.3c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
-              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc15-spec26-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage SPEC CPU2026 checkpoints plus 722.palm_r/201821 regression" >> $GITHUB_OUTPUT
@@ -176,7 +176,7 @@ jobs:
             "gcc15-spec26-1.0c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.lst" >> $GITHUB_OUTPUT
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
-              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc15-spec26-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage SPEC CPU2026 checkpoints" >> $GITHUB_OUTPUT

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -190,7 +190,11 @@ jobs:
       - name: Build GEM5 fast
         run: |
           export GEM5_HOME=$(pwd)
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
+          if [[ "${{ inputs.benchmark_type }}" == gcc15-spec26-* ]]; then
+            export GCBV_REF_SO="/nfs/home/yangxianhui/workspace/GEM5/riscv64-nemu-interpreter-gem5-ref-smstateen-sv48-v3-so"
+          else
+            export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
+          fi
           if [[ "${{ inputs.benchmark_type }}" == gcc12-spec06-smt-* ]]; then
             export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
             export GCB_MULTI_CORE_RESTORER=""
@@ -309,7 +313,10 @@ jobs:
         run: |
           mkdir -p "$PERF_ARCHIVE_DIR"
           cd "$PERF_ARCHIVE_DIR"
-
+          if [[ "$BENCHMARK_TYPE_INPUT" == gcc15-spec26-* ]]; then
+            export GCBV_REF_SO="/nfs/home/yangxianhui/workspace/GEM5/riscv64-nemu-interpreter-gem5-ref-smstateen-sv48-v3-so"
+          fi
+          echo "Using GCBV_REF_SO=$GCBV_REF_SO"
           CONFIG_PATH="$CONFIG_PATH_INPUT"
           if [[ "$CONFIG_PATH" == /* ]]; then
             echo "Error: config_path must be repo-root-relative, got absolute path: '$CONFIG_PATH'"

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -190,11 +190,7 @@ jobs:
       - name: Build GEM5 fast
         run: |
           export GEM5_HOME=$(pwd)
-          if [[ "${{ inputs.benchmark_type }}" == gcc15-spec26-* ]]; then
-            export GCBV_REF_SO="/nfs/home/yangxianhui/workspace/GEM5/riscv64-nemu-interpreter-gem5-ref-smstateen-sv48-v3-so"
-          else
-            export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
-          fi
+          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-notama-tvalref-so"
           if [[ "${{ inputs.benchmark_type }}" == gcc12-spec06-smt-* ]]; then
             export GCBV_MULTI_CORE_REF_SO="/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so"
             export GCB_MULTI_CORE_RESTORER=""
@@ -313,10 +309,7 @@ jobs:
         run: |
           mkdir -p "$PERF_ARCHIVE_DIR"
           cd "$PERF_ARCHIVE_DIR"
-          if [[ "$BENCHMARK_TYPE_INPUT" == gcc15-spec26-* ]]; then
-            export GCBV_REF_SO="/nfs/home/yangxianhui/workspace/GEM5/riscv64-nemu-interpreter-gem5-ref-smstateen-sv48-v3-so"
-          fi
-          echo "Using GCBV_REF_SO=$GCBV_REF_SO"
+
           CONFIG_PATH="$CONFIG_PATH_INPUT"
           if [[ "$CONFIG_PATH" == /* ]]; then
             echo "Error: config_path must be repo-root-relative, got absolute path: '$CONFIG_PATH'"

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -166,18 +166,18 @@ jobs:
               echo "comment=run 80% coverage spec06 int rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec26-0.3c")
-              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.lst" >> $GITHUB_OUTPUT
-              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/spec26_0.3c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_rate_gcc15_rv64gcb_260718/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
-              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.json" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/checkpoints_cov0.3.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc15-spec26-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage SPEC CPU2026 checkpoints plus 722.palm_r/201821 regression" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec26-1.0c")
-              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.lst" >> $GITHUB_OUTPUT
-              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/spec26_1.0c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_rate_gcc15_rv64gcb_260718/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
-              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.json" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/checkpoints_all.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc15-spec26-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage SPEC CPU2026 checkpoints" >> $GITHUB_OUTPUT
               ;;

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -15,7 +15,7 @@ on:
       benchmark_type:
         required: true
         type: string
-        description: "Benchmark type: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+        description: "Benchmark type: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c, gcc15-spec26-0.3c, gcc15-spec26-1.0c"
       specific_benchmarks:
         required: false
         type: string
@@ -165,8 +165,24 @@ jobs:
               echo "artifact_name=performance-score-spec06int-0.8c-with-rvv-extension" >> $GITHUB_OUTPUT
               echo "comment=run 80% coverage spec06 int rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
+            "gcc15-spec26-0.3c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc15-spec26-0.3c" >> $GITHUB_OUTPUT
+              echo "comment=run 30% coverage SPEC CPU2026 checkpoints plus 722.palm_r/201821 regression" >> $GITHUB_OUTPUT
+              ;;
+            "gcc15-spec26-1.0c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_gcc15_rv64gc_base_260517/checkpoint" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc15-spec26-1.0c" >> $GITHUB_OUTPUT
+              echo "comment=run 100% coverage SPEC CPU2026 checkpoints" >> $GITHUB_OUTPUT
+              ;;
             *)
-              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-0.8c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c, gcc15-spec26-0.3c, gcc15-spec26-1.0c"
               exit 1
               ;;
           esac

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -36,6 +36,8 @@ on:
           - spec17-1.0c
           - spec06-rvv-1.0c
           - spec06int-rvv-0.8c
+          - gcc15-spec26-0.3c
+          - gcc15-spec26-1.0c
       specific_benchmarks:
         description: 'Specific benchmarks to run (comma-separated, eg. "mcf,gcc"), leave empty to run all'
         required: false

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -194,7 +194,7 @@ decode QUADRANT {
                     return std::make_shared<IllegalInstFault>(
                             "source reg x0", machInst);
                 }
-                Rc1 = szext<32>(Rc1 + imm);
+                Rc1_sw = (int32_t)(Rc1_sw + imm);
             }});
             0x2: c_li({{
                 imm = CIMM5;
@@ -737,7 +737,7 @@ decode QUADRANT {
         0x06: decode FUNCT3 {
             format IOp {
                 0x0: addiw({{
-                    Rd = szext<32>(Rs1 + imm);
+                    Rd_sw = (int32_t)(Rs1_sw + imm);
                 }}, int32_t);
                 0x1: decode FS3 {
                     0x0: slliw({{

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -194,7 +194,7 @@ decode QUADRANT {
                     return std::make_shared<IllegalInstFault>(
                             "source reg x0", machInst);
                 }
-                Rc1_sw = (int32_t)(Rc1_sw + imm);
+                Rc1 = szext<32>(Rc1 + imm);
             }});
             0x2: c_li({{
                 imm = CIMM5;
@@ -737,7 +737,7 @@ decode QUADRANT {
         0x06: decode FUNCT3 {
             format IOp {
                 0x0: addiw({{
-                    Rd_sw = (int32_t)(Rs1_sw + imm);
+                    Rd = szext<32>(Rs1 + imm);
                 }}, int32_t);
                 0x1: decode FS3 {
                     0x0: slliw({{


### PR DESCRIPTION
Summary:
- Add SPEC CPU2026 0.3c and 1.0c benchmark types.
- Add SPEC26 options to manual performance workflow.
- Add SPEC26 align/perf jobs to existing weekly performance workflow.

Data:
- /nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_0.3c.lst/json
- /nfs/home/share/gem5_ci/spec26_cpts/gcc15/spec26_1.0c.lst/json

Validation:
- Public metadata verified.
- Manual smoke: gcc15-spec26-0.3c, specific_benchmarks=722.palm_r
- Manual 0.3c full: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional SPEC CPU2026 benchmark variants for both automated and manual performance runs.
  * Introduced new weekly alignment and performance test coverage for the new SPEC CPU2026 configurations.
* **Configuration Updates**
  * Expanded weekly job execution capacity and increased the maximum runtime to accommodate the new runs.
* **Documentation**
  * Updated the selectable benchmark options and guidance text shown for these performance workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->