### PR TITLE
misc: Add UART16550 support

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -689,6 +689,9 @@ def makeXiangshanPlatformSystem(mem_mode, mdesc=None, np=1, ruby=False,
     self.uartlite  = UartLite()
     self.uartlite.pio = self.iobus.mem_side_ports
 
+    self.uart16550 = Uart16550(enable_fifo=True)
+    self.uart16550.pio = self.iobus.mem_side_ports
+
     self.lint = Clint()
     self.lint.pio = self.iobus.mem_side_ports
     self.lint.pio_addr = 0x38000000
@@ -709,8 +712,10 @@ def makeXiangshanPlatformSystem(mem_mode, mdesc=None, np=1, ruby=False,
 
     if not ruby:
         self.bridge.ranges = [
-            AddrRange(self.uartlite.pio_addr, self.uartlite.pio_addr +
-            self.uartlite.pio_size),
+            AddrRange(self.uart16550.pio_addr,
+                      self.uart16550.pio_addr + self.uart16550.pio_size),
+            AddrRange(self.uartlite.pio_addr,
+                      self.uartlite.pio_addr + self.uartlite.pio_size),
             AddrRange(self.lint.pio_addr, self.lint.pio_addr + self.lint.pio_size),
             AddrRange(self.hartctrl.pio_addr, self.hartctrl.pio_addr + self.hartctrl.pio_size),
             AddrRange(self.mmcs.pio_addr, self.mmcs.pio_addr + self.mmcs.pio_size),

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -166,8 +166,8 @@ def generate_xiangshan_dtb(system, *, cmdline: str, outdir: str = None) -> str:
     chosen = FdtNode("chosen")
     if cmdline:
         chosen.append(FdtPropertyStrings("bootargs", cmdline))
-    chosen.append(FdtPropertyStrings("stdout-path", "/soc/serial@40600000"))
-    chosen.append(FdtPropertyStrings("linux,stdout-path", "/soc/serial@40600000"))
+    chosen.append(FdtPropertyStrings("stdout-path", "/soc/serial@310b0000"))
+    chosen.append(FdtPropertyStrings("linux,stdout-path", "/soc/serial@310b0000"))
     root.append(chosen)
 
     for mem_range in system.mem_ranges:
@@ -254,14 +254,26 @@ def generate_xiangshan_dtb(system, *, cmdline: str, outdir: str = None) -> str:
     plic_node.appendCompatible(["riscv,plic0"])
     soc_node.append(plic_node)
 
-    uart = system.uartlite
-    uart_node = uart.generateBasicPioDeviceNode(
-        soc_state, "serial", uart.pio_addr, uart.pio_size
+    uart16550 = system.uart16550
+    uart16550_node = uart16550.generateBasicPioDeviceNode(
+        soc_state, "serial", uart16550.pio_addr, uart16550.pio_size
     )
-    uart_node.append(FdtPropertyWords("clock-frequency", [0]))
-    uart_node.append(FdtPropertyStrings("status", "okay"))
-    uart_node.appendCompatible(["xlnx,xps-uartlite-1.00.a"])
-    soc_node.append(uart_node)
+    uart16550_node.append(FdtPropertyWords("clock-frequency", [50000000]))
+    uart16550_node.append(FdtPropertyWords("current-speed", [115200]))
+    uart16550_node.append(FdtPropertyWords("reg-shift", [2]))
+    uart16550_node.append(FdtPropertyWords("reg-io-width", [4]))
+    uart16550_node.append(FdtPropertyStrings("status", "okay"))
+    uart16550_node.appendCompatible(["ns16550a"])
+    soc_node.append(uart16550_node)
+
+    uartlite = system.uartlite
+    uartlite_node = uartlite.generateBasicPioDeviceNode(
+        soc_state, "serial", uartlite.pio_addr, uartlite.pio_size
+    )
+    uartlite_node.append(FdtPropertyWords("clock-frequency", [0]))
+    uartlite_node.append(FdtPropertyStrings("status", "okay"))
+    uartlite_node.appendCompatible(["xlnx,xps-uartlite-1.00.a"])
+    soc_node.append(uartlite_node)
 
     root.append(soc_node)
 

--- a/docs/Gem5_Docs/device/uart16550.md
+++ b/docs/Gem5_Docs/device/uart16550.md
@@ -1,0 +1,197 @@
+# 香山平台 UART16550 实现说明
+
+## 1. 背景与范围
+
+香山平台原有的 `UartLite` 位于 `0x40600000`，主要用于把软件写入的
+字符直接输出到 GEM5 所在终端。部分香山固件和 Linux 设备树则使用
+`ns16550a` 兼容 UART，寄存器基址为 `0x310b0000`。如果 GEM5 没有对应
+设备，OpenSBI 的早期控制台访问会落到未映射地址，无法输出启动信息。
+
+`Uart16550` 是为该平台新增的行为级 MMIO 设备。它直接继承
+`BasicPioDevice`，不复用通用 `Uart8250` 的 `SerialDevice` 和平台中断
+接线，因此可以与 `UartLite` 并存，并保持现有直接输出到 stdout 的使用
+方式。
+
+本文描述当前模型已经实现的行为。它的目标是覆盖启动控制台和常见
+16550 寄存器软件接口，不是一个完整的物理串口、终端输入或中断控制器
+模型。
+
+相关源码：
+
+- `src/dev/serial/uart16550.hh`
+- `src/dev/serial/uart16550.cc`
+- `src/dev/serial/Uart.py`
+- `configs/common/FSConfig.py`
+- `configs/common/xiangshan.py`
+
+## 2. 平台接入和设备树
+
+在 `makeXiangshanPlatformSystem()` 中，平台同时创建下面两个设备，并把
+它们的 PIO 端口接到 `iobus`：
+
+| 设备 | 基址 | 地址范围 | 用途 |
+| --- | ---: | ---: | --- |
+| `Uart16550` | `0x310b0000` | `0x20` bytes | OpenSBI/Linux 的 `ns16550a` 控制台 |
+| `UartLite` | `0x40600000` | 原有范围 | 保持既有平台兼容性 |
+
+非 Ruby 配置还会把两个范围加入 bridge，使 CPU 发出的 PIO 请求能到达相应
+设备。
+
+设备树生成逻辑新增 `serial@310b0000` 节点，并声明：
+
+```dts
+compatible = "ns16550a";
+reg = <0x0 0x310b0000 0x0 0x20>;
+clock-frequency = <50000000>;
+current-speed = <115200>;
+reg-shift = <2>;
+reg-io-width = <4>;
+```
+
+`chosen.stdout-path` 和 `linux,stdout-path` 都切换到
+`/soc/serial@310b0000`。`UartLite` 的设备树节点仍保留，因此已有软件仍能
+按原地址发现它。
+
+## 3. MMIO 访问和寄存器视图
+
+UART 的标准寄存器是 8 位宽，但目标硬件采用 `reg-shift = 2`：相邻寄存器
+之间相隔 4 字节。模型的 `0x20` 字节窗口包含 8 个标准寄存器：
+
+| 偏移 | DLAB = 0 | DLAB = 1 | 说明 |
+| ---: | --- | --- | --- |
+| `0x00` | RBR / THR | DLL | 接收缓冲、发送保持、除数低字节 |
+| `0x04` | IER | DLM | 中断使能、除数高字节 |
+| `0x08` | IIR / FCR | IIR / FCR | 中断识别、FIFO 控制 |
+| `0x0c` | LCR | LCR | 线路控制；bit 7 是 DLAB |
+| `0x10` | MCR | MCR | 调制解调器控制；bit 4 是 loopback |
+| `0x14` | LSR | LSR | 线路状态 |
+| `0x18` | MSR | MSR | 调制解调器状态 |
+| `0x1c` | SCR | SCR | 软件暂存寄存器 |
+
+模型接受 1、2、4 或 8 字节的小端 PIO 访问。写操作只取低 8 位作为寄存器
+值；读操作把 8 位寄存器值零扩展回请求宽度。这与设备树中的
+`reg-io-width = <4>` 相匹配，也允许较窄或较宽的普通 PIO 访问。没有按
+4 字节对齐到寄存器槽的访问读取为 0、写入被忽略。
+
+当 LCR 的 DLAB 位为 1 时，偏移 `0x00` 和 `0x04` 分别访问 DLL 和 DLM；
+DLAB 清零后，它们恢复为 RBR/THR 和 IER。这是 OpenSBI 设置波特率除数时
+使用的标准 16550 bank 切换方式。
+
+## 4. FIFO 和非 FIFO 模式
+
+`Uart16550` 有两个配置参数：
+
+| 参数 | 默认值 | 含义 |
+| --- | ---: | --- |
+| `enable_fifo` | `True` | 设备是否具备 FIFO 硬件能力 |
+| `fifo_depth` | `16` | RX 和 TX FIFO 的容量 |
+
+`enable_fifo` 只表示硬件能力。即使该参数为真，软件仍需通过 FCR bit 0
+在运行时启用 FIFO；只有两个条件同时满足时模型才进入 FIFO 模式。若
+`enable_fifo=False`，FCR 不会启用 FIFO，RX 和 TX 均退化为单字节寄存器。
+
+FCR 的行为如下：
+
+- bit 0：启用或关闭 FIFO。
+- bit 1：清空接收状态，包括 RX FIFO、非 FIFO RBR 和已记录的线路错误。
+- bit 2：清空等待发送的 TX FIFO。
+- bit 7:6：接收触发阈值，依次为 1、4、8、14 字节；阈值不会超过
+  `fifo_depth`。
+
+FIFO 模式下，`receive()` 把字节放入 RX FIFO。FIFO 已满时，新字节被丢弃，
+并在 LSR 中置 overrun。非 FIFO 模式只保留一个 RBR 字节；RBR 尚未读出时
+再次接收同样会置 overrun。读 RBR 会弹出 FIFO 队首，或读取并清空单字节
+RBR。
+
+## 5. 发送、状态位和回环
+
+软件在 DLAB=0 时写 THR。发送路径先把数据放到 TX 队列，再由 `txEvent`
+在 `max(pioDelay, 1)` 个 GEM5 tick 后完成一个字节：
+
+1. 普通模式调用 `putc(byte, stdout)`，因此 OpenSBI 和内核控制台字符出现
+   在运行 GEM5 的终端或重定向日志中。
+2. MCR 的 loopback bit 置位时，发送字节不输出到 stdout，而是送回 RX 路径。
+3. 一个字节完成后，模型继续启动下一个排队的发送。
+
+LSR 由当前状态动态生成：
+
+| 位 | 名称 | 置位条件 |
+| ---: | --- | --- |
+| bit 0 | DR | RX FIFO 或 RBR 中存在可读数据 |
+| bit 1 | OE | RX FIFO/RBR 已满时又接收到数据 |
+| bit 5 | THRE | TX 发送保持队列为空 |
+| bit 6 | TEMT | TX 队列为空且没有正在移出的字节 |
+
+其中 THRE 可以在当前移位寄存器仍在发送时先置位，因为该状态表示发送保持
+寄存器已经可接受下一字节；TEMT 则等待整个发送过程结束。读取 LSR 会清除
+已记录的线路错误位。
+
+当前发送延迟不使用 DLL/DLM 计算真实波特率；DLL/DLM 会保存并可读回，保证
+固件的初始化序列正确，但它们不改变事件调度间隔。
+
+## 6. IER/IIR 与中断边界
+
+模型保存 IER 的低四位，并提供软件可见的 IIR 状态：
+
+- 线路状态错误优先级最高，返回 `0x06`。
+- RX 数据就绪时返回 `0x04`；FIFO 模式还要求队列长度达到 FCR 阈值。
+- TX 保持寄存器空时返回 `0x02`。
+- 没有待处理事件时返回 bit 0 为 1 的 no-interrupt 状态。
+- FIFO 激活时，IIR 还带有 `0xc0` FIFO 标志。
+
+读取 TX-empty IIR 会确认并清除该 pending 状态。当发送保持队列再次为空，
+或重新使能 TX-empty 中断后，模型会再次置位该状态。
+
+这里的 IER/IIR 是寄存器语义，不等同于完整 IRQ 递送。当前 XiangShan
+`NemuPlic` 没有可用的外部 UART 中断接线，设备树也没有为该 UART 发出
+中断属性，因此模型没有向 CPU 发送 UART IRQ。启动控制台使用 LSR 轮询，
+不依赖这个外部中断路径。
+
+## 7. 当前边界和扩展方向
+
+以下能力有意留在后续工作中：
+
+- 没有宿主终端输入连接；`receive()` 目前用于回环或未来接收源。
+- 没有物理 modem 信号建模。非回环模式固定报告可用的 DCD、DSR 和 CTS 状态。
+- 没有 UART 到 PLIC 的外部中断传播。
+- 没有根据波特率、数据位、校验位和停止位模拟实际串行时序。
+- IIR 当前只覆盖线路状态、接收数据和发送保持寄存器空的优先级；没有建模
+  FIFO timeout 或 modem-status 事件。
+
+这些边界避免为当前没有平台接线的软件路径引入额外行为，同时保留了以后接入
+Terminal、PLIC 和更精确串口时序的扩展点。
+
+## 8. 验证记录
+
+实现完成后进行了以下检查：
+
+```bash
+python3 -m py_compile configs/common/FSConfig.py \
+    configs/common/xiangshan.py src/dev/serial/Uart.py
+
+scons -Q build/RISCV/gem5.opt --gold-linker -j64
+```
+
+随后使用下面的启动命令验证控制台路径；外层 `timeout` 仅用于限制会继续进入
+Linux 的长时间运行：
+
+```bash
+stdbuf -o0 -e0 timeout 120s ./build/RISCV/gem5.opt \
+    -d /tmp/uart16550-boot-final \
+    ./configs/example/idealkmhv3.py \
+    --generic-rv-cpt /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/bin/gamess_cytosine.fw_payload.bin \
+    --raw-cpt --disable-difftest
+```
+
+默认 FIFO 配置和把 `enable_fifo` 设置为 `False` 的配置均打印了：
+
+```text
+OpenSBI v1.5
+Platform Name             : xiangshan,Kunminghu-dev
+Platform Features         : medeleg
+Platform HART Count       : 1
+Platform IPI Device       : aclint-mswi
+```
+
+这证明 OpenSBI 已通过 `0x310b0000` 的 UART16550 路径完成早期控制台输出。该
+验证是启动路径检查，不代表完整 Linux 启动或外部 UART IRQ 已覆盖。

--- a/src/dev/serial/SConscript
+++ b/src/dev/serial/SConscript
@@ -45,7 +45,8 @@ if env['CONF']['TARGET_ISA'] == 'null':
 
 SimObject('Serial.py', sim_objects=['SerialDevice', 'SerialNullDevice'])
 SimObject('Terminal.py', sim_objects=['Terminal'], enums=['TerminalDump'])
-SimObject('Uart.py', sim_objects=['Uart', 'SimpleUart', 'Uart8250','UartLite'])
+SimObject('Uart.py', sim_objects=[
+    'Uart', 'SimpleUart', 'Uart8250', 'UartLite', 'Uart16550'])
 
 Source('serial.cc')
 Source('simple.cc')
@@ -53,6 +54,7 @@ Source('terminal.cc')
 Source('uart.cc')
 Source('uart8250.cc')
 Source('uartlite.cc')
+Source('uart16550.cc')
 
 DebugFlag('Terminal')
 DebugFlag('TerminalVerbose')

--- a/src/dev/serial/Uart.py
+++ b/src/dev/serial/Uart.py
@@ -88,3 +88,12 @@ class UartLite(BasicPioDevice):
     cxx_class = 'gem5::UartLite'
     pio_addr = 0x40600000
     pio_size = Param.Addr(0xd, "Size of address range")
+
+class Uart16550(BasicPioDevice):
+    type = 'Uart16550'
+    cxx_header = "dev/serial/uart16550.hh"
+    cxx_class = 'gem5::Uart16550'
+    pio_addr = 0x310b0000
+    pio_size = Param.Addr(0x20, "Size of address range")
+    enable_fifo = Param.Bool(True, "Enable UART16550 FIFO support")
+    fifo_depth = Param.Unsigned(16, "UART16550 RX and TX FIFO depth")

--- a/src/dev/serial/uart16550.cc
+++ b/src/dev/serial/uart16550.cc
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dev/serial/uart16550.hh"
+
+#include <algorithm>
+#include <cstdio>
+
+#include "base/logging.hh"
+#include "mem/packet_access.hh"
+
+namespace gem5
+{
+
+Uart16550::Uart16550(const Params &p)
+    : BasicPioDevice(p, p.pio_size), fifoSupported(p.enable_fifo),
+      fifoDepth(p.fifo_depth),
+      txEvent([this] { completeTransmit(); }, name() + ".tx")
+{
+    fatal_if(fifoSupported && fifoDepth == 0,
+             "%s: FIFO depth must be non-zero", name().c_str());
+}
+
+bool
+Uart16550::fifoActive() const
+{
+    return fifoSupported && (fcr & FcrEnableFifo);
+}
+
+bool
+Uart16550::receiveReady() const
+{
+    return fifoActive() ? !rxFifo.empty() : rbrFull;
+}
+
+bool
+Uart16550::transmitHoldingEmpty() const
+{
+    return txFifo.empty();
+}
+
+unsigned
+Uart16550::receiveTriggerLevel() const
+{
+    unsigned trigger = 0;
+    switch ((fcr & FcrTriggerMask) >> 6) {
+      case 0:
+        trigger = 1;
+        break;
+      case 1:
+        trigger = 4;
+        break;
+      case 2:
+        trigger = 8;
+        break;
+      case 3:
+        trigger = 14;
+        break;
+      default:
+        panic("Invalid UART16550 FIFO trigger level");
+    }
+    return std::min(trigger, static_cast<unsigned>(fifoDepth));
+}
+
+uint8_t
+Uart16550::lineStatus() const
+{
+    uint8_t status = lineStatusErrors;
+    if (receiveReady())
+        status |= LsrDataReady;
+    if (transmitHoldingEmpty())
+        status |= LsrTransmitEmpty;
+    if (transmitHoldingEmpty() && !txBusy)
+        status |= LsrTransmitterEmpty;
+    return status;
+}
+
+uint8_t
+Uart16550::modemStatus() const
+{
+    if (!(mcr & McrLoopback))
+        return MsrDcd | MsrDsr | MsrCts;
+
+    uint8_t status = 0;
+    if (mcr & 0x08)
+        status |= MsrDcd;
+    if (mcr & 0x01)
+        status |= MsrDsr;
+    if (mcr & 0x02)
+        status |= MsrCts;
+    if (mcr & 0x04)
+        status |= 0x40;
+    return status;
+}
+
+uint8_t
+Uart16550::readRbr()
+{
+    uint8_t data = 0;
+    if (fifoActive()) {
+        if (!rxFifo.empty()) {
+            data = rxFifo.front();
+            rxFifo.pop_front();
+        }
+    } else if (rbrFull) {
+        data = rbr;
+        rbrFull = false;
+    }
+    return data;
+}
+
+uint8_t
+Uart16550::readIir()
+{
+    uint8_t iir = fifoActive() ? IirFifoEnabled : 0;
+    const uint8_t lsr = lineStatus();
+
+    if ((ier & IerLineStatus) && (lsr & LsrErrorMask)) {
+        iir |= IirLineStatus;
+    } else if ((ier & IerReceiveData) && receiveReady() &&
+               (!fifoActive() || rxFifo.size() >= receiveTriggerLevel())) {
+        iir |= IirReceiveData;
+    } else if ((ier & IerTransmitEmpty) && txInterruptPending) {
+        iir |= IirTransmitEmpty;
+        txInterruptPending = false;
+    } else {
+        iir |= IirNoInterrupt;
+    }
+    return iir;
+}
+
+uint8_t
+Uart16550::readRegister(Addr offset)
+{
+    if (offset % RegisterStride != 0)
+        return 0;
+
+    switch (offset) {
+      case RbrThrDll:
+        return (lcr & LcrDlab) ? dll : readRbr();
+      case IerDlm:
+        return (lcr & LcrDlab) ? dlm : ier;
+      case IirFcr:
+        return readIir();
+      case Lcr:
+        return lcr;
+      case Mcr:
+        return mcr;
+      case Lsr: {
+        const uint8_t status = lineStatus();
+        lineStatusErrors &= ~LsrErrorMask;
+        return status;
+      }
+      case Msr:
+        return modemStatus();
+      case Scr:
+        return scr;
+      default:
+        return 0;
+    }
+}
+
+void
+Uart16550::writeThr(uint8_t data)
+{
+    if (fifoActive()) {
+        if (txFifo.size() < fifoDepth)
+            txFifo.push_back(data);
+    } else if (txFifo.empty()) {
+        txFifo.push_back(data);
+    } else {
+        // The one-byte holding register exposes the last write.
+        txFifo.back() = data;
+    }
+
+    txInterruptPending = false;
+    startTransmit();
+}
+
+void
+Uart16550::writeIer(uint8_t data)
+{
+    const bool thriWasEnabled = ier & IerTransmitEmpty;
+    ier = data & 0x0f;
+    if (!(ier & IerTransmitEmpty)) {
+        txInterruptPending = false;
+    } else if (!thriWasEnabled && transmitHoldingEmpty()) {
+        txInterruptPending = true;
+    }
+}
+
+void
+Uart16550::writeFcr(uint8_t data)
+{
+    const bool wasActive = fifoActive();
+    fcr = fifoSupported ? data & (FcrEnableFifo | FcrTriggerMask) : 0;
+    const bool isActive = fifoActive();
+
+    if (wasActive != isActive || (data & FcrResetReceive)) {
+        rxFifo.clear();
+        rbrFull = false;
+        lineStatusErrors &= ~LsrErrorMask;
+    }
+    if (wasActive != isActive || (data & FcrResetTransmit))
+        txFifo.clear();
+
+    updateTxInterrupt();
+}
+
+void
+Uart16550::writeRegister(Addr offset, uint8_t data)
+{
+    if (offset % RegisterStride != 0)
+        return;
+
+    switch (offset) {
+      case RbrThrDll:
+        if (lcr & LcrDlab)
+            dll = data;
+        else
+            writeThr(data);
+        break;
+      case IerDlm:
+        if (lcr & LcrDlab)
+            dlm = data;
+        else
+            writeIer(data);
+        break;
+      case IirFcr:
+        writeFcr(data);
+        break;
+      case Lcr:
+        lcr = data;
+        break;
+      case Mcr:
+        mcr = data;
+        break;
+      case Scr:
+        scr = data;
+        break;
+      default:
+        break;
+    }
+}
+
+void
+Uart16550::receive(uint8_t data)
+{
+    if (fifoActive()) {
+        if (rxFifo.size() >= fifoDepth) {
+            lineStatusErrors |= LsrOverrun;
+            return;
+        }
+        rxFifo.push_back(data);
+    } else if (rbrFull) {
+        lineStatusErrors |= LsrOverrun;
+    } else {
+        rbr = data;
+        rbrFull = true;
+    }
+}
+
+Tick
+Uart16550::transmitDelay() const
+{
+    return std::max<Tick>(pioDelay, 1);
+}
+
+void
+Uart16550::startTransmit()
+{
+    if (txBusy || txFifo.empty())
+        return;
+
+    txShift = txFifo.front();
+    txFifo.pop_front();
+    txBusy = true;
+    schedule(txEvent, curTick() + transmitDelay());
+    updateTxInterrupt();
+}
+
+void
+Uart16550::completeTransmit()
+{
+    if (!txBusy)
+        return;
+
+    if (mcr & McrLoopback)
+        receive(txShift);
+    else
+        putc(txShift, stdout);
+
+    txBusy = false;
+    startTransmit();
+    updateTxInterrupt();
+}
+
+void
+Uart16550::updateTxInterrupt()
+{
+    if ((ier & IerTransmitEmpty) && transmitHoldingEmpty())
+        txInterruptPending = true;
+}
+
+uint8_t
+Uart16550::getWriteData(PacketPtr pkt) const
+{
+    switch (pkt->getSize()) {
+      case sizeof(uint8_t):
+        return pkt->getLE<uint8_t>();
+      case sizeof(uint16_t):
+        return pkt->getLE<uint16_t>();
+      case sizeof(uint32_t):
+        return pkt->getLE<uint32_t>();
+      case sizeof(uint64_t):
+        return pkt->getLE<uint64_t>();
+      default:
+        panic("Unsupported UART16550 write size %u", pkt->getSize());
+    }
+}
+
+void
+Uart16550::setReadData(PacketPtr pkt, uint8_t data) const
+{
+    switch (pkt->getSize()) {
+      case sizeof(uint8_t):
+        pkt->setLE<uint8_t>(data);
+        break;
+      case sizeof(uint16_t):
+        pkt->setLE<uint16_t>(data);
+        break;
+      case sizeof(uint32_t):
+        pkt->setLE<uint32_t>(data);
+        break;
+      case sizeof(uint64_t):
+        pkt->setLE<uint64_t>(data);
+        break;
+      default:
+        panic("Unsupported UART16550 read size %u", pkt->getSize());
+    }
+}
+
+Tick
+Uart16550::read(PacketPtr pkt)
+{
+    assert(pkt->getAddr() >= pioAddr && pkt->getAddr() < pioAddr + pioSize);
+    const Addr offset = pkt->getAddr() - pioAddr;
+    setReadData(pkt, readRegister(offset));
+    pkt->makeAtomicResponse();
+    return pioDelay;
+}
+
+Tick
+Uart16550::write(PacketPtr pkt)
+{
+    assert(pkt->getAddr() >= pioAddr && pkt->getAddr() < pioAddr + pioSize);
+    const Addr offset = pkt->getAddr() - pioAddr;
+    writeRegister(offset, getWriteData(pkt));
+    pkt->makeAtomicResponse();
+    return pioDelay;
+}
+
+} // namespace gem5

--- a/src/dev/serial/uart16550.hh
+++ b/src/dev/serial/uart16550.hh
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_SERIAL_UART16550_HH__
+#define __DEV_SERIAL_UART16550_HH__
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+
+#include "dev/io_device.hh"
+#include "params/Uart16550.hh"
+#include "sim/eventq.hh"
+
+namespace gem5
+{
+
+/**
+ * A register-shifted, direct-stdout UART16550 for the XiangShan platform.
+ *
+ * Standard UART registers are eight bits wide but occupy four-byte MMIO
+ * slots, matching the `reg-shift = <2>` hardware interface.  The device has
+ * no external interrupt pin because the XiangShan NemuPlic model does not
+ * expose one; IER/IIR state is still modeled for software compatibility.
+ */
+class Uart16550 : public BasicPioDevice
+{
+  public:
+    using Params = Uart16550Params;
+
+    explicit Uart16550(const Params &p);
+
+    Tick read(PacketPtr pkt) override;
+    Tick write(PacketPtr pkt) override;
+
+    /** Deliver a character to the receive side, for loopback or future I/O. */
+    void receive(uint8_t data);
+
+  private:
+    static constexpr Addr RegisterStride = 4;
+
+    // Standard 16550 registers at register index << 2.
+    static constexpr Addr RbrThrDll = 0x00;
+    static constexpr Addr IerDlm = 0x04;
+    static constexpr Addr IirFcr = 0x08;
+    static constexpr Addr Lcr = 0x0c;
+    static constexpr Addr Mcr = 0x10;
+    static constexpr Addr Lsr = 0x14;
+    static constexpr Addr Msr = 0x18;
+    static constexpr Addr Scr = 0x1c;
+
+    static constexpr uint8_t LcrDlab = 0x80;
+    static constexpr uint8_t McrLoopback = 0x10;
+
+    static constexpr uint8_t IerReceiveData = 0x01;
+    static constexpr uint8_t IerTransmitEmpty = 0x02;
+    static constexpr uint8_t IerLineStatus = 0x04;
+
+    static constexpr uint8_t IirNoInterrupt = 0x01;
+    static constexpr uint8_t IirTransmitEmpty = 0x02;
+    static constexpr uint8_t IirReceiveData = 0x04;
+    static constexpr uint8_t IirLineStatus = 0x06;
+    static constexpr uint8_t IirFifoEnabled = 0xc0;
+
+    static constexpr uint8_t FcrEnableFifo = 0x01;
+    static constexpr uint8_t FcrResetReceive = 0x02;
+    static constexpr uint8_t FcrResetTransmit = 0x04;
+    static constexpr uint8_t FcrTriggerMask = 0xc0;
+
+    static constexpr uint8_t LsrDataReady = 0x01;
+    static constexpr uint8_t LsrOverrun = 0x02;
+    static constexpr uint8_t LsrErrorMask = 0x1e;
+    static constexpr uint8_t LsrTransmitEmpty = 0x20;
+    static constexpr uint8_t LsrTransmitterEmpty = 0x40;
+
+    static constexpr uint8_t MsrDcd = 0x80;
+    static constexpr uint8_t MsrDsr = 0x20;
+    static constexpr uint8_t MsrCts = 0x10;
+
+    const bool fifoSupported;
+    const std::size_t fifoDepth;
+
+    uint8_t rbr = 0;
+    bool rbrFull = false;
+    uint8_t ier = 0;
+    uint8_t lcr = 0;
+    uint8_t mcr = 0;
+    uint8_t scr = 0;
+    uint8_t dll = 12;
+    uint8_t dlm = 0;
+    uint8_t fcr = 0;
+    uint8_t lineStatusErrors = 0;
+
+    std::deque<uint8_t> rxFifo;
+    std::deque<uint8_t> txFifo;
+    bool txBusy = false;
+    uint8_t txShift = 0;
+    bool txInterruptPending = false;
+    EventFunctionWrapper txEvent;
+
+    bool fifoActive() const;
+    bool receiveReady() const;
+    bool transmitHoldingEmpty() const;
+    unsigned receiveTriggerLevel() const;
+
+    uint8_t lineStatus() const;
+    uint8_t modemStatus() const;
+    uint8_t readRbr();
+    uint8_t readIir();
+    uint8_t readRegister(Addr offset);
+    void writeThr(uint8_t data);
+    void writeIer(uint8_t data);
+    void writeFcr(uint8_t data);
+    void writeRegister(Addr offset, uint8_t data);
+
+    void startTransmit();
+    void completeTransmit();
+    void updateTxInterrupt();
+    Tick transmitDelay() const;
+
+    uint8_t getWriteData(PacketPtr pkt) const;
+    void setReadData(PacketPtr pkt, uint8_t data) const;
+};
+
+} // namespace gem5
+
+#endif // __DEV_SERIAL_UART16550_HH__


### PR DESCRIPTION
## Motivation

XiangShan firmware uses an `ns16550a`-compatible UART at `0x310b0000` for the early console. The existing platform only exposes the direct-stdout `UartLite` at `0x40600000`, so the 16550 console path was not modeled.

## Implementation

- Add a standalone `Uart16550` `BasicPioDevice` with the standard 16550 register window at `0x310b0000`.
- Model four-byte register spacing (`reg-shift = 2`) while accepting 1/2/4/8-byte little-endian PIO accesses and using the low register byte.
- Implement DLAB banking, DLL/DLM, IER/IIR, LCR/MCR/LSR/MSR/SCR, receive state, loopback, direct stdout transmission, and dynamic THRE/TEMT status.
- Add configurable FIFO capability through `enable_fifo` and `fifo_depth`; FCR controls runtime FIFO enable, RX/TX reset, and RX trigger levels.
- Keep `UartLite` instantiated at `0x40600000`, wire both devices to the XiangShan I/O bus and non-Ruby bridge, and generate an `ns16550a` DT node with the new UART as stdout.
- Add Chinese implementation documentation under `docs/Gem5_Docs/device/uart16550.md`.

## Scope

The model preserves software-visible IER/IIR state but does not wire an external UART interrupt because the current `NemuPlic` path has no usable UART IRQ connection. Host terminal RX and baud-accurate serial timing are also intentionally out of scope.

## Validation

- `git diff --check`
- `python3 -m py_compile configs/common/FSConfig.py configs/common/xiangshan.py src/dev/serial/Uart.py`
- `scons -Q build/RISCV/gem5.opt --gold-linker -j64`
- Booted the requested raw checkpoint with default FIFO support and with `enable_fifo=false`. Both runs printed `OpenSBI v1.5`, `Platform Name : xiangshan,Kunminghu-dev`, `Platform Features : medeleg`, `Platform HART Count : 1`, and `Platform IPI Device : aclint-mswi`.

The checkpoint run is bounded after the firmware banner because it continues into Linux rather than exiting on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added UART16550 support for the XiangShan platform, including FIFO buffering and standard MMIO register access.
  - Linux and OpenSBI console output now use the UART16550 console at `0x310b0000`.
  - Added loopback and transmit timing behavior for improved UART compatibility.

- **Documentation**
  - Added comprehensive documentation covering registers, FIFO behavior, console configuration, and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->