### PR TITLE
mem-cache: Add dynamic prefetch control

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,6 +60,19 @@
 - `rvv` 标签仍由独立的 RVV on-demand workflow 触发
 - Label 触发只允许同仓库 PR；外部 fork PR 需要先由维护者同步到受信任分支，再通过 label 或 `manual-perf.yml` 触发
 - 需要手动选择配置、benchmark 或 branch/SHA 时，请使用 `manual-perf.yml`
+- 需要动态预取 A/B 时，请使用 `manual-perf.yml` 的 `pf_control_profile` 输入；不要在 `extra_args` 中手写 `--pf-control-profile`
+
+### Dynamic Prefetch Profile
+
+`manual-perf.yml` 和性能测试模板支持 `pf_control_profile`：
+
+| Profile | 语义 |
+| --- | --- |
+| `off` | 默认 base 行为，关闭内置动态预取控制 |
+| `adaptive` | 启用 CI 内置 adaptive profile，窗口为 8000 cycles，并打开 L1D/L2/L2Wrapper PFBad 表 |
+| `default` | 不套内置 profile，仅使用代码中的 `PF_CONTROL_CONFIG` 和可选的 `GEM5_PF_CONTROL_CONFIG` 覆盖 |
+
+动态预取 profile 会被模板统一追加到 gem5 config 参数。这样可以避免 manual 输入、weekly 配置和分布式 runner 之间出现参数口径不一致。
 
 ### 性能结果
 
@@ -99,7 +112,7 @@
 
 #### 4. 其他测试
 - `gem5-vector.yml` - RVV 扩展测试
-- `gem5-ideal-btb-perf-weekly.yml` - 定时任务（每周四）
+- `gem5-ideal-btb-perf-weekly.yml` - 定时任务（每周四），包含 gcc15/spec17 常规回归、gcc12 `idealkmhv3.py` base/adaptive A/B，以及 SMT SPEC06 int-only dynamic prefetch 回归
 
 ---
 
