### PR TITLE
H debug fixes

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -632,6 +632,26 @@ ISA::readMiscReg(int misc_reg)
         auto ic = dynamic_cast<RiscvISA::Interrupts *>(tc->getCpuPtr()->getInterruptController(tc->threadId()));
         return (ic->readIP() & NEMU_HVIP_MASK);
     }
+    if (misc_reg == MISCREG_HIDELEG) {
+        return readMiscRegNoEffect(MISCREG_HIDELEG) & NEMU_HIDELEG_MASK &
+               readMiscRegNoEffect(MISCREG_MIDELEG);
+    }
+    if (misc_reg == MISCREG_VSIE) {
+        auto ic = dynamic_cast<RiscvISA::Interrupts *>(
+                tc->getCpuPtr()->getInterruptController(tc->threadId()));
+        RegVal mask = readMiscReg(MISCREG_HIDELEG) &
+                      (readMiscRegNoEffect(MISCREG_MIDELEG) |
+                       NEMU_MIDELEG_FORCED_MASK);
+        return (ic->readIE() & mask & NEMU_VS_MASK) >> 1;
+    }
+    if (misc_reg == MISCREG_VSIP) {
+        auto ic = dynamic_cast<RiscvISA::Interrupts *>(
+                tc->getCpuPtr()->getInterruptController(tc->threadId()));
+        RegVal mask = readMiscReg(MISCREG_HIDELEG) &
+                      (readMiscRegNoEffect(MISCREG_MIDELEG) |
+                       NEMU_MIDELEG_FORCED_MASK);
+        return (ic->readIP() & mask & NEMU_VS_MASK) >> 1;
+    }
     switch (misc_reg) {
       case MISCREG_HARTID:
         return tc->contextId();
@@ -882,6 +902,16 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 RegVal writeVal = ((old & ~(NEMU_HVIP_MASK)) | (val & NEMU_HVIP_MASK));
                 ic->setIP(writeVal);
             } break;
+            case MISCREG_VSIP: {
+                auto ic = dynamic_cast<RiscvISA::Interrupts *>(
+                    tc->getCpuPtr()->getInterruptController(tc->threadId()));
+                RegVal old = readMiscReg(MISCREG_IP);
+                RegVal mask = NEMU_VSIP_WMASK & readMiscReg(MISCREG_HIDELEG) &
+                              (readMiscReg(MISCREG_MIDELEG) |
+                               NEMU_MIDELEG_FORCED_MASK);
+                RegVal writeVal = (old & ~mask) | ((val << 1) & mask);
+                ic->setIP(writeVal);
+            } break;
 
           case MISCREG_IP:
             {
@@ -902,6 +932,18 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 RegVal hip_Mask = NEMU_HIE_WMASK & (readMiscReg(MISCREG_MIDELEG) | NEMU_MIDELEG_FORCED_MASK);
                 write_val = ((old & ~(hip_Mask)) |(val & hip_Mask));
                 ic->setIE(write_val);
+            }
+            break;
+          case MISCREG_VSIE:
+            {
+                auto ic = dynamic_cast<RiscvISA::Interrupts *>(
+                    tc->getCpuPtr()->getInterruptController(tc->threadId()));
+                RegVal old = readMiscReg(MISCREG_IE);
+                RegVal mask = NEMU_VS_MASK & readMiscReg(MISCREG_HIDELEG) &
+                              (readMiscReg(MISCREG_MIDELEG) |
+                               NEMU_MIDELEG_FORCED_MASK);
+                RegVal writeVal = (old & ~mask) | ((val << 1) & mask);
+                ic->setIE(writeVal);
             }
             break;
           case MISCREG_IE:
@@ -1029,6 +1071,15 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                setMiscRegNoEffect(misc_reg, writeVal);
             }
             break;
