### PR TITLE
bpu: Add SMT-aware request scheduling

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -27,6 +27,8 @@ def setSharedLSQParams(args, system):
         cpu.smtROBPolicy = 'DynamicBorrowing'
         cpu.branchPred.smtFTQMode = 'Shared'
         cpu.branchPred.smtFTQPolicy = 'Partitioned'
+        # Prioritize the thread with the shorter fetch-ready target runway.
+        cpu.branchPred.smtBPURequestPolicy = 'LeastReadyFTQ'
 
 
 if __name__ == '__m5_main__':

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -965,6 +965,9 @@ class SMTFTQMode(ScopedEnum):
 class SMTFTQPolicy(ScopedEnum):
     vals = [ 'Dynamic', 'Partitioned', 'Threshold' ]
 
+class SMTBPURequestPolicy(ScopedEnum):
+    vals = [ 'RoundRobin', 'LeastReadyFTQ' ]
+
 class TimedBaseBTBPredictor(SimObject):
     type = 'TimedBaseBTBPredictor'
     cxx_class = 'gem5::branch_prediction::btb_pred::TimedBaseBTBPredictor'
@@ -1200,6 +1203,10 @@ class DecoupledBPUWithBTB(BranchPredictor):
     smtFTQPolicy = Param.SMTFTQPolicy('Partitioned',
                                       "SMT shared FTQ allocation policy")
     smtFTQThreshold = Param.Int(100, "SMT FTQ Threshold Sharing Parameter")
+    smtBPURequestPolicy = Param.SMTBPURequestPolicy(
+        'RoundRobin',
+        "SMT BPU request policy: round-robin or prioritize the thread with "
+        "the fewest fetch-ready FTQ targets")
     fsq_size = Param.Unsigned(64, "Fetch stream queue size")
     maxHistLen = Param.Unsigned(970, "The length of history")
 

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -51,7 +51,8 @@ SimObject('BranchPredictor.py', sim_objects=[
     'AheadBTB', 'MBTB', 'UBTB', 'DecoupledBPUWithBTB',
     'TimedBaseBTBPredictor', 'BTBRAS', 'BTBTAGE', 'BTBTAGEUpperBound',
     'MicroTAGE',
-    'BTBITTAGE', 'BTBMGSC'], enums=["BpType", "SMTFTQMode", "SMTFTQPolicy"])
+    'BTBITTAGE', 'BTBMGSC'], enums=["BpType", "SMTFTQMode", "SMTFTQPolicy",
+                                    "SMTBPURequestPolicy"])
 
 DebugFlag('Indirect')
 Source('bpred_unit.cc')

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -65,9 +65,11 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       ftqMode(p.smtFTQMode),
       ftqPolicy(p.smtFTQPolicy),
       smtFTQThreshold(p.smtFTQThreshold),
+      smtBPURequestPolicy(p.smtBPURequestPolicy),
       ftq(p.numThreads, p.ftq_size),
       resolveBlockThreshold(p.resolveBlockThreshold),
