### PR TITLE
arch-riscv: Add V cross cache label

### DIFF
--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -497,6 +497,41 @@ DynInst::trap(const Fault &fault)
     cpu->trap(fault, threadNumber, staticInst);
 }
 
+void
+DynInst::updateVectorMemCrossCacheBlock(
+        Addr addr, unsigned size, const std::vector<bool> &byte_enable)
+{
+    if (!isVector() || !isMemRef()) {
+        return;
+    }
+
+    instFlags[VectorMemCrossCacheBlockValid] = true;
+    instFlags[VectorMemCrossCacheBlock] = false;
+
+    if (size == 0 || byte_enable.empty()) {
+        return;
+    }
+
+    const auto first_enabled = std::find(
+            byte_enable.begin(), byte_enable.end(), true);
+    if (first_enabled == byte_enable.end()) {
+        return;
+    }
+
+    const auto last_enabled = std::find(
+            byte_enable.rbegin(), byte_enable.rend(), true);
+    assert(last_enabled != byte_enable.rend());
+
+    const Addr first_addr = addr +
+        std::distance(byte_enable.begin(), first_enabled);
+    const Addr last_addr = addr +
+        size - 1 - std::distance(byte_enable.rbegin(), last_enabled);
+
+    const Addr cache_line_size = cpu ? cpu->cacheLineSize() : 64;
+    instFlags[VectorMemCrossCacheBlock] =
+        (first_addr / cache_line_size) != (last_addr / cache_line_size);
+}
+
 Fault
 DynInst::initiateMemRead(Addr addr, unsigned size, Request::Flags flags,
                                const std::vector<bool> &byte_enable)
@@ -513,6 +548,7 @@ DynInst::initiateMemRead(Addr addr, unsigned size, Request::Flags flags,
             }
         }
     }
+    updateVectorMemCrossCacheBlock(addr, size, byte_enable);
     return cpu->pushRequest(
         dynamic_cast<DynInstPtr::PtrType>(this),
         /* ld */ true, nullptr, size, addr, flags, nullptr, nullptr,
@@ -545,6 +581,7 @@ DynInst::writeMem(uint8_t *data, unsigned size, Addr addr,
             }
         }
     }
+    updateVectorMemCrossCacheBlock(addr, size, byte_enable);
     return cpu->pushRequest(
         dynamic_cast<DynInstPtr::PtrType>(this),
         /* st */ false, data, size, addr, flags, res, nullptr,

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -243,6 +243,8 @@ class DynInst : public ExecContext, public RefCounted
         IsStrictlyOrdered,
         ReqMade,
         MemOpDone,
+        VectorMemCrossCacheBlock,
+        VectorMemCrossCacheBlockValid,
         HtmFromTransaction,
         IsEmptyMov,
         IsConstantFolded,
@@ -515,6 +517,16 @@ class DynInst : public ExecContext, public RefCounted
     bool memOpDone() const { return instFlags[MemOpDone]; }
     void memOpDone(bool f) { instFlags[MemOpDone] = f; }
 
+    bool vectorMemCrossCacheBlock() const
+    {
+        return instFlags[VectorMemCrossCacheBlock];
+    }
+
+    bool vectorMemCrossCacheBlockValid() const
+    {
+        return instFlags[VectorMemCrossCacheBlockValid];
+    }
+
     bool notAnInst() const { return instFlags[NotAnInst]; }
     void setNotAnInst() { instFlags[NotAnInst] = true; }
 
@@ -533,6 +545,9 @@ class DynInst : public ExecContext, public RefCounted
     {
         cpu->demapPage(vaddr, asn);
     }
+
+    void updateVectorMemCrossCacheBlock(
+            Addr addr, unsigned size, const std::vector<bool> &byte_enable);
 
     Fault initiateMemRead(Addr addr, unsigned size, Request::Flags flags,
             const std::vector<bool> &byte_enable) override;


### PR DESCRIPTION
This PR is part of the unit-stride alignment work and adds a flag indicating whether an instruction crosses a cache-line boundary.

Change-Id: I773668a998368101c79fa146603c7302fb60931c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for vector memory operations that span multiple cache lines.
  * Added status indicators to identify when this tracking information is valid.
  * Vector memory reads and writes now automatically evaluate cache-line boundaries before requests are issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->