### PR TITLE
cpu-o3: Initialize selective VP flush in IEW

### DIFF
--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -81,6 +81,7 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
     : dqSize(params.numDQEntries),
       issueToExecQueue(params.backComSize, params.forwardComSize),
       valuePred(params.valuePred),
+      enableSelectiveVPFlush(params.enableSelectiveVPFlush),
       cpu(_cpu),
       scheduler(params.scheduler),
       instQueue(_cpu, this, params),


### PR DESCRIPTION
    IEW declares enableSelectiveVPFlush and uses it to select between full
    squash and selective recovery for value prediction failures. However,
    the member was not initialized from BaseO3CPUParams.

    This caused IEW to read an uninitialized bool, resulting in undefined
    behavior. In the failing run, enableSelectiveVPFlush was configured as
    false, while IEW evaluated its uninitialized member as true and entered
    the selective recovery path. This eventually caused a difftest PC
    mismatch.

    Initialize the IEW member from params, consistent with Rename.

    After rebuilding, the IdealConstantLVP reproducer takes the configured
    full-squash recovery path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for selectively flushing vector processing state during instruction execution.
  * Enables related wake-up and flush behavior to respond to the configured setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->