### PR TITLE
arch-riscv: Isolate old TLB privilege by thread

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -2696,21 +2696,57 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
 }
 
 PrivilegeMode
-TLB::getMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
+TLB::currentMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
 {
-    if (use_old_priv && mode != BaseMMU::Execute) {
-        if (mode == BaseMMU::Execute) {
-            return old_priv_ex;
-        } else {
-            return old_priv_ldst;
-        }
-    }
     STATUS status = (STATUS)tc->readMiscReg(MISCREG_STATUS);
     PrivilegeMode pmode = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
     if (mode != BaseMMU::Execute && status.mprv == 1)
         pmode = (PrivilegeMode)(RegVal)status.mpp;
     return pmode;
 }
+
+PrivilegeMode
+TLB::getMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
+{
+    if (mode != BaseMMU::Execute) {
+        const int tid = tc->threadId();
+        if (tid >= 0) {
+            const auto thread_idx = static_cast<size_t>(tid);
+            if (thread_idx < oldPrivByThread.size() &&
+                oldPrivByThread[thread_idx].valid) {
+                return oldPrivByThread[thread_idx].ldst;
+            }
+        }
+    }
+    return currentMemPriv(tc, mode);
+}
+
+void
+TLB::setOldPriv(ThreadContext *tc)
+{
+    const int tid = tc->threadId();
+    assert(tid >= 0);
+    const auto thread_idx = static_cast<size_t>(tid);
+    if (oldPrivByThread.size() <= thread_idx) {
+        oldPrivByThread.resize(thread_idx + 1);
+    }
+    oldPrivByThread[thread_idx].valid = true;
+    oldPrivByThread[thread_idx].ldst = currentMemPriv(tc, BaseMMU::Read);
+}
+
+void
+TLB::useNewPriv(ThreadContext *tc)
+{
+    const int tid = tc->threadId();
+    if (tid < 0) {
+        return;
+    }
+    const auto thread_idx = static_cast<size_t>(tid);
+    if (thread_idx < oldPrivByThread.size()) {
+        oldPrivByThread[thread_idx].valid = false;
+    }
+}
+
 bool
 TLB::hasTwoStageTranslation(ThreadContext *tc, const RequestPtr &req, BaseMMU::Mode mode)
 {

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -35,6 +35,7 @@
 #include <array>
 #include <cstdint>
 #include <list>
+#include <vector>
 
 #include "arch/generic/tlb.hh"
 #include "arch/riscv/isa.hh"
@@ -109,9 +110,13 @@ class TLB : public BaseTLB
     uint64_t lastPc;
     uint64_t traceFlag;
 
-    bool use_old_priv;
-    PrivilegeMode old_priv_ldst;
-    PrivilegeMode old_priv_ex;
+    struct OldPrivState
+    {
+        bool valid = false;
+        PrivilegeMode ldst = PrivilegeMode::PRV_M;
+    };
+
+    std::vector<OldPrivState> oldPrivByThread;
 
     Walker *walker;
 
@@ -225,6 +230,7 @@ class TLB : public BaseTLB
     Fault createPagefault(Addr vaddr, Addr gPaddr,BaseMMU::Mode mode,bool G);
 
     PrivilegeMode getMemPriv(ThreadContext *tc, BaseMMU::Mode mode);
+    PrivilegeMode currentMemPriv(ThreadContext *tc, BaseMMU::Mode mode);
 
     // Checkpointing
     void serialize(CheckpointOut &cp) const override;
@@ -305,14 +311,8 @@ class TLB : public BaseTLB
     TlbEntry *lookupL2TLB(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden, int f_level, bool sign_used,
                           uint8_t translateMode);
 
-    void setOldPriv(ThreadContext *tc) {
-      use_old_priv = true;
-      old_priv_ex = getMemPriv(tc, BaseMMU::Execute);
-      old_priv_ldst = getMemPriv(tc, BaseMMU::Read);
-    }
-    void useNewPriv(ThreadContext *tc) {
-      use_old_priv = false;
-    }
+    void setOldPriv(ThreadContext *tc);
+    void useNewPriv(ThreadContext *tc);
 
 
     std::vector<TlbEntry> tlbL2L3;  // our TLB


### PR DESCRIPTION
## Motivation

The weekly SMT SPEC06 run [29518462406](https://github.com/OpenXiangShan/GEM5/actions/runs/29518462406) reported nine executable checkpoints aborting with a difftest trap-state mismatch. The representative local reproduction, `povray_21308`, had NEMU continue with `mcause=9` while gem5 raised a load page fault (`mcause=13`) at the machine trap vector.

The RISC-V instruction and data TLBs are shared by SMT threads, but the pre-trap memory privilege state is currently stored in one shared `use_old_priv/old_priv_ldst` pair. A trap from one thread can therefore overwrite or clear the privilege state still needed by the other thread while pre-trap memory operations drain. The second thread then translates an M-mode restorer access with stale lower privilege and raises a false page fault.

Disabling L1 direct TLB compression reproduces the same mismatch at the same tick and sequence, so this is independent of compression. An equivalent per-thread fix previously appeared as `7430750f1a` in #904 and was reverted to keep that compression PR scoped. This PR lands the SMT correctness fix separately with a targeted regression.

## Approach

- Replace the shared old-privilege fields with per-thread state indexed by `ThreadContext::threadId()`.
- Separate live CSR privilege calculation from lookup of saved pre-trap state.
- Save and clear only the calling thread's state in `setOldPriv()` and `useNewPriv()`.
- Keep the existing trap-before-update ordering in `commit.cc` unchanged.

Only `src/arch/riscv/tlb.hh` and `src/arch/riscv/tlb.cc` are changed.

## Validation

Latest `xs-dev` base (`fb9ed15ca4`):

- `scons build/RISCV/gem5.fast --gold-linker -j16`: passed.
- `git diff --check`: passed.

Targeted SMT regression with the same patch on `0e81017d15`, using the multi-context NEMU reference:

- `povray_21308 --maxinsts=30000000`
  - Before: difftest abort at tick `1802024172`, sequence `19285860`, NEMU `mcause=9` versus gem5 `mcause=13`.
  - After: normal max-instruction exit at tick `6351679629`.
- `omnetpp_443 --maxinsts=30000000`
  - Before: difftest abort at tick `2336725269`, NEMU `mcause=5` versus gem5 `mcause=13`.
  - After: normal max-instruction exit at tick `11100717837`.
- Default versus `--disable-l1-direct-compression`: identical pre-fix failure tick, sequence, and CSR mismatch.
- `scons build/RISCV/unittests.opt -j64 --unit-test`: all tests passed outside the filesystem sandbox.

The two missing hmmer checkpoints reported by run90 are checkpoint-inventory issues and are intentionally outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RISC-V memory privilege handling across multiple threads.
  * Ensured privilege state is tracked independently per thread, improving correctness when switching between execution and memory-access contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->