### PR TITLE
feat: add ROB base reserve config and SMT stats

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -926,6 +926,24 @@ def xiangshan_system_init():
         help="PTW MissQueue size",
     )
     parser.add_argument(
+        "--smtROBDonorEntry",
+        type=int,
+        default=8,
+        help="Minimum ROB entries reserved for a borrowing donor to resume",
+    )
+    parser.add_argument(
+        "--smtROBBaseEntry",
+        type=int,
+        default=80,
+        help="Minimum ROB entries reserved for a borrowing base to resume",
+    )
+    parser.add_argument(
+        "--ROBTotalEntry",
+        type=int,
+        default=160,
+        help="Number of reorder buffer entries",
+    )
+    parser.add_argument(
         "--standalone-sc",
         action="store_true",
         default=False,

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -67,8 +67,10 @@ def setKmhV3IdealParams(args, system):
         cpu.squashWidth = 8
         cpu.phyregReleaseWidth = 8
         cpu.RobCompressPolicy = 'kmhv3'
-        cpu.numROBEntries = 160
+        cpu.numROBEntries = args.ROBTotalEntry
         cpu.CROB_instPerGroup = 2 # 1 if not using ROB compression
+        cpu.smtBorrowDonorReserveEntries = args.smtROBDonorEntry
+        cpu.smtBorrowBaseReserveEntries = args.smtROBBaseEntry
 
         # lsu
         cpu.StoreWbStage = 4

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -258,6 +258,8 @@ class BaseO3CPU(BaseCPU):
         8, "Cycles to keep an SMT thread marked as a ROB borrowing donor")
     smtBorrowDonorReserveEntries = Param.Unsigned(
         8, "Minimum ROB entries reserved for a borrowing donor to resume")
+    smtBorrowBaseReserveEntries = Param.Unsigned(
+        80, "Minimum ROB entries reserved for a borrowing base to resume")
 
     branchPred = Param.BranchPredictor(DecoupledBPUWithBTB(),
                                        "Branch Predictor")

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -316,7 +316,17 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
       ADD_STAT(squashDueToSquashAfter, statistics::units::Count::get(),
                "Number of squash due to squash after"),
       ADD_STAT(totalSquash, statistics::units::Count::get(),
-               "Total number of squash")
+               "Total number of squash"),
+      ADD_STAT(ROBFull, statistics::units::Count::get(),
+               "Total number of ROBFull"),
+      ADD_STAT(smtRestEntryWhileROBFull, statistics::units::Count::get(),
+               "Distribution of total rest entries while ROBFull in SMT mode"),
+      ADD_STAT(ROBBorrowingStateChange, statistics::units::Count::get(),
+               "changing times of borrowing state"),
+      ADD_STAT(smtStateHoldCycle, statistics::units::Count::get(),
+               "SMT base/donor state holding cycle distribution"),
+      ADD_STAT(smtROBEntriesWhlieStateChange, statistics::units::Count::get(),
+               "SMT ROB thread used/rest entries distribution while state change")
 {
     using namespace statistics;
 
@@ -432,6 +442,34 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
     totalSquash = squashDueToBranch + squashDueToOrderViolation + \
         squashDueToValuePrediction + squashDueToTrap + squashDueToTC + \
         squashDueToSquashAfter;
+
+    ROBFull
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
+    smtRestEntryWhileROBFull
+        .init(0, 160, 5)
+        .flags(statistics::pdf);
+
+    ROBBorrowingStateChange
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
+    smtStateHoldCycle
+        .init(2, 0, 100, 10)
+        .flags(statistics::pdf);
+    
+    smtStateHoldCycle.subname(0, "Base");
+    smtStateHoldCycle.subname(1, "Donor");
+
+    smtROBEntriesWhlieStateChange
+        .init(4, 0, 160, 8)
+        .flags(statistics::pdf);
+
+    smtROBEntriesWhlieStateChange.subname(0, "BaseToDonor_used");
+    smtROBEntriesWhlieStateChange.subname(1, "BaseToDonor_rest");
+    smtROBEntriesWhlieStateChange.subname(2, "DonorToBase_used");
+    smtROBEntriesWhlieStateChange.subname(3, "DonorToBase_rest");
 }
 
 void
