### PR TITLE
mem: parametrize Dcache Bank Bytes

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -211,6 +211,9 @@ class BaseO3CPU(BaseCPU):
 
     BankConflictCheck = Param.Bool(True, "open Bank conflict check")
     sbufferBankWriteAccurately = Param.Bool(False, "Sbuffer write to memory with bank conflict check")
+    DcacheBankBytes = Param.Unsigned(
+        2,
+        "Dcache bank interleave granularity in bytes for LSQ bank conflict model")
     DcacheSetBits = Param.Unsigned(8, "Dcache set bits for LSQ bank conflict model")
     DcacheSetDivNum = Param.Unsigned(1, "Dcache set div num for LSQ bank conflict model (power of two)")
     EnableLdMissReplay = Param.Bool(True, "Replay Cache missed load instrution from ReplayQueue if True")

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -450,10 +450,16 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
 
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     : cpu(cpu_ptr), iewStage(iew_ptr),
-      recentlyloadAddr(8 * (params.DcacheSetDivNum ? params.DcacheSetDivNum : 1)),
+      recentlyloadAddr(
+          (params.DcacheBankBytes &&
+                   params.DcacheBankBytes <= cpu_ptr->cacheLineSize() ?
+               cpu_ptr->cacheLineSize() / params.DcacheBankBytes : 1) *
+          (params.DcacheSetDivNum ? params.DcacheSetDivNum : 1)),
       _cacheBlocked(false),
       cacheStorePorts(params.cacheStorePorts), usedStorePorts(0),
       cacheLoadPorts(params.cacheLoadPorts), usedLoadPorts(0),
+      numBank(params.DcacheBankBytes ?
+              cpu_ptr->cacheLineSize() / params.DcacheBankBytes : 0),
       sbufferEvictThreshold(params.SbufferEvictThreshold),
       sbufferEntries(params.SbufferEntries),
       storeBufferInactiveThreshold(params.storeBufferInactiveThreshold),
@@ -462,7 +468,11 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       dcacheSetBits(params.DcacheSetBits),
       dcacheSetDivNum(params.DcacheSetDivNum),
       dcacheLineBits(floorLog2(cpu_ptr->cacheLineSize())),
-      dcacheSetBankBits(params.DcacheSetBits + 3),
+      dcacheBankBytes(params.DcacheBankBytes),
+      dcacheBankOffsetBits(params.DcacheBankBytes ?
+                           floorLog2(params.DcacheBankBytes) : 0),
+      dcacheBankIndexBits(numBank ? floorLog2(numBank) : 0),
+      dcacheSetBankBits(params.DcacheSetBits + dcacheBankIndexBits),
       _enableLdMissReplay(params.EnableLdMissReplay),
       _enablePipeNukeCheck(params.EnablePipeNukeCheck),
       _enableReplayBasedMDP(params.EnableReplayBasedMDP),
@@ -496,6 +506,20 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     panic_if(dcacheSetDivNum > (1ULL << dcacheSetBits),
              "DcacheSetDivNum (%u) must be <= num_sets (2^%u)\n",
              dcacheSetDivNum, dcacheSetBits);
+    panic_if(dcacheBankBytes == 0 || !isPowerOf2(dcacheBankBytes),
+             "DcacheBankBytes must be a positive power of two (got %u)\n",
+             dcacheBankBytes);
+    panic_if(dcacheBankBytes > cpu_ptr->cacheLineSize() ||
+                 cpu_ptr->cacheLineSize() % dcacheBankBytes != 0,
+             "DcacheBankBytes (%u) must divide cache line size (%u)\n",
+             dcacheBankBytes, cpu_ptr->cacheLineSize());
+    panic_if(numBank == 0 || !isPowerOf2(numBank),
+             "Derived dcache bank count must be a positive power of two "
+             "(line size=%u, bank bytes=%u, bank count=%u)\n",
+             cpu_ptr->cacheLineSize(), dcacheBankBytes, numBank);
+    DPRINTF(LSQ, "Dcache bank model: line bytes=%u, bank bytes=%u, "
+            "bank count=%u\n",
+            cpu_ptr->cacheLineSize(), dcacheBankBytes, numBank);
 
     cpu->addStatGroup("lsq", &stats);
 
