### PR TITLE
mem: Prioritize older loads in bank conflict checks

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1314,6 +1314,14 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
     int idx = loadPipeSx[0]->size;
     loadPipeSx[0]->insts[idx] = inst;
     loadPipeSx[0]->size++;
+    // Order S0 by age so older loads have higher priority when S1 performs
+    // the bank-conflict check.
+    std::stable_sort(
+        loadPipeSx[0]->insts,
+        loadPipeSx[0]->insts + loadPipeSx[0]->size,
+        [](const DynInstPtr &lhs, const DynInstPtr &rhs) {
+            return lhs->seqNum < rhs->seqNum;
+        });
 
     const int load_pipe_id = inst->issueQue->getLoadPipeId();
     panic_if(load_pipe_id < 0,


### PR DESCRIPTION
## Motivation

Load-pipe S0 currently preserves issue and replay arrival order. Because S1 processes the S0 batch in array order, a younger load can reach the bank-conflict check first and claim the bank before an older load in the same batch.

## Approach

- Stable-sort the bounded S0 active range by instruction sequence number after insertion.
- Give older loads priority when S1 performs the existing bank-conflict check.
- Preserve arrival order for equal sequence numbers.
- Keep the existing S1, bank-token, replay, and statistics paths unchanged.

## Scope

The change is limited to at most `MaxPipeWidth` S0 entries, currently four. It adds no queue, parameter, or persistent state.

## Validation

- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`
- `build/RISCV/gem5.opt -d /tmp/gem5-load-age-order-smoke configs/example/se.py --cpu-type=DerivO3CPU --caches -c tests/test-progs/hello/bin/riscv/linux/hello`
  - Printed `Hello world!` and exited successfully.

A directed workload that forces out-of-order S0 arrival for same-cycle, same-bank loads was not run; the ordering is enforced directly at the S0-to-S1 handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load processing order so older load instructions receive priority.
  * Reduced the likelihood of bank conflicts affecting load execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->