### PR TITLE
cpu-o3: Add SMT progress overlap counters

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -973,6 +973,27 @@ Commit::sampleSmtCommitStates()
         return;
     }
 
+    // Threads that never reached commitInsts() still need an explicit final
+    // state.  Only classify HeadReadyNoCommit when the head group is ready but
+    // this cycle produced no commit attempt or progress for that thread.
+    for (ThreadID tid : *activeThreads) {
+        if (smtCommitStateThisCycle[tid] != SmtCommitState::OtherWait ||
+            rob->isEmpty(tid) ||
+            (commitStatus[tid] != Running && commitStatus[tid] != Idle &&
+             commitStatus[tid] != FetchTrapPending)) {
+            continue;
+        }
+
+        DynInstPtr blocking_inst;
+        if (rob->isHeadGroupReady(tid, &blocking_inst)) {
+            smtCommitStateThisCycle[tid] =
+                SmtCommitState::HeadReadyNoCommit;
+        } else {
+            smtCommitStateThisCycle[tid] =
+                classifyCommitBlocker(blocking_inst);
+        }
+    }
+
     stats.smtCommitStateCycles
         [static_cast<unsigned>(smtCommitStateThisCycle[0])]
         [static_cast<unsigned>(smtCommitStateThisCycle[1])]++;
@@ -1773,6 +1794,11 @@ Commit::commitInsts()
                         onInstBoundary && cpu->checkInterrupts(0))
                         squashAfter(tid, head_inst);
                 } else {
+                    if (smtCommitStateThisCycle[tid] !=
+                        SmtCommitState::Committed) {
+                        smtCommitStateThisCycle[tid] =
+                            SmtCommitState::ControlOrMaintenance;
+                    }
                     DPRINTF(Commit, "Unable to commit head instruction PC:%s "
                             "[tid:%i] [sn:%llu].\n",
                             head_inst->pcState(), tid ,head_inst->seqNum);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -326,7 +326,11 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
       ADD_STAT(smtStateHoldCycle, statistics::units::Count::get(),
                "SMT base/donor state holding cycle distribution"),
       ADD_STAT(smtROBEntriesWhileStateChange, statistics::units::Count::get(),
-               "SMT ROB thread used/rest entries distribution while state change")
+               "SMT ROB thread used/rest entries distribution while state change"),
+      ADD_STAT(smtCommitStateCycles, statistics::units::Cycle::get(),
+               "joint per-thread commit state sampled once per physical cycle"),
+      ADD_STAT(zeroCommitCycles, statistics::units::Cycle::get(),
+               "physical cycles in which no thread committed an instruction")
 {
     using namespace statistics;
 
@@ -470,6 +474,19 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
     smtROBEntriesWhileStateChange.subname(1, "BaseToDonor_rest");
     smtROBEntriesWhileStateChange.subname(2, "DonorToBase_used");
     smtROBEntriesWhileStateChange.subname(3, "DonorToBase_rest");
+
+    static constexpr std::array<const char *, 7> commit_state_names = {
+        "RobEmpty", "ControlOrMaintenance", "LoadWait",
+        "StoreOrAtomicWait", "OtherWait", "HeadReadyNoCommit",
+        "Committed"
+    };
+    smtCommitStateCycles
+        .init(commit_state_names.size(), commit_state_names.size())
+        .flags(statistics::nozero);
+    for (unsigned state = 0; state < commit_state_names.size(); ++state) {
+        smtCommitStateCycles.subname(state, commit_state_names[state]);
+        smtCommitStateCycles.ysubname(state, commit_state_names[state]);
+    }
 }
 
 void
@@ -914,6 +931,62 @@ Commit::hasExecutedYoungerInst(ThreadID tid, InstSeqNum seq_num) const
     return false;
 }
 