@@ -912,6 +950,8 @@ Commit::tick()
             }
         }
     }
+    
+    rob->addBorrowingStateHoldCycle();
 
     commit();
 
@@ -2069,7 +2109,7 @@ Commit::moveInstsToBuffer()
             donor = borrowingDonorCycles[i] > 0;
         }
 
-        rob->setBorrowingDonor(i, donor);
+        rob->setBorrowingDonor(i, donor, this);
     }
 
     // check threads stall & status
@@ -2087,6 +2127,12 @@ Commit::moveInstsToBuffer()
             block_reason = StallReason::CommitSquash;
         } else if (block) {
             block_reason = robInfoFromIEW->iewInfo[i].robHeadStallReason;
+            stats.ROBFull[i]++;
+            unsigned restEntry = rob->getTotalEntries();
+            for (int j = 0; j < numThreads; j++) {
+                restEntry -= rob->getThreadEntries(j);
+            }
+            stats.smtRestEntryWhileROBFull.sample(restEntry);
             if (block_reason == StallReason::NoStall) {
                 block_reason = StallReason::ROBFull;
             }
@@ -2402,6 +2448,22 @@ Commit::dumpTicks(const DynInstPtr &inst)
     assert(archDBer);
     archDBer->memTraceWrite(curTick(), inst->isLoad(), inst->pcState().instAddr(), inst->effAddr, inst->physEffAddr,
                             inst->firstIssue, inst->translatedTick, inst->completionTick, curTick(), 0, inst->pf_source);
+}
+
+
+void
+Commit::recordROBBorrowingStateChangeStats(
+    ThreadID tid, bool old_donor,
+    unsigned state_hold_cycle,
+    unsigned rob_entries_used,
+    unsigned rob_entries_free)
+{
+    stats.smtStateHoldCycle[old_donor].sample(state_hold_cycle);
+    stats.smtROBEntriesWhlieStateChange[(int)(old_donor) * 2]
+        .sample(rob_entries_used);
+    stats.smtROBEntriesWhlieStateChange[(int)(old_donor) * 2 + 1]
+        .sample(rob_entries_free);
+    stats.ROBBorrowingStateChange[tid]++;
 }
 
 } // namespace o3

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -325,7 +325,7 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
                "changing times of borrowing state"),
       ADD_STAT(smtStateHoldCycle, statistics::units::Count::get(),
                "SMT base/donor state holding cycle distribution"),
-      ADD_STAT(smtROBEntriesWhlieStateChange, statistics::units::Count::get(),
+      ADD_STAT(smtROBEntriesWhileStateChange, statistics::units::Count::get(),
                "SMT ROB thread used/rest entries distribution while state change")
 {
     using namespace statistics;
@@ -462,14 +462,14 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
     smtStateHoldCycle.subname(0, "Base");
     smtStateHoldCycle.subname(1, "Donor");
 
-    smtROBEntriesWhlieStateChange
+    smtROBEntriesWhileStateChange
         .init(4, 0, 160, 8)
         .flags(statistics::pdf);
 
-    smtROBEntriesWhlieStateChange.subname(0, "BaseToDonor_used");
-    smtROBEntriesWhlieStateChange.subname(1, "BaseToDonor_rest");
-    smtROBEntriesWhlieStateChange.subname(2, "DonorToBase_used");
-    smtROBEntriesWhlieStateChange.subname(3, "DonorToBase_rest");
+    smtROBEntriesWhileStateChange.subname(0, "BaseToDonor_used");
+    smtROBEntriesWhileStateChange.subname(1, "BaseToDonor_rest");
+    smtROBEntriesWhileStateChange.subname(2, "DonorToBase_used");
+    smtROBEntriesWhileStateChange.subname(3, "DonorToBase_rest");
 }
 
 void
@@ -2459,9 +2459,9 @@ Commit::recordROBBorrowingStateChangeStats(
     unsigned rob_entries_free)
 {
     stats.smtStateHoldCycle[old_donor].sample(state_hold_cycle);
-    stats.smtROBEntriesWhlieStateChange[(int)(old_donor) * 2]
+    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2]
         .sample(rob_entries_used);
-    stats.smtROBEntriesWhlieStateChange[(int)(old_donor) * 2 + 1]
+    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2 + 1]
         .sample(rob_entries_free);
     stats.ROBBorrowingStateChange[tid]++;
 }

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -649,6 +649,12 @@ class Commit
         statistics::Vector squashDueToTC;
         statistics::Vector squashDueToSquashAfter;
         statistics::Formula totalSquash;
