### PR TITLE
arch-riscv: Fix direct compressed TLB demap

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -1012,6 +1012,15 @@ TLB::demapPage(Addr vpn, uint64_t asid)
     if ((l2tlb == nullptr) && (!isStage2))
         panic("l2tlb is fault\n");
 
+    auto vaddrMatches = [vpn](const TlbEntry &entry) {
+        if (entry.isCompressed && entry.translateMode == direct) {
+            return tlbKeyComparablePageBase(vpn, entry.logBytes) ==
+                   tlbKeyComparablePageBase(entry.vaddr, entry.logBytes);
+        }
+        const Addr entry_mask = ~(entry.size() - 1);
+        return (vpn & entry_mask) == (entry.vaddr & entry_mask);
+    };
+
     if (vpn == 0 && asid == 0) {
         flushAll();
         if (!isStage2) {
@@ -1027,14 +1036,12 @@ TLB::demapPage(Addr vpn, uint64_t asid)
             for (i = 0; i < size; i++) {
                 if (!tlb[i].trieHandle)
                     continue;
-                Addr mask = ~(tlb[i].size() - 1);
-                if ((vpn & mask) == (tlb[i].vaddr & mask) &&
-                    tlb[i].asid == asid) {
+                if (vaddrMatches(tlb[i]) && tlb[i].asid == asid) {
                     remove(i);
                     continue;
                 }
                 if (tlb[i].trieHandle) {
-                    mask = ~(tlb[i].size() - 1);
+                    Addr mask = ~(tlb[i].size() - 1);
                     if ((vpn & mask) == (tlb[i].gpaddr & mask) &&
                         tlb[i].vmid == asid)
                         remove(i);
@@ -1044,8 +1051,8 @@ TLB::demapPage(Addr vpn, uint64_t asid)
         } else {
             for (i = 0; i < size; i++) {
                 if (tlb[i].trieHandle) {
-                    Addr mask = ~(tlb[i].size() - 1);
-                    if ((vpn == 0 || (vpn & mask) == (tlb[i].vaddr & mask)) && (asid == 0 || tlb[i].asid == asid))
+                    if ((vpn == 0 || vaddrMatches(tlb[i])) &&
+                        (asid == 0 || tlb[i].asid == asid))
                         remove(i);
                 }
                 if (tlb[i].trieHandle) {


### PR DESCRIPTION
Keep direct compressed TLB vaddr matching in the trie-key-comparable address domain so targeted sfence.vma can remove stale entries.

> fd7deea534 的动机是合理的，但它只把 TLB 的一部分地址比较改成了 key-domain，漏掉了 sfence.vma 的失效路径。
>  ### fd7deea534 想解决什么
>
>  当前 L1 TLB 的 trie key 由 src/arch/riscv/tlb.cc:78 的 buildKey() 生成：
>
>  asid        -> key[63:48]
>  translateMode -> key[47:46]
>  VPN[45:0]   -> key[45:0]
>
>  也就是说，trie 只比较低 46 位 VPN。
>
>  但原来的 compressed TLB 逻辑使用原始 virtual address 做：
>
>  - block overlap 判断；
>  - compressed fallback；
>  - narrow entry 重插入；
>  - refill hint 判断；
>  - compressed entry merge。
>
>  对于 canonical high address，例如：
>
>  0xffffffff8000160c
>
>  原始地址和 trie 使用的低 46-bit key 在表示形式上不同，可能出现：
>
>  1. trie lookup 命中了某个 compressed entry；
>  2. 但 raw vaddr 比较认为它们不是同一个 block；
>  3. merge/fallback 没有正确发生；
>  4. refill 后 entry 的覆盖范围和 trie key 不一致。
>
>  所以 fd7 增加了：
>
>  tlbKeyComparableVaddr()
>  tlbKeyComparablePageBase()
>  l1CompressedBlockBase()
>
>  并把很多 compressed TLB 比较统一到 trie key 的地址域。这部分动机是对的。
>
>  ### 为什么会导致 Linux 卡死
>
>  问题在于 fd7 不仅“比较时归一化”，还把归一化后的地址写回了 TlbEntry::vaddr：
>
>  compressed_entry.vaddr = l1CompressedBlockBase(normalized_vaddr);
>  newEntry->vaddr = new_entry_base;
>  narrow_entry.vaddr = narrow_base;
>  old_entry.vaddr = block_base;
>
>  但是 TlbEntry::vaddr 并不是只用于 trie key。sfence.vma 最终会调用：
>
>  MMU::demapPage(Rs1, Rs2)
>
>  进入 src/arch/riscv/tlb.cc:998，原有失效逻辑是 raw address compare：
>
>  Addr mask = ~(tlb[i].size() - 1);
>  if ((vpn & mask) == (tlb[i].vaddr & mask) &&
>      tlb[i].asid == asid) {
>      remove(i);
>  }
>
>  于是出现不一致：
>
>  sfence.vma 使用 canonical VPN
>  TlbEntry::vaddr 保存 key-domain VPN
>  demapPage() 用 raw address 比较
>
>  针对 canonical high address 的 targeted sfence.vma 可能无法删除该 compressed entry。
>
>  Linux 在切换页表、修改页表和执行 sfence.vma 时依赖这个失效语义。旧的 compressed translation 没有被清掉后，可能继续使用 stale translation，最终表现为：
>
>  PTW:
>    root PTE @ 0x803b5fc0 = 0x207ff401
>    next PTE @ 0x81ffdfc0 = 0
>
>  instruction page fault @ 0xffffffff800dd866
>
>  之后 fault 重试回到：
>
>  0xffffffff8000160c
>
>  每次取指都产生 AddressFault，ROB 中只剩 synthetic gem5 nop，所以最终由 commit watchdog 报：
>
>  Commit stage is stucked for more than 40,000 cycles!
>
>  因此，gem5 nop 不是 Linux 真执行的 nop，而是取指 fault 的占位指令。
>
>  ### 最小修复方案
>
>  保留 fd7 的 alias 修复动机，但让 demapPage() 也使用同一地址域比较。
>
>  可以在 TLB::demapPage() 中增加：
>
>  auto vaddrMatches = [vpn](const TlbEntry &entry) {
>      if (entry.isCompressed && entry.translateMode == direct) {
>          return tlbKeyComparablePageBase(vpn, entry.logBytes) ==
>                 tlbKeyComparablePageBase(entry.vaddr, entry.logBytes);
>      }
>
>      const Addr mask = ~(entry.size() - 1);
>      return (vpn & mask) == (entry.vaddr & mask);
>  };
>
>  然后将原来的：
>
>  (vpn & mask) == (tlb[i].vaddr & mask)
>
>  替换为：
>
>  vaddrMatches(tlb[i])

Change-Id: I58cf34df5678b146c1a8091732ec6556c945b3bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory translation invalidation during page and address-space flushes.
  * Corrected handling of compressed mappings in direct translation mode, helping prevent stale translation entries and ensuring subsequent memory accesses use the correct mappings.
  * Preserved wildcard behavior for broad page and address-space invalidation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->