### PR TITLE
configs: Disable CDP for SMT

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -76,10 +76,11 @@ def _configure_xs_composite(prefetcher, options, pf_buffer_enabled):
 
     _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled)
 
-def _configure_l2_composite_default(prefetcher):
+def _configure_l2_composite_default(prefetcher, options):
     # Normal L2CompositeWithWorker profile.
     prefetcher.enable_bop = True
-    prefetcher.enable_cdp = True
+    # Keep CDP off while evaluating its shared-state bandwidth impact in SMT.
+    prefetcher.enable_cdp = not getattr(options, "smt", False)
     prefetcher.enable_cmc = False
     prefetcher.enable_despacito_stream = True
 
@@ -99,7 +100,7 @@ def _configure_l2_composite(prefetcher, prefetcher_name, options):
         assert prefetcher_name == 'L2CompositeWithWorkerPrefetcher'
         _configure_l2_composite_kmh_align(prefetcher)
     elif prefetcher_name == 'L2CompositeWithWorkerPrefetcher':
-        _configure_l2_composite_default(prefetcher)
+        _configure_l2_composite_default(prefetcher, options)
 
 def _configure_l2_prefetcher(prefetcher, prefetcher_name, options,
                              pf_buffer_enabled):


### PR DESCRIPTION
## Motivation

SPEC06 SMT MCF shows very low CDP accuracy together with a large increase in CDP-issued, unused, and queue-full-dropped prefetches. Because L2 prefetch bandwidth and queue capacity are shared, disabling CDP is a useful single-variable experiment to measure the upper bound from removing that traffic.

This is an A/B performance-policy PR, not yet a claim that CDP should remain permanently disabled for SMT.

## Approach

Disable CDP in the normal `L2CompositeWithWorkerPrefetcher` profile when `options.smt` is true.

The change deliberately preserves:

- CDP for single-thread configurations.
- BOP, CMC, and Despacito settings.
- The existing `kmh_align` profile.
- All prefetch queue sizes, capacities, arbitration, and bandwidth parameters.

## Modeling contract

The only modeled behavior removed in SMT is CDP candidate generation. The expected downstream effects are fewer CDP translations/requests, less L2 PF queue pressure, and more opportunity for demand and other prefetch traffic. No new state or hot-path algorithm is introduced.

## Validation

- Instantiated `idealkmhv3.py`: `enable_cdp=true`.
- Instantiated `smt_idealkmhv3.py`: `enable_cdp=false`.
- SMT CoreMark raw checkpoint with difftest disabled completed normally at tick 474172353.
- CoreMark had zero CDP requests before the change and therefore only serves as a functional smoke test.
- `git diff --check` passed.

## Pending performance validation

Run SPEC06 SMT 0.3c and compare against the same base:

- weighted score and per-workload score, especially MCF;
- L2 `pfIssued_srcs`, `pfUseful_srcs`, `pfUnused_srcs`, and `pfRemovedFull_srcs`;
- BOP traffic/usefulness and demand miss behavior;
- memory bandwidth and queue-pressure indicators.

A broad score improvement would support an SMT-specific disable policy. A mixed result would instead motivate CDP throttling or fair shared-bandwidth arbitration.