### PR TITLE
misc: Add CI parameter solver skill

### DIFF
--- a/.codex/skills/ci-param-solver/SKILL.md
+++ b/.codex/skills/ci-param-solver/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: ci-param-solver
+description: 用于在 OpenXiangShan/GEM5 中把设计空间探索和参数搜索需求整理成 `configs/solver_specs/` 下的 Python `SolveSpec`，做本地预检，并在用户明确授权且输入完备后通过 `gh` 触发 `.github/workflows/manual-solve.yml`。当用户要求生成、修改、校验或提交求解 spec，或要求发起 CI 参数求解任务时使用。
+---
+
+# CI 参数求解
+
+这个技能覆盖一条可追溯的闭环：收集需求 → 生成 spec → 本地校验 → 确认 CI 输入 →
+触发求解工作流 → 回查任务。它不替用户猜测目标、工作负载、分支或搜索预算；缺少会
+改变实验含义的信息时，先提问并暂停写文件/触发 CI。
+
+## 0. 先确认当前仓库事实
+
+以当前源码和工作流为准，文档只是解释。开始时检查：
+
+```bash
+sed -n '1,260p' docs/tools/others/ci-param-solver-user-guide.md
+sed -n '1,260p' .github/workflows/manual-solve.yml
+```
+
+需要时再读：
+
+- `util/solver/spec/`：`SolveSpec`、搜索域、目标函数和停止条件的描述语法
+- `util/solver/parser/`：`problem_ref`、目标绑定和运行时覆盖
+- `configs/solver_specs/`：现有 spec 的命名和 `apply_trial()` 写法
+- `references/solver-rules.md`：本技能的约束速查
+
+如果本地工作流与远端注册状态不一致，以 `gh workflow view/list` 的结果为准；本地有
+`.yml` 不代表远端已经可以 `workflow_dispatch`。
+
+## 1. 信息完备性闸门
+
+先把用户需求归纳成下面四组。每组缺少会影响实验语义的字段都必须追问；不要用邻近
+基准测试、默认参数或“看起来合理”的统计项名称代替。
+
+### A. 求解问题（生成 spec 必需）
+
+必须明确：
+
+- **要改什么**：每个可调参数的名称、真实 gem5 目标路径、类型/表示方式，以及离散候选。
+  `Range(start, stop, step)` 是离散枚举，`Choice([...])` 是显式枚举。
+- **约束**：参数之间的公式、硬性预算、非法组合和默认值。需要耦合映射时，说明应在
+  `apply_trial()` 中如何从抽象变量推导真实参数。
+- **目标**：每个目标是最大化还是最小化、来自哪个精确的 `stats.txt` 指标或
+  `score.txt` 标签；多目标必须说明优先目标（它会影响代表性最佳结果的展示）。
+- **停止条件**：至少给出 `max_trials`；如果要早停，再给 `no_improve_trials` 和
+  `timeout_hours`。
+
+可由 spec 或 CI 输入继承、因此不必重复追问的字段：`config_path`、`benchmark_type`、
+`specific_benchmarks`、`custom_bin`、`extra_args`、`solver_name`。但如果二者冲突，必须让
+用户选择，而不是静默覆盖。
+
+### B. 工作负载语义
+
+必须选择其中一种：
+
+- 内建检查点组：给出准确的 `benchmark_type`，可选给出逗号分隔的
+  `specific_benchmarks`。
+- `custom_bin`：给出一个或多个可访问的绝对路径（逗号或换行分隔），并确认目标只能使用
+  `stats(...)`，不能使用 `score_txt(...)`。
+
+`custom_bin` 下不能同时给 `specific_benchmarks`；内建检查点组下的 `custom_bin` 会被忽略。
+SMT 基准测试（`gcc12-spec06-smt-*`）当前求解运行时不支持，必须换成非 SMT 选择。
+
+### C. CI 执行设置
+
+至少确认：
+
+- `configuration`：`idealkmhv3.py`、`kmhv3.py` 或 `kmhv2.py`，并且目标路径能在该配置
+  上绑定；配置只支持属性访问和列表下标形式的目标路径。
+- `solver_kind`：`auto`、`grid`、`random`、`bayes`、`ga` 或 `nsga2`。多目标优先
+  `nsga2`；`bayes`/`ga` 只用于单目标；小空间且预算覆盖全空间时可用 `grid`。
+- `max_parallel_trials` 和 `max_parallel_workloads`。说明总并发约为二者乘积，并根据
+  工作负载数量平衡二者，不要把候选试验和工作负载混为一个概念。
+- `distributed_servers`：留空表示当前运行节点；`default` 或显式列表/范围表示分布式。
+  若使用分布式，再确认 `distributed_jobs_per_server`（`0` 让求解器推导）。
+- `extra_args`：例如短跑时的 `--maxinsts=1000000`；不要为完整搜索擅自加入短跑限制。
+- `branch`/标签/SHA：CI 检出的真实来源。spec 必须已经存在于该远端引用；仅在本地未
+  提交的文件无法被 CI 使用。
+
+没有明确指定时可以采用并在回复中列出的非语义默认值：`solver_kind=auto`、并行度
+`4/4`、分布式留空、`extra_args` 为空、工作流的默认 `note`。`configuration`、工作负载、
+目标、预算、远端引用不可擅自猜测。
+
+### D. 动作授权
+
+区分两种请求：
+
+1. “只生成/校验 spec”：写文件并做本地验证，不触发远端。
+2. “触发 CI”：只有用户明确要求触发，并且 spec 已在目标远端引用后才执行触发。
+
+如果信息不全，先用一条简短的定向问题收齐缺口，例如：
+
+```text
+为了生成并触发这个求解任务，还缺 4 项：
+1. 要绑定的配置和每个参数的精确目标路径/候选域是什么？
+2. 工作负载使用哪个 benchmark_type（或哪些 custom_bin）？
+3. 目标指标的精确 stats 名称/score.txt 标签、方向和停止预算是什么？
+4. CI 要跑哪个已推送的分支/标签/SHA，以及是否现在触发？
+```
+
+只列仍缺失的项；用户已经明确的内容不要重复询问。收到答案后，先回显一份“最终 spec
+语义 + CI 输入”摘要，再写文件或触发任务。
+
+## 2. 生成 spec
+
+把文件放在 `configs/solver_specs/<snake_case>.py`，定义一个唯一、清晰的 `SolveSpec` 子类。
+遵循这些规则：
+
+```python
+from util.solver.spec import (
+    Choice,
+    InferTunable,
+    Maximize,
+    Range,
+    SolveSpec,
+    Stop,
+)
+
+
+class ExampleSearch(SolveSpec):
+    config_path = "configs/example/kmhv3.py"
+    benchmark_type = "gcc15-spec06-0.3c"
+    specific_benchmarks = ""
+    custom_bin = ""
+    extra_args = ""
+    solver_name = "nsga2"
+
+    threshold = InferTunable(
+        target="system.cpu[0].branchPred.someThreshold",
+        domain=Range(8, 32, step=4),
+    )
+    mode = InferTunable(
+        target="system.cpu[0].branchPred.someMode",
+        domain=Choice([0, 1, 2]),
+    )
+
+    objective = Maximize.stats("system.cpu.ipc")
+    stop = Stop(max_trials=32, no_improve_trials=8, timeout_hours=6)
+```
+
+具体选择：
+
+- 真实存在于 gem5 对象且需要运行时类型推断时用 `InferTunable`；想显式指定类型或
+  定义抽象变量时用 `TunableParam.Unsigned/Float/Bool/VectorUnsigned`。
+- 目标超过一个时用 `objectives = [...]`，语义是 Pareto 支配，不是加权和。
+- 目标依赖多个参数的确定性关系时，只暴露少量语义变量，把关系写进
+  `@classmethod apply_trial(cls, root, trial)`；用 `resolve_target()` 找对象，并用
+  `owner._params[param_name].convert(value)` 转换后赋值。执行顺序是配置默认调优 →
+  直接覆盖 → `apply_trial()`。
+- `score_txt` 只能写成 `Maximize.score_txt("精确标签")`；不要写
+  `Minimize.score_txt`。统计项名称必须与实际 `stats.txt` 完全一致。
+- 不要把与用户目标无关的参数、目标或工作负载混进 spec；复杂工作负载集合优先在
+  `specific_benchmarks`/`custom_bin` 中表达。
+
+生成后输出：文件路径、类名、参数/域摘要、目标和停止条件，并明确哪些字段取了默认值。
+
+## 3. 本地校验（触发前必做）
+
+按风险从低到高执行：
+
+```bash
+python3 -m py_compile configs/solver_specs/<file>.py
+python3 - <<'PY'
+from util.solver.parser.load_spec import parse_problem
+problem = parse_problem("configs/solver_specs/<file>.py:<ClassName>")
+print(problem.name, problem.config_path, problem.benchmark_type)
+print([obj.display_name() for obj in problem.objective_list()])
+print([param.name for param in problem.parameters])
+PY
+```
+
+若有可用且已更新的 `build/RISCV/gem5.fast` 或 `gem5.opt`，再运行真实绑定和预检：
+
+```bash
+python3 util/solver/run_solver.py \
+  --problem-ref configs/solver_specs/<file>.py:<ClassName> \
+  --workdir /tmp/solver_dry_run_<name> \
+  --gem5-build-type opt \
+  --max-parallel-trials 1 \
+  --max-parallel-workloads 1 \
+  --dry-run
+```
+
+根据用户选择补上 `--config-path`、`--benchmark-type`、`--specific-benchmarks`、
+`--custom-bin`、`--extra-args` 和 `--max-trials`。检查 `binding.json`、`parsed_problem.json`
+和 `preview_trials.json`；重点确认 `owner_path`、`param_name`、`resolved_kind`、默认值和
+预览候选。若二进制缺失或旧导致绑定不能执行，要说明这是环境/构建缺口，不要把它包装成
+spec 已通过。
+
+完整工作负载很慢时，用户同意后才做一次短跑验证：单个工作负载、`--max-trials 1`、
+`--max-parallel-trials 1`、`--extra-args=--maxinsts=1000000`。不要用短跑结果替代完整搜索。
+
+## 4. 触发 GitHub Actions
+
+### 4.1 触发前检查
+
+仅当用户明确要求触发时执行：
+
+```bash
+gh --version
+gh auth status
+gh workflow view manual-solve.yml --repo OpenXiangShan/GEM5 --ref <branch-or-tag> --yaml
+```
+
+如果工作流未注册、认证失效、目标引用不含 spec，先停止并报告阻塞原因。不要因为本地
+存在 `.github/workflows/manual-solve.yml` 就声称远端可触发。当前仓库的实际入口是
+`manual-solve.yml`；不要把求解任务误发到普通 `manual-perf.yml`。
+
+触发前再次检查 CI 输入与 spec 的一致性：
+
+- `problem_ref` 用 `ClassName`、`path.py` 或 `path.py:ClassName`；推荐使用相对于仓库根目录
+  的 `path.py:ClassName`。
+- CI `configuration`、`benchmark_type`、`specific_benchmarks`、`custom_bin`、
+  `extra_args`、`max_trials` 会覆盖/补充 spec 中相应值；把最终生效值展示给用户。
+- `custom_bin` 和 `score_txt`、SMT、`custom_bin` 与特定基准测试筛选条件的冲突必须在触发
+  前报错。
+- `--ref` 和工作流的 `branch` 输入通常填同一个远端分支/标签/SHA；必须确保该引用
+  已推送，且包含 spec 文件和工作流。
+
+如果 spec 只存在于本地有未提交修改的工作区，先告诉用户 CI 看不到它，并请用户提供已
+推送的引用，或明确授权后再讨论提交/推送；不要在没有授权时自动推送。
+
+### 4.2 使用随附脚本组装和回查
+
+先用 `--dry-run` 只打印命令并检查输入，再在用户授权后加 `--yes` 实际触发：
+
+```bash
+python3 .codex/skills/ci-param-solver/scripts/solver_ci_dispatch.py dispatch \
+  --repo OpenXiangShan/GEM5 \
+  --workflow manual-solve.yml \
+  --branch <branch-or-sha> \
+  --problem-ref configs/solver_specs/<file>.py:<ClassName> \
+  --configuration <idealkmhv3.py|kmhv3.py|kmhv2.py> \
+  --benchmark-type <group-or-custom_bin> \
+  --solver-kind <auto|grid|random|bayes|ga|nsga2> \
+  --max-parallel-trials <N> \
+  --max-parallel-workloads <N> \
+  [--distributed-servers <list-or-default>] \
+  [--distributed-jobs-per-server <N>] \
+  [--specific-benchmarks <filters>] \
+  [--custom-bin <absolute-paths>] \
+  [--extra-args '<gem5 args>'] \
+  [--max-trials <N>] \
+  [--note '<title>'] \
+  --dry-run
+```
+
+`--dry-run` 输出完整 `gh workflow run` 命令但不联网触发。展示该命令和最终参数；
+得到用户对“现在触发”的明确授权后，去掉 `--dry-run` 并加 `--yes`。随附脚本会：
+
+1. 本地解析 `problem_ref`，校验配置、基准测试/自定义工作负载、目标、SMT、算法和正整数约束；
+2. 检查 `gh auth` 与工作流注册状态；
+3. 调用 `gh workflow run manual-solve.yml --repo ... --ref ... -f key=value ...`；
+4. 查询最近的 `workflow_dispatch` 任务，并报告 URL、状态、结论、来源分支/SHA。
+
+如果找不到新任务，不要只说“已触发”；报告触发输出和回查结果，并让用户检查远端引用、
+工作流注册及令牌的 `workflow` 权限。
+
+### 4.3 不使用随附脚本时的命令形式
+
+```bash
+gh workflow run manual-solve.yml \
+  --repo OpenXiangShan/GEM5 --ref <branch> \
+  -f note='<title>' \
+  -f problem_ref='configs/solver_specs/foo.py:FooSearch' \
+  -f configuration='kmhv3.py' \
+  -f benchmark_type='gcc15-spec06-0.3c' \
+  -f max_parallel_trials='4' \
+  -f max_parallel_workloads='4' \
+  -f solver_kind='nsga2' \
+  -f branch='<branch>'
+```
+
+不要把空的可选输入伪装成用户已确认的语义；可以省略它们，让工作流默认值生效，或在
+命令和回复中明确写出空值。
+
+## 5. 结果交接
+
+触发成功后给出：
+
+- spec 文件和类名、最终生效的 CI 输入
+- 本地验证结果及验证缺口
+- `gh` 触发输出、任务 URL、当前 status/conclusion/head SHA
+- 用户下一步查看产物的顺序：`summary.md` → `best_result.json` → `metadata.json` →
+  `binding.json` → `parsed_problem.json` → `history.jsonl/history.csv` → `charts/`。
+
+求解产物不使用性能 CI 的 `score.txt` 归档定位脚本；需要分析求解结果时，
+直接用 `gh run view`/`gh run download` 获取上述产物。
+
+## 资源
+
+- `scripts/solver_ci_dispatch.py`：输入校验、dry-run 命令预览、工作流触发和新任务回查。
+- `scripts/self_test.py`：基于现有 BOP specs 的离线合法/非法输入回归测试，不触发 CI。
+- `references/solver-rules.md`：从当前源码和用户指南整理的 DSL、目标、工作负载、并行
+  语义速查。
+- `references/test-scenarios.md`：信息不足、规则冲突和信息完整的对话级验收提示词与预期行为。