-      dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
+      dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum,
+                  p.ftq_size, p.numThreads)
 {
     panic_if(ftqMode == SMTFTQMode::Shared &&
              ftqPolicy == SMTFTQPolicy::Threshold &&
@@ -250,6 +252,10 @@ DecoupledBPUWithBTB::canStartPrediction(ThreadID tid) const
 ThreadID
 DecoupledBPUWithBTB::scheduleThread()
 {
+    ThreadID firstEligible = InvalidThreadID;
+    ThreadID selected = InvalidThreadID;
+    unsigned selectedReadyTargets = 0;
+
     for (ThreadID offset = 0; offset < numThreads; ++offset) {
         const ThreadID tid = (nextPredictTid + offset) % numThreads;
 
@@ -258,19 +264,55 @@ DecoupledBPUWithBTB::scheduleThread()
         }
 
         if (!canStartPrediction(tid)) {
-            dbpBtbStats.scheduleIneligibleThreadSkips++;
-            if (threads[tid].redirectPending) {
-                dbpBtbStats.redirectPendingPredictionSkips++;
+            // Preserve the old round-robin skip-counter semantics: only count
+            // ineligible threads before the first eligible thread.
+            if (firstEligible == InvalidThreadID) {
+                dbpBtbStats.scheduleIneligibleThreadSkips++;
+                if (threads[tid].redirectPending) {
+                    dbpBtbStats.redirectPendingPredictionSkips++;
+                }
             }
             continue;
         }
 
-        nextPredictTid = (tid + 1) % numThreads;
-        return tid;
+        if (firstEligible == InvalidThreadID) {
+            firstEligible = tid;
+        }
+
+        if (smtBPURequestPolicy == SMTBPURequestPolicy::RoundRobin) {
+            selected = tid;
+            break;
+        }
+
+        const unsigned readyTargets = ftq.readySize(tid);
+        if (selected == InvalidThreadID ||
+            readyTargets < selectedReadyTargets) {
+            selected = tid;
+            selectedReadyTargets = readyTargets;
+        }
     }
 
-    dbpBtbStats.scheduleNoEligibleThread++;
-    return InvalidThreadID;
+    if (selected == InvalidThreadID) {
+        dbpBtbStats.scheduleNoEligibleThread++;
+        return InvalidThreadID;
+    }
+
+    if (smtBPURequestPolicy == SMTBPURequestPolicy::RoundRobin) {
+        selectedReadyTargets = ftq.readySize(selected);
+    } else if (selected != firstEligible) {
+        dbpBtbStats.smtBPURequestPolicyOverrides++;
+        DPRINTF(Override,
+                "SMT BPU scheduler overrides RR tid %u (%u ready targets) "
+                "with tid %u (%u ready targets)\n",
+                firstEligible, ftq.readySize(firstEligible), selected,
+                selectedReadyTargets);
+    }
+
+    dbpBtbStats.smtBPUSelections++;
+    dbpBtbStats.smtBPUSelectionsByThread[selected]++;
+    dbpBtbStats.smtBPUSelectedReadyTargets.sample(selectedReadyTargets);
+    nextPredictTid = (selected + 1) % numThreads;
+    return selected;
 }
 
 

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -31,6 +31,7 @@
 #include "debug/DBPBTBStats.hh"
 #include "debug/DecoupleBP.hh"
 #include "debug/DecoupleBPProbe.hh"
+#include "enums/SMTBPURequestPolicy.hh"
 #include "enums/SMTFTQMode.hh"
 #include "enums/SMTFTQPolicy.hh"
 #include "params/DecoupledBPUWithBTB.hh"
@@ -125,6 +126,7 @@ class DecoupledBPUWithBTB : public BPredUnit
     SMTFTQMode ftqMode;
     SMTFTQPolicy ftqPolicy;
     unsigned smtFTQThreshold;
+    SMTBPURequestPolicy smtBPURequestPolicy;
 
     FetchTargetQueue ftq;
 
@@ -312,6 +314,10 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar scheduleIneligibleThreadSkips;
         statistics::Scalar scheduleNoEligibleThread;
         statistics::Scalar redirectPendingPredictionSkips;
+        statistics::Scalar smtBPUSelections;
+        statistics::Vector smtBPUSelectionsByThread;
+        statistics::Scalar smtBPURequestPolicyOverrides;
+        statistics::Distribution smtBPUSelectedReadyTargets;
 
         statistics::Scalar s1PredWrongFallthrough;
         statistics::Scalar s1PredWrongUbtb;
@@ -322,7 +328,9 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar s3PredWrongIttage;
         statistics::Scalar s3PredWrongRas;
 
-        DBPBTBStats(statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
+        DBPBTBStats(statistics::Group* parent, unsigned numStages,
+                    unsigned fsqSize, unsigned maxInstsNum,
+                    unsigned ftqSize, unsigned numThreads);
     } dbpBtbStats;
 
   public:

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -439,7 +439,8 @@ classifyBranchImpl(const InstPtr &inst)
 } // anonymous namespace
 
 DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
-    statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum):
+    statistics::Group* parent, unsigned numStages, unsigned fsqSize,
+    unsigned maxInstsNum, unsigned ftqSize, unsigned numThreads):
     statistics::Group(parent),
     ADD_STAT(condNum, statistics::units::Count::get(), "the number of cond branches"),
     ADD_STAT(uncondNum, statistics::units::Count::get(), "the number of uncond branches"),