+          case MISCREG_HIDELEG:
+            {
+                RegVal writeVal = val & NEMU_HIDELEG_MASK;
+                setMiscRegNoEffect(misc_reg, writeVal);
+            }
+            break;
+          case MISCREG_SENVCFG:
+            setMiscRegNoEffect(misc_reg, val & NEMU_SENVCFG_WMASK);
+            break;
           case MISCREG_HSTATUS:
             {
                 RegVal oldVal = readMiscRegNoEffect(MISCREG_HSTATUS);
@@ -1061,6 +1112,8 @@ ISA::unserialize(CheckpointIn &cp)
 {
     DPRINTF(Checkpoint, "Unserializing Riscv Misc Registers\n");
     UNSERIALIZE_CONTAINER(miscRegFile);
+    if (miscRegFile.size() < NUM_MISCREGS)
+        miscRegFile.resize(NUM_MISCREGS, 0);
     UNSERIALIZE_SCALAR(matrixTileM);
     UNSERIALIZE_SCALAR(matrixTileK);
     UNSERIALIZE_SCALAR(matrixTileN);

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -914,12 +914,15 @@ const uint64_t NEMU_COUNTER_MASK = 0xffffffffULL;
 
 const uint64_t NEMU_VS_MASK = ((1 << 10) | (1 << 6) | (1 << 2));
 const uint64_t NEMU_HS_MASK = ((1 << 12) | NEMU_VS_MASK);
+const uint64_t NEMU_HIDELEG_MASK = NEMU_VS_MASK;
 const uint64_t NEMU_HIE_WMASK = NEMU_HS_MASK;
 const uint64_t NEMU_HIE_RMASK = NEMU_HS_MASK;
 
 const uint64_t NEMU_HIP_RMASK = NEMU_HS_MASK;
 const uint64_t NEMU_HVIP_MASK = ((1 << 10) | (1 << 6) | (1 << 2));
+const uint64_t NEMU_VSIP_WMASK = (1 << 2);
 const uint64_t NEMU_MIDELEG_FORCED_MASK = ((1 << 12) | (1 << 10) | (1 << 6) | (1 << 2));
+const uint64_t NEMU_SENVCFG_WMASK = 0;
 const RegVal STATUS_SD_MASK = 1ULL << ((sizeof(uint64_t) * 8) - 1);
 const RegVal STATUS_SXL_MASK = 3ULL << SXL_OFFSET;
 const RegVal STATUS_UXL_MASK = 3ULL << UXL_OFFSET;

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1890,6 +1890,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
     HGATP hgatp = tc->readMiscReg(MISCREG_HGATP);
     Addr vaddr = VADDR_SEXT(hgatp.mode, req->getVaddr());
     STATUS status = tc->readMiscReg(MISCREG_STATUS);
+    STATUS vstatus = tc->readMiscReg(MISCREG_VSSTATUS);
     Fault fault = NoFault;
     PrivilegeMode pmode = getMemPriv(tc, mode);
     bool continuePtw =false;
@@ -1922,7 +1923,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             }
-            fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pteVS, 0, false);
+            fault = checkPermissions(vstatus, pmode, vaddr, mode, e[0]->pteVS, 0, false);
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             }
@@ -1966,7 +1967,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                 //return fault;
                 return std::make_pair(hit_type,fault);
             } else {
-                fault = checkPermissions(status, pmode, vaddr, mode, e[0]->pte, 0, false);
+                fault = checkPermissions(vstatus, pmode, vaddr, mode, e[0]->pte, 0, false);
                 if (fault != NoFault) {
                     return std::make_pair(hit_type, fault);
                 }
@@ -2062,7 +2063,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
             if ((hgatp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))
                 continue;
             e[i_e] = l2tlb->lookupL2TLB(req->getgPaddr(), hgatp.vmid, mode, false, i_e, true, gstage);
-            if (e[i_e]) {
+            if (e[i_e] && e[i_e]->pte.v) {
                 if (e[i_e]->level < hit_level) {
                     e[0] = e[i_e];
                     hit_level = e[i_e]->level;
@@ -2124,7 +2125,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                 if ((vsatp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))
                     continue;
                 e[i_e] = l2tlb->lookupL2TLB(vaddr, vsatp.asid, mode, false, i_e, true, vsstage);
-                if (e[i_e]) {
+                if (e[i_e] && e[i_e]->pte.v) {
                     if (e[i_e]->level < hit_level) {
                         e[0] = e[i_e];
                         hit_level = e[i_e]->level;
@@ -2175,7 +2176,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                         if ((hgatp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))
                             continue;
                         e[i_e] = l2tlb->lookupL2TLB(gPaddr, hgatp.vmid, mode, false, i_e, true, gstage);
-                        if (e[i_e]) {
+                        if (e[i_e] && e[i_e]->pte.v) {
                             if (e[i_e]->level < hit_level) {
                                 e[0] = e[i_e];
                                 hit_level = e[i_e]->level;

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -52,6 +52,7 @@
 #include "arch/riscv/insts/fusion.hh"
 #include "arch/riscv/insts/static_inst.hh"
 #include "arch/riscv/regs/misc.hh"
+#include "arch/riscv/utility.hh"
 #include "base/cprintf.hh"
 #include "base/loader/symtab.hh"
 #include "base/logging.hh"
@@ -1020,13 +1021,55 @@ BaseCPU::diffWithNEMU(ThreadID tid, InstSeqNum seq)
             readGem5Regs(tid);
             uint64_t* nemu_val = (uint64_t*)&(diffAllStates->referenceRegFile.vr[0]);
             uint64_t* gem5_val = (uint64_t*)&(diffAllStates->gem5RegFile.vr[0]);
+            uint8_t* nemu_byte = (uint8_t*)&(diffAllStates->referenceRegFile.vr[0]);
+            uint8_t* gem5_byte = (uint8_t*)&(diffAllStates->gem5RegFile.vr[0]);
+            const uint64_t vtype = diffAllStates->referenceRegFile.vtype;
+            const uint64_t vl = diffAllStates->referenceRegFile.vl;
+            const bool tail_agnostic = bits(vtype, 6);
+            const uint32_t sew_bytes = 1 << bits(vtype, 5, 3);
+            const uint32_t regs_per_group = RiscvISA::vtype_regs_per_group(vtype);
+            const uint32_t elems_per_reg = RiscvISA::VLENB / sew_bytes;
+            const uint32_t vlmax = RiscvISA::vtype_VLMAX(vtype);
+            auto is_tail_agnostic_byte = [&](int byte_idx) {
+                if (!tail_agnostic || vl >= vlmax)
+                    return false;
+                const int reg_idx = byte_idx / RiscvISA::VLENB;
+                const int byte_in_reg = byte_idx % RiscvISA::VLENB;
+                auto reg_is_in_group = [&](const RegId &reg) {
+                    if (!reg.isVecReg())
+                        return false;
+                    const int vec_reg = reg.index();
+                    const int group_base = vec_reg & ~(regs_per_group - 1);
+                    if (reg_idx < group_base ||
+                        reg_idx >= group_base + regs_per_group)
+                        return false;
+                    const uint32_t elem_idx =
+                        (reg_idx - group_base) * elems_per_reg +
+                        byte_in_reg / sew_bytes;
+                    return elem_idx >= vl;
+                };
+                for (int dest_idx = 0; dest_idx < diffInfo.inst->numDestRegs();
+                     dest_idx++) {
+                    if (reg_is_in_group(diffInfo.inst->destRegIdx(dest_idx)))
+                        return true;
+                }
+                for (int src_idx = 0; src_idx < diffInfo.inst->numSrcRegs();
+                     src_idx++) {
+                    if (reg_is_in_group(diffInfo.inst->srcRegIdx(src_idx)))
+                        return true;
+                }
+                return false;
+            };
             bool maybe_error = false;
             int error_idx = 0;
-            for (int i=0; i < RiscvISA::NumVecElemPerVecReg * 32; i++) {
-                if (nemu_val[i] != gem5_val[i]) {
-                    // diff_at = ValueDiff;
+            for (int i = 0; i < RiscvISA::VLENB * 32; i++) {
+                if (nemu_byte[i] != gem5_byte[i] &&
+                    is_tail_agnostic_byte(i))
+                    continue;
+                if (nemu_byte[i] != gem5_byte[i]) {
                     maybe_error = true;
-                    error_idx = (i >> 1) * 2;
+                    error_idx = (i / RiscvISA::VLENB) *
+                                RiscvISA::NumVecElemPerVecReg;
                     break;
                 }
             }

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -922,7 +922,20 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
 
     // Track how many dynamic instructions were fetched for this (legacy) FTQ/FSQ entry.
     ftqEntryFetchedInsts[tid]++;
-    if (run_out) {
+    const bool false_hit = run_out && stream.predTaken && !predict_taken;
+    if (false_hit) {
+        DPRINTF(DecoupleBP,
+                "False BTB hit at FTQ %lu: stream [%#lx, %#lx) "
+                "predicted control %#lx -> %#lx, fetched through %#lx; "
+                "redirect to fall-through %s\n",
+                dbpbtb->ftqHeadId(tid), stream.startPC, stream.predEndPC,
+                stream.predBranchInfo.pc, stream.predBranchInfo.target,
+                curr_pc, next_pc);
+        dbpbtb->nonControlSquash(dbpbtb->ftqHeadId(tid), next_pc,
+                                 inst->seqNum, tid, currentLoopIter);
+        ftqEntryFetchedInsts[tid] = 0;
+        threads[tid].valid = false;
+    } else if (run_out) {
         dbpbtb->consumeFetchTarget(ftqEntryFetchedInsts[tid], tid);
         ftqEntryFetchedInsts[tid] = 0;
         threads[tid].valid = false;


### PR DESCRIPTION
## Motivation

This PR fixes several H-mode checkpoint failures observed after switching to the newer FS0 NEMU reference. The failures were not caused by a single issue, but by a set of CSR semantic gaps, H-mode TLB hit-path mismatches, frontend false BTB recovery behavior, and RVV difftest comparison policy.

## Changes

- Add/align H-mode CSR behavior required by the FS0 NEMU reference:
  - add `SENVCFG` without shifting existing serialized misc-reg indices;
  - resize old checkpoint `miscRegFile` during unserialization;
  - mask `HIDELEG` to virtual interrupt delegation bits;
  - synthesize `VSIE`/`VSIP` from HS interrupt state;
  - keep unsupported `SENVCFG` fields read-only zero.

- Fix H-mode TLB hit validation:
  - use `VSSTATUS` for VS-stage permission checks on H L1 hits;
  - require `pte.v` when selecting H L2 VS/G-stage hit candidates.

- Fix frontend recovery for false BTB hits:
  - detect stream run-out with `stream.predTaken && !predict_taken`;
  - recover through `nonControlSquash()` instead of consuming a stale fetch target.

- Fix RVV difftest tail-agnostic comparison:
  - keep gem5 execution semantics unchanged;
  - mask architecturally unspecified tail-agnostic bytes during vector register comparison.

## Scope

This PR only contains H-mode debug fixes. It does not include H TLB compression changes.

## Validation

Representative H-mode failing checkpoints were used during debugging, including:

- `bzip2_combined/16628`
- `hmmer_retro/0`
- `dealII/367`
- `hmmer_nph3/0`

These fixes reduce the H-mode failure set observed with the newer FS0 NEMU reference and make the representative failures pass targeted validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for virtualization interrupt control and status registers (including VS-level interrupt enable/pending handling) and stricter `senvcfg` access masking.

* **Bug Fixes**
  * Improved VS-stage virtual memory permission checks and tightened L2 TLB entry selection to only consider valid PTEs.
  * Fixed vector difftest comparisons by switching to byte-level matching with tail-agnostic tolerance.
  * Refined fetch-target “run out” recovery for decoupled+BTB-only scenarios.
  * Improved processor state restoration by ensuring misc register storage is correctly sized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->