@@ -205,6 +218,9 @@ A: 性能测试会 checkout 并执行 PR 代码。为了避免 `pull_request_tar
 
 **Q: 新增 benchmark 类型需要修改哪些文件？**
 A: 只需修改 `gem5-perf-template.yml`
+
+**Q: 如何跑动态预取性能测试？**
+A: 使用 `manual-perf.yml`，把 `pf_control_profile` 设为 `adaptive`。base 对比使用默认的 `off`。模板会拒绝通过 `extra_args` 重复传 `--pf-control-profile`，防止一个 run 里出现两个互相冲突的 profile。
 
 ---
 

--- a/.github/workflows/gem5-ideal-btb-perf-weekly.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-weekly.yml
@@ -13,31 +13,63 @@ jobs:
     with:
       config_path: configs/example/kmhv3.py
       benchmark_type: "gcc15-spec06-1.0c"
+      pf_control_profile: "off"
 
   align_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/kmhv3.py
       benchmark_type: "spec17-1.0c"
+      pf_control_profile: "off"
 
   perf_test_spec06:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "gcc15-spec06-1.0c"
+      pf_control_profile: "off"
 
   perf_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "spec17-1.0c"
+      pf_control_profile: "off"
 
   smt_test_spec06:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/smt_idealkmhv3.py
       benchmark_type: "gcc12-spec06-smt-1.0c"
+      pf_control_profile: "off"
       distributed_servers: "default"
       distributed_jobs_per_server: 32
       check_result: false
       timeout_minutes: 720
+
+  smt_dynpf_int_test_spec06:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      config_path: configs/example/smt_idealkmhv3.py
+      benchmark_type: "gcc12-spec06-smt-int-1.0c"
+      pf_control_profile: "adaptive"
+      distributed_servers: "default"
+      distributed_jobs_per_server: 32
+      check_result: false
+      timeout_minutes: 720
+
+  perf_test_spec06_gcc12_base:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      config_path: configs/example/idealkmhv3.py
+      benchmark_type: "gcc12-spec06-1.0c"
+      pf_control_profile: "off"
+      extra_args: "--dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"
+
+  perf_test_spec06_gcc12_dynpf:
+    uses: ./.github/workflows/gem5-perf-template.yml
+    with:
+      config_path: configs/example/idealkmhv3.py
+      benchmark_type: "gcc12-spec06-1.0c"
+      pf_control_profile: "adaptive"
+      extra_args: "--dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -12,10 +12,15 @@ on:
         type: string
         default: ""
         description: "Extra arguments for gem5 (e.g., --disable-mgsc). Only works with .py config files."
+      pf_control_profile:
+        required: false
+        type: string
+        default: "off"
+        description: "Prefetch control profile: off, adaptive, or default."
       benchmark_type:
         required: true
         type: string
-        description: "Benchmark type: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+        description: "Benchmark type: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-smt-int-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
       specific_benchmarks:
         required: false
         type: string
@@ -75,6 +80,8 @@ jobs:
       
       - name: Set benchmark configuration
         id: config
+        env:
+          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
         run: |
           case "${{ inputs.benchmark_type }}" in
               "gcc12-spec06-0.3c")
@@ -100,6 +107,14 @@ jobs:
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
               echo "artifact_name=performance-score-gcc12-spec06-smt-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage dual-context SMT spec06 checkpoints" >> $GITHUB_OUTPUT
+              ;;
+            "gcc12-spec06-smt-int-1.0c")
+              echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/spec_1c_int.lst" >> $GITHUB_OUTPUT
+              echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
+              echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
+              echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/spec06_1c_int.json" >> $GITHUB_OUTPUT
+              echo "artifact_name=performance-score-gcc12-spec06-smt-int-1.0c" >> $GITHUB_OUTPUT
+              echo "comment=run 100% coverage dual-context SMT SPEC06 int checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-0.8c")
               echo "checkpoint_list=/nfs/home/share/gem5_ci/spec06_cpts/spec_0.8c_int.lst" >> $GITHUB_OUTPUT
@@ -158,7 +173,23 @@ jobs:
               echo "comment=run 80% coverage spec06 int rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
             *)
-              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+              echo "Error: Invalid benchmark_type '${{ inputs.benchmark_type }}'. Must be one of: gcc12-spec06-0.3c, gcc12-spec06-smt-0.3c, gcc12-spec06-smt-1.0c, gcc12-spec06-smt-int-1.0c, gcc12-spec06-0.8c, gcc12-spec06-1.0c, gcc15-spec06-0.3c, gcc15-spec06-1.0c, spec17-1.0c, spec06-rvv-1.0c or spec06int-rvv-0.8c"
+              exit 1
+              ;;
+          esac
+
+          case "$PF_CONTROL_PROFILE_INPUT" in
+            ""|"off")
+              echo "pf_artifact_suffix=" >> $GITHUB_OUTPUT
+              ;;
+            "adaptive")
+              echo "pf_artifact_suffix=-pf-adaptive" >> $GITHUB_OUTPUT
+              ;;
+            "default")
+              echo "pf_artifact_suffix=-pf-default" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Error: Invalid pf_control_profile '$PF_CONTROL_PROFILE_INPUT'. Must be one of: off, adaptive, default"
               exit 1
               ;;
           esac
@@ -197,6 +228,7 @@ jobs:
           BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_ARGS_INPUT: ${{ inputs.extra_args }}
+          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
           DISTRIBUTED_SERVERS_RAW: ${{ inputs.distributed_servers }}
           DISTRIBUTED_JOBS_PER_SERVER_RAW: ${{ inputs.distributed_jobs_per_server }}
         run: |
@@ -208,6 +240,11 @@ jobs:
           CONFIG_NAME=$(basename "$CONFIG_PATH_INPUT" .py)
           CONFIG_NAME=$(printf '%s' "$CONFIG_NAME" | tr -c 'A-Za-z0-9._-' '_')
           CONFIG_NAME=${CONFIG_NAME:-config}
+          PF_CONTROL_PROFILE="${PF_CONTROL_PROFILE_INPUT:-off}"
+          if [ "$PF_CONTROL_PROFILE" != "off" ]; then
+            PROFILE_NAME=$(printf '%s' "$PF_CONTROL_PROFILE" | tr -c 'A-Za-z0-9._-' '_')
+            CONFIG_NAME="${CONFIG_NAME}_pf_${PROFILE_NAME}"
+          fi
           TARGET_DIR="${BENCHMARK_DIR}/${TIMESTAMP}_${COMMIT_SHORT}_${CONFIG_NAME}_run${RUN_NUMBER}"
           DEFAULT_DISTRIBUTED_SERVERS="node020-node034,node036-node039"
           DISTRIBUTED_DISPATCH_HOST="ci-runner@172.28.9.101"
@@ -243,6 +280,7 @@ jobs:
           echo "run_number: $RUN_NUMBER" >> "$TARGET_DIR/metadata.txt"
           echo "benchmark_type: $BENCHMARK_TYPE_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "specific_benchmarks: $SPECIFIC_BENCHMARKS_INPUT" >> "$TARGET_DIR/metadata.txt"
+          echo "pf_control_profile: $PF_CONTROL_PROFILE" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers_input: $DISTRIBUTED_SERVERS_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers: $DISTRIBUTED_SERVERS" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_server_domain: " >> "$TARGET_DIR/metadata.txt"
@@ -314,6 +352,7 @@ jobs:
           BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_GEM5_ARGS_RAW: ${{ inputs.extra_args }}
+          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
           CHECKPOINT_LIST: ${{ steps.checkpoints.outputs.checkpoint_list }}
           CHECKPOINT_ROOT_NODE: ${{ steps.config.outputs.checkpoint_root_node }}
           DISTRIBUTED_SERVERS: ${{ steps.archive.outputs.distributed_servers }}
@@ -343,7 +382,25 @@ jobs:
 
           extra_args="$EXTRA_GEM5_ARGS_RAW"
           extra_args="$(echo "$extra_args" | xargs)"
+          extra_args="${extra_args//\$\{GEM5_HOME\}/$GEM5_HOME}"
+          extra_args="${extra_args//\$GEM5_HOME/$GEM5_HOME}"
+          pf_control_profile="${PF_CONTROL_PROFILE_INPUT:-off}"
+
+          case "$pf_control_profile" in
+            "off"|"adaptive"|"default")
+              ;;
+            *)
+              echo "Error: Invalid pf_control_profile '$pf_control_profile'. Must be one of: off, adaptive, default"
+              exit 1
+              ;;
+          esac
+          if [[ "$extra_args" == *"--pf-control-profile"* ]]; then
+            echo "Error: Do not pass --pf-control-profile through extra_args; use pf_control_profile workflow input instead."
+            exit 1
+          fi
+          extra_args="$(printf '%s --pf-control-profile=%s' "$extra_args" "$pf_control_profile" | xargs)"
           echo "Resolved extra gem5 args: $extra_args"
+          printf 'resolved_extra_args: %s\n' "$extra_args" >> "$PERF_ARCHIVE_DIR/metadata.txt"
 
           distributed_servers="$DISTRIBUTED_SERVERS"
           if [ -n "$distributed_servers" ]; then
@@ -461,7 +518,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.config.outputs.artifact_name }}
+          name: ${{ steps.config.outputs.artifact_name }}${{ steps.config.outputs.pf_artifact_suffix }}
           path: score.txt
           retention-days: 30
       

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}{6}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.extra_args && format(' - {0}', github.event.inputs.extra_args) || '') }}
+run-name: ${{ format('{0} - {1} - {2}{3} - pf:{4} - {5} - {6}{7}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.pf_control_profile || 'off', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.extra_args && format(' - {0}', github.event.inputs.extra_args) || '') }}
 
 on:
   workflow_dispatch:
@@ -28,6 +28,7 @@ on:
           - gcc12-spec06-0.3c
           - gcc12-spec06-smt-0.3c
           - gcc12-spec06-smt-1.0c
+          - gcc12-spec06-smt-int-1.0c
           - gcc12-spec06-0.8c
           - gcc12-spec06-1.0c
           - gcc15-spec06-0.3c
@@ -48,6 +49,15 @@ on:
         options:
           - base
           - simple
+      pf_control_profile:
+        description: 'Prefetch control profile'
+        required: false
+        type: choice
+        default: 'off'
+        options:
+          - off
+          - adaptive
+          - default
       extra_args:
         description: 'Extra gem5 args appended to config runs, e.g. --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini'
         required: false
@@ -98,6 +108,7 @@ jobs:
       benchmark_type: ${{ github.event.inputs.benchmark_type }}
       specific_benchmarks: ${{ github.event.inputs.specific_benchmarks }}
       vector_type: ${{ github.event.inputs.vector_type }}
+      pf_control_profile: ${{ github.event.inputs.pf_control_profile }}
       extra_args: ${{ github.event.inputs.extra_args }}
       distributed_servers: ${{ github.event.inputs.distributed_servers }}
       distributed_jobs_per_server: ${{ fromJSON(github.event.inputs.distributed_jobs_per_server || '32') }}

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -315,6 +315,14 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         help="""
                         Force all hardware prefetchers to disable their
                         optional prefetch buffer (QueuedPrefetcher.use_pf_buffer).""")
+    parser.add_argument("--pf-control-profile", action="store",
+                        default="off",
+                        choices=("off", "adaptive", "default"),
+                        help="""
+                        Prefetch admission-control profile. 'off' disables
+                        built-in control/adaptive defaults, 'adaptive' enables
+                        the CI adaptive profile, and 'default' uses only
+                        PF_CONTROL_CONFIG plus GEM5_PF_CONTROL_CONFIG.""")
 
     parser.add_argument("--cpu-clock", action="store", type=str,
                         default='3GHz',

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -69,6 +69,7 @@ PF_CONTROL_CONFIG = {
         "dpf_min_samples": 1,
         "dpf_deadband": 0,
         "improve_margin_bps": 0,
+        "history_fallback": True,
         "best_topk": 1,
         "table_entries": 32,
         "pfbad_entries": {
@@ -351,6 +352,8 @@ def _apply_pf_adaptive(prefetcher, cache_level, config):
         adaptive, 'dpf_deadband', 0, "adaptive.dpf_deadband")
     prefetcher.pf_adaptive_improve_margin_bps = _bps_config(
         adaptive, 'improve_margin_bps', 0, "adaptive.improve_margin_bps")
+    prefetcher.pf_adaptive_history_fallback = bool(
+        adaptive.get('history_fallback', True))
     prefetcher.pf_adaptive_best_topk = _positive_int_config(
         adaptive, 'best_topk', 1, "adaptive.best_topk")
     prefetcher.pf_adaptive_table_entries = _nonnegative_int_config(

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -46,6 +46,7 @@ PF_SOURCE_BY_NAME.update({
 })
 
 PF_CONTROL_CONFIG_ENV = "GEM5_PF_CONTROL_CONFIG"
+PF_CONTROL_PROFILE_NAMES = ("off", "adaptive", "default")
 
 # Central Python-only configuration for prefetch admission control.
 # Batch scripts may point GEM5_PF_CONTROL_CONFIG at a Python file defining
@@ -83,6 +84,34 @@ PF_CONTROL_CONFIG = {
 }
 
 _LOADED_PF_CONTROL_CONFIG = None
+_PF_CONTROL_PROFILE = "off"
+
+PF_CONTROL_PROFILE_CONFIGS = {
+    "off": {
+        "control": {
+            "enabled": False,
+        },
+        "adaptive": {
+            "enabled": False,
+        },
+    },
+    "adaptive": {
+        "control": {
+            "enabled": True,
+            "window": 8000,
+            "admit_pct": 100,
+        },
+        "adaptive": {
+            "enabled": True,
+            "pfbad_entries": {
+                "l1d": 128,
+                "l2": 512,
+                "l2_wrapper": 512,
+            },
+        },
+    },
+    "default": {},
+}
 
 
 def _get_hwp(hwp_option):
@@ -100,12 +129,32 @@ def _deep_update_dict(base, override):
             base[key] = value
 
 
+def set_pf_control_profile(profile):
+    global _PF_CONTROL_PROFILE
+    global _LOADED_PF_CONTROL_CONFIG
+
+    profile = str(profile).strip().lower()
+    if profile not in PF_CONTROL_PROFILE_NAMES:
+        valid = ", ".join(PF_CONTROL_PROFILE_NAMES)
+        fatal(f"Invalid prefetch control profile {profile!r}; valid: {valid}")
+
+    _PF_CONTROL_PROFILE = profile
+    _LOADED_PF_CONTROL_CONFIG = None
+
+
+def _apply_pf_control_profile(config):
+    profile_config = PF_CONTROL_PROFILE_CONFIGS[_PF_CONTROL_PROFILE]
+    _deep_update_dict(config, profile_config)
+
+
 def _load_pf_control_config():
     global _LOADED_PF_CONTROL_CONFIG
     if _LOADED_PF_CONTROL_CONFIG is not None:
         return _LOADED_PF_CONTROL_CONFIG
 
     config = copy.deepcopy(PF_CONTROL_CONFIG)
+    _apply_pf_control_profile(config)
+
     config_path = os.environ.get(PF_CONTROL_CONFIG_ENV, "").strip()
     if config_path:
         try:

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -1,8 +1,87 @@
+import copy
+import os
+import runpy
+
 import m5
 from m5.objects import *
+from m5.util import fatal
 from common.Caches import *
 from common import ObjectList
 from m5.objects.Prefetcher import XSPhysicalSmallBOP, XSVirtualLargeBOP
+
+PF_SOURCE_NAMES = [
+    "PF_NONE",
+    "SStream",
+    "SStride",
+    "SPht",
+    "HWP_BOP",
+    "SPP",
+    "CMC",
+    "IPCP",
+    "IPCP_CS",
+    "IPCP_CPLX",
+    "Berti",
+    "StoreStream",
+    "CDP",
+    "SOpt",
+    "DespacitoStream",
+]
+
+
+def _normalize_pf_source_name(name):
+    return name.replace("_", "").replace("-", "").lower()
+
+
+PF_SOURCE_BY_NAME = {
+    _normalize_pf_source_name(name): idx
+    for idx, name in enumerate(PF_SOURCE_NAMES)
+}
+PF_SOURCE_BY_NAME.update({
+    "bop": PF_SOURCE_BY_NAME["hwpbop"],
+    "stream": PF_SOURCE_BY_NAME["sstream"],
+    "stride": PF_SOURCE_BY_NAME["sstride"],
+    "pht": PF_SOURCE_BY_NAME["spht"],
+    "store": PF_SOURCE_BY_NAME["storestream"],
+    "despacito": PF_SOURCE_BY_NAME["despacitostream"],
+})
+
+PF_CONTROL_CONFIG_ENV = "GEM5_PF_CONTROL_CONFIG"
+
+# Central Python-only configuration for prefetch admission control.
+# Batch scripts may point GEM5_PF_CONTROL_CONFIG at a Python file defining
+# PF_CONTROL_CONFIG with the same nested shape to override these defaults.
+PF_CONTROL_CONFIG = {
+    "control": {
+        "enabled": False,
+        "window": 100000,
+        "admit_pct": 100,
+        "sweep": [],
+        "source_admit_pcts": {},
+        "sweep_windows": 1,
+        "warmup_windows": 0,
+    },
+    "adaptive": {
+        "enabled": False,
+        "min_pct": 5,
+        "pct_quantum": 10,
+        "gradient_step": 10,
+        "pfbad_weight": (3, 2),
+        "dpf_min_samples": 1,
+        "dpf_deadband": 0,
+        "improve_margin_bps": 0,
+        "best_topk": 1,
+        "table_entries": 32,
+        "pfbad_entries": {
+            "l1d": 128,
+            "l2": 256,
+            "l2_wrapper": 256,
+        },
+        "warmup_windows": 1,
+        "max_source_step": 10,
+    },
+}
+
+_LOADED_PF_CONTROL_CONFIG = None
 
 
 def _get_hwp(hwp_option):
@@ -10,6 +89,280 @@ def _get_hwp(hwp_option):
         return NULL
     hwpClass = ObjectList.hwp_list.get(hwp_option)
     return hwpClass()
+
+
+def _deep_update_dict(base, override):
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_update_dict(base[key], value)
+        else:
+            base[key] = value
+
+
+def _load_pf_control_config():
+    global _LOADED_PF_CONTROL_CONFIG
+    if _LOADED_PF_CONTROL_CONFIG is not None:
+        return _LOADED_PF_CONTROL_CONFIG
+
+    config = copy.deepcopy(PF_CONTROL_CONFIG)
+    config_path = os.environ.get(PF_CONTROL_CONFIG_ENV, "").strip()
+    if config_path:
+        try:
+            namespace = runpy.run_path(config_path)
+        except OSError as exc:
+            fatal(f"Cannot load {PF_CONTROL_CONFIG_ENV}={config_path}: {exc}")
+        override = namespace.get("PF_CONTROL_CONFIG")
+        if not isinstance(override, dict):
+            fatal(
+                f"{PF_CONTROL_CONFIG_ENV} file must define "
+                "PF_CONTROL_CONFIG as a dict"
+            )
+        _deep_update_dict(config, override)
+
+    _LOADED_PF_CONTROL_CONFIG = config
+    return config
+
+
+def _config_error(path, requirement, value):
+    fatal(f"PF_CONTROL_CONFIG[{path!r}] must be {requirement} (got {value!r})")
+
+
+def _int_config(value, path):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        _config_error(path, "an integer", value)
+
+
+def _positive_int_config(config, name, default, path):
+    value = _int_config(config.get(name, default), path)
+    if value <= 0:
+        _config_error(path, "> 0", value)
+    return value
+
+
+def _nonnegative_int_config(config, name, default, path):
+    value = _int_config(config.get(name, default), path)
+    if value < 0:
+        _config_error(path, ">= 0", value)
+    return value
+
+
+def _percent_config(config, name, default, path):
+    value = _int_config(config.get(name, default), path)
+    if value < 0 or value > 100:
+        _config_error(path, "in [0, 100]", value)
+    return value
+
+
+def _positive_percent_config(config, name, default, path):
+    value = _percent_config(config, name, default, path)
+    if value <= 0:
+        _config_error(path, "in (0, 100]", value)
+    return value
+
+
+def _bps_config(config, name, default, path):
+    value = _int_config(config.get(name, default), path)
+    if value < 0 or value > 10000:
+        _config_error(path, "in [0, 10000]", value)
+    return value
+
+
+def _parse_pct_list(value, path):
+    if value in (None, ""):
+        return []
+
+    result = []
+    items = value.split(',') if isinstance(value, str) else value
+    for item in items:
+        if isinstance(item, str):
+            item = item.strip()
+            if not item:
+                continue
+        pct = _int_config(item, path)
+        if pct < 0 or pct > 100:
+            _config_error(path, "all entries in [0, 100]", pct)
+        result.append(pct)
+    return result
+
+
+def _parse_pf_source(name):
+    try:
+        value = int(name)
+    except ValueError:
+        key = _normalize_pf_source_name(name)
+        if key not in PF_SOURCE_BY_NAME:
+            valid = ",".join(PF_SOURCE_NAMES)
+            fatal(
+                f"Invalid prefetch source {name!r}; valid sources are "
+                f"{valid} or numeric indexes"
+            )
+        return PF_SOURCE_BY_NAME[key]
+
+    if value < 0 or value >= len(PF_SOURCE_NAMES):
+        fatal(
+            f"Prefetch source index must be in [0, {len(PF_SOURCE_NAMES) - 1}] "
+            f"(got {value})"
+        )
+    return value
+
+
+def _validate_source_pct(pct, path):
+    value = _int_config(pct, path)
+    if value < -1 or value > 100:
+        _config_error(path, "in [-1, 100]", value)
+    return value
+
+
+def _parse_source_pct_table(spec, path):
+    table = [-1] * len(PF_SOURCE_NAMES)
+    if spec in (None, "", {}, []):
+        return []
+
+    if isinstance(spec, dict):
+        items = spec.items()
+    elif isinstance(spec, str):
+        items = []
+        for raw_pair in spec.split(','):
+            pair = raw_pair.strip()
+            if not pair:
+                continue
+            if '=' not in pair:
+                _config_error(path, "source=pct entries", pair)
+            raw_source, raw_pct = pair.split('=', 1)
+            items.append((raw_source.strip(), raw_pct.strip()))
+    elif isinstance(spec, (list, tuple)):
+        if len(spec) == len(PF_SOURCE_NAMES):
+            for idx, pct in enumerate(spec):
+                table[idx] = _validate_source_pct(pct, f"{path}.{idx}")
+            return table
+        items = spec
+    else:
+        _config_error(path, "a dict, full list, pair list, or string", spec)
+
+    for item in items:
+        try:
+            raw_source, raw_pct = item
+        except (TypeError, ValueError):
+            _config_error(path, "source/pct pairs", item)
+        source = _parse_pf_source(str(raw_source).strip())
+        table[source] = _validate_source_pct(raw_pct, f"{path}.{raw_source}")
+    return table
+
+
+def _parse_weight_ratio(spec):
+    if isinstance(spec, (list, tuple)):
+        if len(spec) != 2:
+            _config_error("adaptive.pfbad_weight", "NUM/DEN", spec)
+        raw_num, raw_den = spec
+    else:
+        text = str(spec).strip()
+        if '/' in text:
+            raw_num, raw_den = text.split('/', 1)
+        else:
+            raw_num, raw_den = text, '1'
+    num = _int_config(raw_num, "adaptive.pfbad_weight.numer")
+    den = _int_config(raw_den, "adaptive.pfbad_weight.denom")
+    if num <= 0 or den <= 0:
+        _config_error("adaptive.pfbad_weight", "positive NUM/DEN", spec)
+    return num, den
+
+
+def _adaptive_pfbad_entries_for_level(cache_level, adaptive_config):
+    entries = adaptive_config.get("pfbad_entries", {})
+    if not isinstance(entries, dict):
+        value = _int_config(entries, "adaptive.pfbad_entries")
+        if value < 0:
+            _config_error("adaptive.pfbad_entries", ">= 0", value)
+        return value
+    if cache_level == 'l1d':
+        return _nonnegative_int_config(
+            entries, 'l1d', 128, "adaptive.pfbad_entries.l1d")
+    if cache_level == 'l2':
+        return _nonnegative_int_config(
+            entries, 'l2', 256, "adaptive.pfbad_entries.l2")
+    if cache_level == 'l2_wrapper':
+        return _nonnegative_int_config(
+            entries, 'l2_wrapper',
+            entries.get('l2', 256),
+            "adaptive.pfbad_entries.l2_wrapper")
+    return 0
+
+
+def _apply_pf_control(prefetcher, config):
+    if prefetcher == NULL or not hasattr(prefetcher, 'pf_control'):
+        return
+
+    control = config.get("control", {})
+    admit_pct = _percent_config(
+        control, 'admit_pct', 100, "control.admit_pct")
+    window = _positive_int_config(
+        control, 'window', 100000, "control.window")
+    sweep_windows = _positive_int_config(
+        control, 'sweep_windows', 1, "control.sweep_windows")
+    warmup_windows = _nonnegative_int_config(
+        control, 'warmup_windows', 0, "control.warmup_windows")
+
+    prefetcher.pf_control = bool(control.get('enabled', False))
+    prefetcher.pf_control_window = window
+    prefetcher.pf_control_admit_pct = admit_pct
+    prefetcher.pf_control_sweep = _parse_pct_list(
+        control.get('sweep', []), "control.sweep")
+    prefetcher.pf_control_source_admit_pcts = _parse_source_pct_table(
+        control.get('source_admit_pcts', {}),
+        "control.source_admit_pcts")
+    prefetcher.pf_control_sweep_windows = sweep_windows
+    prefetcher.pf_control_warmup_windows = warmup_windows
+
+
+def _apply_pf_adaptive(prefetcher, cache_level, config):
+    if prefetcher == NULL or not hasattr(prefetcher, 'pf_adaptive'):
+        return
+
+    control = config.get("control", {})
+    adaptive = config.get("adaptive", {})
+    enable = bool(adaptive.get('enabled', False))
+    prefetcher.pf_adaptive = enable and cache_level in (
+        'l1d', 'l2', 'l2_wrapper')
+    if not prefetcher.pf_adaptive:
+        return
+
+    if not bool(control.get('enabled', False)):
+        fatal(
+            "PF_CONTROL_CONFIG['adaptive']['enabled'] requires "
+            "PF_CONTROL_CONFIG['control']['enabled']"
+        )
+
+    weight_num, weight_den = _parse_weight_ratio(
+        adaptive.get('pfbad_weight', (3, 2)))
+
+    prefetcher.pf_adaptive_min_pct = _positive_percent_config(
+        adaptive, 'min_pct', 5, "adaptive.min_pct")
+    prefetcher.pf_adaptive_pct_quantum = _positive_percent_config(
+        adaptive, 'pct_quantum', 10, "adaptive.pct_quantum")
+    prefetcher.pf_adaptive_gradient_step = _nonnegative_int_config(
+        adaptive, 'gradient_step', 10, "adaptive.gradient_step")
+    prefetcher.pf_adaptive_pfbad_weight_numer = weight_num
+    prefetcher.pf_adaptive_pfbad_weight_denom = weight_den
+    prefetcher.pf_adaptive_dpf_min_samples = _nonnegative_int_config(
+        adaptive, 'dpf_min_samples', 1, "adaptive.dpf_min_samples")
+    prefetcher.pf_adaptive_dpf_deadband = _nonnegative_int_config(
+        adaptive, 'dpf_deadband', 0, "adaptive.dpf_deadband")
+    prefetcher.pf_adaptive_improve_margin_bps = _bps_config(
+        adaptive, 'improve_margin_bps', 0, "adaptive.improve_margin_bps")
+    prefetcher.pf_adaptive_best_topk = _positive_int_config(
+        adaptive, 'best_topk', 1, "adaptive.best_topk")
+    prefetcher.pf_adaptive_table_entries = _nonnegative_int_config(
+        adaptive, 'table_entries', 32, "adaptive.table_entries")
+    prefetcher.pf_adaptive_pfbad_entries = (
+        _adaptive_pfbad_entries_for_level(cache_level, adaptive)
+    )
+    prefetcher.pf_adaptive_warmup_windows = _nonnegative_int_config(
+        adaptive, 'warmup_windows', 1, "adaptive.warmup_windows")
+    prefetcher.pf_adaptive_max_source_step = _positive_percent_config(
+        adaptive, 'max_source_step', 10, "adaptive.max_source_step")
+
 
 def is_pf_buffer_enabled(options):
     # Enabled by default; --disable-pf-buffer is the only CLI override.
@@ -144,6 +497,10 @@ def create_prefetcher(cpu, cache_level, options):
 
     if prefetcher == NULL:
         return NULL
+
+    pf_control_config = _load_pf_control_config()
+    _apply_pf_control(prefetcher, pf_control_config)
+    _apply_pf_adaptive(prefetcher, cache_level, pf_control_config)
 
     _register_prefetcher_tlb(prefetcher, cpu)
 

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -18,6 +18,7 @@ from common import CacheConfig
 from common import CpuConfig
 from common import MemConfig
 from common import ObjectList
+from common import PrefetcherConfig
 from common.Caches import *
 from common import Options
 from common.FUScheduler import *
@@ -981,6 +982,8 @@ def xiangshan_system_init():
     if '--ruby' in sys.argv:
         Ruby.define_options(parser)
     args = parser.parse_args()
+
+    PrefetcherConfig.set_pf_control_profile(args.pf_control_profile)
 
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -16,13 +16,13 @@ def enable_prefetch_control():
     PrefetcherConfig.PF_CONTROL_CONFIG = {
         "control": {
             "enabled": True,
-            "window": 5000,
+            "window": 8000,
             "admit_pct": 100,
         },
         "adaptive": {
             "enabled": True,
             "pfbad_entries": {
-                "l1d": 256,
+                "l1d": 128,
                 "l2": 512,
                 "l2_wrapper": 512,
             },

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -7,28 +7,8 @@ from m5.util import addToPath
 addToPath('../')
 
 from common import Simulation
-from common import PrefetcherConfig
 from common.xiangshan import build_xiangshan_system, xiangshan_system_init
 from idealkmhv3 import setKmhV3IdealParams
-
-
-def enable_prefetch_control():
-    PrefetcherConfig.PF_CONTROL_CONFIG = {
-        "control": {
-            "enabled": True,
-            "window": 8000,
-            "admit_pct": 100,
-        },
-        "adaptive": {
-            "enabled": True,
-            "pfbad_entries": {
-                "l1d": 128,
-                "l2": 512,
-                "l2_wrapper": 512,
-            },
-        },
-    }
-    PrefetcherConfig._LOADED_PF_CONTROL_CONFIG = None
 
 
 def setSharedLSQParams(args, system):
@@ -60,7 +40,6 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'
-    enable_prefetch_control()
 
     if args.dramsim3_ini is None:
         gem5_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -7,8 +7,28 @@ from m5.util import addToPath
 addToPath('../')
 
 from common import Simulation
+from common import PrefetcherConfig
 from common.xiangshan import build_xiangshan_system, xiangshan_system_init
 from idealkmhv3 import setKmhV3IdealParams
+
+
+def enable_prefetch_control():
+    PrefetcherConfig.PF_CONTROL_CONFIG = {
+        "control": {
+            "enabled": True,
+            "window": 5000,
+            "admit_pct": 100,
+        },
+        "adaptive": {
+            "enabled": True,
+            "pfbad_entries": {
+                "l1d": 256,
+                "l2": 512,
+                "l2_wrapper": 512,
+            },
+        },
+    }
+    PrefetcherConfig._LOADED_PF_CONTROL_CONFIG = None
 
 
 def setSharedLSQParams(args, system):
@@ -40,6 +60,7 @@ if __name__ == '__m5_main__':
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'
+    enable_prefetch_control()
 
     if args.dramsim3_ini is None:
         gem5_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))

--- a/src/mem/Request.py
+++ b/src/mem/Request.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Beijing Institute of Open Source Chip
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.params import *
+
+
+class PrefetchSourceType(Enum):
+    vals = [
+        "PF_NONE",
+        "SStream",
+        "SStride",
+        "SPht",
+        "HWP_BOP",
+        "SPP",
+        "CMC",
+        "IPCP",
+        "IPCP_CS",
+        "IPCP_CPLX",
+        "Berti",
+        "StoreStream",
+        "CDP",
+        "SOpt",
+        "DespacitoStream",
+    ]

--- a/src/mem/SConscript
+++ b/src/mem/SConscript
@@ -67,6 +67,7 @@ SimObject('HMCController.py', sim_objects=['HMCController'])
 SimObject('SerialLink.py', sim_objects=['SerialLink'])
 SimObject('MemDelay.py', sim_objects=['MemDelay', 'SimpleMemDelay'])
 SimObject('PortTerminator.py', sim_objects=['PortTerminator'])
+SimObject('Request.py', enums=['PrefetchSourceType'])
 
 Source('abstract_mem.cc')
 Source('addr_mapper.cc')

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -817,6 +817,14 @@ BaseCache::recvTimingReq(PacketPtr pkt)
             calculateSliceBusy(pkt);
         }
 
+        if (prefetcher && pkt->req && !pkt->isEviction() &&
+            !pkt->isWriteback() &&
+            !pkt->req->isUncacheable() &&
+            !pkt->req->isCacheMaintenance()) {
+            prefetcher->notifyCacheMissRequest(
+                pkt->getAddr(), pkt->isSecure());
+        }
+
         // ArchDB: for now we only track packet which has PC
         // and is normal load/store
         // TODO: for now there are some bugs in vaddrs
@@ -1028,7 +1036,17 @@ BaseCache::recvTimingResp(PacketPtr pkt)
     const bool pure_prefetch_fill =
         mshr->hasFromPref() && !mshr->hasFromCPU();
     if (pure_prefetch_fill) {
-        pkt->req->setPFSource(mshr->getPFSource());
+        const PrefetchSourceType pf_source = mshr->getPFSource();
+        const int pf_depth = mshr->getPFDepth();
+        pkt->req->setPFSource(pf_source);
+        pkt->req->setPFDepth(pf_depth);
+        Request::XsMetadata xs_meta =
+            pkt->req->hasXsMetadata() ?
+            pkt->req->getXsMetadata() :
+            Request::XsMetadata(pf_source, pf_depth);
+        xs_meta.prefetchSource = pf_source;
+        xs_meta.prefetchDepth = pf_depth;
+        pkt->req->setXsMetadata(xs_meta);
     }
 
     // make sure that if the mshr was due to a whole line write then
@@ -2347,10 +2365,20 @@ BaseCache::handleFill(
     }
 
     Request::XsMetadata blk_meta = blk->getXsMetadata();
-    blk_meta.prefetchSource = prefetch_fill_source;
+    if (prefetch_fill_source != PrefetchSourceType::PF_NONE) {
+        blk_meta.prefetchSource = prefetch_fill_source;
+        if (pkt->req && pkt->req->hasXsMetadata()) {
+            blk_meta.prefetchDepth =
+                pkt->req->getXsMetadata().prefetchDepth;
+        }
+    } else {
+        blk_meta.prefetchSource = PrefetchSourceType::PF_NONE;
+        blk_meta.prefetchDepth = 0;
+    }
     blk->setXsMetadata(blk_meta);
-    DPRINTF(Cache, "%s: Mark blk prefetch source %i from req %p\n",
-            __func__, prefetch_fill_source, pkt->req);
+    DPRINTF(Cache, "%s: Mark blk prefetch source %i depth %i from req %p\n",
+            __func__, blk_meta.prefetchSource, blk_meta.prefetchDepth,
+            pkt->req);
 
     return blk;
 }
@@ -2407,13 +2435,8 @@ BaseCache::allocateBlock(
             if (!evict_blk->isValid()) {
                 continue;
             }
-            const bool prefetch_only =
-                evict_blk->wasPrefetched() &&
-                evict_blk->getDemandHits() == 0;
-            if (!prefetch_only) {
-                pfbad_victims.push_back(
-                    {regenerateBlkAddr(evict_blk), evict_blk->isSecure()});
-            }
+            pfbad_victims.push_back(
+                {regenerateBlkAddr(evict_blk), evict_blk->isSecure()});
         }
     }
 

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -589,8 +589,10 @@ BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
         // no MSHR
         assert(pkt->req->requestorId() < system->maxRequestors());
         stats.cmdStats(pkt).mshrMisses[pkt->req->requestorId()]++;
-        if (prefetcher && pkt->isDemand())
+        if (prefetcher && pkt->isDemand()) {
             prefetcher->incrDemandMhsrMisses();
+            prefetcher->notifyDemandMshrMiss(pkt->getAddr(), pkt->isSecure());
+        }
 
         if (pkt->isEviction() || pkt->cmd == MemCmd::WriteClean) {
             // We use forward_time here because there is an
@@ -1023,6 +1025,11 @@ BaseCache::recvTimingResp(PacketPtr pkt)
     bool is_fill = !mshr->isForward &&
         (pkt->isRead() || pkt->cmd == MemCmd::UpgradeResp ||
          mshr->wasWholeLineWrite);
+    const bool pure_prefetch_fill =
+        mshr->hasFromPref() && !mshr->hasFromCPU();
+    if (pure_prefetch_fill) {
+        pkt->req->setPFSource(mshr->getPFSource());
+    }
 
     // make sure that if the mshr was due to a whole line write then
     // the response is an invalidation
@@ -1066,8 +1073,13 @@ BaseCache::recvTimingResp(PacketPtr pkt)
         }
         blk = handleFill(
             pkt, blk, writebacks, allocate,
+            pure_prefetch_fill ? mshr->getPFSource() :
+                PrefetchSourceType::PF_NONE,
             &dcache_refill_need_data_read);
         assert(blk != nullptr);
+        if (prefetcher) {
+            prefetcher->notifyCachelineRefill(pkt->getAddr(), pkt->isSecure());
+        }
         ppFill->notify(pkt);
     }
 
@@ -2219,8 +2231,9 @@ BaseCache::maintainClusivity(bool from_cache, CacheBlk *blk)
 }
 
 CacheBlk*
-BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
-                      bool allocate, bool *refill_need_data_read)
+BaseCache::handleFill(
+    PacketPtr pkt, CacheBlk *blk, PacketList &writebacks, bool allocate,
+    PrefetchSourceType prefetch_fill_source, bool *refill_need_data_read)
 {
     assert(pkt->isResponse());
     Addr addr = pkt->getAddr();
@@ -2243,8 +2256,9 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
         // need to do a replacement if allocating, otherwise we stick
         // with the temporary storage
         blk = allocate ?
-            allocateBlock(pkt, writebacks, refill_need_data_read) :
-            nullptr;
+            allocateBlock(
+                pkt, writebacks, prefetch_fill_source,
+                refill_need_data_read) : nullptr;
 
         if (!blk) {
             // No replaceable block or a mostly exclusive
@@ -2333,17 +2347,18 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
     }
 
     Request::XsMetadata blk_meta = blk->getXsMetadata();
-    blk_meta.prefetchSource = pkt->req->getPFSource();
+    blk_meta.prefetchSource = prefetch_fill_source;
     blk->setXsMetadata(blk_meta);
-    DPRINTF(Cache, "%s: Mark blk as prefetched by source %i, form req %p\n", __func__,
-            pkt->req->getPFSource(), pkt->req);
+    DPRINTF(Cache, "%s: Mark blk prefetch source %i from req %p\n",
+            __func__, prefetch_fill_source, pkt->req);
 
     return blk;
 }
 
 CacheBlk*
-BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks,
-                         bool *evicted_dirty)
+BaseCache::allocateBlock(
+    const PacketPtr pkt, PacketList &writebacks,
+    PrefetchSourceType prefetch_fill_source, bool *evicted_dirty)
 {
     // Get address
     const Addr addr = pkt->getAddr();
@@ -2381,9 +2396,35 @@ BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks,
     // Print victim block's information
     DPRINTF(CacheRepl, "Replacement victim: %s\n", victim->print());
 
+    struct PfBadVictim
+    {
+        Addr addr;
+        bool secure;
+    };
+    std::vector<PfBadVictim> pfbad_victims;
+    if (prefetcher && prefetch_fill_source != PrefetchSourceType::PF_NONE) {
+        for (const auto &evict_blk : evict_blks) {
+            if (!evict_blk->isValid()) {
+                continue;
+            }
+            const bool prefetch_only =
+                evict_blk->wasPrefetched() &&
+                evict_blk->getDemandHits() == 0;
+            if (!prefetch_only) {
+                pfbad_victims.push_back(
+                    {regenerateBlkAddr(evict_blk), evict_blk->isSecure()});
+            }
+        }
+    }
+
     // Try to evict blocks; if it fails, give up on allocation
     if (!handleEvictions(evict_blks, writebacks, evicted_dirty)) {
         return nullptr;
+    }
+
+    for (const auto &victim_info : pfbad_victims) {
+        prefetcher->notifyPrefetchEvictsDemand(
+            victim_info.addr, victim_info.secure, prefetch_fill_source);
     }
 
     // Insert new block at victimized entry

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -912,9 +912,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @param allocate Whether to allocate a block or use the temp block
      * @return Pointer to the new cache block.
      */
-    CacheBlk *handleFill(PacketPtr pkt, CacheBlk *blk,
-                         PacketList &writebacks, bool allocate,
-                         bool *refill_need_data_read = nullptr);
+    CacheBlk *handleFill(
+        PacketPtr pkt, CacheBlk *blk, PacketList &writebacks, bool allocate,
+        PrefetchSourceType prefetch_fill_source = PrefetchSourceType::PF_NONE,
+        bool *refill_need_data_read = nullptr);
 
     /**
      * Allocate a new block and perform any necessary writebacks
@@ -928,8 +929,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
      * @param writebacks A list of writeback packets for the evicted blocks
      * @return the allocated block
      */
-    CacheBlk *allocateBlock(const PacketPtr pkt, PacketList &writebacks,
-                            bool *evicted_dirty = nullptr);
+    CacheBlk *allocateBlock(
+        const PacketPtr pkt, PacketList &writebacks,
+        PrefetchSourceType prefetch_fill_source = PrefetchSourceType::PF_NONE,
+        bool *evicted_dirty = nullptr);
     /**
      * Evict a cache block.
      *

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -221,6 +221,8 @@ class QueuedPrefetcher(BasePrefetcher):
         "Deadband around zero useful-bad adaptive gradient score")
     pf_adaptive_improve_margin_bps = Param.Unsigned(0,
         "Required demand miss-rate improvement in basis points")
+    pf_adaptive_history_fallback = Param.Bool(True,
+        "Use historical best miss-rate samples as adaptive fallback")
     pf_adaptive_best_topk = Param.Unsigned(1,
         "Number of best FIFO samples averaged for adaptive fallback pct")
     pf_adaptive_table_entries = Param.Unsigned(32,

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -188,6 +188,50 @@ class QueuedPrefetcher(BasePrefetcher):
     throttle_control_percentage = Param.Percent(0, "Percentage of requests \
         that can be throttled depending on the accuracy of the prefetcher.")
 
+    pf_control = Param.Bool(False,
+        "Enable windowed prefetch admission control")
+    pf_control_window = Param.Cycles(100000,
+        "Cycles per prefetch control window")
+    pf_control_admit_pct = Param.Percent(100,
+        "Fallback prefetch admission percentage for prefetch control")
+    pf_control_sweep = VectorParam.Unsigned([],
+        "Optional list of admission percentages to sweep, each in [0, 100]")
+    pf_control_source_admit_pcts = VectorParam.Int([],
+        "Optional per-PrefetchSourceType admission percentages; -1 means use "
+        "the global prefetch control action")
+    pf_control_sweep_windows = Param.Unsigned(1,
+        "Number of windows to hold each prefetch control action")
+    pf_control_warmup_windows = Param.Unsigned(0,
+        "Number of initial windows using the fallback admission percentage")
+    pf_adaptive = Param.Bool(False,
+        "Enable online PFBad-guided prefetch adaptive admission")
+    pf_adaptive_min_pct = Param.Percent(5,
+        "Minimum per-source admission percentage for adaptive mode")
+    pf_adaptive_pct_quantum = Param.Percent(10,
+        "Adaptive admission percentage quantization step")
+    pf_adaptive_gradient_step = Param.Int(10,
+        "Adaptive per-source gradient step in percentage points")
+    pf_adaptive_pfbad_weight_numer = Param.Unsigned(3,
+        "PFBad penalty weight numerator")
+    pf_adaptive_pfbad_weight_denom = Param.Unsigned(2,
+        "PFBad penalty weight denominator")
+    pf_adaptive_dpf_min_samples = Param.Unsigned(1,
+        "Minimum useful+bad samples before trusting adaptive gradient")
+    pf_adaptive_dpf_deadband = Param.Int(0,
+        "Deadband around zero useful-bad adaptive gradient score")
+    pf_adaptive_improve_margin_bps = Param.Unsigned(0,
+        "Required demand miss-rate improvement in basis points")
+    pf_adaptive_best_topk = Param.Unsigned(1,
+        "Number of best FIFO samples averaged for adaptive fallback pct")
+    pf_adaptive_table_entries = Param.Unsigned(32,
+        "Adaptive FIFO experience table entries")
+    pf_adaptive_pfbad_entries = Param.Unsigned(0,
+        "Adaptive PFBad detection table entries")
+    pf_adaptive_warmup_windows = Param.Unsigned(1,
+        "Initial completed windows before adaptive threshold updates")
+    pf_adaptive_max_source_step = Param.Percent(10,
+        "Maximum per-source admission movement per adaptive update")
+
     max_pfahead_recv = Param.Int(1,"Maximum number of pfahead received")
     use_pf_buffer = Param.Bool(False, "use prefetch buffer to filter prefetches")
     max_pf_buffer_size = Param.Int(16, "size of prefetch buffer")

--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -268,6 +268,11 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
              "number of HardPF blocks evicted w/o reference"),
     ADD_STAT(pfUnused_srcs, statistics::units::Count::get(),
              "number of HardPF blocks evicted w/o reference"),
+    ADD_STAT(pfBad, statistics::units::Count::get(),
+             "number of cache miss requests hitting the PFBad table"),
+    ADD_STAT(pfBad_srcs, statistics::units::Count::get(),
+             "number of cache miss requests hitting the PFBad table "
+             "by evictor source"),
     ADD_STAT(pfUseful, statistics::units::Count::get(),
         "number of useful prefetch"),
     ADD_STAT(pfUseful_srcs, statistics::units::Count::get(),
@@ -310,6 +315,10 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
     pfUnused_srcs
         .init(NUM_PF_SOURCES)
         .flags(total | nozero);
+    pfBad.flags(nozero);
+    pfBad_srcs
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
     pfUseful_srcs
         .init(NUM_PF_SOURCES)
         .flags(total | nozero);
@@ -331,6 +340,7 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
         const auto source_name = prefetchSourceTypeName(source);
         pfIssued_srcs.subname(source, source_name);
         pfUnused_srcs.subname(source, source_name);
+        pfBad_srcs.subname(source, source_name);
         pfUseful_srcs.subname(source, source_name);
         pfHitInCache_srcs.subname(source, source_name);
         pfHitInMSHR_srcs.subname(source, source_name);

--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -304,28 +304,39 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
 
     pfIssued_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
 
     pfUnused.flags(nozero);
     pfUnused_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
     pfUseful_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
 
     pfHitInCache_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
     pfHitInMSHR_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
     pfHitInWB_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
     late_srcs
         .init(NUM_PF_SOURCES)
-        .flags(total);
+        .flags(total | nozero);
+
+    for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+        const auto source_name = prefetchSourceTypeName(source);
+        pfIssued_srcs.subname(source, source_name);
+        pfUnused_srcs.subname(source, source_name);
+        pfUseful_srcs.subname(source, source_name);
+        pfHitInCache_srcs.subname(source, source_name);
+        pfHitInMSHR_srcs.subname(source, source_name);
+        pfHitInWB_srcs.subname(source, source_name);
+        late_srcs.subname(source, source_name);
+    }
 
 
     accuracy.flags(total);
@@ -465,11 +476,16 @@ Base::probeNotify(const PacketPtr &pkt, bool miss)
 
     DPRINTF(HWPrefetch, "Reach condition checked\n");
 
+    if (pkt->isDemand()) {
+        notifyDemandAccess(pkt->getAddr(), pkt->isSecure(), miss);
+    }
+
     if (hasBeenPrefetched(pkt->getAddr(), pkt->isSecure())) {
         usefulPrefetches += 1;
         prefetchStats.pfUseful++;
         PrefetchSourceType pf_source = cache->getHitBlkXsMetadata(pkt).prefetchSource;
         prefetchStats.pfUseful_srcs[pf_source]++;
+        notifyPrefetchUseful(pf_source);
         if (miss)
             // This case happens when a demand hits on a prefetched line
             // that's not in the requested coherency state.

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -930,6 +930,9 @@ class Base : public ClockedObject
          * reference. */
         statistics::Scalar pfUnused;
         statistics::Vector pfUnused_srcs;
+        /** The number of cache miss requests hitting the PFBad table. */
+        statistics::Scalar pfBad;
+        statistics::Vector pfBad_srcs;
         /** The number of times a HW-prefetch is useful. */
         statistics::Scalar pfUseful;
 
@@ -1011,7 +1014,7 @@ class Base : public ClockedObject
 
     virtual void recordIssuedPrefetch(PrefetchSourceType source)
     {
-        const int source_idx = static_cast<int>(source);
+        const int source_idx = int(source);
         if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
             source = PrefetchSourceType::PF_NONE;
         }
@@ -1042,6 +1045,16 @@ class Base : public ClockedObject
 
     virtual void prefetchUnused(Addr paddr, PrefetchSourceType pfSource) { prefetchUnused(pfSource); }
 
+    virtual void recordPfBadHit(PrefetchSourceType source)
+    {
+        const int source_idx = int(source);
+        if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
+            source = PrefetchSourceType::PF_NONE;
+        }
+        prefetchStats.pfBad++;
+        prefetchStats.pfBad_srcs[source]++;
+    }
+
     virtual void
     incrDemandMhsrMisses()
     {
@@ -1052,10 +1065,12 @@ class Base : public ClockedObject
 
     virtual void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) {}
 
+    virtual void notifyCacheMissRequest(Addr paddr, bool is_secure) {}
+
     virtual void notifyPrefetchUseful(PrefetchSourceType source) {}
 
     virtual void notifyPrefetchEvictsDemand(
-        Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+        Addr victim_paddr, bool is_secure, PrefetchSourceType evictor_source)
     {}
 
     virtual void notifyCachelineRefill(Addr paddr, bool is_secure) {}

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -999,6 +999,40 @@ class Base : public ClockedObject
 
     virtual void recvPrefetchFromCache(const PacketPtr &pkt) {}
 
+    virtual bool admitIncomingPrefetchPacket(const PacketPtr &pkt)
+    {
+        return true;
+    }
+
+    virtual bool ownsPrefetchRequest(const PacketPtr &pkt) const
+    {
+        return pkt && pkt->req && pkt->req->requestorId() == requestorId;
+    }
+
+    virtual void recordIssuedPrefetch(PrefetchSourceType source)
+    {
+        const int source_idx = static_cast<int>(source);
+        if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
+            source = PrefetchSourceType::PF_NONE;
+        }
+        prefetchStats.pfIssued++;
+        prefetchStats.pfIssued_srcs[source]++;
+        issuedPrefetches += 1;
+    }
+
+    virtual void recordIssuedPrefetch(const PacketPtr &pkt)
+    {
+        PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+        if (pkt && pkt->req) {
+            if (pkt->req->hasXsMetadata()) {
+                source = pkt->req->getXsMetadata().prefetchSource;
+            } else {
+                source = pkt->getPFSource();
+            }
+        }
+        recordIssuedPrefetch(source);
+    }
+
     virtual void
     prefetchUnused(PrefetchSourceType pfSource)
     {
@@ -1013,6 +1047,18 @@ class Base : public ClockedObject
     {
         prefetchStats.demandMshrMisses++;
     }
+
+    virtual void notifyDemandMshrMiss(Addr paddr, bool is_secure) {}
+
+    virtual void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) {}
+
+    virtual void notifyPrefetchUseful(PrefetchSourceType source) {}
+
+    virtual void notifyPrefetchEvictsDemand(
+        Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+    {}
+
+    virtual void notifyCachelineRefill(Addr paddr, bool is_secure) {}
 
     virtual void
     pfHitInCache(PrefetchSourceType pf_type)

--- a/src/mem/cache/prefetch/cdp.cc
+++ b/src/mem/cache/prefetch/cdp.cc
@@ -72,7 +72,7 @@ CDP::CDP(const CDPParams &p)
       byteOrder(p.sys->getGuestByteOrder()),
       cdpStats(this)
 {
-    for (int i = 0; i < PrefetchSourceType::NUM_PF_SOURCES; i++) {
+    for (int i = 0; i < NUM_PF_SOURCES; i++) {
         enable_prf_filter.push_back(false);
     }
     prefetchStatsPtr = &prefetchStats;

--- a/src/mem/cache/prefetch/composite_with_worker.cc
+++ b/src/mem/cache/prefetch/composite_with_worker.cc
@@ -48,6 +48,13 @@ CompositeWithWorkerPrefetcher::postNotifyInsert(const PacketPtr &trigger_pkt, st
 
         bool can_cross_page = (tlb != nullptr);
         if (can_cross_page || samePage(addr_prio.addr, pfi.getAddr())) {
+            if (shouldPfControlAdmitLocally(
+                    addr_prio.pfahead, addr_prio.pfahead_host) &&
+                !admitPfControlCandidate(addr_prio.pfSource)) {
+                continue;
+            }
+            addr_prio.pfSource =
+                sanitizePfControlSourceType(addr_prio.pfSource);
             PrefetchInfo new_pfi(pfi, addr_prio.addr);
             new_pfi.setXsMetadata(Request::XsMetadata(addr_prio.pfSource, addr_prio.depth));
             statsQueued.pfIdentified++;

--- a/src/mem/cache/prefetch/forwarder.cc
+++ b/src/mem/cache/prefetch/forwarder.cc
@@ -187,6 +187,14 @@ PrefetcherForwarder::notifyDemandAccess(
 }
 
 void
+PrefetcherForwarder::notifyCacheMissRequest(Addr paddr, bool is_secure)
+{
+    if (real_pf) {
+        real_pf->notifyCacheMissRequest(paddr, is_secure);
+    }
+}
+
+void
 PrefetcherForwarder::notifyDemandMshrMiss(Addr paddr, bool is_secure)
 {
     if (real_pf) {
@@ -204,11 +212,11 @@ PrefetcherForwarder::notifyPrefetchUseful(PrefetchSourceType source)
 
 void
 PrefetcherForwarder::notifyPrefetchEvictsDemand(
-    Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+    Addr victim_paddr, bool is_secure, PrefetchSourceType evictor_source)
 {
     if (real_pf) {
         real_pf->notifyPrefetchEvictsDemand(
-            victim_paddr, is_secure, source);
+            victim_paddr, is_secure, evictor_source);
     }
 }
 

--- a/src/mem/cache/prefetch/forwarder.cc
+++ b/src/mem/cache/prefetch/forwarder.cc
@@ -131,6 +131,11 @@ PrefetcherForwarder::nofityHitToDownStream(const PacketPtr &pkt)
 void
 PrefetcherForwarder::recvPrefetchFromCache(const PacketPtr &pkt)
 {
+    if (real_pf && !real_pf->ownsPrefetchRequest(pkt) &&
+        !real_pf->admitIncomingPrefetchPacket(pkt)) {
+        delete pkt;
+        return;
+    }
     prefetch_queue.push(pkt);
 }
 
@@ -142,6 +147,9 @@ PrefetcherForwarder::getPacket()
     }
     PacketPtr pkt = prefetch_queue.front();
     prefetch_queue.pop();
+    if (real_pf && !real_pf->ownsPrefetchRequest(pkt)) {
+        real_pf->recordIssuedPrefetch(pkt);
+    }
     return pkt;
 }
 
@@ -166,6 +174,49 @@ PrefetcherForwarder::incrDemandMhsrMisses()
 {
     if (real_pf) {
         real_pf->incrDemandMhsrMisses();
+    }
+}
+
+void
+PrefetcherForwarder::notifyDemandAccess(
+    Addr paddr, bool is_secure, bool miss)
+{
+    if (real_pf) {
+        real_pf->notifyDemandAccess(paddr, is_secure, miss);
+    }
+}
+
+void
+PrefetcherForwarder::notifyDemandMshrMiss(Addr paddr, bool is_secure)
+{
+    if (real_pf) {
+        real_pf->notifyDemandMshrMiss(paddr, is_secure);
+    }
+}
+
+void
+PrefetcherForwarder::notifyPrefetchUseful(PrefetchSourceType source)
+{
+    if (real_pf) {
+        real_pf->notifyPrefetchUseful(source);
+    }
+}
+
+void
+PrefetcherForwarder::notifyPrefetchEvictsDemand(
+    Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+{
+    if (real_pf) {
+        real_pf->notifyPrefetchEvictsDemand(
+            victim_paddr, is_secure, source);
+    }
+}
+
+void
+PrefetcherForwarder::notifyCachelineRefill(Addr paddr, bool is_secure)
+{
+    if (real_pf) {
+        real_pf->notifyCachelineRefill(paddr, is_secure);
     }
 }
 

--- a/src/mem/cache/prefetch/forwarder.hh
+++ b/src/mem/cache/prefetch/forwarder.hh
@@ -57,10 +57,12 @@ class PrefetcherForwarder : public Base
     // stats
     void incrDemandMhsrMisses() override;
     void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) override;
+    void notifyCacheMissRequest(Addr paddr, bool is_secure) override;
     void notifyDemandMshrMiss(Addr paddr, bool is_secure) override;
     void notifyPrefetchUseful(PrefetchSourceType source) override;
     void notifyPrefetchEvictsDemand(
-        Addr victim_paddr, bool is_secure, PrefetchSourceType source) override;
+        Addr victim_paddr, bool is_secure,
+        PrefetchSourceType evictor_source) override;
     void notifyCachelineRefill(Addr paddr, bool is_secure) override;
     void prefetchUnused(PrefetchSourceType pf_type) override;
     void pfHitInMSHR(PrefetchSourceType pf_type) override;

--- a/src/mem/cache/prefetch/forwarder.hh
+++ b/src/mem/cache/prefetch/forwarder.hh
@@ -56,6 +56,12 @@ class PrefetcherForwarder : public Base
 
     // stats
     void incrDemandMhsrMisses() override;
+    void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) override;
+    void notifyDemandMshrMiss(Addr paddr, bool is_secure) override;
+    void notifyPrefetchUseful(PrefetchSourceType source) override;
+    void notifyPrefetchEvictsDemand(
+        Addr victim_paddr, bool is_secure, PrefetchSourceType source) override;
+    void notifyCachelineRefill(Addr paddr, bool is_secure) override;
     void prefetchUnused(PrefetchSourceType pf_type) override;
     void pfHitInMSHR(PrefetchSourceType pf_type) override;
     void pfHitInCache(PrefetchSourceType pf_type) override;

--- a/src/mem/cache/prefetch/l2_composite_with_worker.hh
+++ b/src/mem/cache/prefetch/l2_composite_with_worker.hh
@@ -22,6 +22,8 @@ class L2CompositeWithWorkerPrefetcher : public CompositeWithWorkerPrefetcher
   public:
     L2CompositeWithWorkerPrefetcher(const L2CompositeWithWorkerPrefetcherParams &p);
 
+    using CompositeWithWorkerPrefetcher::prefetchUnused;
+
     void calculatePrefetch(const PrefetchInfo &pfi, std::vector<AddrPriority> &addresses) override {}
 
     void calculatePrefetch(const PrefetchInfo &pfi, std::vector<AddrPriority> &addresses, bool late,

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -213,6 +213,7 @@ Queued::Queued(const QueuedPrefetcherParams &p)
       pfAdaptiveGradientMinSamples(p.pf_adaptive_dpf_min_samples),
       pfAdaptiveGradientDeadband(p.pf_adaptive_dpf_deadband),
       pfAdaptiveImproveMarginBps(p.pf_adaptive_improve_margin_bps),
+      pfAdaptiveHistoryFallback(p.pf_adaptive_history_fallback),
       pfAdaptiveBestTopK(std::max<unsigned>(1, p.pf_adaptive_best_topk)),
       pfAdaptiveTableEntries(p.pf_adaptive_table_entries),
       pfAdaptivePfBadEntries(p.pf_adaptive_pfbad_entries),
@@ -549,16 +550,20 @@ Queued::applyPfAdaptiveUpdate(const PfAdaptiveSample &sample)
         pfAdaptiveMissRateBps(
             sample.demandMisses, sample.demandAccesses);
     uint64_t best_rate = UINT64_MAX;
-    for (const auto &hist : pfAdaptiveSamples) {
-        if (hist.demandAccesses == 0) {
-            continue;
+    if (pfAdaptiveHistoryFallback) {
+        for (const auto &hist : pfAdaptiveSamples) {
+            if (hist.demandAccesses == 0) {
+                continue;
+            }
+            best_rate = std::min(best_rate,
+                pfAdaptiveMissRateBps(
+                    hist.demandMisses, hist.demandAccesses));
         }
-        best_rate = std::min(best_rate,
-            pfAdaptiveMissRateBps(hist.demandMisses, hist.demandAccesses));
     }
 
     const bool have_best = best_rate != UINT64_MAX;
-    const bool update =
+    const bool use_prediction =
+        !pfAdaptiveHistoryFallback ||
         !have_best ||
         current_rate * 10000 <
             best_rate * (10000 - pfAdaptiveImproveMarginBps);
@@ -571,9 +576,9 @@ Queued::applyPfAdaptiveUpdate(const PfAdaptiveSample &sample)
 
         const unsigned pred_pct =
             clampPfAdaptivePct(current_pct + gradient);
-        const unsigned best_pct = getPfAdaptiveBestPct(pf_source);
         unsigned next_pct = pred_pct;
-        if (!update) {
+        if (!use_prediction) {
+            const unsigned best_pct = getPfAdaptiveBestPct(pf_source);
             next_pct = quantizePfAdaptivePct(
                 (best_pct + pred_pct + 1) / 2);
         }

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -37,8 +37,10 @@
 
 #include "mem/cache/prefetch/queued.hh"
 
+#include <algorithm>
 #include <cassert>
 #include <linux/limits.h>
+#include <string>
 
 #include "arch/generic/tlb.hh"
 #include "base/logging.hh"
@@ -57,6 +59,56 @@ namespace gem5
 GEM5_DEPRECATED_NAMESPACE(Prefetcher, prefetch);
 namespace prefetch
 {
+
+namespace
+{
+
+std::array<int, NUM_PF_SOURCES>
+buildPfControlSourceAdmitPct(const std::vector<int> &values)
+{
+    std::array<int, NUM_PF_SOURCES> table{};
+    table.fill(-1);
+
+    if (values.empty()) {
+        return table;
+    }
+
+    panic_if(values.size() != NUM_PF_SOURCES,
+             "pf_control_source_admit_pcts must be empty or have "
+             "%u entries, got %zu",
+             static_cast<unsigned>(NUM_PF_SOURCES), values.size());
+
+    for (size_t idx = 0; idx < values.size(); ++idx) {
+        const int pct = values[idx];
+        panic_if(pct < -1 || pct > 100,
+                 "pf_control_source_admit_pcts[%zu] must be -1 or "
+                 "in [0, 100], got %d",
+                 idx, pct);
+        table[idx] = pct;
+    }
+
+    return table;
+}
+
+unsigned
+sanitizePercentParam(unsigned pct)
+{
+    return std::min<unsigned>(pct, 100);
+}
+
+unsigned
+quantizePercentAboveMin(unsigned pct, unsigned min_pct, unsigned quantum)
+{
+    if (pct <= min_pct) {
+        return min_pct;
+    }
+
+    const unsigned rounded =
+        ((pct + quantum / 2) / quantum) * quantum;
+    return std::max(min_pct, sanitizePercentParam(rounded));
+}
+
+} // namespace
 
 void
 Queued::DeferredPacket::createPkt(Addr paddr, unsigned blk_size, RequestorID requestor_id, bool tag_prefetch, Tick t,
@@ -85,8 +137,10 @@ Queued::DeferredPacket::createPkt(Addr paddr, unsigned blk_size, RequestorID req
     }
 
     req->setFlags(Request::PREFETCH);
-    req->setXsMetadata(Request::XsMetadata(pf_src, prf_depth));
-    DPRINTFR(HWPrefetch, "Create prefetch request for paddr %lx from prefetcher %i\n", paddr, pf_src);
+    const PrefetchSourceType safe_pf_src =
+        owner->sanitizePfControlSourceType(pf_src);
+    req->setXsMetadata(Request::XsMetadata(safe_pf_src, prf_depth));
+    DPRINTFR(HWPrefetch, "Create prefetch request for paddr %lx from prefetcher %i\n", paddr, safe_pf_src);
 
     if (pfInfo.isSecure()) {
         req->setFlags(Request::SECURE);
@@ -138,6 +192,49 @@ Queued::Queued(const QueuedPrefetcherParams &p)
       queueFilter(p.queue_filter), cacheSnoop(p.cache_snoop),
       tagPrefetch(p.tag_prefetch),
       throttleControlPct(p.throttle_control_percentage),
+      pfControl(p.pf_control),
+      pfControlWindow(p.pf_control_window),
+      pfControlDefaultAdmitPct(
+          std::min<unsigned>(p.pf_control_admit_pct, 100)),
+      pfControlSweep(p.pf_control_sweep),
+      pfControlSourceAdmitPct(
+          buildPfControlSourceAdmitPct(
+              p.pf_control_source_admit_pcts)),
+      pfControlSweepWindows(p.pf_control_sweep_windows),
+      pfControlWarmupWindows(p.pf_control_warmup_windows),
+      pfAdaptive(p.pf_adaptive),
+      pfAdaptiveMinPct(sanitizePercentParam(p.pf_adaptive_min_pct)),
+      pfAdaptivePctQuantum(std::max<unsigned>(1, p.pf_adaptive_pct_quantum)),
+      pfAdaptiveGradientStep(p.pf_adaptive_gradient_step),
+      pfAdaptivePfBadWeightNumerator(
+          std::max<unsigned>(1, p.pf_adaptive_pfbad_weight_numer)),
+      pfAdaptivePfBadWeightDenominator(
+          std::max<unsigned>(1, p.pf_adaptive_pfbad_weight_denom)),
+      pfAdaptiveDpfMinSamples(p.pf_adaptive_dpf_min_samples),
+      pfAdaptiveDpfDeadband(p.pf_adaptive_dpf_deadband),
+      pfAdaptiveImproveMarginBps(p.pf_adaptive_improve_margin_bps),
+      pfAdaptiveBestTopK(std::max<unsigned>(1, p.pf_adaptive_best_topk)),
+      pfAdaptiveTableEntries(p.pf_adaptive_table_entries),
+      pfAdaptivePfBadEntries(p.pf_adaptive_pfbad_entries),
+      pfAdaptiveWarmupWindows(p.pf_adaptive_warmup_windows),
+      pfAdaptiveMaxSourceStep(p.pf_adaptive_max_source_step),
+      pfAdaptiveWindowDemandAccesses(0),
+      pfAdaptiveWindowDemandMisses(0),
+      pfAdaptiveWindowPfUsefulBySource{},
+      pfAdaptiveWindowPfBadBySource{},
+      pfAdaptiveLastDpfBySource{},
+      pfAdaptiveSampleCount(0),
+      pfAdaptiveSamples(),
+      pfAdaptivePfBadTable(),
+      pfControlWindowStart(Cycles(0)),
+      pfControlWindowStarted(false),
+      pfControlWindowIndex(0),
+      pfControlWindowCandidates(0),
+      pfControlWindowAdmitted(0),
+      pfControlCurrentAdmitPct(pfControlDefaultAdmitPct),
+      pfControlWindowCandidatesBySource{},
+      pfControlWindowAdmittedBySource{},
+      pfControlCurrentAdmitPctBySource{},
       tlbReqEvent(
           [this]{ processMissingTranslations(queueSize); },
           name()),
@@ -148,8 +245,26 @@ Queued::Queued(const QueuedPrefetcherParams &p)
       PFReqSendEvent(
           [this]{ PFSendEventWrapper(); },
           name())
-      
+
 {
+    panic_if(pfControl && pfControlWindow == Cycles(0),
+             "pf_control_window must be non-zero when PF control "
+             "is enabled");
+    panic_if(pfAdaptive && !pfControl,
+             "pf_control must be enabled when pf_adaptive is enabled");
+    panic_if(pfAdaptive &&
+             (pfAdaptiveMinPct == 0 || pfAdaptiveMinPct > 100),
+             "pf_adaptive_min_pct must be in (0, 100]");
+    panic_if(pfAdaptive && pfAdaptiveGradientStep < 0,
+             "pf_adaptive_gradient_step must be non-negative");
+    panic_if(pfAdaptive && pfAdaptiveImproveMarginBps > 10000,
+             "pf_adaptive_improve_margin_bps must be in [0, 10000]");
+    panic_if(pfAdaptive && pfAdaptiveMaxSourceStep == 0,
+             "pf_adaptive_max_source_step must be positive");
+    pfAdaptiveWindowPfUsefulBySource.fill(0);
+    pfAdaptiveWindowPfBadBySource.fill(0);
+    pfAdaptiveLastDpfBySource.fill(0);
+    refreshPfControlCurrentPcts();
 }
 
 Queued::~Queued()
@@ -210,6 +325,557 @@ Queued::getMaxPermittedPrefetches(size_t total) const
             usefulPrefetches / issuedPrefetches;
     }
     return max_pfs;
+}
+
+unsigned
+Queued::sanitizePfControlPct(unsigned pct) const
+{
+    return std::min<unsigned>(pct, 100);
+}
+
+PrefetchSourceType
+Queued::sanitizePfControlSourceType(PrefetchSourceType source) const
+{
+    const int source_idx = static_cast<int>(source);
+    if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
+        return PrefetchSourceType::PF_NONE;
+    }
+    return source;
+}
+
+unsigned
+Queued::sanitizePfControlSource(PrefetchSourceType source) const
+{
+    return static_cast<unsigned>(sanitizePfControlSourceType(source));
+}
+
+unsigned
+Queued::getPfControlActionPct(uint64_t window_index) const
+{
+    if (!pfControl || window_index < pfControlWarmupWindows ||
+        pfControlSweep.empty()) {
+        return pfControlDefaultAdmitPct;
+    }
+
+    const uint64_t action_windows =
+        std::max<uint64_t>(1, pfControlSweepWindows);
+    const uint64_t action_index =
+        ((window_index - pfControlWarmupWindows) / action_windows) %
+        pfControlSweep.size();
+
+    return sanitizePfControlPct(pfControlSweep[action_index]);
+}
+
+unsigned
+Queued::getPfControlActionPctForSource(
+    uint64_t window_index, PrefetchSourceType source) const
+{
+    if (!pfControl) {
+        return 100;
+    }
+
+    if (pfAdaptive && isPfAdaptiveLevel()) {
+        const unsigned source_idx = sanitizePfControlSource(source);
+        if (pfAdaptiveSampleCount < pfAdaptiveWarmupWindows) {
+            return 100;
+        }
+        return pfControlCurrentAdmitPctBySource[source_idx];
+    }
+
+    if (window_index >= pfControlWarmupWindows) {
+        const unsigned source_idx = sanitizePfControlSource(source);
+        const int source_pct = pfControlSourceAdmitPct[source_idx];
+        if (source_pct >= 0) {
+            return sanitizePfControlPct(source_pct);
+        }
+    }
+
+    return getPfControlActionPct(window_index);
+}
+
+void
+Queued::refreshPfControlCurrentPcts()
+{
+    pfControlCurrentAdmitPct =
+        getPfControlActionPct(pfControlWindowIndex);
+    statsQueued.pfControlCurrentAdmitPct = pfControlCurrentAdmitPct;
+
+    for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+        const auto pf_source = static_cast<PrefetchSourceType>(source);
+        const unsigned pct =
+            getPfControlActionPctForSource(
+                pfControlWindowIndex, pf_source);
+        pfControlCurrentAdmitPctBySource[source] = pct;
+        statsQueued.pfControlCurrentAdmitPctBySource[source] = pct;
+    }
+}
+
+bool
+Queued::isPfAdaptiveLevel() const
+{
+    return pfAdaptive && cache &&
+        (cache->level() == 1 || cache->level() == 2);
+}
+
+unsigned
+Queued::quantizePfAdaptivePct(unsigned pct) const
+{
+    const unsigned quantum = std::max<unsigned>(1, pfAdaptivePctQuantum);
+    return quantizePercentAboveMin(pct, pfAdaptiveMinPct, quantum);
+}
+
+unsigned
+Queued::clampPfAdaptivePct(int pct) const
+{
+    const int min_pct = static_cast<int>(pfAdaptiveMinPct);
+    const int clamped = std::min<int>(100, std::max<int>(min_pct, pct));
+    return quantizePfAdaptivePct(static_cast<unsigned>(clamped));
+}
+
+int
+Queued::computePfAdaptiveDpf(PrefetchSourceType source) const
+{
+    const unsigned source_idx = sanitizePfControlSource(source);
+    const uint64_t useful = pfAdaptiveWindowPfUsefulBySource[source_idx];
+    const uint64_t bad = pfAdaptiveWindowPfBadBySource[source_idx];
+    const uint64_t samples = useful + bad;
+    if (samples < pfAdaptiveDpfMinSamples) {
+        return 0;
+    }
+
+    const int64_t useful_score =
+        static_cast<int64_t>(useful) *
+        static_cast<int64_t>(pfAdaptivePfBadWeightDenominator);
+    const int64_t bad_score =
+        static_cast<int64_t>(bad) *
+        static_cast<int64_t>(pfAdaptivePfBadWeightNumerator);
+    const int64_t score = useful_score - bad_score;
+    const int64_t deadband =
+        static_cast<int64_t>(pfAdaptiveDpfDeadband) *
+        static_cast<int64_t>(pfAdaptivePfBadWeightDenominator);
+
+    const int64_t abs_score = score < 0 ? -score : score;
+    if (pfAdaptiveDpfDeadband > 0 && abs_score <= deadband) {
+        return 0;
+    }
+
+    return score > 0 ? pfAdaptiveGradientStep :
+        -pfAdaptiveGradientStep;
+}
+
+uint64_t
+Queued::pfAdaptiveMissRateBps(
+    uint64_t misses, uint64_t accesses) const
+{
+    if (accesses == 0) {
+        return 0;
+    }
+    return misses * 10000 / accesses;
+}
+
+unsigned
+Queued::getPfAdaptiveBestPct(PrefetchSourceType source) const
+{
+    if (pfAdaptiveSamples.empty()) {
+        const unsigned source_idx = sanitizePfControlSource(source);
+        return pfControlCurrentAdmitPctBySource[source_idx];
+    }
+
+    std::vector<const PfAdaptiveSample *> ranked;
+    ranked.reserve(pfAdaptiveSamples.size());
+    for (const auto &sample : pfAdaptiveSamples) {
+        if (sample.demandAccesses != 0) {
+            ranked.push_back(&sample);
+        }
+    }
+
+    if (ranked.empty()) {
+        const unsigned source_idx = sanitizePfControlSource(source);
+        return pfControlCurrentAdmitPctBySource[source_idx];
+    }
+
+    std::sort(ranked.begin(), ranked.end(),
+        [this](const auto *lhs, const auto *rhs) {
+            const uint64_t lhs_rate =
+                pfAdaptiveMissRateBps(
+                    lhs->demandMisses, lhs->demandAccesses);
+            const uint64_t rhs_rate =
+                pfAdaptiveMissRateBps(
+                    rhs->demandMisses, rhs->demandAccesses);
+            return lhs_rate < rhs_rate;
+        });
+
+    const unsigned source_idx = sanitizePfControlSource(source);
+    const size_t take = std::min<size_t>(
+        ranked.size(), std::max<unsigned>(1, pfAdaptiveBestTopK));
+    uint64_t sum = 0;
+    for (size_t idx = 0; idx < take; ++idx) {
+        sum += ranked[idx]->pctBySource[source_idx];
+    }
+    return quantizePfAdaptivePct(
+        static_cast<unsigned>((sum + take / 2) / take));
+}
+
+void
+Queued::pushPfAdaptiveSample(const PfAdaptiveSample &sample)
+{
+    if (pfAdaptiveTableEntries == 0) {
+        return;
+    }
+    if (pfAdaptiveSamples.size() >= pfAdaptiveTableEntries) {
+        pfAdaptiveSamples.pop_front();
+        statsQueued.pfAdaptiveTableEvictions++;
+    }
+    pfAdaptiveSamples.push_back(sample);
+    statsQueued.pfAdaptiveTableSize = pfAdaptiveSamples.size();
+}
+
+void
+Queued::applyPfAdaptiveUpdate(const PfAdaptiveSample &sample)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+
+    const uint64_t current_rate =
+        pfAdaptiveMissRateBps(
+            sample.demandMisses, sample.demandAccesses);
+    uint64_t best_rate = UINT64_MAX;
+    for (const auto &hist : pfAdaptiveSamples) {
+        if (hist.demandAccesses == 0) {
+            continue;
+        }
+        best_rate = std::min(best_rate,
+            pfAdaptiveMissRateBps(hist.demandMisses, hist.demandAccesses));
+    }
+
+    const bool have_best = best_rate != UINT64_MAX;
+    const bool update =
+        !have_best ||
+        current_rate * 10000 <
+            best_rate * (10000 - pfAdaptiveImproveMarginBps);
+
+    for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+        const auto pf_source = static_cast<PrefetchSourceType>(source);
+        const int current_pct =
+            static_cast<int>(pfControlCurrentAdmitPctBySource[source]);
+        const int dpf = sample.dpfBySource[source];
+        pfAdaptiveLastDpfBySource[source] = dpf;
+
+        const unsigned pred_pct =
+            clampPfAdaptivePct(current_pct + dpf);
+        const unsigned best_pct = getPfAdaptiveBestPct(pf_source);
+        unsigned next_pct = pred_pct;
+        if (!update) {
+            next_pct = quantizePfAdaptivePct(
+                (best_pct + pred_pct + 1) / 2);
+        }
+
+        const int max_step =
+            static_cast<int>(std::max<unsigned>(
+                1, pfAdaptiveMaxSourceStep));
+        const int delta =
+            static_cast<int>(next_pct) - current_pct;
+        if (delta > max_step) {
+            next_pct = current_pct + max_step;
+        } else if (delta < -max_step) {
+            next_pct = current_pct - max_step;
+        }
+
+        next_pct = clampPfAdaptivePct(static_cast<int>(next_pct));
+        pfControlCurrentAdmitPctBySource[source] = next_pct;
+        statsQueued.pfControlCurrentAdmitPctBySource[source] = next_pct;
+        statsQueued.pfAdaptivePctBySource[source] = next_pct;
+        statsQueued.pfAdaptiveDpfBySource[source] = dpf;
+    }
+
+    statsQueued.pfAdaptiveUpdates++;
+}
+
+void
+Queued::resetPfAdaptiveWindowCounters()
+{
+    pfAdaptiveWindowDemandAccesses = 0;
+    pfAdaptiveWindowDemandMisses = 0;
+    pfAdaptiveWindowPfUsefulBySource.fill(0);
+    pfAdaptiveWindowPfBadBySource.fill(0);
+}
+
+void
+Queued::recordPfAdaptiveDemandMiss(Addr paddr, bool is_secure)
+{
+    pfAdaptiveWindowDemandMisses++;
+
+    const Addr block_addr = blockAddress(paddr);
+    auto it = std::find_if(
+        pfAdaptivePfBadTable.begin(),
+        pfAdaptivePfBadTable.end(),
+        [block_addr, is_secure](const PfBadEntry &entry) {
+            return entry.valid && entry.blockAddr == block_addr &&
+                entry.secure == is_secure;
+        });
+
+    if (it == pfAdaptivePfBadTable.end()) {
+        return;
+    }
+
+    const unsigned source_idx = sanitizePfControlSource(it->source);
+    pfAdaptiveWindowPfBadBySource[source_idx]++;
+    statsQueued.pfAdaptivePfBadHits++;
+    pfAdaptivePfBadTable.erase(it);
+    statsQueued.pfAdaptivePfBadTableSize =
+        pfAdaptivePfBadTable.size();
+}
+
+void
+Queued::updatePfControlWindow()
+{
+    if (!pfControl) {
+        return;
+    }
+
+    const Cycles now = curCycle();
+    if (!pfControlWindowStarted) {
+        pfControlWindowStart = now;
+        pfControlWindowStarted = true;
+        refreshPfControlCurrentPcts();
+        return;
+    }
+
+    while (now - pfControlWindowStart >= pfControlWindow) {
+        const unsigned pct = pfControlCurrentAdmitPct;
+        statsQueued.pfControlWindows++;
+        statsQueued.pfControlWindowsByPct[pct]++;
+
+        if (isPfAdaptiveLevel()) {
+            PfAdaptiveSample sample;
+            sample.windowIndex = pfControlWindowIndex;
+            sample.demandAccesses = pfAdaptiveWindowDemandAccesses;
+            sample.demandMisses = pfAdaptiveWindowDemandMisses;
+            sample.pctBySource = pfControlCurrentAdmitPctBySource;
+            sample.pfUsefulBySource = pfAdaptiveWindowPfUsefulBySource;
+            sample.pfBadBySource = pfAdaptiveWindowPfBadBySource;
+            for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+                const auto pf_source =
+                    static_cast<PrefetchSourceType>(source);
+                sample.dpfBySource[source] =
+                    computePfAdaptiveDpf(pf_source);
+            }
+
+            if (sample.demandAccesses != 0) {
+                statsQueued.pfAdaptiveWindows++;
+                statsQueued.pfAdaptiveDemandAccesses +=
+                    sample.demandAccesses;
+                statsQueued.pfAdaptiveDemandMisses += sample.demandMisses;
+                for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+                    statsQueued.pfAdaptivePfUsefulBySource[source] +=
+                        sample.pfUsefulBySource[source];
+                    statsQueued.pfAdaptivePfBadBySource[source] +=
+                        sample.pfBadBySource[source];
+                }
+
+                if (pfAdaptiveSampleCount < pfAdaptiveWarmupWindows) {
+                    statsQueued.pfAdaptiveWarmupWindows++;
+                } else {
+                    applyPfAdaptiveUpdate(sample);
+                }
+                pfAdaptiveSampleCount++;
+                pushPfAdaptiveSample(sample);
+            }
+            resetPfAdaptiveWindowCounters();
+        }
+
+        pfControlWindowStart += pfControlWindow;
+        pfControlWindowIndex++;
+        pfControlWindowCandidates = 0;
+        pfControlWindowAdmitted = 0;
+        pfControlWindowCandidatesBySource.fill(0);
+        pfControlWindowAdmittedBySource.fill(0);
+        if (!isPfAdaptiveLevel()) {
+            refreshPfControlCurrentPcts();
+        }
+    }
+}
+
+bool
+Queued::shouldPfControlAdmitLocally(
+    bool pfahead, int pfahead_host) const
+{
+    if (!pfahead || !hasHintDownStream() || cache == nullptr) {
+        return true;
+    }
+    return pfahead_host <= static_cast<int>(cache->level());
+}
+
+bool
+Queued::admitPfControlCandidate(PrefetchSourceType source)
+{
+    if (!pfControl) {
+        return true;
+    }
+
+    updatePfControlWindow();
+
+    const unsigned source_idx = sanitizePfControlSource(source);
+    if (source_idx == PrefetchSourceType::PF_NONE) {
+        return true;
+    }
+    const unsigned pct = pfControlCurrentAdmitPctBySource[source_idx];
+    statsQueued.pfControlCandidates++;
+    statsQueued.pfControlCandidatesByPct[pct]++;
+    statsQueued.pfControlCandidatesBySource[source_idx]++;
+    pfControlWindowCandidates++;
+    pfControlWindowCandidatesBySource[source_idx]++;
+
+    const uint64_t allowed =
+        (pfControlWindowCandidatesBySource[source_idx] * pct + 99) / 100;
+    const bool admit =
+        allowed > pfControlWindowAdmittedBySource[source_idx];
+
+    if (admit) {
+        pfControlWindowAdmitted++;
+        pfControlWindowAdmittedBySource[source_idx]++;
+        statsQueued.pfControlAdmitted++;
+        statsQueued.pfControlAdmittedByPct[pct]++;
+        statsQueued.pfControlAdmittedBySource[source_idx]++;
+    } else {
+        statsQueued.pfControlDropped++;
+        statsQueued.pfControlDroppedByPct[pct]++;
+        statsQueued.pfControlDroppedBySource[source_idx]++;
+        DPRINTF(HWPrefetch,
+                "PF control dropped candidate from source %i at "
+                "admit_pct=%u\n",
+                source, pct);
+    }
+
+    return admit;
+}
+
+bool
+Queued::admitPfControlDeferredPacket(const DeferredPacket &dpp)
+{
+    if (!pfControl) {
+        return true;
+    }
+    if (!shouldPfControlAdmitLocally(dpp.pfahead, dpp.pfahead_host)) {
+        return true;
+    }
+
+    PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+    if (dpp.pkt != nullptr && dpp.pkt->req->hasXsMetadata()) {
+        source = dpp.pkt->req->getXsMetadata().prefetchSource;
+    } else {
+        source = dpp.pfInfo.getXsMetadata().prefetchSource;
+    }
+    return admitPfControlCandidate(source);
+}
+
+void
+Queued::notifyDemandAccess(Addr paddr, bool is_secure, bool miss)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+    updatePfControlWindow();
+    pfAdaptiveWindowDemandAccesses++;
+    if (miss) {
+        recordPfAdaptiveDemandMiss(paddr, is_secure);
+    }
+}
+
+void
+Queued::notifyDemandMshrMiss(Addr paddr, bool is_secure)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+    updatePfControlWindow();
+}
+
+void
+Queued::notifyPrefetchUseful(PrefetchSourceType source)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+    updatePfControlWindow();
+    const unsigned source_idx = sanitizePfControlSource(source);
+    if (source_idx == PrefetchSourceType::PF_NONE) {
+        return;
+    }
+    pfAdaptiveWindowPfUsefulBySource[source_idx]++;
+}
+
+void
+Queued::notifyPrefetchEvictsDemand(
+    Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+{
+    if (!isPfAdaptiveLevel() || pfAdaptivePfBadEntries == 0) {
+        return;
+    }
+    updatePfControlWindow();
+
+    const unsigned source_idx = sanitizePfControlSource(source);
+    if (source_idx == PrefetchSourceType::PF_NONE) {
+        return;
+    }
+
+    const Addr block_addr = blockAddress(victim_paddr);
+    auto it = std::find_if(
+        pfAdaptivePfBadTable.begin(),
+        pfAdaptivePfBadTable.end(),
+        [block_addr, is_secure](const PfBadEntry &entry) {
+            return entry.valid && entry.blockAddr == block_addr &&
+                entry.secure == is_secure;
+        });
+    if (it != pfAdaptivePfBadTable.end()) {
+        it->source = source;
+        it->insertWindow = pfControlWindowIndex;
+        return;
+    }
+
+    if (pfAdaptivePfBadTable.size() >= pfAdaptivePfBadEntries) {
+        const auto &oldest = pfAdaptivePfBadTable.front();
+        if (oldest.valid) {
+            const unsigned evicted_source =
+                sanitizePfControlSource(oldest.source);
+            if (evicted_source !=
+                static_cast<unsigned>(PrefetchSourceType::PF_NONE)) {
+                pfAdaptiveWindowPfBadBySource[evicted_source]++;
+                statsQueued.pfAdaptivePfBadOverflowBad++;
+                statsQueued.pfAdaptivePfBadOverflowBySource[evicted_source]++;
+            }
+        }
+        pfAdaptivePfBadTable.pop_front();
+        statsQueued.pfAdaptivePfBadTableEvictions++;
+    }
+
+    pfAdaptivePfBadTable.push_back(
+        PfBadEntry{true, block_addr, is_secure, source,
+                      pfControlWindowIndex});
+    statsQueued.pfAdaptivePfBadTableSize =
+        pfAdaptivePfBadTable.size();
+}
+
+void
+Queued::notifyCachelineRefill(Addr paddr, bool is_secure)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+    const Addr block_addr = blockAddress(paddr);
+    auto it = std::find_if(
+        pfAdaptivePfBadTable.begin(),
+        pfAdaptivePfBadTable.end(),
+        [block_addr, is_secure](const PfBadEntry &entry) {
+            return entry.valid && entry.blockAddr == block_addr &&
+                entry.secure == is_secure;
+        });
+    if (it != pfAdaptivePfBadTable.end()) {
+        pfAdaptivePfBadTable.erase(it);
+        statsQueued.pfAdaptivePfBadTableSize =
+            pfAdaptivePfBadTable.size();
+    }
 }
 
 void
@@ -293,6 +959,13 @@ Queued::notify(const PacketPtr &pkt, const PrefetchInfo &pfi)
 
         bool can_cross_page = (tlb != nullptr);
         if (can_cross_page || samePage(addr_prio.addr, pfi.getAddr())) {
+            if (shouldPfControlAdmitLocally(
+                    addr_prio.pfahead, addr_prio.pfahead_host) &&
+                !admitPfControlCandidate(addr_prio.pfSource)) {
+                continue;
+            }
+            addr_prio.pfSource =
+                sanitizePfControlSourceType(addr_prio.pfSource);
             PrefetchInfo new_pfi(pfi, addr_prio.addr);
             new_pfi.setXsMetadata(Request::XsMetadata(addr_prio.pfSource,addr_prio.depth));
             statsQueued.pfIdentified++;
@@ -341,6 +1014,13 @@ Queued::PFSendEventWrapper()
 
         bool can_cross_page = (tlb != nullptr);
         if (can_cross_page || samePage(addr_prio.addr, pfi.getAddr())) {
+            if (shouldPfControlAdmitLocally(
+                    addr_prio.pfahead, addr_prio.pfahead_host) &&
+                !admitPfControlCandidate(addr_prio.pfSource)) {
+                continue;
+            }
+            addr_prio.pfSource =
+                sanitizePfControlSourceType(addr_prio.pfSource);
             PrefetchInfo new_pfi(pfi, addr_prio.addr);
             new_pfi.setXsMetadata(Request::XsMetadata(addr_prio.pfSource,addr_prio.depth));
             statsQueued.pfIdentified++;
@@ -365,6 +1045,21 @@ Queued::hasPendingPacket()
     return !pfq.empty();
 }
 
+bool
+Queued::admitIncomingPrefetchPacket(const PacketPtr &pkt)
+{
+    if (!pfControl || pkt == nullptr || pkt->req == nullptr) {
+        return true;
+    }
+    PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+    if (pkt->req->hasXsMetadata()) {
+        source = pkt->req->getXsMetadata().prefetchSource;
+    } else {
+        source = pkt->getPFSource();
+    }
+    return admitPfControlCandidate(source);
+}
+
 PacketPtr
 Queued::getPacket()
 {
@@ -382,10 +1077,8 @@ Queued::getPacket()
     }
     pfq.pop_front();
 
-    prefetchStats.pfIssued++;
-    prefetchStats.pfIssued_srcs[pkt->req->getXsMetadata().prefetchSource]++;
-    issuedPrefetches += 1;
     assert(pkt != nullptr);
+    recordIssuedPrefetch(pkt);
     DPRINTF(HWPrefetch, "Generating prefetch for %#x.\n", pkt->getAddr());
 
     return pkt;
@@ -409,11 +1102,137 @@ Queued::QueuedStats::QueuedStats(statistics::Group *parent)
     ADD_STAT(pfUsefulSpanPage, statistics::units::Count::get(),
              "number of prefetches that is useful and crossed the page"),
     ADD_STAT(pfRemovedFull_srcs, statistics::units::Count::get(),
-        "src distribute of Removedfull prefetch")
-{   using namespace statistics;
+        "src distribute of Removedfull prefetch"),
+    ADD_STAT(pfControlCandidates, statistics::units::Count::get(),
+             "prefetch control candidate prefetches"),
+    ADD_STAT(pfControlAdmitted, statistics::units::Count::get(),
+             "prefetch control admitted prefetches"),
+    ADD_STAT(pfControlDropped, statistics::units::Count::get(),
+             "prefetch control dropped prefetches"),
+    ADD_STAT(pfControlWindows, statistics::units::Count::get(),
+             "prefetch control completed windows"),
+    ADD_STAT(pfControlCurrentAdmitPct, statistics::units::Count::get(),
+             "prefetch control current admission percentage"),
+    ADD_STAT(pfControlCandidatesByPct, statistics::units::Count::get(),
+             "prefetch control candidates by admission percentage"),
+    ADD_STAT(pfControlAdmittedByPct, statistics::units::Count::get(),
+             "prefetch control admitted prefetches by admission percentage"),
+    ADD_STAT(pfControlDroppedByPct, statistics::units::Count::get(),
+             "prefetch control dropped prefetches by admission percentage"),
+    ADD_STAT(pfControlWindowsByPct, statistics::units::Count::get(),
+             "prefetch control completed windows by admission percentage"),
+    ADD_STAT(pfControlCandidatesBySource, statistics::units::Count::get(),
+             "prefetch control candidates by prefetch source"),
+    ADD_STAT(pfControlAdmittedBySource, statistics::units::Count::get(),
+             "prefetch control admitted prefetches by prefetch source"),
+    ADD_STAT(pfControlDroppedBySource, statistics::units::Count::get(),
+             "prefetch control dropped prefetches by prefetch source"),
+    ADD_STAT(pfControlCurrentAdmitPctBySource,
+             statistics::units::Count::get(),
+             "prefetch control current admission percentage by "
+             "prefetch source"),
+    ADD_STAT(pfAdaptiveWindows, statistics::units::Count::get(),
+             "adaptive prefetch completed windows"),
+    ADD_STAT(pfAdaptiveUpdates, statistics::units::Count::get(),
+             "adaptive prefetch threshold updates"),
+    ADD_STAT(pfAdaptiveWarmupWindows, statistics::units::Count::get(),
+             "adaptive prefetch warmup windows"),
+    ADD_STAT(pfAdaptiveDemandAccesses, statistics::units::Count::get(),
+             "adaptive prefetch windowed demand accesses"),
+    ADD_STAT(pfAdaptiveDemandMisses, statistics::units::Count::get(),
+             "adaptive prefetch windowed demand cache misses"),
+    ADD_STAT(pfAdaptiveTableSize, statistics::units::Count::get(),
+             "adaptive prefetch FIFO experience table size"),
+    ADD_STAT(pfAdaptiveTableEvictions, statistics::units::Count::get(),
+             "adaptive prefetch FIFO experience table evictions"),
+    ADD_STAT(pfAdaptivePfBadTableSize, statistics::units::Count::get(),
+             "adaptive prefetch PFBad table size"),
+    ADD_STAT(pfAdaptivePfBadTableEvictions,
+             statistics::units::Count::get(),
+             "adaptive prefetch PFBad table evictions"),
+    ADD_STAT(pfAdaptivePfBadOverflowBad,
+             statistics::units::Count::get(),
+             "adaptive prefetch bad counts charged when PFBad table "
+             "overflows"),
+    ADD_STAT(pfAdaptivePfBadHits, statistics::units::Count::get(),
+             "adaptive prefetch demand misses hitting PFBad table"),
+    ADD_STAT(pfAdaptivePctBySource, statistics::units::Count::get(),
+             "adaptive prefetch current admission percentage by source"),
+    ADD_STAT(pfAdaptiveDpfBySource, statistics::units::Count::get(),
+             "adaptive prefetch latest per-source gradient"),
+    ADD_STAT(pfAdaptivePfUsefulBySource, statistics::units::Count::get(),
+             "adaptive prefetch useful counts by source"),
+    ADD_STAT(pfAdaptivePfBadBySource, statistics::units::Count::get(),
+             "adaptive prefetch bad counts by source"),
+    ADD_STAT(pfAdaptivePfBadOverflowBySource,
+             statistics::units::Count::get(),
+             "adaptive prefetch PFBad overflow bad counts by source")
+{
+    using namespace statistics;
     pfRemovedFull_srcs
         .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfControlCandidatesByPct
+        .init(101)
+        .flags(total | nozero);
+    pfControlAdmittedByPct
+        .init(101)
+        .flags(total | nozero);
+    pfControlDroppedByPct
+        .init(101)
+        .flags(total | nozero);
+    pfControlWindowsByPct
+        .init(101)
+        .flags(total | nozero);
+    pfControlCandidatesBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfControlAdmittedBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfControlDroppedBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfControlCurrentAdmitPctBySource
+        .init(NUM_PF_SOURCES)
         .flags(total);
+    pfAdaptivePctBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total);
+    pfAdaptiveDpfBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total);
+    pfAdaptivePfUsefulBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfAdaptivePfBadBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfAdaptivePfBadOverflowBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    for (unsigned pct = 0; pct <= 100; ++pct) {
+        const auto name = std::to_string(pct);
+        pfControlCandidatesByPct.subname(pct, name);
+        pfControlAdmittedByPct.subname(pct, name);
+        pfControlDroppedByPct.subname(pct, name);
+        pfControlWindowsByPct.subname(pct, name);
+    }
+    for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
+        const auto source_name = prefetchSourceTypeName(source);
+        pfRemovedFull_srcs.subname(source, source_name);
+        pfControlCandidatesBySource.subname(source, source_name);
+        pfControlAdmittedBySource.subname(source, source_name);
+        pfControlDroppedBySource.subname(source, source_name);
+        pfControlCurrentAdmitPctBySource.subname(
+            source, source_name);
+        pfAdaptivePctBySource.subname(source, source_name);
+        pfAdaptiveDpfBySource.subname(source, source_name);
+        pfAdaptivePfUsefulBySource.subname(source, source_name);
+        pfAdaptivePfBadBySource.subname(source, source_name);
+        pfAdaptivePfBadOverflowBySource.subname(
+            source, source_name);
+    }
 }
 
 

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -76,7 +76,7 @@ buildPfControlSourceAdmitPct(const std::vector<int> &values)
     panic_if(values.size() != NUM_PF_SOURCES,
              "pf_control_source_admit_pcts must be empty or have "
              "%u entries, got %zu",
-             static_cast<unsigned>(NUM_PF_SOURCES), values.size());
+             unsigned(NUM_PF_SOURCES), values.size());
 
     for (size_t idx = 0; idx < values.size(); ++idx) {
         const int pct = values[idx];
@@ -210,8 +210,8 @@ Queued::Queued(const QueuedPrefetcherParams &p)
           std::max<unsigned>(1, p.pf_adaptive_pfbad_weight_numer)),
       pfAdaptivePfBadWeightDenominator(
           std::max<unsigned>(1, p.pf_adaptive_pfbad_weight_denom)),
-      pfAdaptiveDpfMinSamples(p.pf_adaptive_dpf_min_samples),
-      pfAdaptiveDpfDeadband(p.pf_adaptive_dpf_deadband),
+      pfAdaptiveGradientMinSamples(p.pf_adaptive_dpf_min_samples),
+      pfAdaptiveGradientDeadband(p.pf_adaptive_dpf_deadband),
       pfAdaptiveImproveMarginBps(p.pf_adaptive_improve_margin_bps),
       pfAdaptiveBestTopK(std::max<unsigned>(1, p.pf_adaptive_best_topk)),
       pfAdaptiveTableEntries(p.pf_adaptive_table_entries),
@@ -221,8 +221,8 @@ Queued::Queued(const QueuedPrefetcherParams &p)
       pfAdaptiveWindowDemandAccesses(0),
       pfAdaptiveWindowDemandMisses(0),
       pfAdaptiveWindowPfUsefulBySource{},
-      pfAdaptiveWindowPfBadBySource{},
-      pfAdaptiveLastDpfBySource{},
+      pfAdaptiveWindowPfUnusedBySource{},
+      pfAdaptiveWindowPfBadHitsBySource{},
       pfAdaptiveSampleCount(0),
       pfAdaptiveSamples(),
       pfAdaptivePfBadTable(),
@@ -262,8 +262,8 @@ Queued::Queued(const QueuedPrefetcherParams &p)
     panic_if(pfAdaptive && pfAdaptiveMaxSourceStep == 0,
              "pf_adaptive_max_source_step must be positive");
     pfAdaptiveWindowPfUsefulBySource.fill(0);
-    pfAdaptiveWindowPfBadBySource.fill(0);
-    pfAdaptiveLastDpfBySource.fill(0);
+    pfAdaptiveWindowPfUnusedBySource.fill(0);
+    pfAdaptiveWindowPfBadHitsBySource.fill(0);
     refreshPfControlCurrentPcts();
 }
 
@@ -336,7 +336,7 @@ Queued::sanitizePfControlPct(unsigned pct) const
 PrefetchSourceType
 Queued::sanitizePfControlSourceType(PrefetchSourceType source) const
 {
-    const int source_idx = static_cast<int>(source);
+    const int source_idx = int(source);
     if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
         return PrefetchSourceType::PF_NONE;
     }
@@ -346,7 +346,13 @@ Queued::sanitizePfControlSourceType(PrefetchSourceType source) const
 unsigned
 Queued::sanitizePfControlSource(PrefetchSourceType source) const
 {
-    return static_cast<unsigned>(sanitizePfControlSourceType(source));
+    return unsigned(sanitizePfControlSourceType(source));
+}
+
+bool
+Queued::isPfControlSourceNone(PrefetchSourceType source) const
+{
+    return sanitizePfControlSourceType(source) == PrefetchSourceType::PF_NONE;
 }
 
 unsigned
@@ -401,7 +407,7 @@ Queued::refreshPfControlCurrentPcts()
     statsQueued.pfControlCurrentAdmitPct = pfControlCurrentAdmitPct;
 
     for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
-        const auto pf_source = static_cast<PrefetchSourceType>(source);
+        const auto pf_source = PrefetchSourceType(source);
         const unsigned pct =
             getPfControlActionPctForSource(
                 pfControlWindowIndex, pf_source);
@@ -427,39 +433,41 @@ Queued::quantizePfAdaptivePct(unsigned pct) const
 unsigned
 Queued::clampPfAdaptivePct(int pct) const
 {
-    const int min_pct = static_cast<int>(pfAdaptiveMinPct);
+    const int min_pct = int(pfAdaptiveMinPct);
     const int clamped = std::min<int>(100, std::max<int>(min_pct, pct));
-    return quantizePfAdaptivePct(static_cast<unsigned>(clamped));
+    return quantizePfAdaptivePct(unsigned(clamped));
 }
 
 int
-Queued::computePfAdaptiveDpf(PrefetchSourceType source) const
+Queued::computePfAdaptiveSourceGradient(
+    uint64_t useful, uint64_t pfbad_hits, uint64_t unused) const
 {
-    const unsigned source_idx = sanitizePfControlSource(source);
-    const uint64_t useful = pfAdaptiveWindowPfUsefulBySource[source_idx];
-    const uint64_t bad = pfAdaptiveWindowPfBadBySource[source_idx];
-    const uint64_t samples = useful + bad;
-    if (samples < pfAdaptiveDpfMinSamples) {
+    const uint64_t samples = useful + pfbad_hits + unused;
+    if (samples < pfAdaptiveGradientMinSamples) {
         return 0;
     }
 
-    const int64_t useful_score =
-        static_cast<int64_t>(useful) *
-        static_cast<int64_t>(pfAdaptivePfBadWeightDenominator);
-    const int64_t bad_score =
-        static_cast<int64_t>(bad) *
-        static_cast<int64_t>(pfAdaptivePfBadWeightNumerator);
-    const int64_t score = useful_score - bad_score;
-    const int64_t deadband =
-        static_cast<int64_t>(pfAdaptiveDpfDeadband) *
-        static_cast<int64_t>(pfAdaptivePfBadWeightDenominator);
+    // Gradient input is intentionally simple:
+    //   useful     = prefetches later hit by demand,
+    //   pfbad_hits = cache misses for lines evicted by this prefetch source,
+    //   unused     = prefetches evicted without a demand hit.
+    // FIFO overflow is diagnostic only; feeding it back here would make table
+    // capacity directly change the controller decision.
+    const double pfbad_weight =
+        double(pfAdaptivePfBadWeightNumerator) /
+        pfAdaptivePfBadWeightDenominator;
+    const double useful_score = useful;
+    const double bad_score =
+        pfbad_hits * pfbad_weight + unused * 0.5;
+    const double score = useful_score - bad_score;
+    const double deadband = pfAdaptiveGradientDeadband;
 
-    const int64_t abs_score = score < 0 ? -score : score;
-    if (pfAdaptiveDpfDeadband > 0 && abs_score <= deadband) {
+    const double abs_score = score < 0.0 ? -score : score;
+    if (pfAdaptiveGradientDeadband > 0 && abs_score <= deadband) {
         return 0;
     }
 
-    return score > 0 ? pfAdaptiveGradientStep :
+    return score > 0.0 ? pfAdaptiveGradientStep :
         -pfAdaptiveGradientStep;
 }
 
@@ -513,7 +521,7 @@ Queued::getPfAdaptiveBestPct(PrefetchSourceType source) const
         sum += ranked[idx]->pctBySource[source_idx];
     }
     return quantizePfAdaptivePct(
-        static_cast<unsigned>((sum + take / 2) / take));
+        unsigned((sum + take / 2) / take));
 }
 
 void
@@ -556,14 +564,13 @@ Queued::applyPfAdaptiveUpdate(const PfAdaptiveSample &sample)
             best_rate * (10000 - pfAdaptiveImproveMarginBps);
 
     for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
-        const auto pf_source = static_cast<PrefetchSourceType>(source);
+        const auto pf_source = PrefetchSourceType(source);
         const int current_pct =
-            static_cast<int>(pfControlCurrentAdmitPctBySource[source]);
-        const int dpf = sample.dpfBySource[source];
-        pfAdaptiveLastDpfBySource[source] = dpf;
+            int(pfControlCurrentAdmitPctBySource[source]);
+        const int gradient = sample.gradientBySource[source];
 
         const unsigned pred_pct =
-            clampPfAdaptivePct(current_pct + dpf);
+            clampPfAdaptivePct(current_pct + gradient);
         const unsigned best_pct = getPfAdaptiveBestPct(pf_source);
         unsigned next_pct = pred_pct;
         if (!update) {
@@ -572,21 +579,19 @@ Queued::applyPfAdaptiveUpdate(const PfAdaptiveSample &sample)
         }
 
         const int max_step =
-            static_cast<int>(std::max<unsigned>(
-                1, pfAdaptiveMaxSourceStep));
-        const int delta =
-            static_cast<int>(next_pct) - current_pct;
+            int(std::max<unsigned>(1, pfAdaptiveMaxSourceStep));
+        const int delta = int(next_pct) - current_pct;
         if (delta > max_step) {
             next_pct = current_pct + max_step;
         } else if (delta < -max_step) {
             next_pct = current_pct - max_step;
         }
 
-        next_pct = clampPfAdaptivePct(static_cast<int>(next_pct));
+        next_pct = clampPfAdaptivePct(int(next_pct));
         pfControlCurrentAdmitPctBySource[source] = next_pct;
         statsQueued.pfControlCurrentAdmitPctBySource[source] = next_pct;
         statsQueued.pfAdaptivePctBySource[source] = next_pct;
-        statsQueued.pfAdaptiveDpfBySource[source] = dpf;
+        statsQueued.pfAdaptiveGradientBySource[source] = gradient;
     }
 
     statsQueued.pfAdaptiveUpdates++;
@@ -598,33 +603,83 @@ Queued::resetPfAdaptiveWindowCounters()
     pfAdaptiveWindowDemandAccesses = 0;
     pfAdaptiveWindowDemandMisses = 0;
     pfAdaptiveWindowPfUsefulBySource.fill(0);
-    pfAdaptiveWindowPfBadBySource.fill(0);
+    pfAdaptiveWindowPfUnusedBySource.fill(0);
+    pfAdaptiveWindowPfBadHitsBySource.fill(0);
 }
 
 void
-Queued::recordPfAdaptiveDemandMiss(Addr paddr, bool is_secure)
+Queued::recordPfAdaptiveDemandMiss()
 {
     pfAdaptiveWindowDemandMisses++;
+}
 
+std::deque<Queued::PfBadEntry>::iterator
+Queued::findPfAdaptivePfBadEntry(Addr paddr, bool is_secure)
+{
     const Addr block_addr = blockAddress(paddr);
-    auto it = std::find_if(
+    return std::find_if(
         pfAdaptivePfBadTable.begin(),
         pfAdaptivePfBadTable.end(),
         [block_addr, is_secure](const PfBadEntry &entry) {
             return entry.valid && entry.blockAddr == block_addr &&
                 entry.secure == is_secure;
         });
+}
 
+bool
+Queued::recordPfAdaptivePfBadMissHit(Addr paddr, bool is_secure)
+{
+    auto it = findPfAdaptivePfBadEntry(paddr, is_secure);
     if (it == pfAdaptivePfBadTable.end()) {
-        return;
+        return false;
     }
 
-    const unsigned source_idx = sanitizePfControlSource(it->source);
-    pfAdaptiveWindowPfBadBySource[source_idx]++;
-    statsQueued.pfAdaptivePfBadHits++;
+    recordPfAdaptivePfBadHit(it->evictorSource);
     pfAdaptivePfBadTable.erase(it);
     statsQueued.pfAdaptivePfBadTableSize =
         pfAdaptivePfBadTable.size();
+    return true;
+}
+
+void
+Queued::recordPfAdaptivePfBadHit(PrefetchSourceType evictor_source)
+{
+    if (isPfControlSourceNone(evictor_source)) {
+        return;
+    }
+    const unsigned source_idx = sanitizePfControlSource(evictor_source);
+
+    pfAdaptiveWindowPfBadHitsBySource[source_idx]++;
+    recordPfBadHit(evictor_source);
+    statsQueued.pfAdaptivePfBadHits++;
+    statsQueued.pfAdaptivePfBadHitsBySource[source_idx]++;
+}
+
+bool
+Queued::clearPfAdaptivePfBadEntry(Addr paddr, bool is_secure)
+{
+    auto it = findPfAdaptivePfBadEntry(paddr, is_secure);
+    if (it == pfAdaptivePfBadTable.end()) {
+        return false;
+    }
+
+    pfAdaptivePfBadTable.erase(it);
+    statsQueued.pfAdaptivePfBadTableSize =
+        pfAdaptivePfBadTable.size();
+    return true;
+}
+
+void
+Queued::recordPfAdaptivePfBadOverflowEviction(
+    PrefetchSourceType evictor_source)
+{
+    if (isPfControlSourceNone(evictor_source)) {
+        return;
+    }
+    const unsigned source_idx = sanitizePfControlSource(evictor_source);
+
+    statsQueued.pfAdaptivePfBadOverflowEvictions++;
+    statsQueued.pfAdaptivePfBadOverflowBySource[source_idx]++;
 }
 
 void
@@ -654,12 +709,15 @@ Queued::updatePfControlWindow()
             sample.demandMisses = pfAdaptiveWindowDemandMisses;
             sample.pctBySource = pfControlCurrentAdmitPctBySource;
             sample.pfUsefulBySource = pfAdaptiveWindowPfUsefulBySource;
-            sample.pfBadBySource = pfAdaptiveWindowPfBadBySource;
+            sample.pfUnusedBySource = pfAdaptiveWindowPfUnusedBySource;
+            sample.pfBadHitsBySource =
+                pfAdaptiveWindowPfBadHitsBySource;
             for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
-                const auto pf_source =
-                    static_cast<PrefetchSourceType>(source);
-                sample.dpfBySource[source] =
-                    computePfAdaptiveDpf(pf_source);
+                sample.gradientBySource[source] =
+                    computePfAdaptiveSourceGradient(
+                        sample.pfUsefulBySource[source],
+                        sample.pfBadHitsBySource[source],
+                        sample.pfUnusedBySource[source]);
             }
 
             if (sample.demandAccesses != 0) {
@@ -670,8 +728,6 @@ Queued::updatePfControlWindow()
                 for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
                     statsQueued.pfAdaptivePfUsefulBySource[source] +=
                         sample.pfUsefulBySource[source];
-                    statsQueued.pfAdaptivePfBadBySource[source] +=
-                        sample.pfBadBySource[source];
                 }
 
                 if (pfAdaptiveSampleCount < pfAdaptiveWarmupWindows) {
@@ -704,7 +760,7 @@ Queued::shouldPfControlAdmitLocally(
     if (!pfahead || !hasHintDownStream() || cache == nullptr) {
         return true;
     }
-    return pfahead_host <= static_cast<int>(cache->level());
+    return pfahead_host <= int(cache->level());
 }
 
 bool
@@ -716,10 +772,10 @@ Queued::admitPfControlCandidate(PrefetchSourceType source)
 
     updatePfControlWindow();
 
-    const unsigned source_idx = sanitizePfControlSource(source);
-    if (source_idx == PrefetchSourceType::PF_NONE) {
+    if (isPfControlSourceNone(source)) {
         return true;
     }
+    const unsigned source_idx = sanitizePfControlSource(source);
     const unsigned pct = pfControlCurrentAdmitPctBySource[source_idx];
     statsQueued.pfControlCandidates++;
     statsQueued.pfControlCandidatesByPct[pct]++;
@@ -779,8 +835,18 @@ Queued::notifyDemandAccess(Addr paddr, bool is_secure, bool miss)
     updatePfControlWindow();
     pfAdaptiveWindowDemandAccesses++;
     if (miss) {
-        recordPfAdaptiveDemandMiss(paddr, is_secure);
+        recordPfAdaptiveDemandMiss();
     }
+}
+
+void
+Queued::notifyCacheMissRequest(Addr paddr, bool is_secure)
+{
+    if (!isPfAdaptiveLevel()) {
+        return;
+    }
+    updatePfControlWindow();
+    recordPfAdaptivePfBadMissHit(paddr, is_secure);
 }
 
 void
@@ -799,37 +865,35 @@ Queued::notifyPrefetchUseful(PrefetchSourceType source)
         return;
     }
     updatePfControlWindow();
-    const unsigned source_idx = sanitizePfControlSource(source);
-    if (source_idx == PrefetchSourceType::PF_NONE) {
+    if (isPfControlSourceNone(source)) {
         return;
     }
+    const unsigned source_idx = sanitizePfControlSource(source);
     pfAdaptiveWindowPfUsefulBySource[source_idx]++;
 }
 
 void
 Queued::notifyPrefetchEvictsDemand(
-    Addr victim_paddr, bool is_secure, PrefetchSourceType source)
+    Addr victim_paddr, bool is_secure, PrefetchSourceType evictor_source)
 {
     if (!isPfAdaptiveLevel() || pfAdaptivePfBadEntries == 0) {
         return;
     }
     updatePfControlWindow();
 
-    const unsigned source_idx = sanitizePfControlSource(source);
-    if (source_idx == PrefetchSourceType::PF_NONE) {
+    evictor_source = sanitizePfControlSourceType(evictor_source);
+    if (isPfControlSourceNone(evictor_source)) {
         return;
     }
+    const unsigned source_idx = sanitizePfControlSource(evictor_source);
+
+    statsQueued.pfAdaptivePfBadCandidates++;
+    statsQueued.pfAdaptivePfBadCandidatesBySource[source_idx]++;
 
     const Addr block_addr = blockAddress(victim_paddr);
-    auto it = std::find_if(
-        pfAdaptivePfBadTable.begin(),
-        pfAdaptivePfBadTable.end(),
-        [block_addr, is_secure](const PfBadEntry &entry) {
-            return entry.valid && entry.blockAddr == block_addr &&
-                entry.secure == is_secure;
-        });
+    auto it = findPfAdaptivePfBadEntry(block_addr, is_secure);
     if (it != pfAdaptivePfBadTable.end()) {
-        it->source = source;
+        it->evictorSource = evictor_source;
         it->insertWindow = pfControlWindowIndex;
         return;
     }
@@ -837,22 +901,15 @@ Queued::notifyPrefetchEvictsDemand(
     if (pfAdaptivePfBadTable.size() >= pfAdaptivePfBadEntries) {
         const auto &oldest = pfAdaptivePfBadTable.front();
         if (oldest.valid) {
-            const unsigned evicted_source =
-                sanitizePfControlSource(oldest.source);
-            if (evicted_source !=
-                static_cast<unsigned>(PrefetchSourceType::PF_NONE)) {
-                pfAdaptiveWindowPfBadBySource[evicted_source]++;
-                statsQueued.pfAdaptivePfBadOverflowBad++;
-                statsQueued.pfAdaptivePfBadOverflowBySource[evicted_source]++;
-            }
+            recordPfAdaptivePfBadOverflowEviction(oldest.evictorSource);
         }
         pfAdaptivePfBadTable.pop_front();
         statsQueued.pfAdaptivePfBadTableEvictions++;
     }
 
     pfAdaptivePfBadTable.push_back(
-        PfBadEntry{true, block_addr, is_secure, source,
-                      pfControlWindowIndex});
+        PfBadEntry{true, block_addr, is_secure, evictor_source,
+                   pfControlWindowIndex});
     statsQueued.pfAdaptivePfBadTableSize =
         pfAdaptivePfBadTable.size();
 }
@@ -863,19 +920,23 @@ Queued::notifyCachelineRefill(Addr paddr, bool is_secure)
     if (!isPfAdaptiveLevel()) {
         return;
     }
-    const Addr block_addr = blockAddress(paddr);
-    auto it = std::find_if(
-        pfAdaptivePfBadTable.begin(),
-        pfAdaptivePfBadTable.end(),
-        [block_addr, is_secure](const PfBadEntry &entry) {
-            return entry.valid && entry.blockAddr == block_addr &&
-                entry.secure == is_secure;
-        });
-    if (it != pfAdaptivePfBadTable.end()) {
-        pfAdaptivePfBadTable.erase(it);
-        statsQueued.pfAdaptivePfBadTableSize =
-            pfAdaptivePfBadTable.size();
+    clearPfAdaptivePfBadEntry(paddr, is_secure);
+}
+
+void
+Queued::prefetchUnused(PrefetchSourceType pf_source)
+{
+    Base::prefetchUnused(pf_source);
+    if (!isPfAdaptiveLevel()) {
+        return;
     }
+
+    updatePfControlWindow();
+    if (isPfControlSourceNone(pf_source)) {
+        return;
+    }
+    const unsigned source_idx = sanitizePfControlSource(pf_source);
+    pfAdaptiveWindowPfUnusedBySource[source_idx]++;
 }
 
 void
@@ -1150,23 +1211,30 @@ Queued::QueuedStats::QueuedStats(statistics::Group *parent)
     ADD_STAT(pfAdaptivePfBadTableEvictions,
              statistics::units::Count::get(),
              "adaptive prefetch PFBad table evictions"),
-    ADD_STAT(pfAdaptivePfBadOverflowBad,
+    ADD_STAT(pfAdaptivePfBadCandidates,
              statistics::units::Count::get(),
-             "adaptive prefetch bad counts charged when PFBad table "
-             "overflows"),
+             "adaptive prefetch PFBad candidate evictions"),
+    ADD_STAT(pfAdaptivePfBadCandidatesBySource,
+             statistics::units::Count::get(),
+             "adaptive prefetch PFBad candidates by evictor source"),
+    ADD_STAT(pfAdaptivePfBadOverflowEvictions,
+             statistics::units::Count::get(),
+             "adaptive prefetch PFBad table entries evicted by FIFO "
+             "overflow"),
     ADD_STAT(pfAdaptivePfBadHits, statistics::units::Count::get(),
-             "adaptive prefetch demand misses hitting PFBad table"),
+             "adaptive prefetch cache miss requests hitting PFBad table"),
     ADD_STAT(pfAdaptivePctBySource, statistics::units::Count::get(),
              "adaptive prefetch current admission percentage by source"),
-    ADD_STAT(pfAdaptiveDpfBySource, statistics::units::Count::get(),
-             "adaptive prefetch latest per-source gradient"),
+    ADD_STAT(pfAdaptiveGradientBySource, statistics::units::Count::get(),
+             "adaptive prefetch latest per-source threshold gradient"),
     ADD_STAT(pfAdaptivePfUsefulBySource, statistics::units::Count::get(),
              "adaptive prefetch useful counts by source"),
-    ADD_STAT(pfAdaptivePfBadBySource, statistics::units::Count::get(),
-             "adaptive prefetch bad counts by source"),
+    ADD_STAT(pfAdaptivePfBadHitsBySource, statistics::units::Count::get(),
+             "adaptive prefetch cache miss requests hitting PFBad table "
+             "by evictor source"),
     ADD_STAT(pfAdaptivePfBadOverflowBySource,
              statistics::units::Count::get(),
-             "adaptive prefetch PFBad overflow bad counts by source")
+             "adaptive prefetch PFBad FIFO overflow evictions by source")
 {
     using namespace statistics;
     pfRemovedFull_srcs
@@ -1199,13 +1267,16 @@ Queued::QueuedStats::QueuedStats(statistics::Group *parent)
     pfAdaptivePctBySource
         .init(NUM_PF_SOURCES)
         .flags(total);
-    pfAdaptiveDpfBySource
+    pfAdaptiveGradientBySource
         .init(NUM_PF_SOURCES)
         .flags(total);
     pfAdaptivePfUsefulBySource
         .init(NUM_PF_SOURCES)
         .flags(total | nozero);
-    pfAdaptivePfBadBySource
+    pfAdaptivePfBadCandidatesBySource
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
+    pfAdaptivePfBadHitsBySource
         .init(NUM_PF_SOURCES)
         .flags(total | nozero);
     pfAdaptivePfBadOverflowBySource
@@ -1227,9 +1298,10 @@ Queued::QueuedStats::QueuedStats(statistics::Group *parent)
         pfControlCurrentAdmitPctBySource.subname(
             source, source_name);
         pfAdaptivePctBySource.subname(source, source_name);
-        pfAdaptiveDpfBySource.subname(source, source_name);
+        pfAdaptiveGradientBySource.subname(source, source_name);
         pfAdaptivePfUsefulBySource.subname(source, source_name);
-        pfAdaptivePfBadBySource.subname(source, source_name);
+        pfAdaptivePfBadCandidatesBySource.subname(source, source_name);
+        pfAdaptivePfBadHitsBySource.subname(source, source_name);
         pfAdaptivePfBadOverflowBySource.subname(
             source, source_name);
     }

--- a/src/mem/cache/prefetch/queued.hh
+++ b/src/mem/cache/prefetch/queued.hh
@@ -248,15 +248,15 @@ class Queued : public Base
     /** Per-window gradient step in percentage points. */
     const int pfAdaptiveGradientStep;
 
-    /** PFBad penalty multiplier represented as a fixed-point ratio. */
+    /** PFBad penalty multiplier as numerator / denominator. */
     const unsigned pfAdaptivePfBadWeightNumerator;
     const unsigned pfAdaptivePfBadWeightDenominator;
 
     /** Minimum useful+bad samples before trusting a source gradient. */
-    const unsigned pfAdaptiveDpfMinSamples;
+    const unsigned pfAdaptiveGradientMinSamples;
 
-    /** Deadband around zero useful-bad score. */
-    const int pfAdaptiveDpfDeadband;
+    /** Deadband around zero useful-minus-weighted-bad score. */
+    const int pfAdaptiveGradientDeadband;
 
     /** Required miss-rate improvement in basis points. */
     const unsigned pfAdaptiveImproveMarginBps;
@@ -280,8 +280,9 @@ class Queued : public Base
     uint64_t pfAdaptiveWindowDemandAccesses;
     uint64_t pfAdaptiveWindowDemandMisses;
     std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfUsefulBySource;
-    std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfBadBySource;
-    std::array<int, NUM_PF_SOURCES> pfAdaptiveLastDpfBySource;
+    std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfUnusedBySource;
+    /** Cache miss requests hitting the PFBad table; overflow is not included. */
+    std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfBadHitsBySource;
     uint64_t pfAdaptiveSampleCount;
 
     struct PfAdaptiveSample
@@ -290,9 +291,10 @@ class Queued : public Base
         uint64_t demandAccesses = 0;
         uint64_t demandMisses = 0;
         std::array<unsigned, NUM_PF_SOURCES> pctBySource{};
-        std::array<int, NUM_PF_SOURCES> dpfBySource{};
+        std::array<int, NUM_PF_SOURCES> gradientBySource{};
         std::array<uint64_t, NUM_PF_SOURCES> pfUsefulBySource{};
-        std::array<uint64_t, NUM_PF_SOURCES> pfBadBySource{};
+        std::array<uint64_t, NUM_PF_SOURCES> pfUnusedBySource{};
+        std::array<uint64_t, NUM_PF_SOURCES> pfBadHitsBySource{};
     };
 
     struct PfBadEntry
@@ -300,7 +302,7 @@ class Queued : public Base
         bool valid = false;
         Addr blockAddr = 0;
         bool secure = false;
-        PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+        PrefetchSourceType evictorSource = PrefetchSourceType::PF_NONE;
         uint64_t insertWindow = 0;
     };
 
@@ -353,12 +355,14 @@ class Queued : public Base
         statistics::Scalar pfAdaptiveTableEvictions;
         statistics::Scalar pfAdaptivePfBadTableSize;
         statistics::Scalar pfAdaptivePfBadTableEvictions;
-        statistics::Scalar pfAdaptivePfBadOverflowBad;
+        statistics::Scalar pfAdaptivePfBadCandidates;
+        statistics::Vector pfAdaptivePfBadCandidatesBySource;
+        statistics::Scalar pfAdaptivePfBadOverflowEvictions;
         statistics::Scalar pfAdaptivePfBadHits;
         statistics::Vector pfAdaptivePctBySource;
-        statistics::Vector pfAdaptiveDpfBySource;
+        statistics::Vector pfAdaptiveGradientBySource;
         statistics::Vector pfAdaptivePfUsefulBySource;
-        statistics::Vector pfAdaptivePfBadBySource;
+        statistics::Vector pfAdaptivePfBadHitsBySource;
         statistics::Vector pfAdaptivePfBadOverflowBySource;
     } statsQueued;
 
@@ -446,6 +450,7 @@ class Queued : public Base
     PrefetchSourceType sanitizePfControlSourceType(
         PrefetchSourceType source) const;
     unsigned sanitizePfControlSource(PrefetchSourceType source) const;
+    bool isPfControlSourceNone(PrefetchSourceType source) const;
     unsigned getPfControlActionPct(uint64_t window_index) const;
     unsigned getPfControlActionPctForSource(
         uint64_t window_index, PrefetchSourceType source) const;
@@ -458,22 +463,33 @@ class Queued : public Base
     bool isPfAdaptiveLevel() const;
     unsigned quantizePfAdaptivePct(unsigned pct) const;
     unsigned clampPfAdaptivePct(int pct) const;
-    int computePfAdaptiveDpf(PrefetchSourceType source) const;
+    int computePfAdaptiveSourceGradient(
+        uint64_t useful, uint64_t pfbad_hits, uint64_t unused) const;
     uint64_t pfAdaptiveMissRateBps(
         uint64_t misses, uint64_t accesses) const;
     unsigned getPfAdaptiveBestPct(PrefetchSourceType source) const;
     void pushPfAdaptiveSample(const PfAdaptiveSample &sample);
     void applyPfAdaptiveUpdate(const PfAdaptiveSample &sample);
     void resetPfAdaptiveWindowCounters();
-    void recordPfAdaptiveDemandMiss(Addr paddr, bool is_secure);
+    std::deque<PfBadEntry>::iterator findPfAdaptivePfBadEntry(
+        Addr paddr, bool is_secure);
+    void recordPfAdaptiveDemandMiss();
+    void recordPfAdaptivePfBadHit(PrefetchSourceType evictor_source);
+    bool recordPfAdaptivePfBadMissHit(Addr paddr, bool is_secure);
+    bool clearPfAdaptivePfBadEntry(Addr paddr, bool is_secure);
+    void recordPfAdaptivePfBadOverflowEviction(
+        PrefetchSourceType evictor_source);
 
   public:
     void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) override;
+    void notifyCacheMissRequest(Addr paddr, bool is_secure) override;
     void notifyDemandMshrMiss(Addr paddr, bool is_secure) override;
     void notifyPrefetchUseful(PrefetchSourceType source) override;
     void notifyPrefetchEvictsDemand(
-        Addr victim_paddr, bool is_secure, PrefetchSourceType source) override;
+        Addr victim_paddr, bool is_secure,
+        PrefetchSourceType evictor_source) override;
     void notifyCachelineRefill(Addr paddr, bool is_secure) override;
+    void prefetchUnused(PrefetchSourceType pf_source) override;
 
   public:
     void rxHint(BaseMMU::Translation *dpp) override {

--- a/src/mem/cache/prefetch/queued.hh
+++ b/src/mem/cache/prefetch/queued.hh
@@ -261,6 +261,9 @@ class Queued : public Base
     /** Required miss-rate improvement in basis points. */
     const unsigned pfAdaptiveImproveMarginBps;
 
+    /** Enable historical best-sample fallback in adaptive updates. */
+    const bool pfAdaptiveHistoryFallback;
+
     /** Number of best FIFO samples to average for fallback pct. */
     const unsigned pfAdaptiveBestTopK;
 

--- a/src/mem/cache/prefetch/queued.hh
+++ b/src/mem/cache/prefetch/queued.hh
@@ -38,7 +38,9 @@
 #ifndef __MEM_CACHE_PREFETCH_QUEUED_HH__
 #define __MEM_CACHE_PREFETCH_QUEUED_HH__
 
+#include <array>
 #include <cstdint>
+#include <deque>
 #include <list>
 #include <utility>
 
@@ -213,6 +215,108 @@ class Queued : public Base
     /** Percentage of requests that can be throttled */
     const unsigned int throttleControlPct;
 
+    /** Enable windowed admission sweep for prefetch control. */
+    const bool pfControl;
+
+    /** Window length in this prefetcher's clock domain. */
+    const Cycles pfControlWindow;
+
+    /** Fallback admission percentage when no sweep action is active. */
+    const unsigned pfControlDefaultAdmitPct;
+
+    /** Optional table of admission percentages to sweep over time. */
+    const std::vector<unsigned> pfControlSweep;
+
+    /** Optional per-source admission override; -1 means use global action. */
+    const std::array<int, NUM_PF_SOURCES> pfControlSourceAdmitPct;
+
+    /** Number of windows to stay at each sweep entry. */
+    const unsigned pfControlSweepWindows;
+
+    /** Initial windows that keep the fallback admission percentage. */
+    const unsigned pfControlWarmupWindows;
+
+    /** Enable online PFBad-guided adaptive admission. */
+    const bool pfAdaptive;
+
+    /** Lowest adaptive admission percentage for an active source. */
+    const unsigned pfAdaptiveMinPct;
+
+    /** Adaptive admission quantization step. */
+    const unsigned pfAdaptivePctQuantum;
+
+    /** Per-window gradient step in percentage points. */
+    const int pfAdaptiveGradientStep;
+
+    /** PFBad penalty multiplier represented as a fixed-point ratio. */
+    const unsigned pfAdaptivePfBadWeightNumerator;
+    const unsigned pfAdaptivePfBadWeightDenominator;
+
+    /** Minimum useful+bad samples before trusting a source gradient. */
+    const unsigned pfAdaptiveDpfMinSamples;
+
+    /** Deadband around zero useful-bad score. */
+    const int pfAdaptiveDpfDeadband;
+
+    /** Required miss-rate improvement in basis points. */
+    const unsigned pfAdaptiveImproveMarginBps;
+
+    /** Number of best FIFO samples to average for fallback pct. */
+    const unsigned pfAdaptiveBestTopK;
+
+    /** FIFO experience table capacity. */
+    const unsigned pfAdaptiveTableEntries;
+
+    /** PFBad detection FIFO capacity. */
+    const unsigned pfAdaptivePfBadEntries;
+
+    /** Number of completed initial windows before adaptive updates. */
+    const unsigned pfAdaptiveWarmupWindows;
+
+    /** Maximum pct movement per source per adaptive update. */
+    const unsigned pfAdaptiveMaxSourceStep;
+
+    /** Windowed counters used by the online adaptive controller. */
+    uint64_t pfAdaptiveWindowDemandAccesses;
+    uint64_t pfAdaptiveWindowDemandMisses;
+    std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfUsefulBySource;
+    std::array<uint64_t, NUM_PF_SOURCES> pfAdaptiveWindowPfBadBySource;
+    std::array<int, NUM_PF_SOURCES> pfAdaptiveLastDpfBySource;
+    uint64_t pfAdaptiveSampleCount;
+
+    struct PfAdaptiveSample
+    {
+        uint64_t windowIndex = 0;
+        uint64_t demandAccesses = 0;
+        uint64_t demandMisses = 0;
+        std::array<unsigned, NUM_PF_SOURCES> pctBySource{};
+        std::array<int, NUM_PF_SOURCES> dpfBySource{};
+        std::array<uint64_t, NUM_PF_SOURCES> pfUsefulBySource{};
+        std::array<uint64_t, NUM_PF_SOURCES> pfBadBySource{};
+    };
+
+    struct PfBadEntry
+    {
+        bool valid = false;
+        Addr blockAddr = 0;
+        bool secure = false;
+        PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+        uint64_t insertWindow = 0;
+    };
+
+    std::deque<PfAdaptiveSample> pfAdaptiveSamples;
+    std::deque<PfBadEntry> pfAdaptivePfBadTable;
+
+    Cycles pfControlWindowStart;
+    bool pfControlWindowStarted;
+    uint64_t pfControlWindowIndex;
+    uint64_t pfControlWindowCandidates;
+    uint64_t pfControlWindowAdmitted;
+    unsigned pfControlCurrentAdmitPct;
+    std::array<uint64_t, NUM_PF_SOURCES> pfControlWindowCandidatesBySource;
+    std::array<uint64_t, NUM_PF_SOURCES> pfControlWindowAdmittedBySource;
+    std::array<unsigned, NUM_PF_SOURCES> pfControlCurrentAdmitPctBySource;
+
     EventFunctionWrapper tlbReqEvent;
 
     struct QueuedStats : public statistics::Group
@@ -227,6 +331,35 @@ class Queued : public Base
         statistics::Scalar pfSpanPage;
         statistics::Scalar pfUsefulSpanPage;
         statistics::Vector pfRemovedFull_srcs;
+        statistics::Scalar pfControlCandidates;
+        statistics::Scalar pfControlAdmitted;
+        statistics::Scalar pfControlDropped;
+        statistics::Scalar pfControlWindows;
+        statistics::Scalar pfControlCurrentAdmitPct;
+        statistics::Vector pfControlCandidatesByPct;
+        statistics::Vector pfControlAdmittedByPct;
+        statistics::Vector pfControlDroppedByPct;
+        statistics::Vector pfControlWindowsByPct;
+        statistics::Vector pfControlCandidatesBySource;
+        statistics::Vector pfControlAdmittedBySource;
+        statistics::Vector pfControlDroppedBySource;
+        statistics::Vector pfControlCurrentAdmitPctBySource;
+        statistics::Scalar pfAdaptiveWindows;
+        statistics::Scalar pfAdaptiveUpdates;
+        statistics::Scalar pfAdaptiveWarmupWindows;
+        statistics::Scalar pfAdaptiveDemandAccesses;
+        statistics::Scalar pfAdaptiveDemandMisses;
+        statistics::Scalar pfAdaptiveTableSize;
+        statistics::Scalar pfAdaptiveTableEvictions;
+        statistics::Scalar pfAdaptivePfBadTableSize;
+        statistics::Scalar pfAdaptivePfBadTableEvictions;
+        statistics::Scalar pfAdaptivePfBadOverflowBad;
+        statistics::Scalar pfAdaptivePfBadHits;
+        statistics::Vector pfAdaptivePctBySource;
+        statistics::Vector pfAdaptiveDpfBySource;
+        statistics::Vector pfAdaptivePfUsefulBySource;
+        statistics::Vector pfAdaptivePfBadBySource;
+        statistics::Vector pfAdaptivePfBadOverflowBySource;
     } statsQueued;
 
   public:
@@ -245,6 +378,8 @@ class Queued : public Base
     PacketPtr getPacket() override;
 
     bool hasPendingPacket() override;
+
+    bool admitIncomingPrefetchPacket(const PacketPtr &pkt) override;
 
     Tick nextPrefetchReadyTime() const override
     {
@@ -306,6 +441,39 @@ class Queued : public Base
     RequestPtr createPrefetchRequest(Addr addr, PrefetchInfo const &pfi, PacketPtr pkt, PrefetchSourceType pf_src, int prf_depth);
 
     unsigned offloadBandwidth{1};
+
+    unsigned sanitizePfControlPct(unsigned pct) const;
+    PrefetchSourceType sanitizePfControlSourceType(
+        PrefetchSourceType source) const;
+    unsigned sanitizePfControlSource(PrefetchSourceType source) const;
+    unsigned getPfControlActionPct(uint64_t window_index) const;
+    unsigned getPfControlActionPctForSource(
+        uint64_t window_index, PrefetchSourceType source) const;
+    void refreshPfControlCurrentPcts();
+    void updatePfControlWindow();
+    bool shouldPfControlAdmitLocally(
+        bool pfahead, int pfahead_host) const;
+    bool admitPfControlCandidate(PrefetchSourceType source);
+    bool admitPfControlDeferredPacket(const DeferredPacket &dpp);
+    bool isPfAdaptiveLevel() const;
+    unsigned quantizePfAdaptivePct(unsigned pct) const;
+    unsigned clampPfAdaptivePct(int pct) const;
+    int computePfAdaptiveDpf(PrefetchSourceType source) const;
+    uint64_t pfAdaptiveMissRateBps(
+        uint64_t misses, uint64_t accesses) const;
+    unsigned getPfAdaptiveBestPct(PrefetchSourceType source) const;
+    void pushPfAdaptiveSample(const PfAdaptiveSample &sample);
+    void applyPfAdaptiveUpdate(const PfAdaptiveSample &sample);
+    void resetPfAdaptiveWindowCounters();
+    void recordPfAdaptiveDemandMiss(Addr paddr, bool is_secure);
+
+  public:
+    void notifyDemandAccess(Addr paddr, bool is_secure, bool miss) override;
+    void notifyDemandMshrMiss(Addr paddr, bool is_secure) override;
+    void notifyPrefetchUseful(PrefetchSourceType source) override;
+    void notifyPrefetchEvictsDemand(
+        Addr victim_paddr, bool is_secure, PrefetchSourceType source) override;
+    void notifyCachelineRefill(Addr paddr, bool is_secure) override;
 
   public:
     void rxHint(BaseMMU::Translation *dpp) override {

--- a/src/mem/cache/prefetch/worker.cc
+++ b/src/mem/cache/prefetch/worker.cc
@@ -59,23 +59,41 @@ WorkerPrefetcher::transfer()
     unsigned count = 0;
     auto dpp_it = localBuffer.begin();
     while (count < depth && !localBuffer.empty()) {
+        auto drop_local_packet = [&dpp_it]() {
+            if (dpp_it->pkt != nullptr) {
+                delete dpp_it->pkt;
+                dpp_it->pkt = nullptr;
+            }
+        };
         if (queueFilter) {
             if (alreadyInQueue(pfq, dpp_it->pfInfo, dpp_it->priority)) {
+                drop_local_packet();
                 DPRINTF(WorkerPref, "Worker: [%lx, %d] was already in pfq\n", dpp_it->pfInfo.getAddr(),
                         dpp_it->pfahead_host);
             } else if (alreadyInQueue(pfqMissingTranslation, dpp_it->pfInfo,
                                       dpp_it->priority)) {
+                drop_local_packet();
                 DPRINTF(WorkerPref, "Worker: [%lx, %d] was already in pfq\n", dpp_it->pfInfo.getAddr(),
                         dpp_it->pfahead_host);
+            } else if (!admitPfControlDeferredPacket(*dpp_it)) {
+                drop_local_packet();
+                DPRINTF(WorkerPref, "Worker: [%lx, %d] dropped by PF control admission\n",
+                        dpp_it->pfInfo.getAddr(), dpp_it->pfahead_host);
             } else {
                 addToQueue(pfq, *dpp_it);
                 DPRINTF(WorkerPref, "Worker: put [%lx, %d] into local pfq\n", dpp_it->pfInfo.getAddr(),
                         dpp_it->pfahead_host);
             }
         } else {
-            addToQueue(pfq, *dpp_it);
-            DPRINTF(WorkerPref, "Worker: put [%lx, %d] into local pfq\n", dpp_it->pfInfo.getAddr(),
-                    dpp_it->pfahead_host);
+            if (!admitPfControlDeferredPacket(*dpp_it)) {
+                drop_local_packet();
+                DPRINTF(WorkerPref, "Worker: [%lx, %d] dropped by PF control admission\n",
+                        dpp_it->pfInfo.getAddr(), dpp_it->pfahead_host);
+            } else {
+                addToQueue(pfq, *dpp_it);
+                DPRINTF(WorkerPref, "Worker: put [%lx, %d] into local pfq\n", dpp_it->pfInfo.getAddr(),
+                        dpp_it->pfahead_host);
+            }
         }
         dpp_it = localBuffer.erase(dpp_it);
         count++;

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -420,6 +420,7 @@ class Request
             validXsMetadata = false;
             instXsMetadata = nullptr;
             prefetchSource = PF_NONE;
+            prefetchDepth = 0;
         }
     } XsMetadata;
 
@@ -1220,6 +1221,8 @@ class Request
     {
         privateFlags.set(VALID_XS_METADATA);
         _xsMetadata = xs_metadata;
+        pfSource = xs_metadata.prefetchSource;
+        pfDepth = xs_metadata.prefetchDepth;
     }
 
     bool isStorePFTrain() const { return _flags.isSet(STORE_PF_TRAIN); }
@@ -1333,10 +1336,22 @@ class Request
     bool firstReqAfterSquash{false};
 
   public:
-    void setPFSource(PrefetchSourceType pf_source) { pfSource = pf_source; }
+    void setPFSource(PrefetchSourceType pf_source)
+    {
+        pfSource = pf_source;
+        if (hasXsMetadata()) {
+            _xsMetadata.prefetchSource = pf_source;
+        }
+    }
     PrefetchSourceType getPFSource() const { return static_cast<PrefetchSourceType>(pfSource); }
 
-    void setPFDepth(int pf_depth) { pfDepth = pf_depth; }
+    void setPFDepth(int pf_depth)
+    {
+        pfDepth = pf_depth;
+        if (hasXsMetadata()) {
+            _xsMetadata.prefetchDepth = pf_depth;
+        }
+    }
     int getPFDepth() const { return pfDepth; }
 
     bool isFromBOP() const { return pfSource == PrefetchSourceType::HWP_BOP; }

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -62,31 +62,39 @@
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/o3/dyn_inst_xsmeta.hh"
+#include "enums/PrefetchSourceType.hh"
 #include "mem/htm.hh"
 #include "sim/cur_tick.hh"
 
 namespace gem5
 {
 
-enum PrefetchSourceType
+using enums::PrefetchSourceType;
+using enums::PF_NONE;
+using enums::SStream;
+using enums::SStride;
+using enums::SPht;
+using enums::HWP_BOP;
+using enums::SPP;
+using enums::CMC;
+using enums::IPCP;
+using enums::IPCP_CS;
+using enums::IPCP_CPLX;
+using enums::Berti;
+using enums::StoreStream;
+using enums::CDP;
+using enums::SOpt;
+using enums::DespacitoStream;
+
+static constexpr unsigned NUM_PF_SOURCES = enums::Num_PrefetchSourceType;
+
+inline const char *
+prefetchSourceTypeName(unsigned source)
 {
-    PF_NONE = 0,
-    SStream,
-    SStride,
-    SPht,
-    HWP_BOP,
-    SPP,
-    CMC,
-    IPCP,
-    IPCP_CS,
-    IPCP_CPLX,
-    Berti,
-    StoreStream,
-    CDP,
-    SOpt,
-    DespacitoStream,
-    NUM_PF_SOURCES
-};
+    return source < NUM_PF_SOURCES ?
+        enums::PrefetchSourceTypeStrings[source] :
+        enums::PrefetchSourceTypeStrings[PF_NONE];
+}
 
 enum DcacheRespType
 {


### PR DESCRIPTION
Summary

This PR adds adaptive prefetch control support and wires it into the gem5
performance CI flow. The new --pf-control-profile={off,adaptive,default}
interface makes dynamic prefetching explicit: base runs keep the control path
disabled by default, while manual and weekly jobs can enable the built-in
adaptive profile when needed.

For CI regression, this PR adds an SMT int-only dynamic prefetch job using
gcc12-spec06-smt-int-1.0c, and adds gcc12 idealkmhv3.py base/adaptive A/B
weekly jobs using the 8-channel DRAMSim3 configuration. 

In manual perf test, add option to turn on/off dynmaic-pf-control

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable prefetch-control profiles: `off`, `adaptive`, and `default`.
  - Added adaptive and windowed prefetch admission control with per-source tracking.
  - Added prefetch source metadata and expanded performance statistics.
  - Added support for the `gcc12-spec06-smt-int-1.0c` benchmark.

- **Documentation**
  - Documented profile configuration, workflow usage, artifact naming, and related FAQs.

- **Bug Fixes**
  - Improved cleanup of dropped prefetch packets.
  - Preserved prefetch metadata across cache fills and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->