@@ -493,11 +494,19 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     ADD_STAT(commitFalseHit, statistics::units::Count::get(), "false hit detected at commit"),
     ADD_STAT(predictionBlockedForUpdate, statistics::units::Count::get(), "prediction blocked for update priority"),
     ADD_STAT(scheduleIneligibleThreadSkips, statistics::units::Count::get(),
-    "round-robin BPU scheduler skipped an active thread that could not start a new prediction"),
+    "BPU scheduler skipped an active thread that could not start a new prediction"),
     ADD_STAT(scheduleNoEligibleThread, statistics::units::Count::get(),
-    "round-robin BPU scheduler found no thread eligible to start a new prediction"),
+    "BPU scheduler found no thread eligible to start a new prediction"),
     ADD_STAT(redirectPendingPredictionSkips, statistics::units::Count::get(),
-    "round-robin BPU scheduler skipped prediction because a redirect was pending"),
+    "BPU scheduler skipped prediction because a redirect was pending"),
+    ADD_STAT(smtBPUSelections, statistics::units::Count::get(),
+    "number of selections made by the SMT BPU request scheduler"),
+    ADD_STAT(smtBPUSelectionsByThread, statistics::units::Count::get(),
+    "number of SMT BPU request scheduler selections for each thread"),
+    ADD_STAT(smtBPURequestPolicyOverrides, statistics::units::Count::get(),
+    "times the SMT BPU request policy selected a thread other than the round-robin candidate"),
+    ADD_STAT(smtBPUSelectedReadyTargets, statistics::units::Count::get(),
+    "distribution of fetch-ready FTQ targets for the selected SMT thread"),
     ADD_STAT(s1PredWrongFallthrough, statistics::units::Count::get(), "S1pred wrong full throughs"),
     ADD_STAT(s1PredWrongUbtb, statistics::units::Count::get(),"S1pred wrong using ubtb "),
     ADD_STAT(s1PredWrongAbtb, statistics::units::Count::get(), "S1pred wrong using abtb "),
@@ -520,6 +529,8 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     branchClassCounts.init(NumBranchClasses);
     branchClassMisses.init(NumBranchClasses);
     controlSquashByClass.init(NumBranchClasses);
+    smtBPUSelectionsByThread.init(numThreads);
+    smtBPUSelectedReadyTargets.init(0, ftqSize, 1);
     for (int i = 0; i < NumS1SourceBuckets; ++i) {
         s1PredWrongBySourceAndReason.subname(i, S1SourceLabels[i]);
     }

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -76,6 +76,12 @@ public:
         return true;
     }
     inline uint32_t size(ThreadID tid) const { return queue[tid].cap.size(); }
