### PR TITLE
sim: Restore macOS build compatibility

### DIFF
--- a/src/mem/cache/prefetch/prefetch_filter.cc
+++ b/src/mem/cache/prefetch/prefetch_filter.cc
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <iterator>
 #include <climits>
-#include <linux/limits.h>
 #include <string>
 
 #include "base/stats/group.hh"

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -38,7 +38,7 @@
 #include "mem/cache/prefetch/queued.hh"
 
 #include <cassert>
-#include <linux/limits.h>
+#include <climits>
 
 #include "arch/generic/tlb.hh"
 #include "base/logging.hh"

--- a/src/sim/arch_db.cc
+++ b/src/sim/arch_db.cc
@@ -179,8 +179,10 @@ ArchDBer::strideTraceWrite(Tick tick, Addr addr, Addr PC, Addr hashPC, bool hit,
 
   sprintf(memTraceSQLBuf,
           "INSERT INTO StrideTrainTrace(Tick,Addr,PC,HashPC,QueryHit,IsFirstShot,Miss,IsTrain,SITE) "
-          "VALUES(%ld,%ld,%ld,%ld,%d,%d,%d,%d,'%s');",
-          tick, addr, PC, hashPC, hit, isFirstShot, miss, is_train, "StrideTrain");
+          "VALUES(%lld,%lld,%lld,%lld,%d,%d,%d,%d,'%s');",
+          sqliteSignedInt(tick), sqliteSignedInt(addr),
+          sqliteSignedInt(PC), sqliteSignedInt(hashPC),
+          hit, isFirstShot, miss, is_train, "StrideTrain");
   rc = sqlite3_exec(mem_db, memTraceSQLBuf, callback, 0, &zErrMsg);
   if (rc != SQLITE_OK) {
     fatal("SQL error: %s\n", zErrMsg);
@@ -194,8 +196,11 @@ ArchDBer::despacitoTraceWrite(Tick tick, Addr vaddr, Addr paddr, Addr PC, bool h
 
   sprintf(memTraceSQLBuf,
           "INSERT INTO DespacitoTrainTrace(Tick,vAddr,pAddr,PC,hasPC,Miss,IsTrain,SITE) "
-          "VALUES(%ld,%ld,%ld,%ld,%d,%d,%d,'%s');",
-          tick, vaddr, paddr, PC, hasPC, miss, is_train, is_train?"DespacitoTrain":"DespacitoPrefetch");
+          "VALUES(%lld,%lld,%lld,%lld,%d,%d,%d,'%s');",
+          sqliteSignedInt(tick), sqliteSignedInt(vaddr),
+          sqliteSignedInt(paddr), sqliteSignedInt(PC),
+          hasPC, miss, is_train,
+          is_train ? "DespacitoTrain" : "DespacitoPrefetch");
   rc = sqlite3_exec(mem_db, memTraceSQLBuf, callback, 0, &zErrMsg);
   if (rc != SQLITE_OK) {
     fatal("SQL error: %s\n", zErrMsg);


### PR DESCRIPTION
## Motivation

The current `xs-dev` branch cannot complete a RISC-V gem5 build on macOS. Apple Clang rejects mismatched `%ld` formatting for `Tick`/`Addr`, and two prefetch sources include the Linux-only `<linux/limits.h>` header.

This extracts commit `177ba6369947f331018c77edf0288cf836323087` from #978 into a standalone build-fix PR so other changes can be validated independently on macOS.

## Approach

- Format SQLite trace integers through `sqliteSignedInt()` and `%lld`.
- Replace the Linux-only limits include in `queued.cc` with `<climits>`.
- Remove the redundant Linux-only limits include from `prefetch_filter.cc`.

## Scope

Build portability only. No prefetch policy, timing, resource, or statistics behavior is changed.

## Validation

Validated locally on macOS together with the independent Forwarder change under development:

- `scons build/RISCV/gem5.opt -j8` — passed (final link run outside the filesystem sandbox so Clang could create temporary files).
- `./build/RISCV/gem5.opt configs/example/se.py --help` — passed.
- SMT CoreMark raw checkpoint with `smt_idealkmhv3.py --disable-difftest` — completed normally at tick 474172353.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility across platforms by replacing platform-specific limit handling with standard library support.
  - Improved trace data recording by ensuring large timestamps and addresses are stored correctly, reducing the risk of inaccurate or truncated database entries.

- **Refactor**
  - Simplified internal formatting and standardized handling of trace-related numeric values without changing the public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->