+
+        statistics::Vector ROBFull;
+        statistics::Distribution smtRestEntryWhileROBFull;
+        statistics::Vector ROBBorrowingStateChange;
+        statistics::VectorDistribution smtStateHoldCycle;
+        statistics::VectorDistribution smtROBEntriesWhlieStateChange;
     } stats;
 
     bool ismispred[MaxThreads] = {false};
@@ -683,6 +689,12 @@ class Commit
     void traceCommitDifftest(ThreadID tid, const DynInstPtr &head_inst);
 
 public:
+    void recordROBBorrowingStateChangeStats(
+        ThreadID tid, bool old_donor,
+        unsigned state_hold_cycle,
+        unsigned rob_entries_used,
+        unsigned rob_entries_free);
+
     const CommitStats& getCommitStats() const { return stats; }
     uint64_t getTraceCommitIndex(ThreadID tid) const { return traceCommitIndex[tid]; }
 };

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -654,7 +654,7 @@ class Commit
         statistics::Distribution smtRestEntryWhileROBFull;
         statistics::Vector ROBBorrowingStateChange;
         statistics::VectorDistribution smtStateHoldCycle;
-        statistics::VectorDistribution smtROBEntriesWhlieStateChange;
+        statistics::VectorDistribution smtROBEntriesWhileStateChange;
     } stats;
 
     bool ismispred[MaxThreads] = {false};

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -133,6 +133,7 @@ ROB::allocateGroup_kmhv3(const DynInstPtr inst, ThreadID tid)
 ROB::ROB(CPU *_cpu, const BaseO3CPUParams &params)
     : robPolicy(params.smtROBPolicy),
       borrowingDonorReserveEntries(params.smtBorrowDonorReserveEntries),
+      borrowingBaseReserveEntries(params.smtBorrowBaseReserveEntries),
       robWalkPolicy(params.robWalkPolicy),
       cpu(_cpu),
       numEntries(params.numROBEntries),
@@ -146,6 +147,7 @@ ROB::ROB(CPU *_cpu, const BaseO3CPUParams &params)
 {
     for (ThreadID tid = 0; tid < MaxThreads; ++tid) {
         borrowingDonor[tid] = false;
+        borrowingStateHoldCycle[tid] = 0;
     }
 
     //Figure out rob policy
@@ -337,7 +339,7 @@ ROB::borrowingLimit(ThreadID tid) const
     }
 
     const unsigned active_threads = std::max(1U, activeThreadCount());
-    const unsigned base = std::max(1U, numEntries / active_threads);
+    const unsigned base = borrowingBaseReserveEntries;
     const unsigned donor_resume_quota =
         std::min(base, borrowingDonorReserveEntries);
 
@@ -358,6 +360,31 @@ ROB::borrowingLimit(ThreadID tid) const
     }
 
     return numEntries - reserved;
+}
+
+void 
+ROB::setBorrowingDonor(ThreadID tid, bool donor, Commit* commit)
+{ 
+    if (borrowingDonor[tid] != donor) {
+        bool old_donor = borrowingDonor[tid];
+        unsigned state_hold_cycle = borrowingStateHoldCycle[tid];
+        unsigned rob_entries_used = threadGroups[tid].size();
+        unsigned rob_entries_free = numFreeEntries(tid);
+
+        commit->recordROBBorrowingStateChangeStats(
+            tid, old_donor, state_hold_cycle,
+            rob_entries_used, rob_entries_free);
+
+        borrowingDonor[tid] = donor; 
+        borrowingStateHoldCycle[tid] = 0;
+    }
+}
+
+void 
+ROB::addBorrowStateHoldCycle() {
+    for (int i = 0; i < numThreads; ++i) {
+        borrowingStateHoldCycle[i]++;
+    }
 }
 
 bool

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -46,6 +46,7 @@
 #include "base/logging.hh"
 #include "cpu/o3/dyn_inst.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/commit.hh"
 #include "debug/Fetch.hh"
 #include "debug/ROB.hh"
 #include "params/BaseO3CPU.hh"