--- a/.codex/skills/ci-param-solver/agents/openai.yaml
+++ b/.codex/skills/ci-param-solver/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CI 参数求解"
+  short_description: "根据需求生成并校验求解 spec，并安全触发 CI 参数搜索任务"
+  default_prompt: "使用 $ci-param-solver 将我的参数搜索需求整理成经过校验的求解 spec，并在得到授权后触发 CI 求解工作流。"

--- a/.codex/skills/ci-param-solver/references/solver-rules.md
+++ b/.codex/skills/ci-param-solver/references/solver-rules.md
@@ -1,0 +1,81 @@
+# 求解规则与输入矩阵
+
+本文是 `ci-param-solver` 工作流的简明参考。如果工作流或解析器发生变化，应重新检查
+仓库源码。
+
+## 求解 spec 约定
+
+`configs/solver_specs/*.py` 中应包含一个 `SolveSpec` 子类，并定义：
+
+- 必填项：`config_path`、`benchmark_type`、`objective` 或 `objectives`、`stop`
+- 可选项：`specific_benchmarks`、`custom_bin`、`extra_args`、`solver_name`、
+  `summary_top_n`
+
+支持的配置路径为 `configs/example/idealkmhv3.py`、
+`configs/example/kmhv3.py` 和 `configs/example/kmhv2.py`；工作流也接受这三个文件的
+基本名称。目标路径只能使用属性访问和列表下标，不能写任意 Python 表达式。
+
+参数声明方式：
+
+| 声明 | 用途 |
+| --- | --- |
+| `InferTunable` | 绑定时推断真实 gem5 `ParamDesc` 类型 |
+| `TunableParam.Unsigned` / `Float` / `Bool` / `VectorUnsigned` | 显式指定类型，或定义由 `apply_trial()` 映射的抽象变量 |
+
+搜索域是离散的：`Range(start, stop, step)` 和 `Choice([...])`。
+
+## 目标函数约定
+
+```python
+Maximize.stats("metric", benchmark_aggregate="mean")
+Minimize.stats("metric", benchmark_aggregate="mean")
+Maximize.score_txt("Estimated Int score per GHz")
+```
+
+不支持 `Minimize.score_txt`。当 `benchmark_type = "custom_bin"` 时，不能使用
+`score_txt` 目标。对于内建基准测试组，统计项会先经过仓库中的 `gem5_data_proc` 路径
+按权重聚合，再做基准测试间聚合；自定义工作负载则对各个工作负载结果做算术聚合。
+
+目标超过一个时使用 `objectives = [...]`。求解器使用 Pareto 支配关系比较候选试验。
+`nsga2` 是明确的多目标后端；`bayes` 和 `ga` 只支持单目标。如果有限搜索空间不超过
+试验预算，`auto` 会选择 `grid`；否则多目标选择 NSGA-II，单目标选择 GA，除非
+`solver_name` 或命令行参数进行了覆盖。
+
+每次运行的第一个真实试验都是配置默认值基线。该试验不包含参数赋值，并占用一个
+`max_trials` 名额。
+
+## 工作流输入约定（`manual-solve.yml`）
+
+| 输入项 | 含义 | 默认值或约束 |
+| --- | --- | --- |
+| `note` | 任务标题前缀 | `Manual Solver Run` |
+| `problem_ref` | 类名、文件路径或文件路径加类名 | 必填；默认 `VTAGEIPCSearch` |
+| `configuration` | 运行时配置文件基本名称 | `kmhv2.py`、`kmhv3.py`、`idealkmhv3.py` |
+| `benchmark_type` | 内建检查点组或 `custom_bin` | 使用工作流中列出的非 SMT 选项 |
+| `max_parallel_trials` | 并行候选试验数 | 默认 `4`，必须为正数 |
+| `max_parallel_workloads` | 单个试验内的并行工作负载数 | 默认 `4`，必须为正数 |
+| `distributed_servers` | 留空、`default` 或显式服务器列表 | 留空表示当前运行节点 |
+| `distributed_jobs_per_server` | 每台服务器的工作负载并发上限 | `0` 表示自动推导 |
+| `solver_kind` | 候选生成算法 | `auto`、`grid`、`random`、`bayes`、`ga`、`nsga2` |
+| `specific_benchmarks` | 内建检查点组的筛选条件 | 自定义工作负载模式下不得使用 |
+| `custom_bin` | `.bin`、`.gz` 或 `.zstd` 绝对路径 | 自定义工作负载模式下必填 |
+| `extra_args` | 附加 gem5 命令行参数 | 默认留空 |
+| `max_trials` | 运行时停止条件覆盖值 | 留空时使用 spec 中的值 |
+| `branch` | 检出的远端引用 | 留空时使用工作流 SHA |
+
+工作流拒绝 `gcc12-spec06-smt-*`。在自定义工作负载模式下，
+`specific_benchmarks` 必须留空，并且不能使用 `score_txt` 目标。在内建检查点组模式下，
+`custom_bin` 会被忽略，基准测试筛选条件可以留空。
+
+## 执行语义
+
+一个候选试验由一组参数赋值以及所有选定工作负载组成。所有工作负载完成后，再聚合该
+候选试验的目标值。`max_parallel_trials` 限制一个批次中的并行候选试验数，
+`max_parallel_workloads` 限制单个候选试验内部的并行工作负载数。启用分布式服务器后，
+全局工作负载并发预算仍为二者的乘积，`distributed_jobs_per_server` 负责限制每台服务器。
+
+## 产物查看顺序
+
+工作流上传 `summary.md`、`best_result.json`、`metadata.json`、
+`parsed_problem.json`、`binding.json`、`history.jsonl`、`history.csv` 和 `charts/`。
+被取消的任务可能没有 `summary.md`，此时应优先检查 JSON 产物。