+Commit::SmtCommitState
+Commit::classifyCommitBlocker(const DynInstPtr &inst) const
+{
+    if (!inst) {
+        return SmtCommitState::OtherWait;
+    }
+    if (inst->isLoad()) {
+        return SmtCommitState::LoadWait;
+    }
+    if (inst->isStore() || inst->isAtomic()) {
+        return SmtCommitState::StoreOrAtomicWait;
+    }
+    return SmtCommitState::OtherWait;
+}
+
+void
+Commit::resetSmtCommitStates()
+{
+    smtCommitStateThisCycle.fill(SmtCommitState::RobEmpty);
+    for (ThreadID tid : *activeThreads) {
+        if (rob->isEmpty(tid)) {
+            continue;
+        }
+        if (commitStatus[tid] != Running && commitStatus[tid] != Idle &&
+            commitStatus[tid] != FetchTrapPending) {
+            smtCommitStateThisCycle[tid] =
+                SmtCommitState::ControlOrMaintenance;
+        } else {
+            smtCommitStateThisCycle[tid] = SmtCommitState::OtherWait;
+        }
+    }
+}
+
+void
+Commit::sampleSmtCommitStates()
+{
+    // The joint state matrix is intentionally dual-hart.  Do not expose a
+    // misleading first-two-thread projection for wider SMT configurations.
+    if (numThreads > 2) {
+        return;
+    }
+
+    stats.smtCommitStateCycles
+        [static_cast<unsigned>(smtCommitStateThisCycle[0])]
+        [static_cast<unsigned>(smtCommitStateThisCycle[1])]++;
+
+    bool any_committed = false;
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        any_committed |=
+            smtCommitStateThisCycle[tid] == SmtCommitState::Committed;
+    }
+    if (!any_committed) {
+        stats.zeroCommitCycles++;
+    }
+}
+
 void
 Commit::tick()
 {
@@ -922,6 +995,8 @@ Commit::tick()
 
     if (activeThreads->empty())
         return;
+
+    resetSmtCommitStates();
 
     std::list<ThreadID>::iterator threads = activeThreads->begin();
     std::list<ThreadID>::iterator end = activeThreads->end();
@@ -956,6 +1031,7 @@ Commit::tick()
     commit();
 
     markCompletedInsts();
+    sampleSmtCommitStates();
 
     threads = activeThreads->begin();
 
@@ -1335,8 +1411,14 @@ Commit::commitInsts()
             }
 
             head_inst = rob->readHeadInst(commit_thread);
+            DynInstPtr blocking_inst;
 
-            if (!rob->isHeadGroupReady(commit_thread)) {
+            if (!rob->isHeadGroupReady(commit_thread, &blocking_inst)) {
+                if (smtCommitStateThisCycle[commit_thread] !=
+                    SmtCommitState::Committed) {
+                    smtCommitStateThisCycle[commit_thread] =
+                        classifyCommitBlocker(blocking_inst);
+                }
                 if (debug::Commit && head_inst->readyToCommit()) {
                     InstSeqNum seqnum =
                         rob->getHeadGroupLastDoneSeq(commit_thread);
@@ -1347,6 +1429,12 @@ Commit::commitInsts()
                         head_inst->seqNum, seqnum);
                 }
                 break;
+            }
+
+            if (smtCommitStateThisCycle[commit_thread] !=
+                SmtCommitState::Committed) {
+                smtCommitStateThisCycle[commit_thread] =
+                    SmtCommitState::HeadReadyNoCommit;
             }
 
             ThreadID tid = head_inst->threadNumber;
@@ -1367,6 +1455,11 @@ Commit::commitInsts()
                 rob->drainSquashedHead(commit_thread);
 
                 ++stats.commitSquashedInsts;
+                if (smtCommitStateThisCycle[commit_thread] !=
+                    SmtCommitState::Committed) {
+                    smtCommitStateThisCycle[commit_thread] =
+                        SmtCommitState::ControlOrMaintenance;
+                }
                 // Notify potential listeners that this instruction is squashed
                 ppSquash->notify(head_inst);
 