@@ -824,21 +848,20 @@ LSQ::willDcacheRefillTagWriteNextCycle() const
 LSQ::DcacheBankMask
 LSQ::fullDcacheBankMask() const
 {
-    DcacheBankMask mask = {};
-    std::fill(mask.begin(), mask.end(), true);
-    return mask;
+    return DcacheBankMask(numBank, true);
 }
 
 LSQ::DcacheBankMask
-LSQ::storeMaskToDcacheBanks(const std::vector<bool> &mask) const
+LSQ::storeMaskToDcacheBanks(Addr block_addr,
+                            const std::vector<bool> &mask) const
 {
-    assert(mask.size() == DcacheBankCount * 8);
-    DcacheBankMask bank_mask = {};
+    assert(mask.size() == cpu->cacheLineSize());
+    DcacheBankMask bank_mask(numBank, false);
     if (sbufferBankWriteAccurately) {
-        for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
-            bank_mask.at(bank) = std::any_of(
-                mask.begin() + 8 * bank, mask.begin() + 8 * bank + 8,
-                [](bool v) { return v; });
+        for (unsigned byte = 0; byte < mask.size(); ++byte) {
+            if (mask.at(byte)) {
+                bank_mask.at(bankNum(block_addr + byte)) = true;
+            }
         }
     } else {
         std::fill(bank_mask.begin(), bank_mask.end(), true);
@@ -860,7 +883,8 @@ LSQ::makeDcacheRefillMainPipeRequest(
     req.needTagWrite = true;
     req.needDataWrite = true;
     req.needWritebackPort = need_data_read;
-    req.readBanks = need_data_read ? fullDcacheBankMask() : DcacheBankMask{};
+    req.readBanks = need_data_read ? fullDcacheBankMask() :
+        DcacheBankMask(numBank, false);
     req.writeBanks = fullDcacheBankMask();
     req.onComplete = std::move(on_complete);
     return req;
@@ -875,20 +899,26 @@ LSQ::makeStoreBufferMainPipeRequest(
     req.addr = entry.blockVaddr;
     req.div = getDcacheDiv(entry.blockVaddr);
     req.setKey = getDcacheSetKey(entry.blockVaddr);
-    req.writeBanks = storeMaskToDcacheBanks(entry.validMask);
+    req.writeBanks = storeMaskToDcacheBanks(entry.blockVaddr, entry.validMask);
+    req.readBanks = DcacheBankMask(numBank, false);
     req.needDataWrite = dcacheBankMaskAny(req.writeBanks);
     req.needTagWrite = false;
 
-    DcacheBankMask full_write = fullDcacheBankMask();
-    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
-        const bool bank_fully_written = std::all_of(
-            entry.validMask.begin() + 8 * bank,
-            entry.validMask.begin() + 8 * bank + 8,
-            [](bool v) { return v; });
-        full_write.at(bank) = bank_fully_written;
+    DcacheBankMask full_write(numBank, false);
+    DcacheBankMask bank_has_bytes(numBank, false);
+    DcacheBankMask bank_fully_written(numBank, true);
+    for (unsigned byte = 0; byte < entry.validMask.size(); ++byte) {
+        const unsigned bank = bankNum(entry.blockVaddr + byte);
+        bank_has_bytes.at(bank) = true;
+        bank_fully_written.at(bank) = bank_fully_written.at(bank) &&
+            entry.validMask.at(byte);
+    }
+    for (unsigned bank = 0; bank < numBank; ++bank) {
+        full_write.at(bank) = bank_has_bytes.at(bank) &&
+            bank_fully_written.at(bank);
     }
 
-    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+    for (unsigned bank = 0; bank < numBank; ++bank) {
         req.readBanks.at(bank) = req.writeBanks.at(bank) && !full_write.at(bank);
     }
     req.needDataRead = dcacheBankMaskAny(req.readBanks);
@@ -906,7 +936,7 @@ LSQ::markDcacheMainPipeBusyBanks()
 
     auto mark_banks = [this](const DcacheMainPipeRequest &req,
                              const DcacheBankMask &mask) {
-        for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+        for (unsigned bank = 0; bank < numBank; ++bank) {
             if (mask.at(bank)) {
                 bankOccupied.at(req.div).at(bank) = true;
             }
@@ -936,7 +966,8 @@ bool
 LSQ::dcacheBankMaskOverlap(const DcacheBankMask &lhs,
                            const DcacheBankMask &rhs) const
 {
-    for (unsigned bank = 0; bank < DcacheBankCount; ++bank) {
+    assert(lhs.size() == numBank && rhs.size() == numBank);
+    for (unsigned bank = 0; bank < numBank; ++bank) {
         if (lhs.at(bank) && rhs.at(bank)) {
             return true;
         }
@@ -1085,9 +1116,9 @@ LSQ::getDcacheSetKey(Addr vaddr) const
 uint64_t
 LSQ::getDcacheBankSetKey(Addr vaddr) const
 {
-    // [setIndex][bankIndex][dataOffset]
-    //         ^ (cacheLineBits)   ^ (3 bits)
-    return (vaddr >> 3) & ((1ULL << dcacheSetBankBits) - 1);
+    // Vaddr: [TagBits][setIndex][bankIndex][dataOffset]
+    // BankSetKey: [setIndex][bankIndex]
+    return (getDcacheSetKey(vaddr) << dcacheBankIndexBits) | bankNum(vaddr);
 }
 
 uint64_t
@@ -1101,7 +1132,7 @@ bool
 LSQ::loadBankConflictedCheck(Addr vaddr)
 {
     bool now_bank_conflict = false;
-    const int bankIndex = bankNum(vaddr);
+    const unsigned bankIndex = bankNum(vaddr);
     const unsigned div = getDcacheDiv(vaddr);
     const uint64_t key = getDcacheDivBankSetKey(vaddr);
 

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1161,7 +1161,10 @@ class LSQ
     uint64_t
     getDcacheDivBankSetKey(Addr vaddr) const;
 
-    Addr bankNum(Addr a) const { return (a >> 3) & 0x7; };
+    unsigned bankNum(Addr a) const
+    {
+        return (a >> dcacheBankOffsetBits) & (numBank - 1);
+    }
 
     bool loadBankConflictedCheck(Addr vaddr);
 
@@ -1287,9 +1290,7 @@ class LSQ
     int storeWbStage() const { return _storeWbStage; }
 
   public:
-    static constexpr unsigned DcacheBankCount = 8;
-
-    using DcacheBankMask = std::array<bool, DcacheBankCount>;
+    using DcacheBankMask = std::vector<bool>;
     using DcacheMainPipeCompleteCallback = std::function<void(Tick)>;
     using DcacheMainPipeS2Callback =
         std::function<DcacheMainPipeS2Result(Tick)>;
@@ -1368,7 +1369,8 @@ class LSQ
     dcacheMainPipeStage(DcacheMainPipeStage stage) const;
 
     DcacheBankMask fullDcacheBankMask() const;
-    DcacheBankMask storeMaskToDcacheBanks(const std::vector<bool> &mask) const;
+    DcacheBankMask storeMaskToDcacheBanks(
+        Addr block_addr, const std::vector<bool> &mask) const;
 
     DcacheMainPipeRequest makeDcacheRefillMainPipeRequest(
         Addr addr, bool need_data_read,
@@ -1426,7 +1428,7 @@ class LSQ
     /** The number of used cache ports in this cycle by loads. */
     int usedLoadPorts;
 
-    const int numBank = DcacheBankCount;
+    const unsigned numBank;
     bool dcacheWriteStall = false;
     const uint32_t sbufferEvictThreshold;
     const uint32_t sbufferEntries;
@@ -1451,6 +1453,9 @@ class LSQ
     const unsigned dcacheSetBits;
     const unsigned dcacheSetDivNum;
     const unsigned dcacheLineBits;
+    const unsigned dcacheBankBytes;
+    const unsigned dcacheBankOffsetBits;
+    const unsigned dcacheBankIndexBits;
     const unsigned dcacheSetBankBits;
 
     bool _enableLdMissReplay;


### PR DESCRIPTION
Introduce `DcacheBankBytes` parameter to control the granularity in bytes for LSQ bank conflict check.

**Set it to 2 Bytes to align with RTL settings**

Change-Id: I6fb205897af53c32cc9e9a6853017c6dd3bc518b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable D-cache bank granularity setting for out-of-order CPU simulations.
  * Updated D-cache bank conflict modeling to support variable cache bank counts and layouts.

* **Bug Fixes**
  * Improved bank-mask handling for cache refills and store-buffer requests.
  * Added validation for compatible bank sizes and cache-line configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->