### PR TITLE
fix(cache): fix SMT CAS(LR/SC) livelock in cache_blk.hh

### DIFF
--- a/src/mem/cache/cache_blk.hh
+++ b/src/mem/cache/cache_blk.hh
@@ -376,7 +376,7 @@ class CacheBlk : public TaggedEntry
         assert(pkt->isLLSC());
         auto l = lockList.begin();
         while (l != lockList.end()) {
-            if (l->intersects(pkt->req))
+            if (l->matches(pkt->req))
                 l = lockList.erase(l);
             else
                 ++l;
@@ -487,7 +487,8 @@ class CacheBlk : public TaggedEntry
             req->setExtraData(success ? 1 : 0);
             // clear any intersected locks from other contexts (our LL
             // should already have cleared them)
-            clearLoadLocks(req);
+            if (success)
+                clearLoadLocks(req);
             return success;
         } else {
             // a normal write, if there is any lock not from this


### PR DESCRIPTION
## Motivation

Under SMT, two threads executing kernel CAS spinlocks (LR/SC loops) on the same address can enter a permanent livelock: both threads' SC instructions fail every cycle, the lock is never acquired, and forward progress halts. This was observed on perlbench_checkspam (slice 24373) with enlarged IQ sizes (50%), where simulation stalled at ~tick 6.6B with both threads' IPC dropping to near zero.

## Environment

- **Branch**: `xs-dev`
- **Base commit**: `45bed11d1b` (cpu-o3: Avoid SMT frontend work during pending redirects (#935))
- **Config**: SMT-2, warmup=20M, maxinsts=40M
- **IQ sizes**: int=24, mem=24, fp=28, vec=64 (default × 1.5)

## Approach

### Symptom

RISC-V kernel spinlocks use LR/SC loops to implement CAS:

```asm
lr_d   a2, (a0)      ; load lock value, establish reservation
bne    a2, a5, +14   ; lock held → skip SC
sc_d   a1, a4, (a0)  ; attempt to write (acquire lock)
c_bnez a1, -12       ; SC failed → retry
```

During livelock, both threads repeatedly execute LR → SC → fail → retry. `bne` never branches — the lock value stays 0 (free) because neither thread ever successfully acquires it. Stats: tid=0 issued 170 LRs, tid=1 issued 169 LRs, 507 total SCs all failed. Baseline counts are all zero.

### Root Cause

Two bugs in `src/mem/cache/cache_blk.hh` reservation management interact to cause livelock:

**Bug 1 — `trackLoadLocked()` (line 379)**: Uses `intersects()` (address-only) to clear existing reservations on LR. This causes one thread's LR to erase another thread's reservation. In real hardware, each hart has an independent reservation register — LR is a load and should not affect other harts.

**Bug 2 — `checkWrite()` (line 490)**: Calls `clearLoadLocks()` unconditionally — even on SC **failure**. A failed SC writes nothing and should have no side effect on other threads' reservations.

Combined effect — livelock sequence:

```
Step 1: tid=0 lr_d → trackLoadLocked
   → lockList = [{ctx=0, addr=X}]

Step 2: tid=1 lr_d → trackLoadLocked
   → intersects(addr=X) hits ctx=0's Lock → erase
   → add ctx=1
   → lockList = [{ctx=1, addr=X}]          ← ctx=0's reservation gone

Step 3: tid=0 sc_d → checkWrite
   → matches(ctx=0) not found → success=false
   → setExtraData(0) → a1=1 (SC failed)
   → clearLoadLocks(ctx=0) → clears ctx≠0 locks → ctx=1 erased
   → lockList = []                          ← now completely empty

Step 4: tid=1 sc_d → checkWrite
   → matches(ctx=1) not found (lockList empty) → success=false
   → setExtraData(0) → a1=1 (SC failed)

Both retry → lock value still 0 (never written) → bne not taken → both SC fail again → infinite loop
```

### Fix

File: `src/mem/cache/cache_blk.hh` (2 hunks, 3 lines changed)

```diff
 // trackLoadLocked (line 379): LR only replaces same-thread's old reservation
-            if (l->intersects(pkt->req))
+            if (l->matches(pkt->req))

 // checkWrite (line 490): only clear other threads' reservations on SC success
-            clearLoadLocks(req);
+            if (success)
+                clearLoadLocks(req);
```

Corrected behavior after fix:

```
tid=0 lr_d → lockList = [{ctx=0}, {ctx=1}]  (can coexist)
tid=1 lr_d → lockList = [{ctx=1}, {ctx=0}]  (no mutual invalidation)
tid=0 sc_d → matches(ctx=0) success → write lock → clearLoadLocks clears ctx=1
tid=1 sc_d → matches(ctx=1) not found → fail → no side effect → retry
tid=1 lr_d → reads lock held → bne taken → waits for release
```

One thread succeeds, the other waits — correct spinlock behavior.

## Scope

`src/mem/cache/cache_blk.hh` only. No configuration or other functional code changes. Affects all ISAs using LL/SC atomics (RISC-V, ARM, MIPS).

## Validation

Single-slice verification (perlbench_checkspam 24373, IQ×1.5, SMT-2):

| Config | tid0 IPC | tid1 IPC | Status |
| -- | -- | -- | -- |
| Baseline (default IQ) | 1.3616 | 1.3671 | Normal |
| IQ×1.5 before fix | 0.2715 | 0.2719 | Livelock at tick ~6.6B |
| IQ×1.5 after fix | 1.3697 | 1.3711 | Normal (IPC restored) |

SPEC06 INT full regression (12 benchmarks, IQ×1.5, SMT-2): 
- no new difftest failures introduced, previously stuck slice now completes normally.

tianfengshuo.tfs@alibaba-inc.com
[commit_progress.log](https://github.com/user-attachments/files/30117281/commit_progress.log)

