### PR TITLE
cpu-o3: Modify the fetch module F1 stage scheduling process under SMT…

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -2032,23 +2032,25 @@ Fetch::fetch(bool &status_change)
     //////////////////////////////////////////
     // Start actual fetch
     //////////////////////////////////////////
+    std::list<ThreadID>::iterator threadit = activeThreads->begin();
+    std::list<ThreadID>::iterator end = activeThreads->end();
+    while (threadit != end) {
+        ThreadID tid = *threadit++;
+    performInstructionFetch(tid);
+    }
     auto tid = getEligibleFetchTargetTid();
-
     if (tid == InvalidThreadID) {
         return;
     }
-
     if (!checkDecoupledFrontend(tid)) {
         return;
     }
-
     if (!prepareFetchAddress(tid, status_change)) {
         return;
     }
-
     ++fetchStats.cycles;
-
-    performInstructionFetch(tid);
+    sendNextCacheRequest(tid, *threads[tid].fetchpc);
+    
 }
 
 StallReason
@@ -2273,8 +2275,7 @@ Fetch::performInstructionFetch(ThreadID tid)
         wroteToTimeBuffer = true;
     }
 
-    assert(fetchStatus[tid] == Running && "Fetch should be running");
-    sendNextCacheRequest(tid, pc_state);
+   // assert(fetchStatus[tid] == Running && "Fetch should be running");
 }
 
 void


### PR DESCRIPTION
There is an error in thread passing across different stages of the fetch module. The phenomenon is that the current fetch has a pipeline of f0, f1, f2, f3, and the model has been simplified. f0 initiates value fetch requests; f1 receives requests returned by the icache and performs predecode to write instructions into the fetch queue; f2 and f3 DE equivalently handle the process using a timebuffer with a three-cycle delay. The issue is that after f0 performs thread scheduling to select a thread (e.g., thread 0), f1 in the same cycle can only process the thread selected by f0 (thread 0). This affects the fairness of the fetch module in handling two threads. If there is a branch instruction in between and f0 has limited fetch bandwidth, bubbles may be inserted; if the model were not simplified, even more bubbles would occur. The current fix is to have the f1 stage process instruction packets from both threads for predecode. The SPECint2006 benchmark score improves by 0.51%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instruction fetching across active threads each cycle.
  * Updated cache-request scheduling to select an eligible thread before requesting the next instruction cache line.
  * Improved fetch sequencing and coordination for decoupled front-end operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->