@@ -1381,6 +1474,8 @@ Commit::commitInsts()
                                                 num_committed_per_thread[tid]);
 
                 if (commit_success) {
+                    smtCommitStateThisCycle[tid] =
+                        SmtCommitState::Committed;
                     cpu->perfCCT->updateInstPos(head_inst->seqNum,
                                                 PerfRecord::AtCommit);
                     auto res = head_inst->getResult();

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -41,6 +41,7 @@
 #ifndef __CPU_O3_COMMIT_HH__
 #define __CPU_O3_COMMIT_HH__
 
+#include <array>
 #include <cstdint>
 #include <list>
 #include <map>

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -168,6 +168,18 @@ class Commit
         SquashAfterPending, //< Committing instructions before a squash.
     };
 
+    enum class SmtCommitState : unsigned
+    {
+        RobEmpty,
+        ControlOrMaintenance,
+        LoadWait,
+        StoreOrAtomicWait,
+        OtherWait,
+        HeadReadyNoCommit,
+        Committed,
+        NumStates
+    };
+
   private:
     /** Overall commit status. */
     CommitStatus _status;
@@ -176,6 +188,7 @@ class Commit
     std::set<uint64_t> faultNum;
     /** Per-thread status. */
     ThreadStatus commitStatus[MaxThreads];
+    std::array<SmtCommitState, MaxThreads> smtCommitStateThisCycle = {};
 
     boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
 
@@ -370,6 +383,9 @@ class Commit
 
     /** Commits as many instructions as possible. */
     void commitInsts();
+    SmtCommitState classifyCommitBlocker(const DynInstPtr &inst) const;
+    void resetSmtCommitStates();
+    void sampleSmtCommitStates();
     bool hasExecutedYoungerInst(ThreadID tid, InstSeqNum seq_num) const;
     void updateMstatusSd(ThreadID tid);
 
@@ -655,6 +671,8 @@ class Commit
         statistics::Vector ROBBorrowingStateChange;
         statistics::VectorDistribution smtStateHoldCycle;
         statistics::VectorDistribution smtROBEntriesWhileStateChange;
+        statistics::Vector2d smtCommitStateCycles;
+        statistics::Scalar zeroCommitCycles;
     } stats;
 
     bool ismispred[MaxThreads] = {false};

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1871,7 +1871,7 @@ IEW::tick()
 
         writebackInsts();
     }
-    scheduler->issueAndSelect(exeStatus == Squashing);
+    scheduler->issueAndSelect();
 
     bool broadcast_free_entries = false;
 
@@ -1933,6 +1933,13 @@ IEW::tick()
             wroteToTimeBuffer = true;
         }
     }
+
+    std::array<bool, MaxThreads> control_blocked = {};
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        control_blocked[tid] = fromCommit->commitInfo[tid].squash ||
+            fromCommit->commitInfo[tid].robSquashing;
+    }
+    scheduler->sampleSmtIssueStates(control_blocked);
 
     DPRINTF(IEW,"LQ has %i free entries. SQ has %i free entries.\n",
             ldstQueue.numFreeLoadEntries(), ldstQueue.numFreeStoreEntries());

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1871,7 +1871,7 @@ IEW::tick()
 
         writebackInsts();
     }
-    scheduler->issueAndSelect();
+    scheduler->issueAndSelect(exeStatus == Squashing);
 
     bool broadcast_free_entries = false;
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1463,7 +1463,8 @@ Scheduler::noteIssueCandidate(ThreadID tid)
 }
 
 void
