### PR TITLE
mem: Align DRAMsim3 request admission

### DIFF
--- a/src/mem/dramsim3.cc
+++ b/src/mem/dramsim3.cc
@@ -57,7 +57,8 @@ DRAMsim3::DRAMsim3(const Params &p) :
     write_cb(std::bind(&DRAMsim3::writeComplete,
                        this, 0, std::placeholders::_1)),
     wrapper(p.configFile, p.filePath, read_cb, write_cb),
-    retryReq(false), retryResp(false), startTick(0),
+    retryReq(false), retryReqAddr(0), retryReqIsWrite(false),
+    retryResp(false), startTick(0),
     nbrOutstandingReads(0), nbrOutstandingWrites(0),
     sendResponseEvent([this]{ sendResponse(); }, name()),
     tickEvent([this]{ tick(); }, name())
@@ -151,7 +152,7 @@ DRAMsim3::tick()
 
         // is the connected port waiting for a retry, if so check the
         // state and send a retry if conditions have changed
-        if (retryReq && nbrOutstanding() < wrapper.queueSize()) {
+        if (retryReq && wrapper.canAccept(retryReqAddr, retryReqIsWrite)) {
             retryReq = false;
             port.sendRetryReq();
         }
@@ -206,14 +207,8 @@ DRAMsim3::recvTimingReq(PacketPtr pkt)
 
     // if we cannot accept we need to send a retry once progress can
     // be made
-    bool outstanding_full = (nbrOutstanding() >= wrapper.queueSize());
-    // bool can_accept = (nbrOutstanding() < wrapper.queueSize()) &&
-    //                   wrapper.canAccept(pkt->getAddr(), pkt->isWrite());
-    bool wrapper_can_acc = true;
-    if (!outstanding_full) {
-        wrapper_can_acc = wrapper.canAccept(pkt->getAddr(), pkt->isWrite());
-    }
-    bool can_accept = !outstanding_full && wrapper_can_acc;
+    bool wrapper_can_acc = wrapper.canAccept(pkt->getAddr(), pkt->isWrite());
+    bool can_accept = wrapper_can_acc;
 
     DPRINTF(DRAMsim3, "Can accept: %i, outstanding: %u, queue size: %u, wrapper can acc: %i, is write: %i\n",
             can_accept, nbrOutstanding(), wrapper.queueSize(), wrapper_can_acc, pkt->isWrite());
@@ -258,6 +253,8 @@ DRAMsim3::recvTimingReq(PacketPtr pkt)
         return true;
     } else {
         retryReq = true;
+        retryReqAddr = pkt->getAddr();
+        retryReqIsWrite = pkt->isWrite();
         return false;
     }
 }

--- a/src/mem/dramsim3.hh
+++ b/src/mem/dramsim3.hh
@@ -111,6 +111,8 @@ class DRAMsim3 : public AbstractMemory
      * Is the connected port waiting for a retry from us
      */
     bool retryReq;
+    Addr retryReqAddr;
+    bool retryReqIsWrite;
 
     /**
      * Are we waiting for a retry for sending a response.


### PR DESCRIPTION
## Motivation

DRAMsim3 exposes address- and request-type-specific admission through
`WillAcceptTransaction(address, is_write)`, which the gem5 wrapper already
provides as `canAccept(address, is_write)`.

The current request path additionally gates admission with `nbrOutstanding()`.
That count includes pending gem5 responses, so response-side backpressure can
block new DRAM requests even when the selected DRAMsim3 controller queue can
accept them. The retry path also checks only the aggregate outstanding count,
which can send a retry before the original request's queue is available.

## Changes

- Use `wrapper.canAccept(address, is_write)` for initial request admission.
- Save the address and direction of a rejected request.
- Recheck that same request with `wrapper.canAccept()` before sending retry.
- Keep `nbrOutstanding()` unchanged for response and drain lifecycle tracking.
- Do not add or modify diagnostic statistics.

## Impact

This removes the coupling between gem5's pending response queue and DRAMsim3
request admission. It can reduce conservative backpressure, especially with
multiple channels or temporarily blocked upstream responses.

The response queue may grow beyond the DRAMsim3 transaction queue size under
sustained response-side backpressure. The PR is therefore opened as a draft
until a targeted DRAMsim3 timing-mode smoke/A-B run is attached.

## Validation

- `git diff --check`
- Source-level red/green check for initial admission, saved retry parameters,
  and retry-time admission
- `scons build/RISCV/gem5.opt --gold-linker -j8`
- `gem5.opt --help`
- Verified the commit changes only:
  - `src/mem/dramsim3.cc`
  - `src/mem/dramsim3.hh`

## Remaining Validation

- Run a targeted DRAMsim3 timing-mode workload.
- Compare baseline and patched behavior under request pressure and
  response-side backpressure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deferred memory requests during retries.
  * Requests are now retried based on whether the memory system can accept their specific address and read/write type.
  * Reduced the risk of incorrect retry timing when memory capacity or queue availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->