### PR TITLE
configs: Align KMHv3 parameters with RTL

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -40,11 +40,12 @@ def setKmhV3Params(args, system):
         setPtwLevelLimitParams(args, cpu.mmu.itb)
         setPtwLevelLimitParams(args, cpu.mmu.dtb)
         cpu.fetchWidth = 32
-        cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
-        cpu.commitToFetchDelay = 2
+        cpu.iewToFetchDelay = 4 # for resolved update, should train branch after squash
+        cpu.commitToFetchDelay = 4
         cpu.fetchQueueSize = 64
 
         # decode
+        cpu.fetchToDecodeDelay = 3
         cpu.decodeWidth = 8
         cpu.enable_loadFusion = False
         cpu.enableConstantFolding = False
@@ -53,7 +54,7 @@ def setKmhV3Params(args, system):
         cpu.renameWidth = 8
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
-        cpu.enable_storeSet_train = False
+        cpu.enable_storeSet_train = True
 
         # dispatch
         cpu.enableDispatchStage = False
@@ -94,16 +95,16 @@ def setKmhV3Params(args, system):
         cpu.sbufferBankWriteAccurately = False
 
         # lsq
-        cpu.LQEntries = 72
-        cpu.SQEntries = 56
-        cpu.RARQEntries = 72
-        cpu.RAWQEntries = 32
+        cpu.LQEntries = 120
+        cpu.SQEntries = 64
+        cpu.RARQEntries = 96
+        cpu.RAWQEntries = 56
         cpu.LoadCompletionWidth = 8
         cpu.StoreCompletionWidth = 4
         cpu.RARDequeuePerCycle = 4
         cpu.RAWDequeuePerCycle = 4
         cpu.SbufferEntries = 16
-        cpu.SbufferEvictThreshold = 7
+        cpu.SbufferEvictThreshold = 8
         cpu.store_prefetch_train = False
 
         # branch predictor
@@ -200,7 +201,7 @@ if __name__ == '__m5_main__':
     # Set default bp_type based on ideal_kmhv3 flag
     # If user didn't specify bp_type, set default based on ideal_kmhv3
     args.bp_type = 'DecoupledBPUWithBTB'
-    args.l2_size = '1MB'
+    args.l2_size = '2MB'
     args.kmh_align = True   # align prefetcher in RTL, spec06 decrease 1 score
 
     # Match the memories with the CPUs, based on the options for the test system


### PR DESCRIPTION
Match RTL pipeline delays and enable StoreSet training for KMHv3.

Tested: git diff --check

Change-Id: I0463d75449032b05a49e04c8a0ee39cda6b94258
Co-authored-by: OmX <omx@oh-my-codex.dev>

cpu-o3: Fix resovle update bug

Change-Id: I5ea94abdc6ed9fe2bc56aa67df3be436b310e953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Updated processor timing and buffering settings to support smoother workload execution.
  * Increased memory queue capacity to better handle demanding workloads.
  * Enabled store-set training for improved memory dependency management.
  * Increased the default L2 cache size from 1 MB to 2 MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->