-Scheduler::sampleSmtIssueStates(bool control_blocked)
+Scheduler::sampleSmtIssueStates(
+    const std::array<bool, MaxThreads> &control_blocked)
 {
     // The joint state and thread mask dimensions are intentionally dual-hart.
     // Leave them disabled for wider SMT configurations instead of producing a
@@ -1480,7 +1481,7 @@ Scheduler::sampleSmtIssueStates(bool control_blocked)
         if (issueProgressThisCycle[tid]) {
             state[tid] = SmtIssueState::Issued;
             any_progress = true;
-        } else if (control_blocked) {
+        } else if (control_blocked[tid]) {
             state[tid] = SmtIssueState::ControlBlocked;
         } else if (issueCandidateThisCycle[tid]) {
             state[tid] = SmtIssueState::EligibleNoIssue;
@@ -1497,7 +1498,9 @@ Scheduler::sampleSmtIssueStates(bool control_blocked)
 
     std::array<unsigned, MaxThreads> max_miss_depth = {};
     for (ThreadID tid = 0; tid < cpu->numThreads; ++tid) {
-        max_miss_depth[tid] = lsq->maxInflightLoadDepth(tid);
+        if (!issueProgressThisCycle[tid]) {
+            max_miss_depth[tid] = lsq->maxInflightLoadDepth(tid);
+        }
     }
     for (unsigned level = 1; level <= NumTrackedMissLevels; ++level) {
         unsigned mask = 0;
@@ -1512,7 +1515,7 @@ Scheduler::sampleSmtIssueStates(bool control_blocked)
 }
 
 void
-Scheduler::issueAndSelect(bool control_blocked)
+Scheduler::issueAndSelect()
 {
     issueCandidateThisCycle.fill(false);
     issueProgressThisCycle.fill(false);
@@ -1530,7 +1533,6 @@ Scheduler::issueAndSelect(bool control_blocked)
     for (auto it : issueQues) {
         it->issueToFu();
     }
-    sampleSmtIssueStates(control_blocked);
     if (instsToFu.size() < intel_fewops) {
         stats.exec_stall_cycle++;
     }

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1234,8 +1234,9 @@ Scheduler::SchedulerStats::init(unsigned)
         smtIssueStateCycles.ysubname(state, state_names[state]);
     }
 
+    static_assert(NumTrackedMissLevels == level_names.size());
     noIssueOutstandingMissMaskCycles
-        .init(level_names.size(), mask_names.size())
+        .init(NumTrackedMissLevels, mask_names.size())
         .flags(statistics::nozero);
     for (unsigned level = 0; level < level_names.size(); ++level) {
         noIssueOutstandingMissMaskCycles.subname(

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -630,6 +630,7 @@ IssueQue::issueToFu()
     // replay first
     for (; !replayQ.empty() && replayed < outports; replayed++) {
         auto& inst = replayQ.front();
+        scheduler->noteIssueCandidate(inst->threadNumber);
 
         if (inst->isLoad()) {
             // Loads selected here enter loadpipe S0 next cycle, so block on
@@ -661,6 +662,7 @@ IssueQue::issueToFu()
         if (!inst) {
             continue;
         }
+        scheduler->noteIssueCandidate(inst->threadNumber);
         // Loads selected here enter loadpipe S0 next cycle, so block on
         // the mainpipe tag-write state predicted for that admission point.
         bool blockLoad = inst->isLoad() &&
@@ -1199,8 +1201,49 @@ Scheduler::SchedulerStats::SchedulerStats(statistics::Group* parent)
       ADD_STAT(memstall_l2miss,
                "Cycles with no uops executed and at least X in-flight load that has missed the L2-cache"),
       ADD_STAT(memstall_l3miss,
-               "Cycles with no uops executed and at least X in-flight load that has missed the L3-cache")
+               "Cycles with no uops executed and at least X in-flight load that has missed the L3-cache"),
+      ADD_STAT(smtIssueStateCycles, statistics::units::Cycle::get(),
+               "joint per-thread issue state sampled once per physical cycle"),
+      ADD_STAT(zeroIssueCycles, statistics::units::Cycle::get(),
+               "physical cycles in which no thread issued an instruction"),
+      ADD_STAT(noIssueOutstandingMissMaskCycles,
+               statistics::units::Cycle::get(),
+               "per-level thread mask with no issue progress and a tracked "
+               "outstanding demand load at or beyond that cache miss depth")
 {
+}
+
+void
+Scheduler::SchedulerStats::init(unsigned)
+{
+    static constexpr std::array<const char *, 5> state_names = {
+        "NoIqWork", "ControlBlocked", "Waiting", "EligibleNoIssue",
+        "Issued"
+    };
+    static constexpr std::array<const char *, 3> level_names = {
+        "L1Miss", "L2Miss", "L3Miss"
+    };
+    static constexpr std::array<const char *, 4> mask_names = {
+        "None", "Tid0", "Tid1", "Both"
+    };
+
+    smtIssueStateCycles.init(state_names.size(), state_names.size())
+        .flags(statistics::nozero);
+    for (unsigned state = 0; state < state_names.size(); ++state) {
+        smtIssueStateCycles.subname(state, state_names[state]);
+        smtIssueStateCycles.ysubname(state, state_names[state]);
+    }
+
+    noIssueOutstandingMissMaskCycles
+        .init(level_names.size(), mask_names.size())
+        .flags(statistics::nozero);
+    for (unsigned level = 0; level < level_names.size(); ++level) {
+        noIssueOutstandingMissMaskCycles.subname(
+            level, level_names[level]);
+    }
+    for (unsigned mask = 0; mask < mask_names.size(); ++mask) {
+        noIssueOutstandingMissMaskCycles.ysubname(mask, mask_names[mask]);
+    }
 }
 
 bool
@@ -1365,6 +1408,7 @@ Scheduler::setCPU(CPU* cpu, LSQ* lsq)
 {
     this->cpu = cpu;
     this->lsq = lsq;
+    stats.init(cpu->numThreads);
     for (auto it : issueQues) {
         it->setCPU(cpu);
         it->selector->setparent(this, it);
@@ -1396,6 +1440,7 @@ Scheduler::addToFU(const DynInstPtr& inst)
     inst->issueTick = curTick() - inst->fetchTick;
 #endif
     inst->clearCancel();
+    issueProgressThisCycle[inst->threadNumber] = true;
     DPRINTF(Schedule, "%s [sn:%llu] add to FUs\n", enums::OpClassStrings[inst->opClass()], inst->seqNum);
     instsToFu.push_back(inst);
 }
@@ -1411,8 +1456,67 @@ Scheduler::tick()
 }
 
 void
-Scheduler::issueAndSelect()
+Scheduler::noteIssueCandidate(ThreadID tid)
 {
+    assert(tid < MaxThreads);
+    issueCandidateThisCycle[tid] = true;
+}
+
+void
+Scheduler::sampleSmtIssueStates(bool control_blocked)
+{
+    // The joint state and thread mask dimensions are intentionally dual-hart.
+    // Leave them disabled for wider SMT configurations instead of producing a
+    // truncated or out-of-range mask.
+    if (cpu->numThreads > 2) {
+        return;
+    }
+
+    std::array<SmtIssueState, MaxThreads> state;
+    state.fill(SmtIssueState::NoIqWork);
+
+    bool any_progress = false;
+    for (ThreadID tid = 0; tid < cpu->numThreads; ++tid) {
+        if (issueProgressThisCycle[tid]) {
+            state[tid] = SmtIssueState::Issued;
+            any_progress = true;
+        } else if (control_blocked) {
+            state[tid] = SmtIssueState::ControlBlocked;
+        } else if (issueCandidateThisCycle[tid]) {
+            state[tid] = SmtIssueState::EligibleNoIssue;
+        } else if (getIQInsts(tid) > 0) {
+            state[tid] = SmtIssueState::Waiting;
+        }
+    }
+
+    stats.smtIssueStateCycles[static_cast<unsigned>(state[0])]
+                                  [static_cast<unsigned>(state[1])]++;
+    if (!any_progress) {
+        stats.zeroIssueCycles++;
+    }
+
+    std::array<unsigned, MaxThreads> max_miss_depth = {};
+    for (ThreadID tid = 0; tid < cpu->numThreads; ++tid) {
+        max_miss_depth[tid] = lsq->maxInflightLoadDepth(tid);
+    }
+    for (unsigned level = 1; level <= NumTrackedMissLevels; ++level) {
+        unsigned mask = 0;
+        for (ThreadID tid = 0; tid < cpu->numThreads; ++tid) {
+            if (!issueProgressThisCycle[tid] &&
+                max_miss_depth[tid] >= level) {
+                mask |= 1U << tid;
+            }
+        }
+        stats.noIssueOutstandingMissMaskCycles[level - 1][mask]++;
+    }
+}
+
+void
+Scheduler::issueAndSelect(bool control_blocked)
+{
+    issueCandidateThisCycle.fill(false);
+    issueProgressThisCycle.fill(false);
+
     // must wait for all insts was issued
     for (auto it : issueQues) {
         it->selectInst();
@@ -1426,6 +1530,7 @@ Scheduler::issueAndSelect()
     for (auto it : issueQues) {
         it->issueToFu();
     }
+    sampleSmtIssueStates(control_blocked);
     if (instsToFu.size() < intel_fewops) {
         stats.exec_stall_cycle++;
     }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -1,6 +1,7 @@
 #ifndef __CPU_O3_ISSUE_QUEUE_HH__
 #define __CPU_O3_ISSUE_QUEUE_HH__
 
+#include <array>
 #include <cstdint>
 #include <list>
 #include <string>
@@ -388,7 +389,6 @@ class Scheduler : public SimObject
     void specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_queue);
     bool ready(OpClass op, int disp_seq);
     void noteIssueCandidate(ThreadID tid);
-    void sampleSmtIssueStates(bool control_blocked);
 
   public:
     PendingWakeEventsType specWakeEvents;
@@ -401,7 +401,9 @@ class Scheduler : public SimObject
     void setMainRdpOpt(bool enable);
 
     void tick();
-    void issueAndSelect(bool control_blocked = false);
+    void issueAndSelect();
+    void sampleSmtIssueStates(
+        const std::array<bool, MaxThreads> &control_blocked);
     void lookahead(std::deque<DynInstPtr>& insts);
     bool ready(const DynInstPtr& inst, int disp_seq);
     DynInstPtr getInstByDstReg(RegIndex flatIdx, ThreadID tid,

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -311,6 +311,20 @@ class Scheduler : public SimObject
     bool old_disp = false;
     const int intRegfileBanks;
 
+    enum class SmtIssueState : unsigned
+    {
+        NoIqWork,
+        ControlBlocked,
+        Waiting,
+        // A candidate reached issue admission but did not enter a FU this
+        // cycle; this is not a count of every ready instruction in the IQ.
+        EligibleNoIssue,
+        Issued,
+        NumStates
+    };
+
+    static constexpr unsigned NumTrackedMissLevels = 3;
+
     struct SchedulerStats : public statistics::Group
     {
         SchedulerStats(statistics::Group* parent);
@@ -320,6 +334,11 @@ class Scheduler : public SimObject
         statistics::Scalar memstall_l1miss;
         statistics::Scalar memstall_l2miss;
         statistics::Scalar memstall_l3miss;
+        statistics::Vector2d smtIssueStateCycles;
+        statistics::Scalar zeroIssueCycles;
+        statistics::Vector2d noIssueOutstandingMissMaskCycles;
+
+        void init(unsigned num_threads);
     } stats;
 
     struct disp_policy
@@ -341,6 +360,8 @@ class Scheduler : public SimObject
     std::vector<uint8_t*> dispOpdist;
 
     std::vector<DynInstPtr> instsToFu;
+    std::array<bool, MaxThreads> issueCandidateThisCycle = {};
+    std::array<bool, MaxThreads> issueProgressThisCycle = {};
 
     std::vector<bool> earlyScoreboard;
     std::vector<bool> bypassScoreboard;
@@ -366,6 +387,8 @@ class Scheduler : public SimObject
     // should call at issue first/last cycle,
     void specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_queue);
     bool ready(OpClass op, int disp_seq);
+    void noteIssueCandidate(ThreadID tid);
+    void sampleSmtIssueStates(bool control_blocked);
 
   public:
     PendingWakeEventsType specWakeEvents;
@@ -378,7 +401,7 @@ class Scheduler : public SimObject
     void setMainRdpOpt(bool enable);
 
     void tick();
-    void issueAndSelect();
+    void issueAndSelect(bool control_blocked = false);
     void lookahead(std::deque<DynInstPtr>& insts);
     bool ready(const DynInstPtr& inst, int disp_seq);
     DynInstPtr getInstByDstReg(RegIndex flatIdx, ThreadID tid,

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -3306,6 +3306,7 @@ LSQ::SplitDataRequest::recvTimingResp(PacketPtr pkt)
         _hasStaleTranslation = false;
         LSQRequest::_inst->hasPendingCacheReq(false);
         LSQRequest::_inst->pendingCacheReq = nullptr;
+        detachInflightLoad();
     }
     return true;
 }
@@ -3492,12 +3493,11 @@ LSQ::SingleDataRequest::sendPacketToCache()
                                             tag_read_fail, mshr_used, mshr_alias_fail, hit_in_write_buffer);
     if (success) {
         _packets[0]->setLSQPtr(lsqUnit()->getLsq());
-        if (isLoad()) {
-            attachInflightLoad();
-        }
-
         if (!bank_conflict) {
             _numOutstandingPackets = 1;
+            if (isLoad()) {
+                attachInflightLoad();
+            }
             LSQRequest::_inst->hasPendingCacheReq(true);
             LSQRequest::_inst->pendingCacheReq = this;
             DPRINTF(LSQ, "sendPacketToCache success [sn:%llu], pkt: %#lx\n",

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1684,6 +1684,18 @@ int LSQ::numLoads(ThreadID tid) const { return thread.at(tid).numLoads(); }
 int LSQ::numRAREntries(ThreadID tid) const { return thread.at(tid).numRAREntries(); }
 int LSQ::numRAWEntries(ThreadID tid) const { return thread.at(tid).numRAWEntries(); }
 
+unsigned
+LSQ::maxInflightLoadDepth(ThreadID tid) const
+{
+    unsigned max_depth = 0;
+    for (const auto *request : thread.at(tid).inflightLoads) {
+        if (request->isAnyOutstandingRequest()) {
+            max_depth = std::max(max_depth, request->maxRequestDepth());
+        }
+    }
+    return max_depth;
+}
+
 int LSQ::anyInflightLoadsNotComplete()
 {
     int l1miss = 0, l2miss = 0, l3miss = 0, any = 0;
@@ -3118,6 +3130,30 @@ LSQ::LSQRequest::detachInflightLoad()
     }
 }
 
+void
+LSQ::LSQRequest::attachInflightLoad()
+{
+    if (!isLoad()) {
+        return;
+    }
+
+    auto &inflight = _port.inflightLoads;
+    if (std::find(inflight.begin(), inflight.end(), this) == inflight.end()) {
+        assert(inflight.size() < _port.numLoads() + 4);
+        inflight.emplace_back(this);
+    }
+}
+
+unsigned
+LSQ::LSQRequest::maxRequestDepth() const
+{
+    unsigned max_depth = 0;
+    for (const auto &request : _reqs) {
+        max_depth = std::max(max_depth, static_cast<unsigned>(request->depth));
+    }
+    return max_depth;
+}
+
 LSQ::LSQRequest::~LSQRequest()
 {
     assert(!isAnyOutstandingRequest());
@@ -3457,8 +3493,7 @@ LSQ::SingleDataRequest::sendPacketToCache()
     if (success) {
         _packets[0]->setLSQPtr(lsqUnit()->getLsq());
         if (isLoad()) {
-            assert(lsqUnit()->inflightLoads.size() < lsqUnit()->numLoads() + 4);
-            lsqUnit()->inflightLoads.emplace_back(this);
+            attachInflightLoad();
         }
 
         if (!bank_conflict) {
@@ -3515,6 +3550,9 @@ LSQ::SplitDataRequest::sendPacketToCache()
         } else {
             break;
         }
+    }
+    if (isLoad() && _numOutstandingPackets > 0) {
+        attachInflightLoad();
     }
     if (bank_conflict) {
         lsqUnit()->bankConflictReplaySchedule();

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -424,6 +424,9 @@ class LSQ
         /** Remove the request from the in-flight load tracker if present. */
         void detachInflightLoad();
 
+        /** Add the request to the in-flight load tracker once. */
+        void attachInflightLoad();
+
         bool squashed() const override;
 
 
@@ -562,13 +565,15 @@ class LSQ
          * Test if there is any in-flight translation or mem access request
          */
         bool
-        isAnyOutstandingRequest()
+        isAnyOutstandingRequest() const
         {
             return numInTranslationFragments > 0 ||
                 _numOutstandingPackets > 0 ||
                 (flags.isSet(Flag::WritebackScheduled) &&
                  !flags.isSet(Flag::WritebackDone));
         }
+
+        unsigned maxRequestDepth() const;
 
         /**
          * Test if the LSQRequest has been released, i.e. self-owned.
@@ -971,6 +976,9 @@ class LSQ
     int numLoads(ThreadID tid) const;
 
     int anyInflightLoadsNotComplete();
+
+    /** Maximum cache-miss depth among tracked outstanding loads of a tid. */
+    unsigned maxInflightLoadDepth(ThreadID tid) const;
 
     bool anyStoreNotExecute();
 

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -588,9 +588,13 @@ ROB::drainSquashedHead(ThreadID tid)
 }
 
 bool
-ROB::isHeadGroupReady(ThreadID tid)
+ROB::isHeadGroupReady(ThreadID tid, DynInstPtr *blocking_inst)
 {
     stats.reads++;
+
+    if (blocking_inst) {
+        *blocking_inst = nullptr;
+    }
 
     if (!threadGroups[tid].empty() && threadGroups[tid].front() != 0) {
         auto it = instList[tid].begin();
@@ -600,6 +604,9 @@ ROB::isHeadGroupReady(ThreadID tid)
             if (!inst->readyToCommit()) {
                 if (i > 0 && inst->isSerializeBefore()) {
                     return true;
+                }
+                if (blocking_inst) {
+                    *blocking_inst = inst;
                 }
                 return false;
             }

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -191,7 +191,8 @@ class ROB
 //    bool isHeadReady();
 
     /** Is the oldest group of instructions across a particular thread ready. */
-    bool isHeadGroupReady(ThreadID tid);
+    bool isHeadGroupReady(ThreadID tid,
+                          DynInstPtr *blocking_inst = nullptr);
 
     InstSeqNum getHeadGroupLastDoneSeq(ThreadID tid);
 


### PR DESCRIPTION
## Motivation
Current SPEC06 SMT analysis has per-thread IPC and stall counters, but cannot distinguish latency hiding from synchronized stalls or physical issue/commit contention.

## Changes
- Add dual-thread physical-cycle issue state matrix and zero-issue cycles.
- Add per-level outstanding demand-load miss masks for no-issue cycles.
- Add dual-thread commit state matrix, including the actual blocking instruction in the ROB head group, and zero-commit cycles.
- Keep existing ROBHeadStallReason and scheduling behavior unchanged; counters are observational only.

## Validation
- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Dual-hart CoreMark smoke with `--smt` and `GCBV_MULTI_CORE_REF_SO`, exits via `m5_exit`.
- Issue and commit state matrices each sum to 1,437,282 physical cycles; miss-mask matrices also conserve the same cycle count.

The joint matrices are intentionally dual-hart; wider SMT configurations skip sampling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMT performance statistics for both issue and commit behavior, including blocked states, joint progress combinations, outstanding-miss conditions, and “zero-issue/zero-commit” cycles.
  * Added per-thread visibility into the maximum inflight load depth.
  * Enhanced commit-readiness diagnostics by reporting which instruction blocks head-group readiness.

* **Improvements**
  * Improved per-cycle SMT issue-state sampling (candidate/progress tracking) for up to two-thread SMT configurations.
  * Strengthened in-flight load tracking consistency for split cache requests, ensuring proper attachment on issue and detachment on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->