### PR TITLE
cpu-o3: Add thread IDs to PerfCCT traces

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -684,6 +684,7 @@ def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
             name = PerfRecord.vals[i]
             type_str = "bigint unsigned" if name.lower().startswith(('at', 'pc', 'result')) else "char(20)"
             perfCCT_cmd += "," + name + " " + type_str + " NOT NULL"
+        perfCCT_cmd += ",TID int unsigned NOT NULL"
         perfCCT_cmd += ");"
 
         perfCCT_cmd += """

--- a/docs/tools/alignToRTL/PerfCCT_usage.md
+++ b/docs/tools/alignToRTL/PerfCCT_usage.md
@@ -74,6 +74,8 @@ gem5生成出数据库后，使用以下命令来dump出可读数据
 
 --period (-p) tick per cycle, RTL上是1, GEM5上3GHz设置为333, （若是2Ghz设置为500）
 
+--tid 只显示指定 hardware thread 的指令，例如 `--tid 0`。该选项要求数据库的 `LifeTimeCommitTrace` 包含 `TID` 列。
+
 举例：
 
 python3 util/perfcct.py test.db --z 1.5 -p 333

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1890,10 +1890,10 @@ Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
     DynInstPtr instruction = new (arrays) DynInst(
             arrays, staticInst, curMacroop, this_pc, next_pc, seq, cpu);
 
+    instruction->setTid(tid);
+
     cpu->perfCCT->createMeta(instruction);
     cpu->perfCCT->updateInstPos(instruction->seqNum, PerfRecord::AtFetch);
-
-    instruction->setTid(tid);
 
     instruction->setThreadState(cpu->thread[tid]);
 

--- a/src/cpu/o3/perfCCT.cc
+++ b/src/cpu/o3/perfCCT.cc
@@ -14,6 +14,7 @@ InstMeta::reset(const DynInstPtr inst)
     posTick.resize((int)PerfRecord::AtCommit + 1, 0);
     disasm = inst->staticInst->disassemble(inst->pcState().instAddr());
     pc = inst->pcState().instAddr();
+    tid = inst->threadNumber;
     value = 0;
 
     isload = inst->isLoad();
@@ -34,6 +35,7 @@ PerfCCT::PerfCCT(bool enable, ArchDBer* db) : enableCCT(enable), archdb(db)
         for (int i=1; i < (int)PerfRecord::Num_PerfRecord; i++) {
             ss << "," << PerfRecordStrings[i];
         }
+        ss << ",TID";
         ss << ") VALUES(";
         sql_insert_cmd = ss.str();
         ss.str(std::string());
@@ -117,6 +119,7 @@ PerfCCT::commitMeta(InstSeqNum sn)
     ss << "," << (meta->value & 0x0fffffffffffffffllu);
     ss << ",\'" << meta->disasm << "\'";
     ss << "," << (meta->pc & 0x0fffffffffffffffllu);
+    ss << "," << meta->tid;
     ss << ");";
     archdb->execmd(ss.str());
     ss.str(std::string());

--- a/src/cpu/o3/perfCCT.hh
+++ b/src/cpu/o3/perfCCT.hh
@@ -54,6 +54,7 @@ class InstMeta
     std::vector<Tick> posTick;
     std::string disasm;
     Addr pc;
+    ThreadID tid;
     uint64_t value;
 
     bool isload;

--- a/util/perfcct.py
+++ b/util/perfcct.py
@@ -10,6 +10,8 @@ parser.add_argument('-z', '--zoom', action='store', type=float, default=1)
 parser.add_argument('-p', '--period', action='store', default=333)
 parser.add_argument('-r', '--rtl_dasm', action='store_true', default=False,
                     help='used for rtl log analysis, use dasm to disassemble the instructions')
+parser.add_argument('--tid', type=int, default=None,
+                    help='only show instructions from this hardware thread')
 
 args = parser.parse_args()
 
@@ -82,7 +84,17 @@ if args.visual:
 
 with sql.connect(sqldb) as con:
     cur = con.cursor()
-    cur.execute("SELECT * FROM LifeTimeCommitTrace")
+    table_columns = [row[1].lower() for row in
+                     cur.execute("PRAGMA table_info(LifeTimeCommitTrace)")]
+    if args.tid is not None:
+        if 'tid' not in table_columns:
+            parser.error("the trace database has no TID column")
+        if args.tid < 0:
+            parser.error("--tid must be non-negative")
+        cur.execute("SELECT * FROM LifeTimeCommitTrace WHERE TID = ?",
+                    (args.tid,))
+    else:
+        cur.execute("SELECT * FROM LifeTimeCommitTrace")
     col_name = [i[0] for i in cur.description]
     col_name = col_name[1:]
     col_name = [i.lower() for i in col_name]
@@ -99,6 +111,8 @@ with sql.connect(sqldb) as con:
                 if val < 0:
                     val = val + 1 << 64
                 records.append(hex(val))
+            elif col_name[i] == 'tid':
+                records.append(f'tid={val}')
             else:
                 if val not in inst_translate_map:
                     inst_translate_map[val] = DisAssemble(val)


### PR DESCRIPTION
## Motivation

PerfCCT lifetime traces currently merge instructions from all SMT threads without preserving thread identity, which makes per-thread latency analysis impossible.

## Approach

- record the dynamic instruction thread ID in PerfCCT metadata
- add a TID column to LifeTimeCommitTrace
- display TID in util/perfcct.py and support filtering with --tid
- report a clear error when --tid is used with an older database

## Validation

- python3 -m py_compile util/perfcct.py configs/common/xiangshan.py
- scons build/RISCV/gem5.opt --gold-linker -j64
- ran a 5000-instruction-per-thread SMT CoreMark probe with lifetime tracing
- confirmed both TID 0 and TID 1 rows are present and --tid filtering has no cross-thread rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional thread ID (`--tid`) filtering for performance trace analysis.
  * Filtered trace records now include thread ID information in generated output.
* **Bug Fixes**
  * Ensured thread IDs are consistently captured and stored in lifetime commit traces.
  * Added validation for thread-filtering requests and required trace schema support.
* **Documentation**
  * Documented the new `--tid` option and database requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->