--- a/.codex/skills/ci-param-solver/references/test-scenarios.md
+++ b/.codex/skills/ci-param-solver/references/test-scenarios.md
@@ -1,0 +1,169 @@
+# 手工测试场景
+
+技能可以被发现后，在新的 Codex 会话中使用以下提示词。除非提示词明确授权触发 CI，
+否则所有测试都应离线完成。
+
+## 场景 1：信息不足
+
+提示词：
+
+```text
+$ci-param-solver 帮我做一个 L2 BOP 参数求解并跑 CI。
+```
+
+预期行为：
+
+- 不创建 spec，也不调用 `gh workflow run`。
+- 只询问仍缺少的语义信息：配置、目标路径、搜索域、参数约束、工作负载模式、目标指标、
+  停止预算、CI 并行度、远端引用，以及当前是否授权触发。
+- 不自行编造检查点组、指标名称、参数范围或分支。
+
+## 场景 2：信息互相矛盾
+
+提示词：
+
+```text
+$ci-param-solver 使用
+configs/solver_specs/l2_vbop_bop_large_nsga2_score_search.py:
+L2VbopBopLargeNsga2ScoreSearch，但把 benchmark_type 改成 custom_bin，
+custom_bin=/tmp/example.zstd，同时保留最大化 SPEC 分数，
+specific_benchmarks=mcf，solver_kind=bayes，max_parallel_trials=0；现在触发 CI。
+```
+
+预期行为：
+
+- 拒绝 `custom_bin + score_txt`。
+- 拒绝 `custom_bin + specific_benchmarks`。
+- 拒绝让这个七目标 spec 使用 `bayes`，并建议改用 `nsga2`。
+- 拒绝将候选试验并行度设置为零。
+- 在用户解决所有冲突前，不创建文件，也不触发任务。
+
+## 场景 3：完整的内建 BOP 请求
+
+提示词：
+
+```text
+$ci-param-solver 使用现有
+configs/solver_specs/l2_vbop_bop_large_nsga2_score_search.py:
+L2VbopBopLargeNsga2ScoreSearch。
+configuration=kmhv3.py；benchmark_type=gcc15-spec06-0.3c；
+specific_benchmarks=mcf,omnetpp,xalancbmk；solver_kind=nsga2；
+max_trials=4000；max_parallel_trials=16；max_parallel_workloads=10；
+distributed_servers=default；distributed_jobs_per_server=0；
+branch=solver-bop-demo。只校验并展示 CI 命令，不实际触发。
+```
+
+预期行为：
+
+- 复用现有 spec，不创建重复文件。
+- 报告八个可调参数和七个目标函数。
+- 确认参数赋值空间包含 705024 个点，此外还有一个配置默认值基线。
+- 确认 `score_max = round_max * score_ratio // 100`。
+- 在本地环境允许的范围内执行解析和预检。
+- 打印完整的 `gh workflow run manual-solve.yml ...` 命令，但不触发任务。
+
+## 场景 4：完整的自定义工作负载 BOP 请求
+
+提示词：
+
+```text
+$ci-param-solver 使用现有
+configs/solver_specs/l2_vbop_bop_large_nsga2_bin_search.py:
+L2VbopBopLargeNsga2BinSearch。
+configuration=kmhv3.py；benchmark_type=custom_bin；
+custom_bin=/tmp/example.zstd；solver_kind=nsga2；
+max_parallel_trials=32；max_parallel_workloads=1；
+branch=solver-bop-custom-demo。只校验，不触发 CI。
+```
+
+预期行为：
+
+- 接受自定义工作负载模式下只包含统计项的目标函数。
+- 要求显式提供非空的自定义工作负载路径。
+- 保持 `specific_benchmarks` 为空。
+- 报告八个可调参数和六个目标函数。
+
+## 场景 5：正确描述 CDP 预取器参数求解
+
+这个案例用于测试用户是否能一次性提供足够完整、且符合当前 gem5 配置结构的需求。
+`kmhv3.py` 默认使用对齐 L2，CDP 对象的目标路径从
+`system.l2_wrappers[0].prefetcher.cdp` 开始。下面的搜索范围是一个可运行的示例，实际
+实验可以根据已有基线和敏感性分析调整。
+
+提示词：
+
+```text
+$ci-param-solver 请生成一个 CDP 预取器参数求解 spec，只生成并预检，不触发 CI。
+
+一、配置和运行模式
+- configuration 使用 configs/example/kmhv3.py。
+- 使用默认对齐 L2：不加 --classic-l2，不加 --no-pf，保持
+  l2_wrapper_hwp_type=L2CompositeWithWorkerPrefetcher。
+- CDP 必须保持启用，固定
+  system.l2_wrappers[0].prefetcher.enable_cdp=True。
+
+二、要搜索的参数
+所有直接参数都位于 system.l2_wrappers[0].prefetcher.cdp 下：
+- vpn_reset_period：Range(32, 512, step=32)，整数，表示 VPN 表重置周期。
+- throttle_aggressiveness：Range(0.5, 4.0, step=0.25)，浮点数。
+- filter_entry_granularity：Choice([64, 128, 256, 512, 1024, 2048, 4096, 8192])，
+  单位是字节，只选择不小于 64 的 2 的幂。
+- filter_entry_region_blks：Choice([16, 32, 64, 128])，必须保持偶数。
+- filter_table_assoc：Choice([64, 128, 256])。
+- filter_table_sets：Choice([1, 2, 4, 8])，这是一个抽象搜索变量，不是 gem5 直接参数。
+
+三、表结构约束
+- VPN 表结构固定为 vpn_sub_entries=4、vpn_assoc=4、vpn_entries=16，
+  只搜索 vpn_reset_period。
+- filter_table_entries 是 MemorySize 参数，不直接声明为 TunableParam.Unsigned；
+  在 apply_trial() 中根据 filter_table_assoc * filter_table_sets 推导，保证总表项数
+  能被组相联度整除，并写入
+  system.l2_wrappers[0].prefetcher.cdp.filter_table_entries。
+- filter_table_indexing_policy 和 filter_table_replacement_policy 固定使用配置默认值，
+  不把策略对象作为本次搜索变量。
+- filter_entry_granularity 和 filter_entry_region_blks 的约束必须在 spec 中保留，
+  不能让求解器生成违反 CDP 构造函数断言的候选。
+
+四、目标函数
+- 最大化 system.cpu.ipc。
+- 最大化 system.l2_wrappers.prefetcher.accuracy。
+- 最大化 system.l2_wrappers.prefetcher.coverage。
+- 将以下 CDP 计数器作为结果检查项，只有确认它们在 stats.txt 中的完整名称后，
+  才决定是否加入 objectives：
+  system.l2_wrappers.prefetcher.cdp.cdpStats.pfHitCDP、
+  system.l2_wrappers.prefetcher.cdp.cdpStats.actualFilted、
+  system.l2_wrappers.prefetcher.cdp.cdpStats.inserted。
+
+五、工作负载和停止条件
+- benchmark_type=gcc15-spec06-0.3c。
+- specific_benchmarks=mcf,omnetpp,xalancbmk。
+- 使用 nsga2；最多 1000 个 trial，连续 20 个 trial 无提升时停止，最长 20 小时。
+
+六、CI 预览参数
+- max_parallel_trials=8，max_parallel_workloads=10。
+- distributed_servers=default，distributed_jobs_per_server=0。
+- branch=cdp-solver-demo。
+- extra_args 留空；只做预检，不触发 CI。
+```
+
+预期行为：
+
+- 识别这是 `kmhv3.py` 对齐 L2 下的 CDP，而不是 `system.l2_caches[*].prefetcher` 路径。
+- 将 `filter_table_sets` 作为抽象变量，在 `apply_trial()` 中推导
+  `filter_table_entries`，而不是把两个相关参数独立搜索。
+- 注意 `filter_table_entries` 的真实类型是 `MemorySize`，绑定后应检查 `binding.json` 中的
+  `resolved_kind`，不能强行声明为 `TunableParam.Unsigned`。
+- 检查 `filter_entry_granularity >= 64` 且为 2 的幂、`filter_entry_region_blks` 为偶数，
+  并拒绝违反这些约束的候选。
+- 对 `accuracy`、`coverage` 和 CDP 计数器先检查实际 `stats.txt` 名称；不能只根据 C++
+  成员名猜测统计路径。
+- 生成 spec 后执行 `py_compile`、`parse_problem` 和可用范围内的 dry-run，并展示最终 CI
+  参数；由于提示词明确“不触发”，不得调用 `gh workflow run`。
+
+## 离线自动检查
+
+```bash
+python3 .codex/skills/ci-param-solver/scripts/self_test.py
+python3 /nfs/home/lixin/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  .codex/skills/ci-param-solver
+```

