### PR TITLE
mem-cache: Forward unused prefetch addresses

### DIFF
--- a/src/mem/cache/prefetch/forwarder.cc
+++ b/src/mem/cache/prefetch/forwarder.cc
@@ -178,6 +178,14 @@ PrefetcherForwarder::prefetchUnused(PrefetchSourceType pf_type)
 }
 
 void
+PrefetcherForwarder::prefetchUnused(Addr paddr, PrefetchSourceType pf_type)
+{
+    if (real_pf) {
+        real_pf->prefetchUnused(paddr, pf_type);
+    }
+}
+
+void
 PrefetcherForwarder::pfHitInMSHR(PrefetchSourceType pf_type)
 {
     if (real_pf) {

--- a/src/mem/cache/prefetch/forwarder.hh
+++ b/src/mem/cache/prefetch/forwarder.hh
@@ -57,6 +57,7 @@ class PrefetcherForwarder : public Base
     // stats
     void incrDemandMhsrMisses() override;
     void prefetchUnused(PrefetchSourceType pf_type) override;
+    void prefetchUnused(Addr paddr, PrefetchSourceType pf_type) override;
     void pfHitInMSHR(PrefetchSourceType pf_type) override;
     void pfHitInCache(PrefetchSourceType pf_type) override;
     void pfHitInWB(PrefetchSourceType pf_type) override;


### PR DESCRIPTION
## Motivation

Aligned L2 cache slices use `PrefetcherForwarder` to connect cache events to the real wrapper-level L2 prefetcher. Cache eviction reports unused prefetches through `prefetchUnused(paddr, source)`, but the forwarder only overrode the source-only overload. The inherited address-aware overload therefore discarded `paddr` before forwarding.

For CDP, this prevented `L2CompositeWithWorkerPrefetcher::prefetchUnused(paddr, source)` from calling `recordUnusedPrefetch(paddr)`, leaving its physical-region negative-feedback filter untrained even when millions of CDP prefetches were reported unused.

## Approach

Add the address-aware `PrefetcherForwarder::prefetchUnused` override and forward both the physical address and prefetch source to the real prefetcher.

## Scope and modeling contract

- Restored causal path: unused CDP block eviction -> physical-address feedback -> CDP filter-table update -> possible suppression of later candidates in that physical region.
- No new state, parameter, capacity, arbitration, latency, or bandwidth behavior.
- Existing source-only forwarding remains unchanged.
- Statistics remain counted once by the real prefetcher; the forwarder itself does not add accounting.
- Per-event complexity remains O(1).

## Validation

- `scons build/RISCV/mem/cache/prefetch/forwarder.o -j3` — passed on macOS.
- Both Forwarder overload symbols are present in the compiled object.
- `git diff --check` — passed.
- Full `scons build/RISCV/gem5.opt -j8` — passed when combined only for local validation with the standalone macOS build fix in #984.
- SMT CoreMark raw checkpoint using `smt_idealkmhv3.py --disable-difftest` — completed normally at tick 474172353.

CoreMark issued no CDP prefetches, so it validates build/startup behavior but not the expected `unusefulInsertFilter` transition. SPEC06 MCF A/B is still required to quantify the performance impact and confirm that unused CDP feedback becomes nonzero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unused prefetch notifications by forwarding the associated address and prefetch source information when available.
  * Prevented unnecessary actions when no underlying prefetcher is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->