### PR TITLE
arch-riscv: Fix sign extension under Clang PGO and TLB refill

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -285,10 +285,10 @@ decode QUADRANT {
                     }
                     0x1: decode CFUNCT2LOW {
                         0x0: c_subw({{
-                            Rp1_sd = (int32_t)Rp1_sd - Rp2_sw;
+                            Rp1 = szext<32>(Rp1 - Rp2);
                         }});
                         0x1: c_addw({{
-                            Rp1_sd = (int32_t)Rp1_sd + Rp2_sw;
+                            Rp1 = szext<32>(Rp1 + Rp2);
                         }});
                         0x2: c_mul({{
                             Rp1_sd = (Rp1_sd * Rp2_sd);
@@ -741,7 +741,7 @@ decode QUADRANT {
                 }}, int32_t);
                 0x1: decode FS3 {
                     0x0: slliw({{
-                        Rd_sd = Rs1_sw << imm;
+                        Rd = szext<32>(Rs1 << imm);
                     }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT5; }});
                     0x1: slli_uw({{
                         Rd = ((uint64_t)(Rs1_uw)) << imm;
@@ -852,9 +852,9 @@ decode QUADRANT {
                 0x0: AtomicMemOp::amoadd_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
-                    TypedAtomicOpFunctor<int32_t> *amo_op =
-                          new AtomicGenericOp<int32_t>(Rs2_sw,
-                                  [](int32_t* b, int32_t a){ *b += a; });
+                    TypedAtomicOpFunctor<uint32_t> *amo_op =
+                          new AtomicGenericOp<uint32_t>(Rs2_sw,
+                                  [](uint32_t* b, uint32_t a){ *b += a; });
                 }}, mem_flags=ATOMIC_RETURN_OP, inst_flags=MemAtomicOp);
                 0x1: AtomicMemOp::amoswap_w({{
                     Rd_sd = Mem_sw;
@@ -1274,21 +1274,21 @@ decode QUADRANT {
             format ROp {
                 0x0: decode FUNCT7 {
                     0x0: addw({{
-                        Rd_sd = Rs1_sw + Rs2_sw;
+                        Rd = szext<32>(Rs1 + Rs2);
                     }});
                     0x1: mulw({{
-                        Rd_sd = (int32_t)(Rs1_sw*Rs2_sw);
+                        Rd = szext<32>(Rs1 * Rs2);
                     }}, IntMultOp);
                     0x4: add_uw({{
                         Rd = Rs1_uw + Rs2;
                     }});
                     0x20: subw({{
-                        Rd_sd = Rs1_sw - Rs2_sw;
+                        Rd = szext<32>(Rs1 - Rs2);
                     }});
                 }
                 0x1: decode FUNCT7 {
                     0x0: sllw({{
-                        Rd_sd = Rs1_sw << Rs2<4:0>;
+                        Rd = szext<32>(Rs1 << Rs2<4:0>);
                     }});
                     0x30: rolw({{
                         int shamt = Rs2 & (32 - 1);
@@ -1319,7 +1319,7 @@ decode QUADRANT {
                         // However, instruction fusion relies on zext.h, so we do a 'decode RS2' to distinct them.
                         // refer to src/arch/riscv/insts/fusion.cc.
                         default: packw({{
-                            Rd_sd = sext<32>((Rs2_uh << 16) | Rs1_uh);
+                            Rd_sd = szext<32>((static_cast<uint32_t>(Rs2_uh) << 16) | static_cast<uint32_t>(Rs1_uh));
                         }});
                     }
                     0x10: sh2add_uw({{

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -194,7 +194,7 @@ decode QUADRANT {
                     return std::make_shared<IllegalInstFault>(
                             "source reg x0", machInst);
                 }
-                Rc1_sw = (int32_t)(Rc1_sw + imm);
+                Rc1 = szext<32>(Rc1 + imm);
             }});
             0x2: c_li({{
                 imm = CIMM5;
@@ -737,7 +737,7 @@ decode QUADRANT {
         0x06: decode FUNCT3 {
             format IOp {
                 0x0: addiw({{
-                    Rd_sw = (int32_t)(Rs1_sw + imm);
+                    Rd = szext<32>(Rs1 + imm);
                 }}, int32_t);
                 0x1: decode FS3 {
                     0x0: slliw({{

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -82,6 +82,26 @@ buildKey(Addr vpn, uint16_t asid, uint8_t translateMode)
            ((vpn >> PGSHFT) & (((uint64_t)1 << 46) - 1));
 }
 
+static Addr
+tlbKeyComparableVaddr(Addr vaddr)
+{
+    return ((vaddr >> PGSHFT) & ((static_cast<Addr>(1) << 46) - 1))
+           << PGSHFT;
+}
+
+static Addr
+tlbKeyComparablePageBase(Addr vaddr, unsigned log_bytes)
+{
+    const Addr normalized_vaddr = tlbKeyComparableVaddr(vaddr);
+    return (normalized_vaddr >> log_bytes) << log_bytes;
+}
+
+static Addr
+l1CompressedBlockBase(Addr vaddr)
+{
+    return tlbKeyComparablePageBase(vaddr, PGSHFT + L2TLB_BLK_OFFSET);
+}
+
 static bool
 isCompressibleLeafPte(PTE pte)
 {
@@ -347,7 +367,7 @@ TLB::lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden,
 {
     TlbEntry *entry = trie.lookup(buildKey(vpn, asid, translateMode));
     if (!hidden && entry && entry->isCompressed) {
-        const uint8_t sub_idx = (vpn >> PageShift) & 0x7;
+        const uint8_t sub_idx = (vpn >> PageShift) & VADDR_CHOOSE_MASK;
         if (!(entry->validIdx & (1 << sub_idx))) {
             TlbEntry *fallback_entry =
                 lookupL1CompressedFallback(vpn, asid, translateMode, entry);
@@ -720,6 +740,29 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     }
 
     if (newEntry) {
+        if (entry.isCompressed && translateMode == direct &&
+            newEntry->isCompressed) {
+            const Addr entry_base =
+                tlbKeyComparablePageBase(entry.vaddr, entry.logBytes);
+            const Addr new_entry_base =
+                tlbKeyComparablePageBase(newEntry->vaddr, newEntry->logBytes);
+            panic_if(entry_base != new_entry_base ||
+                         newEntry->logBytes != entry.logBytes,
+                     "direct L1 compressed refill matched a different block: "
+                     "vpn %#x entry_base %#x new_entry_base %#x entry_log %#x "
+                     "new_entry_log %#x\n",
+                     vpn, entry_base, new_entry_base, entry.logBytes,
+                     newEntry->logBytes);
+            panic_if((newEntry->validIdx & entry.pteIdx) != entry.pteIdx,
+                     "direct L1 compressed refill found an existing entry "
+                     "without the refill subentry: vpn %#x entry_vaddr %#x "
+                     "new_entry_vaddr %#x entry_valid %#x new_entry_valid %#x "
+                     "entry_pte_idx %#x\n",
+                     vpn, entry.vaddr, newEntry->vaddr, entry.validIdx,
+                     newEntry->validIdx, entry.pteIdx);
+            newEntry->vaddr = new_entry_base;
+        }
+
         // update PTE flags (maybe we set the dirty/writable flag)
         newEntry->pte = entry.pte;
         Addr newEntryAddr = buildKey(newEntry->vaddr, newEntry->asid, translateMode);
@@ -1326,7 +1369,9 @@ TLB::refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
             return false;
         Addr vaddr = VADDR_SEXT(satp.mode, req->getVaddr());
         const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
-        return entry.asid == satp.asid && covers(vaddr, entry.vaddr) &&
+        return entry.asid == satp.asid &&
+               tlbKeyComparablePageBase(vaddr, entry.logBytes) ==
+                   tlbKeyComparablePageBase(entry.vaddr, entry.logBytes) &&
                (entry.validIdx & (1 << sub_idx));
     }
 
@@ -1371,8 +1416,7 @@ TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
         return nullptr;
 
     const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
-    const Addr block_base = (vaddr >> (PageShift + L2TLB_BLK_OFFSET))
-        << (PageShift + L2TLB_BLK_OFFSET);
+    const Addr block_base = l1CompressedBlockBase(vaddr);
 
     TlbEntry *fallback = nullptr;
     for (size_t i = 0; i < size; i++) {
@@ -1381,7 +1425,9 @@ TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
             continue;
         if (!entry.isCompressed || entry.translateMode != direct)
             continue;
-        if (entry.asid != asid || entry.vaddr != block_base || entry.level != 0)
+        if (entry.asid != asid ||
+            l1CompressedBlockBase(entry.vaddr) != block_base ||
+            entry.level != 0)
             continue;
         if (!(entry.validIdx & (1 << sub_idx)))
             continue;
@@ -1400,7 +1446,8 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
         return nullptr;
 
     TlbEntry *merged_entry = nullptr;
-    const Addr block_base = entry.vaddr;
+    const Addr block_base =
+        tlbKeyComparablePageBase(entry.vaddr, entry.logBytes);
     const Addr block_limit = block_base + entry.size();
 
     auto reinsert_narrow = [this](TlbEntry &narrow_entry,
@@ -1415,8 +1462,12 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
         }
         narrow_entry.l1CompressedNarrow = true;
 
+        const Addr narrow_base =
+            tlbKeyComparablePageBase(narrow_entry.vaddr,
+                                     narrow_entry.logBytes);
+        narrow_entry.vaddr = narrow_base;
         const Addr narrow_vaddr =
-            narrow_entry.vaddr + (static_cast<Addr>(narrow_idx) << PageShift);
+            narrow_base + (static_cast<Addr>(narrow_idx) << PageShift);
         for (size_t j = 0; j < size; j++) {
             if (j == entry_idx)
                 continue;
@@ -1434,8 +1485,11 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
                 continue;
             }
 
+            const Addr other_base =
+                tlbKeyComparablePageBase(other_entry.vaddr,
+                                         other_entry.logBytes);
             Addr other_vaddr =
-                other_entry.vaddr + (static_cast<Addr>(other_idx) << PageShift);
+                other_base + (static_cast<Addr>(other_idx) << PageShift);
             if (other_vaddr == narrow_vaddr)
                 remove(j);
         }
@@ -1455,13 +1509,14 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
         if (old_entry.asid != entry.asid)
             continue;
 
-        const Addr old_base = old_entry.vaddr;
+        const Addr old_base =
+            tlbKeyComparablePageBase(old_entry.vaddr, old_entry.logBytes);
         const Addr old_limit = old_base + old_entry.size();
         if (old_limit <= block_base || old_base >= block_limit)
             continue;
 
         if (old_entry.isCompressed) {
-            if (old_entry.vaddr != block_base || old_entry.logBytes != entry.logBytes ||
+            if (old_base != block_base || old_entry.logBytes != entry.logBytes ||
                 old_entry.paddr != entry.paddr ||
                 !hasSameCompressionAttrs(old_entry.pte, entry.pte)) {
                 old_entry.validIdx &= ~entry.validIdx;
@@ -1493,6 +1548,7 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
                 if (new_valid_idx & (1 << sub_idx))
                     old_entry.ppnLow[sub_idx] = entry.ppnLow[sub_idx];
             }
+            old_entry.vaddr = block_base;
             old_entry.validIdx |= new_valid_idx;
             old_entry.pteIdx |= entry.pteIdx & old_entry.validIdx;
             old_entry.pte = entry.pte;
@@ -1542,7 +1598,9 @@ TLB::buildL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
     if (valid_count == 0)
         return false;
 
-    const uint8_t pte_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+    const Addr normalized_vaddr = tlbKeyComparableVaddr(vaddr);
+    const uint8_t pte_idx =
+        (normalized_vaddr >> PageShift) & VADDR_CHOOSE_MASK;
     assert(valid_idx & (1 << pte_idx));
 
     compressed_entry = base_entry;
@@ -1551,8 +1609,7 @@ TLB::buildL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
     compressed_entry.pteIdx = 1 << pte_idx;
     compressed_entry.ppnLow = ppn_low;
     compressed_entry.paddr = base_ppn_high;
-    compressed_entry.vaddr = (vaddr >> (PageShift + L2TLB_BLK_OFFSET))
-                             << (PageShift + L2TLB_BLK_OFFSET);
+    compressed_entry.vaddr = l1CompressedBlockBase(normalized_vaddr);
     compressed_entry.logBytes = PageShift + L2TLB_BLK_OFFSET;
     compressed_entry.level = 0;
 
@@ -1570,7 +1627,9 @@ TLB::buildSingleL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
     if (!isCompressibleLeafPte(base_entry.pte))
         return false;
 
-    const uint8_t pte_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+    const Addr normalized_vaddr = tlbKeyComparableVaddr(vaddr);
+    const uint8_t pte_idx =
+        (normalized_vaddr >> PageShift) & VADDR_CHOOSE_MASK;
 
     compressed_entry = base_entry;
     compressed_entry.isCompressed = true;
@@ -1583,14 +1642,13 @@ TLB::buildSingleL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
         compressed_entry.ppnLow[pte_idx] =
             base_entry.pte.ppn & VADDR_CHOOSE_MASK;
         compressed_entry.paddr = base_entry.pte.ppn >> L2TLB_BLK_OFFSET;
-        compressed_entry.vaddr = (vaddr >> (PageShift + L2TLB_BLK_OFFSET))
-                                 << (PageShift + L2TLB_BLK_OFFSET);
+        compressed_entry.vaddr = l1CompressedBlockBase(normalized_vaddr);
         compressed_entry.logBytes = PageShift + L2TLB_BLK_OFFSET;
     } else {
         compressed_entry.validIdx = (1 << l2tlbLineSize) - 1;
         compressed_entry.paddr = base_entry.paddr;
-        compressed_entry.vaddr = (vaddr >> base_entry.logBytes)
-                                 << base_entry.logBytes;
+        compressed_entry.vaddr =
+            tlbKeyComparablePageBase(normalized_vaddr, base_entry.logBytes);
         compressed_entry.logBytes = base_entry.logBytes;
     }
 


### PR DESCRIPTION
Change-Id: Ie15ebedd5fe287396175c6894ef19a09ed21cb80

fix addiw sign extension bug in SPEC26(721.gcc_r_29128)

verification: passed the SPEC26 CI test.
https://github.com/OpenXiangShan/GEM5/actions/runs/29897848227
https://github.com/OpenXiangShan/GEM5/actions/runs/29897873570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RV64 “word” operations (including addiw and shifts) to correctly propagate 32-bit results with proper sign/zero extension across both compressed and standard decode paths.
  * Improved L1 TLB direct-compression reliability by using consistent normalized “comparable” compressed block bases for lookups and comparisons.
  * Strengthened L1 compressed refill handling and insertion/merge behavior with additional validation and normalized compressed entry address storage for more accurate hit detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->