--- a/.codex/skills/ci-param-solver/scripts/self_test.py
+++ b/.codex/skills/ci-param-solver/scripts/self_test.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Offline semantic tests for the ci-param-solver dispatch helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+HELPER = Path(__file__).with_name("solver_ci_dispatch.py")
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+BOP_SCORE = (
+    "configs/solver_specs/l2_vbop_bop_large_nsga2_score_search.py:"
+    "L2VbopBopLargeNsga2ScoreSearch"
+)
+BOP_BIN = (
+    "configs/solver_specs/l2_vbop_bop_large_nsga2_bin_search.py:"
+    "L2VbopBopLargeNsga2BinSearch"
+)
+
+
+def run_case(name: str, arguments: list[str], expected: int, needle: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "validate", *arguments],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != expected or needle not in output:
+        raise AssertionError(
+            f"{name}: expected exit={expected} and {needle!r}; "
+            f"got exit={result.returncode}\n{output}"
+        )
+    print(f"PASS {name}: exit={result.returncode}, matched={needle!r}")
+
+
+def check_bop_constraint() -> None:
+    from configs.solver_specs.l2_vbop_bop_large_nsga2_score_search import (
+        L2VbopBopLargeNsga2ScoreSearch,
+    )
+
+    class Param:
+        def convert(self, value):
+            return value
+
+    class BopLarge:
+        def __init__(self):
+            self._params = {"score_max": Param()}
+            self.score_max = None
+
+    root = SimpleNamespace(
+        system=SimpleNamespace(
+            l2_wrappers=[
+                SimpleNamespace(prefetcher=SimpleNamespace(bop_large=BopLarge()))
+            ]
+        )
+    )
+    trial = SimpleNamespace(round_max=50, score_ratio=70)
+    L2VbopBopLargeNsga2ScoreSearch.apply_trial(root, trial)
+    actual = root.system.l2_wrappers[0].prefetcher.bop_large.score_max
+    if actual != 35:
+        raise AssertionError(f"BOP score_max derivation returned {actual}, expected 35")
+    print("PASS bop_apply_trial_constraint: 50 * 70 // 100 = 35")
+
+
+def main() -> int:
+    common = [
+        "--branch",
+        "solver-bop-demo",
+        "--configuration",
+        "kmhv3.py",
+    ]
+
+    run_case(
+        "complete_builtin_bop",
+        [
+            *common,
+            "--problem-ref",
+            BOP_SCORE,
+            "--benchmark-type",
+            "gcc15-spec06-0.3c",
+            "--specific-benchmarks",
+            "mcf,omnetpp,xalancbmk",
+            "--solver-kind",
+            "nsga2",
+            "--max-parallel-trials",
+            "16",
+            "--max-parallel-workloads",
+            "10",
+            "--max-trials",
+            "4000",
+        ],
+        0,
+        "7 objective(s)",
+    )
+    run_case(
+        "complete_custom_bop",
+        [
+            *common,
+            "--problem-ref",
+            BOP_BIN,
+            "--benchmark-type",
+            "custom_bin",
+            "--custom-bin",
+            "/tmp/example.zstd",
+            "--solver-kind",
+            "nsga2",
+            "--max-parallel-trials",
+            "32",
+            "--max-parallel-workloads",
+            "1",
+        ],
+        0,
+        "benchmark_type=custom_bin",
+    )
+    run_case(
+        "reject_custom_score",
+        [
+            *common,
+            "--problem-ref",
+            BOP_SCORE,
+            "--benchmark-type",
+            "custom_bin",
+            "--custom-bin",
+            "/tmp/example.zstd",
+            "--solver-kind",
+            "nsga2",
+        ],
+        2,
+        "score_txt objective does not support benchmark_type=custom_bin",
+    )
+    run_case(
+        "reject_multiobjective_bayes",
+        [
+            *common,
+            "--problem-ref",
+            BOP_SCORE,
+            "--benchmark-type",
+            "gcc15-spec06-0.3c",
+            "--solver-kind",
+            "bayes",
+        ],
+        2,
+        "supports only single-objective specs",
+    )
+    run_case(
+        "reject_custom_filter",
+        [
+            *common,
+            "--problem-ref",
+            BOP_BIN,
+            "--benchmark-type",
+            "custom_bin",
+            "--custom-bin",
+            "/tmp/example.zstd",
+            "--specific-benchmarks",
+            "mcf",
+        ],
+        2,
+        "specific_benchmarks must be empty",
+    )
+    run_case(
+        "reject_zero_parallelism",
+        [
+            *common,
+            "--problem-ref",
+            BOP_SCORE,
+            "--benchmark-type",
+            "gcc15-spec06-0.3c",
+            "--max-parallel-trials",
+            "0",
+        ],
+        2,
+        "max_parallel_trials must be > 0",
+    )
+    run_case(
+        "reject_smt",
+        [
+            *common,
+            "--problem-ref",
+            BOP_SCORE,
+            "--benchmark-type",
+            "gcc12-spec06-smt-0.3c",
+        ],
+        2,
+        "SMT benchmark_type",
+    )
+    check_bop_constraint()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/ci-param-solver/scripts/solver_ci_dispatch.py
+++ b/.codex/skills/ci-param-solver/scripts/solver_ci_dispatch.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Validate and dispatch the GEM5 manual solver workflow.
+
+The skill is responsible for deciding whether a user's request is complete.
+This helper handles only deterministic input validation, command construction,
+and the post-dispatch run lookup.  It never edits a solver spec.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import time
+
+
+CONFIGURATIONS = {"kmhv2.py", "kmhv3.py", "idealkmhv3.py"}
+SOLVER_KINDS = {"auto", "grid", "random", "bayes", "ga", "nsga2"}
+SMT_PREFIX = "gcc12-spec06-smt-"
+
+
+def _nonempty(value: str, field: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        raise ValueError(f"{field} must not be empty")
+    return value
+
+
+def _positive(value: str, field: str) -> str:
+    value = _nonempty(value, field)
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an integer, got {value!r}") from exc
+    if number <= 0:
+        raise ValueError(f"{field} must be > 0, got {number}")
+    return str(number)
+
+
+def _nonnegative(value: str, field: str) -> str:
+    value = _nonempty(value, field)
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an integer, got {value!r}") from exc
+    if number < 0:
+        raise ValueError(f"{field} must be >= 0, got {number}")
+    return str(number)
+
+
+def _validate_local_spec(args: argparse.Namespace, values: dict[str, str]) -> None:
+    """Reuse the repository parser for semantic checks before dispatch.
+
+    The target ref is the source of truth for CI, but the skill requires the
+    spec to be locally parseable before it dispatches. This catches conflicts
+    such as `custom_bin + score_txt` and multi-objective `bayes`/`ga` before
+    `gh workflow run` is invoked.
+    """
+
+    repo_root = Path(__file__).resolve().parents[4]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    try:
+        from util.solver.parser.load_spec import parse_problem
+        from util.solver.run_solver import apply_runtime_overrides
+    except Exception as exc:  # pragma: no cover - repository import failure
+        print(f"warning: local solver parser is unavailable: {exc}", file=sys.stderr)
+        return
+
+    runtime_args = argparse.Namespace(
+        max_trials=int(values["max_trials"]) if values["max_trials"] else None,
+        config_path=values["configuration"],
+        benchmark_type=values["benchmark_type"],
+        custom_bin=values["custom_bin"],
+        specific_benchmarks=values["specific_benchmarks"],
+        extra_args=values["extra_args"],
+    )
+    try:
+        problem = parse_problem(values["problem_ref"])
+        problem = apply_runtime_overrides(problem, runtime_args)
+    except Exception as exc:
+        raise ValueError(f"problem_ref/spec semantic validation failed: {exc}") from exc
+
+    if values["solver_kind"] in {"bayes", "ga"} and problem.is_multi_objective():
+        raise ValueError(
+            f"solver_kind={values['solver_kind']} supports only single-objective specs; "
+            "use nsga2 for this multi-objective problem"
+        )
+
+    print(
+        "local spec check: "
+        f"{problem.name}, {len(problem.parameters)} parameter(s), "
+        f"{len(problem.objective_list())} objective(s), "
+        f"benchmark_type={problem.benchmark_type}"
+    )
+
+
+def validate(args: argparse.Namespace) -> dict[str, str]:
+    """Validate workflow semantics and return normalized string inputs."""
+
+    normalized = {
+        "note": (args.note or "Manual Solver Run").strip(),
+        "problem_ref": _nonempty(args.problem_ref, "problem_ref"),
+        "configuration": _nonempty(args.configuration, "configuration"),
+        "benchmark_type": _nonempty(args.benchmark_type, "benchmark_type"),
+        "max_parallel_trials": _positive(
+            args.max_parallel_trials, "max_parallel_trials"
+        ),
+        "max_parallel_workloads": _positive(
+            args.max_parallel_workloads, "max_parallel_workloads"
+        ),
+        "distributed_servers": (args.distributed_servers or "").strip(),
+        "distributed_jobs_per_server": _nonnegative(
+            args.distributed_jobs_per_server, "distributed_jobs_per_server"
+        ),
+        "solver_kind": _nonempty(args.solver_kind, "solver_kind"),
+        "specific_benchmarks": (args.specific_benchmarks or "").strip(),
+        "custom_bin": (args.custom_bin or "").strip(),
+        "extra_args": (args.extra_args or "").strip(),
+        "max_trials": (args.max_trials or "").strip(),
+        "branch": _nonempty(args.branch, "branch"),
+    }
+
+    if normalized["configuration"] not in CONFIGURATIONS:
+        allowed = ", ".join(sorted(CONFIGURATIONS))
+        raise ValueError(
+            f"unsupported configuration {normalized['configuration']!r}; "
+            f"choose one of: {allowed}"
+        )
+    if normalized["solver_kind"] not in SOLVER_KINDS:
+        raise ValueError(
+            f"unsupported solver_kind {normalized['solver_kind']!r}; "
+            f"choose one of: {', '.join(sorted(SOLVER_KINDS))}"
+        )
+    if normalized["benchmark_type"].startswith(SMT_PREFIX):
+        raise ValueError(
+            f"SMT benchmark_type {normalized['benchmark_type']!r} is not "
+            "supported by the solver workflow"
+        )
+
+    is_custom = normalized["benchmark_type"] == "custom_bin"
+    if is_custom and not normalized["custom_bin"]:
+        raise ValueError("custom_bin is required when benchmark_type=custom_bin")
+    if is_custom and normalized["specific_benchmarks"]:
+        raise ValueError(
+            "specific_benchmarks must be empty when benchmark_type=custom_bin"
+        )
+    if not is_custom and normalized["custom_bin"]:
+        print(
+            "warning: custom_bin is ignored for a built-in benchmark_type",
+            file=sys.stderr,
+        )
+        normalized["custom_bin"] = ""
+    if normalized["max_trials"]:
+        normalized["max_trials"] = _positive(
+            normalized["max_trials"], "max_trials"
+        )
+    _validate_local_spec(args, normalized)
+    return normalized
+
+
+def workflow_command(args: argparse.Namespace, values: dict[str, str]) -> list[str]:
+    ref = (args.ref or values["branch"]).strip()
+    command = [
+        "gh",
+        "workflow",
+        "run",
+        args.workflow,
+        "--repo",
+        args.repo,
+        "--ref",
+        ref,
+    ]
+    for key in (
+        "note",
+        "problem_ref",
+        "configuration",
+        "benchmark_type",
+        "max_parallel_trials",
+        "max_parallel_workloads",
+        "distributed_servers",
+        "distributed_jobs_per_server",
+        "solver_kind",
+        "specific_benchmarks",
+        "custom_bin",
+        "extra_args",
+        "max_trials",
+        "branch",
+    ):
+        command.extend(["-f", f"{key}={values[key]}"])
+    return command
+
+
+def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(command, check=check, text=True, capture_output=True)
+
+
+def check_gh_and_workflow(args: argparse.Namespace) -> None:
+    try:
+        _run(["gh", "--version"])
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError("gh is not installed or cannot be executed") from exc
+
+    auth = _run(["gh", "auth", "status"], check=False)
+    if auth.returncode != 0:
+        detail = (auth.stderr or auth.stdout).strip()
+        raise RuntimeError(
+            "gh authentication is not ready; run `gh auth login` first"
+            + (f": {detail}" if detail else "")
+        )
+
+    ref = (args.ref or args.branch).strip()
+    workflow = _run(
+        [
+            "gh",
+            "workflow",
+            "view",
+            args.workflow,
+            "--repo",
+            args.repo,
+            "--ref",
+            ref,
+            "--yaml",
+        ],
+        check=False,
+    )
+    if workflow.returncode != 0:
+        detail = (workflow.stderr or workflow.stdout).strip()
+        raise RuntimeError(
+            f"workflow {args.workflow!r} is not registered or not visible in "
+            f"{args.repo}; local workflow files are not sufficient"
+            + (f": {detail}" if detail else "")
+        )
+
+
+def _run_list(args: argparse.Namespace) -> list[dict]:
+    result = _run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            args.workflow,
+            "--repo",
+            args.repo,
+            "--event",
+            "workflow_dispatch",
+            "--limit",
+            "10",
+            "--json",
+            "databaseId,status,conclusion,url,createdAt,headBranch,headSha,displayTitle",
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        print(f"run lookup failed: {detail}", file=sys.stderr)
+        return []
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        print("run lookup returned non-JSON output:", result.stdout, file=sys.stderr)
+        return []
+    return payload if isinstance(payload, list) else []
+
+
+def find_recent_run(args: argparse.Namespace, started: datetime) -> dict | None:
+    candidates = _run_list(args)
+    lower_bound = started - timedelta(seconds=120)
+    ref = (args.ref or args.branch).strip()
+    for run in candidates:
+        created_raw = run.get("createdAt", "")
+        try:
+            created = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            continue
+        if created < lower_bound:
+            continue
+        if ref and run.get("headBranch") not in {None, ref}:
+            # A SHA ref may not have a matching headBranch; keep those records.
+            if not all(character in "0123456789abcdefABCDEF" for character in ref):
+                continue
+        return run
+    return None
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", default="OpenXiangShan/GEM5")
+    parser.add_argument("--workflow", default="manual-solve.yml")
+    parser.add_argument("--ref", default="", help="workflow ref; defaults to --branch")
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--problem-ref", required=True)
+    parser.add_argument("--configuration", required=True)
+    parser.add_argument("--benchmark-type", required=True)
+    parser.add_argument("--max-parallel-trials", default="4")
+    parser.add_argument("--max-parallel-workloads", default="4")
+    parser.add_argument("--distributed-servers", default="")
+    parser.add_argument("--distributed-jobs-per-server", default="0")
+    parser.add_argument("--solver-kind", default="auto")
+    parser.add_argument("--specific-benchmarks", default="")
+    parser.add_argument("--custom-bin", default="")
+    parser.add_argument("--extra-args", default="")
+    parser.add_argument("--max-trials", default="")
+    parser.add_argument("--note", default="Manual Solver Run")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate")
+    add_common_arguments(validate_parser)
+
+    dispatch_parser = subparsers.add_parser("dispatch")
+    add_common_arguments(dispatch_parser)
+    dispatch_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the gh command without checking auth or dispatching",
+    )
+    dispatch_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="authorize the actual workflow dispatch",
+    )
+    dispatch_parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=8,
+        help="seconds to wait before looking up the newly created run",
+    )
+
+    args = parser.parse_args()
+    try:
+        values = validate(args)
+        print(json.dumps(values, ensure_ascii=False, indent=2))
+        if args.command == "validate":
+            return 0
+
+        command = workflow_command(args, values)
+        print("command:")
+        print(shlex.join(command))
+        if args.dry_run:
+            return 0
+        if not args.yes:
+            raise RuntimeError(
+                "refusing to dispatch without --yes; show the command first and "
+                "run it again after explicit user authorization"
+            )
+        check_gh_and_workflow(args)
+        started = datetime.now(timezone.utc)
+        result = subprocess.run(command, text=True, capture_output=True)
+        if result.stdout:
+            print(result.stdout.rstrip())
+        if result.returncode != 0:
+            if result.stderr:
+                print(result.stderr.rstrip(), file=sys.stderr)
+            return result.returncode
+        if args.wait_seconds > 0:
+            time.sleep(args.wait_seconds)
+        run = find_recent_run(args, started)
+        if run is None:
+            print("dispatch completed, but no recent workflow_dispatch run was found")
+            return 0
+        print("run:")
+        print(json.dumps(run, ensure_ascii=False, indent=2))
+        return 0
+    except (RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the ci-param-solver skill and its workflow guidance
- add offline semantic validation and manual-solve dispatch helper scripts
- document solver rules and acceptance scenarios

## Validation
- python3 .codex/skills/ci-param-solver/scripts/self_test.py
- skill-creator quick_validate.py .codex/skills/ci-param-solver
- python3 -m py_compile (with PYTHONPYCACHEPREFIX=/tmp/ci-param-solver-pycache)

Only .codex/skills/ci-param-solver is included in this commit; unrelated worktree files remain untouched.