### PR TITLE
misc: Run SMT 0.3c perf test after each xs-dev commit

### DIFF
--- a/.github/workflows/gem5-smt-spec06-0.3c.yml
+++ b/.github/workflows/gem5-smt-spec06-0.3c.yml
@@ -1,6 +1,9 @@
 name: gem5 SMT SPEC2006 Performance Test(0.3c)
 
 on:
+  # Run after every commit merged into the main development branch.
+  push:
+    branches: [ xs-dev ]
   schedule:
     # Run every Tuesday at 23:59 UTC+8 (15:59 UTC)
     - cron: '59 15 * * 2'


### PR DESCRIPTION
## Motivation

SMT SPEC06 0.3c performance CI currently runs weekly, manually, or via the trusted perf-smt label, so performance changes can go unobserved between weekly runs.

## Change

Add a push trigger for xs-dev to .github/workflows/gem5-smt-spec06-0.3c.yml. This runs the existing SMT 0.3c performance template once for each commit pushed to xs-dev after merge, while preserving the schedule, perf-smt label, and manual triggers.

## Validation

- git diff --check
- Ruby YAML parser validation
- Confirmed push.branches is xs-dev and existing reusable-workflow inputs are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performance testing now runs automatically when changes are pushed to the `xs-dev` branch.
  * Existing scheduled, pull request, and manually triggered test options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->