+    inline uint32_t readySize(ThreadID tid) const {
+        const FetchTargetId tail = queue[tid].baseTargetId +
+                                   queue[tid].cap.size();
+        return queue[tid].fetchptr >= tail ? 0 :
+            static_cast<uint32_t>(tail - queue[tid].fetchptr);
+    }
 
     int getTargetTid();
     int getTargetTid(const std::array<bool, MaxThreads> &eligible,

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -52,6 +52,11 @@ GTest('history_manager.test',
     'history_manager.test.cc',
 )
 
+GTest('ftq.test',
+    '../ftq.cc',
+    'ftq.test.cc',
+)
+
 # add --unit-test to enable unit test mode for RAS
 # TODO: Fix RAS test
 # GTest('ras.test',
@@ -68,6 +73,7 @@ env.Append(UNITTESTS=['uras.test',
         'microtage.test',
         'folded_hist.test',
         'history_manager.test',
+        'ftq.test',
         'jump_ahead.test',
         'fetch_target_queue.test',
         'decoupled_bpred.test'])

--- a/src/cpu/pred/btb/test/ftq.test.cc
+++ b/src/cpu/pred/btb/test/ftq.test.cc
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include "cpu/pred/btb/ftq.hh"
+
+namespace gem5
+{
+namespace branch_prediction
+{
+namespace btb_pred
+{
+namespace test
+{
+
+namespace
+{
+
+FetchTarget
+target(ThreadID tid)
+{
+    FetchTarget entry;
+    entry.tid = tid;
+    return entry;
+}
+
+} // anonymous namespace
+
+TEST(FetchTargetQueueTest, ReadySizeTracksUnconsumedTargets)
+{
+    FetchTargetQueue ftq(2, 8);
+    auto t0 = target(0);
+    auto t1 = target(1);
+
+    EXPECT_EQ(ftq.readySize(0), 0);
+    EXPECT_EQ(ftq.readySize(1), 0);
+
+    ftq.insert(t0);
+    ftq.insert(t0);
+    ftq.insert(t0);
+    ftq.insert(t1);
+    EXPECT_EQ(ftq.readySize(0), 3);
+    EXPECT_EQ(ftq.readySize(1), 1);
+
+    ftq.finishTarget(0);
+    EXPECT_EQ(ftq.readySize(0), 2);
+
+    ftq.commitTarget(0);
+    EXPECT_EQ(ftq.size(0), 2);
+    EXPECT_EQ(ftq.readySize(0), 2);
+}
+
+TEST(FetchTargetQueueTest, ReadySizeResetsAfterSquashAndClear)
+{
+    FetchTargetQueue ftq(1, 8);
+    auto entry = target(0);
+
+    ftq.insert(entry);
+    ftq.insert(entry);
+    ftq.insert(entry);
+    EXPECT_EQ(ftq.readySize(0), 3);
+
+    ftq.squashAfter(ftq.frontId(0), 0);
+    EXPECT_EQ(ftq.size(0), 1);
+    EXPECT_EQ(ftq.readySize(0), 0);
+
+    ftq.clear(0);
+    EXPECT_EQ(ftq.size(0), 0);
+    EXPECT_EQ(ftq.readySize(0), 0);
+}
+
+} // namespace test
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/mem/cache/prefetch/prefetch_filter.cc
+++ b/src/mem/cache/prefetch/prefetch_filter.cc
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <iterator>
 #include <climits>
-#include <linux/limits.h>
 #include <string>
 
 #include "base/stats/group.hh"

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -38,7 +38,7 @@
 #include "mem/cache/prefetch/queued.hh"
 
 #include <cassert>
-#include <linux/limits.h>
+#include <climits>
 
 #include "arch/generic/tlb.hh"
 #include "base/logging.hh"

--- a/src/sim/arch_db.cc
+++ b/src/sim/arch_db.cc
@@ -179,8 +179,10 @@ ArchDBer::strideTraceWrite(Tick tick, Addr addr, Addr PC, Addr hashPC, bool hit,
 
   sprintf(memTraceSQLBuf,
           "INSERT INTO StrideTrainTrace(Tick,Addr,PC,HashPC,QueryHit,IsFirstShot,Miss,IsTrain,SITE) "
-          "VALUES(%ld,%ld,%ld,%ld,%d,%d,%d,%d,'%s');",
-          tick, addr, PC, hashPC, hit, isFirstShot, miss, is_train, "StrideTrain");
+          "VALUES(%lld,%lld,%lld,%lld,%d,%d,%d,%d,'%s');",
+          sqliteSignedInt(tick), sqliteSignedInt(addr),
+          sqliteSignedInt(PC), sqliteSignedInt(hashPC),
+          hit, isFirstShot, miss, is_train, "StrideTrain");
   rc = sqlite3_exec(mem_db, memTraceSQLBuf, callback, 0, &zErrMsg);
   if (rc != SQLITE_OK) {
     fatal("SQL error: %s\n", zErrMsg);
@@ -194,8 +196,11 @@ ArchDBer::despacitoTraceWrite(Tick tick, Addr vaddr, Addr paddr, Addr PC, bool h
 
   sprintf(memTraceSQLBuf,
           "INSERT INTO DespacitoTrainTrace(Tick,vAddr,pAddr,PC,hasPC,Miss,IsTrain,SITE) "
-          "VALUES(%ld,%ld,%ld,%ld,%d,%d,%d,'%s');",
-          tick, vaddr, paddr, PC, hasPC, miss, is_train, is_train?"DespacitoTrain":"DespacitoPrefetch");
+          "VALUES(%lld,%lld,%lld,%lld,%d,%d,%d,'%s');",
+          sqliteSignedInt(tick), sqliteSignedInt(vaddr),
+          sqliteSignedInt(paddr), sqliteSignedInt(PC),
+          hasPC, miss, is_train,
+          is_train ? "DespacitoTrain" : "DespacitoPrefetch");
   rc = sqlite3_exec(mem_db, memTraceSQLBuf, callback, 0, &zErrMsg);
   if (rc != SQLITE_OK) {
     fatal("SQL error: %s\n", zErrMsg);


### PR DESCRIPTION
## Motivation

Improve single-port BPU request allocation between SMT threads without changing predictor port count or redirect semantics. Also restore the existing macOS build compatibility fixes needed to validate the change locally.

## Changes

- Add a parameterized SMT BPU request policy with `RoundRobin` as the default.
- Add `LeastReadyFTQ`, which prioritizes the eligible thread with fewer fetch-ready FTQ targets and uses round-robin order as the tie-break.
- Keep redirect-pending and the existing eligibility checks ahead of policy selection.
- Enable the new policy in `smt_idealkmhv3.py`.
- Add scheduler observability stats and FTQ ready-depth tests.
- Restore macOS-compatible limit headers and ArchDB integer formatting.

## Validation

- `scons build/RISCV/gem5.opt -j8` passed on macOS.
- `./build/RISCV/gem5.opt configs/example/smt_idealkmhv3.py --help` passed.
- `util/style.py -m` passed.
- `git diff --check` passed before commit.
- The new FTQ test source compiled, but linking the unit-test executable is blocked locally by Homebrew gtest headers being mixed with the repository's bundled gtest sources. Product code compilation is unaffected.

## Performance validation

A full `gcc12-spec06-smt-0.3c` manual performance run will be triggered for this branch. Compare against the `xs-dev` baseline, with attention to `ftqNotValid`, `smtBPURequestPolicyOverrides`, per-thread selections, IPC, and weighted score.