### PR TITLE
mem: Hash DCache VIPT index

### DIFF
--- a/configs/common/Caches.py
+++ b/configs/common/Caches.py
@@ -85,7 +85,7 @@ class L1_DCache(L1Cache):
     wpu = MMRUWpu(use_virtual = True)
 
     tags = VIPTSetAssoc()
-    tags.indexing_policy = VIPTSetAssociative()
+    tags.indexing_policy = VIPTSetAssociative(use_hash_index = True)
 
     force_hit = False
 

--- a/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
+++ b/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
@@ -59,6 +59,9 @@ class VIPTSetAssociative(SetAssociative):
     cxx_header = "mem/cache/tags/indexing_policies/vipt_set_associative.hh"
 
     page_size = Param.Int(4096, "page size in bytes")
+    use_hash_index = Param.Bool(
+        False,
+        "Use XiangShan's hash(vaddr[47:12]) DCache set index")
 
 class SkewedAssociative(BaseIndexingPolicy):
     type = 'SkewedAssociative'

--- a/src/mem/cache/tags/indexing_policies/vipt_set_associative.cc
+++ b/src/mem/cache/tags/indexing_policies/vipt_set_associative.cc
@@ -48,13 +48,36 @@
 
 #include <cassert>
 
+#include "base/logging.hh"
 #include "mem/cache/replacement_policies/replaceable_entry.hh"
 
 namespace gem5
 {
 
+namespace
+{
+
+// XiangShan's hashBitPairs(vaddr, hi=47, lo=12, step=2).
+constexpr unsigned DCACHE_HASH_LOW_BIT = 12;
+constexpr unsigned DCACHE_HASH_HIGH_BIT = 47;
+constexpr unsigned DCACHE_HASH_WIDTH = 2;
+constexpr uint32_t DCACHE_HASH_MASK = (1U << DCACHE_HASH_WIDTH) - 1;
+
+uint32_t
+hash_dcache_alias(const Addr addr)
+{
+    uint32_t hash = 0;
+    for (unsigned bit = DCACHE_HASH_LOW_BIT; bit <= DCACHE_HASH_HIGH_BIT;
+         bit += DCACHE_HASH_WIDTH) {
+        hash ^= static_cast<uint32_t>((addr >> bit) & DCACHE_HASH_MASK);
+    }
+    return hash;
+}
+
+} // anonymous namespace
+
 VIPTSetAssociative::VIPTSetAssociative(const Params &p)
-    : SetAssociative(p)
+    : SetAssociative(p), useHashIndex(p.use_hash_index)
 {
     assert(sliceShift == 0);
     if (tagShift > floorLog2(p.page_size)) {
@@ -65,6 +88,38 @@ VIPTSetAssociative::VIPTSetAssociative(const Params &p)
 
     assert(tagShift > aliasBits);
     assert(p.page_size % 2 == 0);
+
+    // The RTL function hashes two-bit lanes from vaddr[47:12].  Refuse an
+    // unsupported geometry instead of silently using a different policy.
+    fatal_if(useHashIndex && p.page_size != (1U << DCACHE_HASH_LOW_BIT),
+             "VIPT hashed index requires a 4 KiB page, got %d bytes",
+             p.page_size);
+    fatal_if(useHashIndex && setShift != 6,
+             "VIPT hashed index requires 64 B cache blocks, got %u B",
+             1U << setShift);
+    fatal_if(useHashIndex && aliasBits > DCACHE_HASH_WIDTH,
+             "VIPT hashed index provides %u alias bits, but this cache "
+             "requires %llu",
+             DCACHE_HASH_WIDTH,
+             static_cast<unsigned long long>(aliasBits));
+}
+
+uint32_t
+VIPTSetAssociative::extractSet(const Addr addr) const
+{
+    if (!useHashIndex || aliasBits == 0) {
+        return SetAssociative::extractSet(addr);
+    }
+
+    // Keep the page-offset (non-alias) part of the set index unchanged, and
+    // replace only the virtual-page-dependent alias part with the RTL hash.
+    const uint32_t directSet = SetAssociative::extractSet(addr);
+    const uint32_t nonAliasMask = setMask >> aliasBits;
+    const uint32_t aliasMask = (1U << aliasBits) - 1;
+    const uint32_t aliasShift = tagShift - aliasBits - setShift;
+    const uint32_t hashedAlias = hash_dcache_alias(addr) & aliasMask;
+
+    return (directSet & nonAliasMask) | (hashedAlias << aliasShift);
 }
 
 Addr

--- a/src/mem/cache/tags/indexing_policies/vipt_set_associative.hh
+++ b/src/mem/cache/tags/indexing_policies/vipt_set_associative.hh
@@ -102,6 +102,9 @@ class VIPTSetAssociative : public SetAssociative
   protected:
     uint64_t aliasBits;
 
+    /** Whether to use XiangShan's hashed DCache alias index. */
+    const bool useHashIndex;
+
   public:
     /**
      * Convenience typedef.
@@ -113,6 +116,24 @@ class VIPTSetAssociative : public SetAssociative
      */
     VIPTSetAssociative(const Params &p);
 
+    /**
+     * Get the hashed set index for an address.
+     *
+     * With useHashIndex enabled, the non-alias set bits keep their
+     * untranslated address values and the alias bits are replaced with the
+     * RTL's XOR-folded hash of vaddr[47:12].  For the 64 KiB, 4-way, 64 B
+     * DCache this is:
+     *
+     *  vaddr[47:46] ^ vaddr[45:44] ^ ... ^ vaddr[13:12]
+     *         ┴───────────────────┬──────────────────┴
+     *                         set[7:6]
+     *                             │                     vaddr[11:6]
+     *                             │                     ┴────┬────┴
+     *                             │                      set[5:0]
+     *                             ┴─────────────┬─────────────┴
+     *                                        set[7:0]
+     */
+    uint32_t extractSet(const Addr addr) const override;
 
     /**
      * Regenerate an entry's address from its tag and assigned set.


### PR DESCRIPTION
## Motivation

XiangShan hashes the virtual-page-dependent DCache VIPT alias bits when selecting a refill set. GEM5 previously used the raw virtual set index, which can place refills differently from RTL and create excessive conflict refills.

## Design

- Add `use_hash_index` to `VIPTSetAssociative`, defaulting to `False` for generic users of the policy.
- Enable it by default for KMHv3 `L1_DCache`, so the target DCache follows the RTL mapping without a command-line override.
- XOR-fold the two-bit lanes in `vaddr[47:12]`:

  ```text
  H   = vaddr[47:46] ^ vaddr[45:44] ^ ... ^ vaddr[13:12]
  set = {H[1:0], vaddr[11:6]}
  ```

  This is the RTL mapping for the 64 KiB, 4-way, 64 B DCache.
- Replace only the virtual-page-dependent alias portion of the set index. Existing VIPT alias lookup still enumerates all candidates, and `regenerateAddr()` remains unchanged.
- Reject enabled geometries outside the aligned assumptions: 4 KiB pages, 64 B blocks, and at most two alias bits.

## Scope

This changes DCache tag-store placement only. It does not change the existing alias lookup abstraction, address regeneration, WPU policy, LSQ-bank modeling, or timing pipelines.

## Validation

- `python3 -m py_compile configs/common/Caches.py src/mem/cache/tags/indexing_policies/IndexingPolicies.py`
- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j48`
- Default-enable smoke: a no-override bwaves 11749 restore generated `use_hash_index=true` in `config.ini` and completed normally with difftest enabled.

The final post-reset bwaves 11749 measurement compares hash off and hash on with the same checkpoint, reference model, embedded restorer, and instruction limit:

| Metric | Hash off | Hash on | Change |
|---|---:|---:|---:|
| Committed instructions | 20,000,007 | 19,999,994 | comparable |
| IPC | 2.176916 | 3.308521 | +51.982% |
| Cycles | 9,187,314 | 6,044,996 | -34.203% |
| DCache refill events | 1,412,482 | 819,269 | -41.998% |
| Demand misses | 2,789,177 | 485,376 | -82.598% |
| Overall misses | 2,789,177 | 485,376 | -82.598% |
| Replacements | 1,412,482 | 819,269 | -41.998% |

Both A/B runs completed normally with difftest enabled; no fatal error, panic, assertion, or difftest mismatch was reported.

Related PR in Xiangshan RTL：https://github.com/OpenXiangShan/XiangShan/pull/6166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional hashed set indexing for VIPT set-associative caches.
  * Enabled the hashed indexing configuration for the L1 data cache by default.
  * Added validation for supported page size, cache line size, and hash settings.

* **Bug Fixes**
  * Improved cache set selection to align with the hashed D-cache indexing behavior when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->