@@ -381,7 +382,7 @@ ROB::setBorrowingDonor(ThreadID tid, bool donor, Commit* commit)
 }
 
 void 
-ROB::addBorrowStateHoldCycle() {
+ROB::addBorrowingStateHoldCycle() {
     for (int i = 0; i < numThreads; ++i) {
         borrowingStateHoldCycle[i]++;
     }

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -214,8 +214,10 @@ class ROB
     }
 
     /** Returns whether the thread may borrow unused ROB capacity. */
-    void setBorrowingDonor(ThreadID tid, bool donor)
-    { borrowingDonor[tid] = donor; }
+    void setBorrowingDonor(ThreadID tid, bool donor, Commit* commit);
+
+    /** add cycle count for borrowing state holding cycle stats */
+    void addBorrowingStateHoldCycle();
 
     /** Returns whether the thread can reserve the requested ROB entries. */
     bool canAllocate(ThreadID tid, unsigned entries) const;

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -67,6 +67,8 @@ namespace o3
 
 class CPU;
 
+class Commit;
+
 struct DerivO3CPUParams;
 
 /**
@@ -98,6 +100,11 @@ class ROB
 
     /** Minimum entries a donor thread keeps for restarting after a stall. */
     const unsigned borrowingDonorReserveEntries;
+
+    /** Minimum entries a base thread keeps for restarting after a stall. */
+    const unsigned borrowingBaseReserveEntries;
+
+    unsigned borrowingStateHoldCycle[MaxThreads];
 
     ROBWalkPolicy robWalkPolicy;
 
@@ -216,6 +223,9 @@ class ROB
     /** Returns the number of entries being used by a specific thread. */
     unsigned getThreadEntries(ThreadID tid)
     { return threadGroups[tid].size(); }
+
+    unsigned getTotalEntries() 
+    { return numEntries; }
 
     /** Returns if the ROB is full. */
     bool isFull()


### PR DESCRIPTION
- Add `smtBorrowBaseReserveEntries` config parameter to control the
  number of reserved ROB entries per thread in the base state of the
  DynamicBorrowing policy (default unchanged).
- Update `configs/common/xiangshan.py` and `configs/example/idealkmhv3.py`
  to support command-line configuration of ROB total entries
  (`--ROBTotalEntry`), donor-state reserved entries (`--smtROBDonorEntry`),
  and base-state reserved entries (`--smtROBBaseEntry`).
  Usage: `build/RISCV/gem5.opt -d $OUTDIR configs/example/smt_idealkmhv3.py --ROBTotalEntry $Total --smtROBDonorEntry $Donor --smtROBBaseEntry $Base`
- Add the following statistics for ROB and SMT borrowing analysis:
  - `ROBFull` — total ROB-full event count
  - `smtRestEntryWhileROBFull` — distribution of remaining entries when ROB is full in SMT mode
  - `ROBBorrowingStateChange` — number of borrowing state transitions (DynamicBorrowing only)
  - `smtStateHoldCycle` — cycle distribution of base/donor state holding (DynamicBorrowing only)
  - `smtROBEntriesWhileStateChange` — per-thread used/remaining entry distribution at state transitions (DynamicBorrowing only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line options to configure SMT ROB sizing and reservation levels (`--smtROBDonorEntry`, `--smtROBBaseEntry`, `--ROBTotalEntry`).
  * Made ROB capacity and SMT borrowing reserves driven by these parameters, including a minimum base reserve for resuming.
* **Monitoring**
  * Added new statistics for SMT/ROB borrowing state changes, borrowing-state hold cycles, ROB-full behavior, and tracking ROB entry usage while blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->