### PR TITLE
cpu-o3: fix unnecessary portBusy setting

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -941,7 +941,7 @@ IssueQue::scheduleInst()
 
             if (!opPipelined[inst->opClass()]) {
                 portBusy[pi] = -1ll;
-            } else if (scheduler->getCorrectedOpLat(inst) > 1) {
+            } else if (scheduler->getCorrectedOpLat(inst) > 1 && inst->numDestRegs() > 0) {
                 portBusy[pi] |= 1ll << scheduler->getCorrectedOpLat(inst);
             }
 


### PR DESCRIPTION
If the instruction has no destination reg, it's not necessary to set portBusy.

Change-Id: I46b08d12a9d33e7c8bb8811d8cfa1c8e8b6fab45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction scheduling for pipelined operations without destination registers, ensuring port availability is tracked accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->