### PR TITLE
SPEC06 RVV fixes

### DIFF
--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -200,10 +200,8 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
             tc->setMiscReg(epc, tc->pcState().instAddr());
         }
 
-        if (_cause == INST_ILLEGAL)
-            tc->setMiscReg(tval, 0);
-        else
-            tc->setMiscReg(tval, trap_value());
+        // Preserve the faulting instruction encoding for illegal-instruction traps.
+        tc->setMiscReg(tval, trap_value());
         if (_code == INST_G_PAGE || _code == LOAD_G_PAGE || _code == STORE_G_PAGE) {
             if (prv == PRV_S && (g_trap_value() != 0)) {
                 tc->setMiscReg(MISCREG_HTVAL, g_trap_value() >> 2);

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -628,9 +628,15 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
         // Fill mask destination tail bits with ones.
         // Mask-producing instructions always treat their tail as agnostic.
         const uint64_t rVl = xc->readMiscReg(MISCREG_VL);
-        for (uint64_t bit = rVl; bit < VLEN; ++bit) {
-            Vd[bit / 8] |= static_cast<uint8_t>(
-                1U << (bit % 8));
+        const uint64_t vstart = xc->readMiscReg(MISCREG_VSTART);
+
+        // If vstart >= vl, no destination elements, including tail
+        // elements, may be updated.
+        if (vstart < rVl) {
+            for (uint64_t bit = rVl; bit < VLEN; ++bit) {
+                Vd[bit / 8] |= static_cast<uint8_t>(
+                    1U << (bit % 8));
+            }
         }
 
         xc->setRegOperand(this, 0, &tmp_d0);
@@ -930,6 +936,27 @@ class Vcompress_vm : public VectorNonSplitInst
                     vs_array[i / elem_num_per_vreg].template as<Type>()
                     [i % elem_num_per_vreg];
                 vd_ptr++;
+            }
+        }
+
+        // RVV vcompress tail-agnostic fix.
+        //
+        // vd_ptr is the number of elements selected by the mask.
+        // All destination elements after vd_ptr are tail elements.
+        // For fractional LMUL, also fill the unused part of the
+        // physical destination register to match the reference model.
+        if ((rVl != 0) && machInst.vtype8.vta) {
+            const uint32_t physical_elem_count =
+                regLength * elem_num_per_vreg;
+
+            for (uint32_t i = vd_ptr;
+                 i < physical_elem_count;
+                 ++i) {
+                vd_array[
+                    i / elem_num_per_vreg
+                ].template as<Type>()[
+                    i % elem_num_per_vreg
+                ] = static_cast<Type>(-1);
             }
         }
         for (uint32_t i = 0; i < regLength; i++) {

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -625,6 +625,14 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
                 memcpy(Vd + i * byte_offset, s + i * byte_offset, byte_offset);
             }
         }
+        // Fill mask destination tail bits with ones.
+        // Mask-producing instructions always treat their tail as agnostic.
+        const uint64_t rVl = xc->readMiscReg(MISCREG_VL);
+        for (uint64_t bit = rVl; bit < VLEN; ++bit) {
+            Vd[bit / 8] |= static_cast<uint8_t>(
+                1U << (bit % 8));
+        }
+
         xc->setRegOperand(this, 0, &tmp_d0);
         if (traceData)
             traceData->setData(tmp_d0);

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1724,6 +1724,45 @@ decode QUADRANT {
                         fd = freg(f16_to_f32(f16(freg(Fs1_bits))));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
+                    0x4: fround_s({{
+                        RM_REQUIRED;
+                        freg_t fd;
+                        fd = freg(f32_roundToInt(
+                            f32(freg(Fs1_bits)),
+                            softfloat_roundingMode,
+                            false));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatCvtOp);
+
+                    0x5: froundnx_s({{
+                        RM_REQUIRED;
+                        freg_t fd;
+                        fd = freg(f32_roundToInt(
+                            f32(freg(Fs1_bits)),
+                            softfloat_roundingMode,
+                            true));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatCvtOp);
                 }
                 0x21: decode CONV_SGN {
                     0x0: fcvt_d_s({{
@@ -1744,6 +1783,45 @@ decode QUADRANT {
                         freg_t fd;
                         fd = freg(f16_to_f64(f16(freg(Fs1_bits))));
                         Fd_bits = fd.v;
+                    }}, FloatCvtOp);
+                    0x4: fround_d({{
+                        RM_REQUIRED;
+                        freg_t fd;
+                        fd = freg(f64_roundToInt(
+                            f64(freg(Fs1_bits)),
+                            softfloat_roundingMode,
+                            false));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatCvtOp);
+
+                    0x5: froundnx_d({{
+                        RM_REQUIRED;
+                        freg_t fd;
+                        fd = freg(f64_roundToInt(
+                            f64(freg(Fs1_bits)),
+                            softfloat_roundingMode,
+                            true));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
                     }}, FloatCvtOp);
                 }
                 0x22: decode CONV_SGN {
@@ -2039,30 +2117,211 @@ decode QUADRANT {
                         Rd = f16_classify(f16(freg(Fs1_bits)));
                     }}, FloatMiscOp);
                 }
-                0x78: fmv_w_x({{
-                    freg_t fd;
-                    fd = freg(f32(Rs1_uw));
-                    Fd_bits = fd.v;
-                    status.fs = 3;
-                    xc->setMiscReg(MISCREG_STATUS,status);
-                    if(xc->readMiscReg(MISCREG_VIRMODE) == 1) {
-                            STATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+                0x78: decode RS2 {
+                    0x0: fmv_w_x({{
+                        freg_t fd;
+                        fd = freg(f32(Rs1_uw));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
                             vsstatus.fs = 3;
-                            xc->setMiscReg(MISCREG_VSSTATUS,vsstatus);
-                    }
-                }}, FloatMvOp);
-                0x79: fmv_d_x({{
-                    freg_t fd;
-                    fd = freg(f64(Rs1));
-                    Fd_bits = fd.v;
-                    status.fs = 3;
-                    xc->setMiscReg(MISCREG_STATUS,status);
-                }}, FloatMvOp);
-                0x7a: fmv_h_x({{
-                    freg_t fd;
-                    fd = freg(f16(Rs1_uh));
-                    Fd_bits = fd.v;
-                }}, FloatMvOp);
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+
+                    0x1: fli_s({{
+                        static const uint32_t fliSTable[32] = {
+                            0xbf800000U, //  0: -1.0
+                            0x00800000U, //  1: min positive normal
+                            0x37800000U, //  2: 2^-16
+                            0x38000000U, //  3: 2^-15
+                            0x3b800000U, //  4: 2^-8
+                            0x3c000000U, //  5: 2^-7
+                            0x3d800000U, //  6: 2^-4
+                            0x3e000000U, //  7: 2^-3
+                            0x3e800000U, //  8: 0.25
+                            0x3ea00000U, //  9: 0.3125
+                            0x3ec00000U, // 10: 0.375
+                            0x3ee00000U, // 11: 0.4375
+                            0x3f000000U, // 12: 0.5
+                            0x3f200000U, // 13: 0.625
+                            0x3f400000U, // 14: 0.75
+                            0x3f600000U, // 15: 0.875
+                            0x3f800000U, // 16: 1.0
+                            0x3fa00000U, // 17: 1.25
+                            0x3fc00000U, // 18: 1.5
+                            0x3fe00000U, // 19: 1.75
+                            0x40000000U, // 20: 2.0
+                            0x40200000U, // 21: 2.5
+                            0x40400000U, // 22: 3.0
+                            0x40800000U, // 23: 4.0
+                            0x41000000U, // 24: 8.0
+                            0x41800000U, // 25: 16.0
+                            0x43000000U, // 26: 128.0
+                            0x43800000U, // 27: 256.0
+                            0x47000000U, // 28: 2^15
+                            0x47800000U, // 29: 2^16
+                            0x7f800000U, // 30: +infinity
+                            0x7fc00000U  // 31: canonical NaN
+                        };
+
+                        freg_t fd;
+                        fd = freg(f32(fliSTable[RS1]));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+                }
+                0x79: decode RS2 {
+                    0x0: fmv_d_x({{
+                        freg_t fd;
+                        fd = freg(f64(Rs1));
+                        Fd_bits = fd.v;
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+
+                    0x1: fli_d({{
+                        static const uint64_t fliDTable[32] = {
+                            0xbff0000000000000ULL,
+                            0x0010000000000000ULL,
+                            0x3ef0000000000000ULL,
+                            0x3f00000000000000ULL,
+                            0x3f70000000000000ULL,
+                            0x3f80000000000000ULL,
+                            0x3fb0000000000000ULL,
+                            0x3fc0000000000000ULL,
+                            0x3fd0000000000000ULL,
+                            0x3fd4000000000000ULL,
+                            0x3fd8000000000000ULL,
+                            0x3fdc000000000000ULL,
+                            0x3fe0000000000000ULL,
+                            0x3fe4000000000000ULL,
+                            0x3fe8000000000000ULL,
+                            0x3fec000000000000ULL,
+                            0x3ff0000000000000ULL,
+                            0x3ff4000000000000ULL,
+                            0x3ff8000000000000ULL,
+                            0x3ffc000000000000ULL,
+                            0x4000000000000000ULL,
+                            0x4004000000000000ULL,
+                            0x4008000000000000ULL,
+                            0x4010000000000000ULL,
+                            0x4020000000000000ULL,
+                            0x4030000000000000ULL,
+                            0x4060000000000000ULL,
+                            0x4070000000000000ULL,
+                            0x40e0000000000000ULL,
+                            0x40f0000000000000ULL,
+                            0x7ff0000000000000ULL,
+                            0x7ff8000000000000ULL
+                        };
+
+                        Fd_bits = fliDTable[RS1];
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+                }
+                0x7a: decode RS2 {
+                    0x0: fmv_h_x({{
+                        freg_t fd;
+                        fd = freg(f16(Rs1_uh));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+
+                    0x1: fli_h({{
+                        static const uint16_t fliHTable[32] = {
+                            0xbc00U, //  0: -1.0
+                            0x0400U, //  1: min positive normal
+                            0x0100U, //  2: 2^-16, subnormal
+                            0x0200U, //  3: 2^-15, subnormal
+                            0x1c00U, //  4: 2^-8
+                            0x2000U, //  5: 2^-7
+                            0x2c00U, //  6: 2^-4
+                            0x3000U, //  7: 2^-3
+                            0x3400U, //  8: 0.25
+                            0x3500U, //  9: 0.3125
+                            0x3600U, // 10: 0.375
+                            0x3700U, // 11: 0.4375
+                            0x3800U, // 12: 0.5
+                            0x3900U, // 13: 0.625
+                            0x3a00U, // 14: 0.75
+                            0x3b00U, // 15: 0.875
+                            0x3c00U, // 16: 1.0
+                            0x3d00U, // 17: 1.25
+                            0x3e00U, // 18: 1.5
+                            0x3f00U, // 19: 1.75
+                            0x4000U, // 20: 2.0
+                            0x4100U, // 21: 2.5
+                            0x4200U, // 22: 3.0
+                            0x4400U, // 23: 4.0
+                            0x4800U, // 24: 8.0
+                            0x4c00U, // 25: 16.0
+                            0x5800U, // 26: 128.0
+                            0x5c00U, // 27: 256.0
+                            0x7800U, // 28: 2^15
+                            0x7c00U, // 29: +infinity
+                            0x7c00U, // 30: +infinity
+                            0x7e00U  // 31: canonical NaN
+                        };
+
+                        freg_t fd;
+                        fd = freg(f16(fliHTable[RS1]));
+                        Fd_bits = fd.v;
+
+                        status.fs = 3;
+                        xc->setMiscReg(MISCREG_STATUS, status);
+
+                        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+                            STATUS vsstatus =
+                                xc->readMiscReg(MISCREG_VSSTATUS);
+                            vsstatus.fs = 3;
+                            xc->setMiscReg(
+                                MISCREG_VSSTATUS, vsstatus);
+                        }
+                    }}, FloatMvOp);
+                }
             }
         }
 

--- a/src/arch/riscv/isa/vector/base/decoder.isa
+++ b/src/arch/riscv/isa/vector/base/decoder.isa
@@ -28,7 +28,7 @@ decode QUADRANT {
                     }}, inst_flags=VectorUnitStrideMaskLoadOp);
                     0x10: VleffOp::vle8ff_v({{
                         Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei8_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -67,7 +67,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle16ff_v({{
                         Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei16_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -106,7 +106,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle32ff_v({{
                         Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei32_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -145,7 +145,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle64ff_v({{
                         Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei64_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -1925,8 +1925,22 @@ decode QUADRANT {
                         0x1: VectorNonSplitFormat::vfmv_s_f({{
                             auto fd = ftype_freg<et>(freg(Fs1_bits));
                             std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
+
+                            // RVV vfmv.s.f tail-agnostic fix.
+                            //
+                            // When vl is nonzero, element 0 receives the
+                            // scalar floating-point value. All remaining
+                            // elements are tail elements.
                             if (rVl) {
                                 Vd_vu[0] = fd.v;
+
+                                if (machInst.vtype8.vta) {
+                                    for (uint32_t i = 1;
+                                         i < RiscvISA::VLENB / sizeof(Vd_vu[0]);
+                                         ++i) {
+                                        Vd_vu[i] = ~vu(0);
+                                    }
+                                }
                             }
                         }}, OPFVV, VectorMiscOp);
                     }
@@ -2190,6 +2204,16 @@ decode QUADRANT {
                             std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
                             if (rVl) {
                                 Vd_vu[0] = Rs1_vu;
+
+                                // vmv.s.x only writes element 0. The remaining
+                                // destination elements are tail elements and
+                                // follow the vta policy.
+                                if (machInst.vtype8.vta) {
+                                    std::memset(
+                                        Vd_vu + 1,
+                                        0xff,
+                                        RiscvISA::VLENB - sizeof(vu));
+                                }
                             }
                         }}, OPMVX, VectorMiscOp);
                     }

--- a/src/arch/riscv/isa/vector/base/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.isa
@@ -83,14 +83,14 @@ let {{
                     %s
                 } else if (machInst.vtype8.vma) {
                     std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
                 }
-            } else if (machInst.vtype8.vta) {
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
                 std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
@@ -100,12 +100,73 @@ let {{
             return """
             if (ei < rVl) {
                 %s
-            } else if (machInst.vtype8.vta) {
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
                 std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
+            }
+            """ % code
+
+
+    def wideningAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    std::memset(
+                        tmp_d0.as<uint8_t>() +
+                            i * sizeof(vwu),
+                        0xff,
+                        sizeof(vwu));
+                }
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
+                std::memset(
+                    tmp_d0.as<uint8_t>() +
+                        i * sizeof(vwu),
+                    0xff,
+                    sizeof(vwu));
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
+                std::memset(
+                    tmp_d0.as<uint8_t>() +
+                        i * sizeof(vwu),
+                    0xff,
+                    sizeof(vwu));
+            }
+            """ % code
+
+    def narrowingAgnosticWrapper(code):
+        return """
+            // Narrowing operations write the destination element at
+            // i + offset. Handle active, mask-agnostic and
+            // tail-agnostic destination elements consistently.
+            if (rVl != 0) {
+                if (ei < rVl) {
+                    if (this->vm || elem_mask(v0, ei)) {
+                        %s
+                    } else if (machInst.vtype8.vma) {
+                        std::memset(
+                            tmp_d0.as<uint8_t>() +
+                                (i + offset) * sizeof(ElemType),
+                            0xff,
+                            sizeof(ElemType));
+                    }
+                } else if (machInst.vtype8.vta) {
+                    std::memset(
+                        tmp_d0.as<uint8_t>() +
+                            (i + offset) * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+                }
             }
             """ % code
 
@@ -117,7 +178,7 @@ let {{
                     %s
                 } else if (machInst.vtype8.vma) {
                     const uint32_t agnostic_bit = offset + i;
-                    reinterpret_cast<uint8_t *>(Vd)[agnostic_bit / 8] |=
+                    tmp_d0.as<uint8_t>()[agnostic_bit / 8] |=
                         static_cast<uint8_t>(
                             1U << (agnostic_bit %% 8));
                 }
@@ -290,7 +351,7 @@ def format VectorIntExtFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
 
-    code = maskCondWrapper(code)
+    code = regularAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     vm_decl_rd = vmDeclAndReadData()
@@ -351,7 +412,7 @@ def format VectorIntWideningFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = wideningAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
 
@@ -411,7 +472,7 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     # code
-    code = maskCondWrapper(code)
+    code = narrowingAgnosticWrapper(code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = narrowingOpRegisterConstraintChecks(code)
@@ -642,7 +703,7 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = regularAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -706,7 +767,7 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = wideningAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -754,7 +815,30 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = """
+    // RVV widening-conversion agnostic fix.
+    if (ei < rVl) {
+        if (this->vm ||
+            elem_mask(v0, ei)) {
+            %s
+        } else if (
+            machInst.vtype8.vma) {
+            std::memset(
+                tmp_d0.as<uint8_t>() +
+                    i * sizeof(vwu),
+                0xff,
+                sizeof(vwu));
+        }
+    } else if (
+        (rVl != 0) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                i * sizeof(vwu),
+            0xff,
+            sizeof(vwu));
+    }
+    """ % (code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -798,7 +882,7 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = narrowingAgnosticWrapper(code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -1057,6 +1141,26 @@ def format VectorMaskFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
     code = loopWrapper(code, micro_inst = False)
+    code += """
+    // Mask logical instructions always have an
+    // agnostic tail.  Match the reference model by
+    // choosing all ones for tail bits.
+    //
+    // Prestart bits remain undisturbed, and when
+    // vstart >= vl (including vl == 0), vd is not
+    // modified.
+    const uint64_t mask_vstart =
+        xc->readMiscReg(MISCREG_VSTART);
+
+    if (mask_vstart < rVl) {
+        for (uint32_t bit = rVl;
+             bit < VLEN;
+             ++bit) {
+            Vd_ub[bit / 8] =
+                ASSIGN_VD_BIT(bit, true);
+        }
+    }
+    """
 
     iop = InstObjParams(name,
         Name,
@@ -1087,7 +1191,7 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
@@ -1101,6 +1205,16 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     code = """
     if (microIdx * elem_num_per_vreg < rVl) {
         %s
+
+        // Integer reduction writes only destination element 0.
+        // Match the reference model by filling the remaining
+        // tail elements with ones under the tail-agnostic policy.
+        if (machInst.vtype8.vta) {
+            std::memset(
+                tmp_d0.as<uint8_t>() + sizeof(ElemType),
+                0xff,
+                RiscvISA::VLENB - sizeof(ElemType));
+        }
     }
     """ % (code)
 
@@ -1130,16 +1244,25 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = "RegId(VecRegClass, VecTempReg0)"
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
-    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
+    set_src_reg_idx += """
+        // Carry the ordered-reduction accumulator through a renamed
+        // internal vector temporary register.
+        if (_microIdx != 0) {
+            accSrcIdx = _numSrcRegs;
+            setSrcRegIdx(
+                _numSrcRegs++,
+                RegId(VecRegClass, VecTempReg0));
+        }
+    """
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
@@ -1167,8 +1290,11 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
         VectorReduceMicroDeclare.subst(microiop) + \
         VectorReduceMicroConstructor.subst(microiop) + \
         VectorReduceFloatMicroExecute.subst(microiop) + \
+        VectorReduceFloatFinalMicroDeclare.subst(iop) + \
+        VectorReduceFloatFinalMicroConstructor.subst(iop) + \
+        VectorReduceFloatFinalMicroExecute.subst(iop) + \
         VectorReduceMacroDeclare.subst(iop) + \
-        VectorReduceMacroConstructor.subst(iop)
+        VectorReduceFloatMacroConstructor.subst(iop)
     decode_block = VectorFloatDecodeBlock.subst(iop)
 }};
 
@@ -1183,7 +1309,7 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
@@ -1283,7 +1409,7 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()

--- a/src/arch/riscv/isa/vector/base/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.isa
@@ -74,6 +74,62 @@ let {{
             }
             """ % (code)
 
+
+    def regularAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+                }
+            } else if (machInst.vtype8.vta) {
+                std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            } else if (machInst.vtype8.vta) {
+                std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+            }
+            """ % code
+
+    def maskResultAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    const uint32_t agnostic_bit = offset + i;
+                    reinterpret_cast<uint8_t *>(Vd)[agnostic_bit / 8] |=
+                        static_cast<uint8_t>(
+                            1U << (agnostic_bit %% 8));
+                }
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            }
+            """ % code
+
     def eiDeclarePrefix(code, widening = False):
         if widening:
             return '''
@@ -183,7 +239,7 @@ def format VectorIntFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = regularAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
 
@@ -420,7 +476,7 @@ def format VectorIntMaskFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     #code
-    code = maskCondWrapper(code, mask_cond)
+    code = maskResultAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
 
@@ -540,7 +596,7 @@ def format VectorFloatFormat(code, category, *flags) {{
     if v0_required:
         set_src_reg_idx += setSrcVm()
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = regularAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -797,7 +853,7 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
 
-    code = maskCondWrapper(code)
+    code = maskResultAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)

--- a/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
@@ -359,8 +359,12 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     }
 
-    const int32_t t_micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    const int32_t micro_vlmax = vlmul < 0 ? t_micro_vlmax : t_micro_vlmax / 2;
+    // Each widening micro-op writes one physical destination vector
+    // register. Since the destination element width is 2 * SEW, the
+    // number of destination elements handled by one micro-op is
+    // independent of LMUL. LMUL is represented by the number of
+    // generated micro-ops.
+    const int32_t micro_vlmax = VLEN / (2 * sew);
     [[maybe_unused]] const size_t offset =
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
     uint32_t elem_num_per_vreg = micro_vlmax;
@@ -586,8 +590,12 @@ Fault
 
     VRM_REQUIRED;
 
-    const int32_t t_micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    const int32_t micro_vlmax = vlmul < 0 ? t_micro_vlmax : t_micro_vlmax / 2;
+    // Each widening micro-op writes one physical destination vector
+    // register. Since the destination element width is 2 * SEW, the
+    // number of destination elements handled by one micro-op is
+    // independent of LMUL. LMUL is represented by the number of
+    // generated micro-ops.
+    const int32_t micro_vlmax = VLEN / (2 * sew);
     [[maybe_unused]] const size_t offset =
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
     uint32_t elem_num_per_vreg = micro_vlmax;
@@ -1307,6 +1315,172 @@ template<typename ElemType>
 
 }};
 
+
+def template VectorReduceFloatMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+{
+    const uint32_t num_reduce_microops =
+        vflmul < 1 ? 1 : vflmul;
+
+    StaticInstPtr microop;
+
+    // Reduction data micro-ops only update VecTempReg0.
+    for (uint32_t i = 0; i < num_reduce_microops; ++i) {
+        microop =
+            new %(class_name)sMicro<ElemType>(_machInst, i);
+        microop->setDelayedCommit();
+        this->microops.push_back(microop);
+    }
+
+    // Write architectural vd only after every source-register
+    // chunk has been renamed and consumed.
+    microop =
+        new %(class_name)sFinalMicro<ElemType>(
+            _machInst, num_reduce_microops);
+    microop->setDelayedCommit();
+    this->microops.push_back(microop);
+
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+}};
+
+
+def template VectorReduceFloatFinalMicroDeclare {{
+
+template<typename ElemType>
+class %(class_name)sFinalMicro : public VectorArithMicroInst
+{
+  private:
+    RegId srcRegIdxArr[3];
+    RegId destRegIdxArr[1];
+
+  public:
+    %(class_name)sFinalMicro(
+        ExtMachInst _machInst,
+        uint8_t _microIdx);
+
+    Fault execute(
+        ExecContext *xc,
+        Trace::InstRecord *traceData) const override;
+
+    using VectorArithMicroInst::generateDisassembly;
+};
+
+}};
+
+
+def template VectorReduceFloatFinalMicroConstructor {{
+
+template<typename ElemType>
+%(class_name)sFinalMicro<ElemType>::%(class_name)sFinalMicro(
+    ExtMachInst _machInst,
+    uint8_t _microIdx)
+    : VectorArithMicroInst(
+          "%(mnemonic)s_final_micro",
+          _machInst,
+          %(op_class)s,
+          _microIdx)
+{
+    setRegIdxArrays(
+        reinterpret_cast<RegIdArrayPtr>(
+            &std::remove_pointer_t<decltype(this)>::srcRegIdxArr),
+        reinterpret_cast<RegIdArrayPtr>(
+            &std::remove_pointer_t<decltype(this)>::destRegIdxArr));
+
+    _numSrcRegs = 0;
+    _numDestRegs = 0;
+
+    // Architectural destination.
+    setDestRegIdx(
+        _numDestRegs++,
+        RegId(VecRegClass, _machInst.vd));
+    _numTypedDestRegs[VecRegClass]++;
+
+    // Final renamed accumulator value.
+    setSrcRegIdx(
+        _numSrcRegs++,
+        RegId(VecRegClass, VecTempReg0));
+
+    // Original architectural destination. Because the reduction
+    // data micro-ops do not write vd, this remains the pre-instruction
+    // value even when vd overlaps the vs2 register group.
+    setSrcRegIdx(
+        _numSrcRegs++,
+        RegId(VecRegClass, _machInst.vd));
+
+    SET_VL_SRC();
+}
+
+}};
+
+
+def template VectorReduceFloatFinalMicroExecute {{
+
+template<typename ElemType>
+Fault
+%(class_name)sFinalMicro<ElemType>::execute(
+    ExecContext *xc,
+    Trace::InstRecord *traceData) const
+{
+    using et = ElemType;
+    using vu = decltype(et::v);
+
+    if (machInst.vill) {
+        return std::make_shared<IllegalInstFault>(
+            "VILL is set", machInst);
+    }
+
+    auto &tmp_d0 =
+        *(RiscvISAInst::VecRegContainer *)
+        xc->getWritableRegOperand(this, 0);
+    auto Vd = tmp_d0.as<vu>();
+
+    // Begin with the original destination so vl=0 and
+    // tail-undisturbed behavior preserve the previous contents.
+    RiscvISAInst::VecRegContainer tmp_old;
+    xc->getRegOperand(this, 1, &tmp_old);
+    auto OldVd = tmp_old.as<vu>();
+
+    for (uint32_t i = 0; i < VLEN / sew; ++i) {
+        Vd[i] = OldVd[i];
+    }
+
+    RiscvISAInst::VecRegContainer tmp_acc;
+    xc->getRegOperand(this, 0, &tmp_acc);
+    auto Acc = tmp_acc.as<vu>();
+
+    uint64_t rVl = 0;
+    assert(vlsrcIdx > 0);
+    rVl = xc->getRegOperand(this, vlsrcIdx);
+
+    if (rVl != 0) {
+        // A vector reduction writes only element zero.
+        Vd[0] = Acc[0];
+
+        if (machInst.vtype8.vta) {
+            for (uint32_t i = 1; i < VLEN / sew; ++i) {
+                Vd[i] = ~vu(0);
+            }
+        }
+    }
+
+    xc->setRegOperand(this, 0, &tmp_d0);
+
+    if (traceData) {
+        traceData->setData(tmp_d0);
+    }
+
+    return NoFault;
+}
+
+}};
+
+
 def template VectorReduceMicroDeclare {{
 
 template<typename ElemType>
@@ -1316,6 +1490,7 @@ private:
     // vs2, vs1, vd, vm
     RegId srcRegIdxArr[8];
     RegId destRegIdxArr[1];
+    int8_t accSrcIdx = -1;
 public:
     %(class_name)s(ExtMachInst _machInst,
                    uint8_t _microIdx);
@@ -1384,36 +1559,62 @@ Fault
 
 def template VectorReduceFloatMicroExecute {{
 
-template <typename ElemType>
+template<typename ElemType>
 Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  Trace::InstRecord* traceData) const
+%(class_name)s<ElemType>::execute(
+    ExecContext *xc,
+    Trace::InstRecord *traceData) const
 {
     %(type_def)s;
+
     if (machInst.vill) {
-        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+        return std::make_shared<IllegalInstFault>(
+            "VILL is set", machInst);
     }
 
     %(op_decl)s;
     %(op_rd)s;
     %(vm_decl_rd)s;
-    COPY_OLD_VD();
 
-    uint32_t micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+    const uint32_t micro_vlmax =
+        VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+
+    // The first data micro-op starts with vs1[0].
+    // Later data micro-ops continue from the previous renamed
+    // VecTempReg0 version.
+    vu accumulator = Vs1[0];
+
+    if (accSrcIdx >= 0) {
+        RiscvISAInst::VecRegContainer tmp_acc;
+        xc->getRegOperand(this, accSrcIdx, &tmp_acc);
+        accumulator = tmp_acc.as<vu>()[0];
+    }
+
+    // Every statically generated micro-op must produce a new temp
+    // version, including chunks that are inactive because of vl.
+    Vd[0] = accumulator;
+
     if (micro_vlmax * this->microIdx < rVl) {
-        Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
-
         auto reduce_loop =
-            [&, this](const auto& f, const auto* _, const auto* vs2) {
+            [&, this](
+                const auto& f,
+                const auto *,
+                const auto *vs2) {
                 vu tmp_val = Vd[0];
-                for (uint32_t i = 0; i < micro_vlmax; i++) {
-                    uint32_t ei = i + micro_vlmax * this->microIdx;
-                    if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                        tmp_val = f(tmp_val, Vs2[i]).v;
+
+                for (uint32_t i = 0; i < micro_vlmax; ++i) {
+                    const uint32_t ei =
+                        i + micro_vlmax * this->microIdx;
+
+                    if ((ei < rVl) &&
+                        (this->vm || elem_mask(v0, ei))) {
+                        tmp_val = f(tmp_val, vs2[i]).v;
                     }
                 }
+
                 return tmp_val;
             };
+
         %(code)s;
     }
 
@@ -1422,6 +1623,7 @@ Fault
 }
 
 }};
+
 
 def template VectorReduceFloatWideningMicroExecute {{
 
@@ -1594,6 +1796,60 @@ Fault
     uint32_t elem_num_per_vreg = VLENB / std::max(vd_eewb, vs1_eewb);
 
     %(code)s;
+
+    // RVV gather final agnostic fix.
+    //
+    // A gather instruction can contain multiple micro-ops
+    // for different vs2 source registers. Apply destination
+    // agnostic policy only after the last source-register
+    // micro-op for this destination chunk.
+    const uint64_t gather_vstart =
+        xc->readMiscReg(MISCREG_VSTART);
+
+    // Only architectural destination-register chunks may
+    // receive tail/mask agnostic updates. Gather decomposition
+    // can create extra micro-ops beyond the current LMUL group.
+    const uint32_t gather_vd_vregs =
+        vflmul < 1 ? 1 : vflmul;
+
+    if ((vd_idx < gather_vd_vregs) &&
+        (vs2_idx + 1 == vs2_vregs) &&
+        (gather_vstart < rVl)) {
+        for (uint32_t gather_i = 0;
+             gather_i < elem_num_per_vreg;
+             ++gather_i) {
+            // Tail and mask policies are properties of
+            // destination elements, not the vs1 index chunk.
+            const uint32_t gather_ei =
+                gather_i +
+                vd_idx * elem_num_per_vreg +
+                vd_bias;
+
+            const uint32_t gather_vd_i =
+                gather_i + vd_bias;
+
+            if (gather_vd_i >= vd_elems) {
+                continue;
+            }
+
+            const bool gather_is_tail =
+                gather_ei >= rVl;
+
+            const bool gather_is_inactive =
+                (gather_ei >= gather_vstart) &&
+                (gather_ei < rVl) &&
+                !this->vm &&
+                !elem_mask(v0, gather_ei);
+
+            if ((gather_is_tail &&
+                 machInst.vtype8.vta) ||
+                (gather_is_inactive &&
+                 machInst.vtype8.vma)) {
+                Vd[gather_vd_i] = ~vu(0);
+            }
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;
@@ -1738,6 +1994,19 @@ Fault
             };
 
         %(code)s;
+    }
+
+    // A reduction only writes destination element 0. All remaining
+    // destination elements are tail elements. Apply tail-agnostic
+    // filling only on the final micro-op, after the reduction result
+    // has been accumulated.
+    if ((rVl != 0) &&
+        this->isLastMicroop() &&
+        machInst.vtype8.vta) {
+        std::memset(
+            reinterpret_cast<uint8_t *>(Vd) + sizeof(Vd[0]),
+            0xff,
+            VLEN / 8 - sizeof(Vd[0]));
     }
 
     %(op_wb)s;

--- a/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
@@ -1936,6 +1936,30 @@ Fault
     %(vm_decl_rd)s;
     COPY_OLD_VD();
     %(code)s;
+
+    // Fill RVV tail-agnostic and mask-agnostic slide elements with ones.
+    for (uint32_t agnostic_i = 0;
+         agnostic_i < elem_num_per_vreg;
+         ++agnostic_i) {
+        const uint32_t agnostic_ei =
+            vmi.rs + agnostic_i;
+
+        const bool is_tail = agnostic_ei >= rVl;
+        const bool is_masked_off =
+            agnostic_ei < rVl &&
+            !this->vm &&
+            !elem_mask(v0, agnostic_ei);
+
+        if ((is_tail && machInst.vtype8.vta) ||
+            (is_masked_off && machInst.vtype8.vma)) {
+            std::memset(
+                reinterpret_cast<uint8_t *>(Vd) +
+                    agnostic_i * sizeof(ElemType),
+                0xff,
+                sizeof(ElemType));
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;
@@ -1964,6 +1988,30 @@ Fault
     %(vm_decl_rd)s;
     COPY_OLD_VD();
     %(code)s;
+
+    // Fill RVV tail-agnostic and mask-agnostic slide elements with ones.
+    for (uint32_t agnostic_i = 0;
+         agnostic_i < elem_num_per_vreg;
+         ++agnostic_i) {
+        const uint32_t agnostic_ei =
+            vmi.rs + agnostic_i;
+
+        const bool is_tail = agnostic_ei >= rVl;
+        const bool is_masked_off =
+            agnostic_ei < rVl &&
+            !this->vm &&
+            !elem_mask(v0, agnostic_ei);
+
+        if ((is_tail && machInst.vtype8.vta) ||
+            (is_masked_off && machInst.vtype8.vma)) {
+            std::memset(
+                reinterpret_cast<uint8_t *>(Vd) +
+                    agnostic_i * sizeof(ElemType),
+                0xff,
+                sizeof(ElemType));
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;

--- a/src/arch/riscv/isa/vector/base/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/base/vector_conf.isa
@@ -95,6 +95,24 @@ def template VConfExecute {{
     {
         auto tc = xc->tcBase();
 
+        // All vector configuration instructions are illegal when the
+        // vector context is disabled. This check must happen before
+        // writing vstart, vtype or vl, because those writes may mark
+        // the vector context Dirty.
+        STATUS status = xc->readMiscReg(MISCREG_STATUS);
+        if (status.vs == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "Vector state is off", machInst);
+        }
+
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+            if (vsstatus.vs == 0) {
+                return std::make_shared<IllegalInstFault>(
+                    "Vector state is off in virtual mode", machInst);
+            }
+        }
+
         %(op_decl)s;
         %(op_rd)s;
         %(code)s;
@@ -115,7 +133,7 @@ def template VConfExecute {{
             uint32_t new_vill =
                 !(vflmul >= 0.125 && vflmul <= 8) ||
                 sew > std::min(vflmul, 1.0f) * ELEN ||
-                bits(requested_vtype, 30, 8) != 0;
+                (requested_vtype >> 8) != 0;
 
             if (new_vill) {
                 vlmax = 0;

--- a/src/arch/riscv/isa/vector/base/vector_mem.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.isa
@@ -63,9 +63,9 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     vfof_set_code = ''
     vfof_zero_idx_check_code = ''
     vfof_get_code = ''
+    vfof_adjust_mem_size_code = ''
     if vfof:
         vfof_set_code = '''
-        auto base_addr = Rs1;
         uint32_t elem_size = (eew / 8);
         if (fault != NoFault) {
             auto addr_fault = dynamic_cast<AddressFault*>(fault.get());
@@ -73,18 +73,43 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             if (addr_fault) {
                 auto fault_addr = addr_fault->trap_value();
                 assert(fault_addr >= EA);
-                *fault_elem_idx = (fault_addr - base_addr) / elem_size;
+                // This value is consumed by VleffEnd as the number of
+                // successful elements in this micro-op, so it must be local
+                // to this micro-op's effective address.
+                *fault_elem_idx = (fault_addr - EA) / elem_size;
             }
         } else {
             *fault_elem_idx = mem_size / elem_size;
         }
         '''
         vfof_zero_idx_check_code = '''
-        if (fault != NoFault && *fault_elem_idx == 0)
-            return fault;
+        // Only a fault on architectural element zero traps.
+        // A later fault terminates fault-only-first normally.
+        if (fault != NoFault) {
+            if ((vmi.rs + *fault_elem_idx) == 0)
+                return fault;
+
+            // Suppress the architectural exception.  The successful prefix
+            // will be completed and VleffEnd will shorten VL.
+            fault = NoFault;
+        }
         '''
         vfof_get_code = '''
         Vfof_ud[0] = *fault_elem_idx;
+        '''
+        vfof_adjust_mem_size_code = '''
+        if (pkt) {
+            // fault_elem_idx was calculated during initiateAcc relative
+            // to this micro-op's EA.  It is the successful prefix length.
+            mem_size = std::min<uint32_t>(
+                mem_size,
+                static_cast<uint32_t>(*fault_elem_idx * eewb));
+        } else {
+            // A later micro-op whose first local element faults contributes
+            // zero elements to the fault-only-first result.
+            mem_size = 0;
+        }
+        *fault_elem_idx = mem_size / eewb;
         '''
 
     vecWhole = base_type == 'VlWhole' or base_type == 'VsWhole'
@@ -114,6 +139,78 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     agnostic_load_code = ''
     if base_type.startswith('Vl') and not vecWhole:
         agnostic_load_code = '''
+    using RvvLoadMicroType =
+        std::remove_cv_t<
+            std::remove_pointer_t<
+                decltype(this)>>;
+
+    if constexpr (
+        std::is_base_of_v<
+            VlIndexMicroInst,
+            RvvLoadMicroType>) {
+
+    // RVV indexed-load per-element agnostic fix.
+    //
+    // Each indexed-load micro-op processes one destination
+    // element. Filling every tail element from each micro-op
+    // can corrupt unread indices when vd overlaps vs2.
+    const size_t agnostic_ei = vmi.rs;
+    const size_t agnostic_vd_elem =
+        vmi.rs % elem_num_per_vreg;
+    const size_t agnostic_elem_bytes =
+        VLENB / elem_num_per_vreg;
+
+    auto agnostic_vd_bytes =
+        tmp_d0.as<uint8_t>();
+
+    if ((agnostic_ei < rVl) &&
+        !this->vm &&
+        !elem_mask(v0, agnostic_ei) &&
+        machInst.vtype8.vma) {
+        std::memset(
+            agnostic_vd_bytes +
+                agnostic_vd_elem *
+                    agnostic_elem_bytes,
+            0xff,
+            agnostic_elem_bytes);
+    } else if (
+        (rVl != 0) &&
+        (agnostic_ei >= rVl) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            agnostic_vd_bytes +
+                agnostic_vd_elem *
+                    agnostic_elem_bytes,
+            0xff,
+            agnostic_elem_bytes);
+    }
+    // RVV indexed-load fractional-LMUL physical tail fix.
+    //
+    // For fractional LMUL, architectural VLMAX occupies only
+    // part of one physical vector register. No micro-op exists
+    // for elements beyond VLMAX, so the final indexed-load
+    // micro-op must apply tail-agnostic policy to that region.
+    //
+    // Do this only after every index has been consumed, avoiding
+    // corruption when vd overlaps the index register group.
+    if ((machInst.nf == 0) &&
+        this->isLastMicroop() &&
+        (rVl != 0) &&
+        (vflmul < 1) &&
+        machInst.vtype8.vta) {
+        const size_t physical_tail_begin =
+            vmi.re * agnostic_elem_bytes;
+
+        if (physical_tail_begin < VLENB) {
+            std::memset(
+                agnostic_vd_bytes + physical_tail_begin,
+                0xff,
+                VLENB - physical_tail_begin);
+        }
+    }
+
+} else {
+
     // Fill RVV tail-agnostic and mask-agnostic load elements with ones.
     const size_t reg_elem_base =
         (vmi.rs / elem_num_per_vreg) * elem_num_per_vreg;
@@ -121,28 +218,33 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     auto vd_bytes =
         tmp_d0.as<uint8_t>();
 
-    for (size_t vdElemIdx = 0;
-         vdElemIdx < elem_num_per_vreg;
-         ++vdElemIdx) {
-        const size_t agnostic_ei =
-            reg_elem_base + vdElemIdx;
+    // When vl is zero, no destination elements may be updated,
+    // including tail-agnostic and mask-agnostic elements.
+    if (rVl != 0) {
+        for (size_t vdElemIdx = 0;
+            vdElemIdx < elem_num_per_vreg;
+            ++vdElemIdx) {
+            const size_t agnostic_ei =
+                reg_elem_base + vdElemIdx;
 
-        if (agnostic_ei >= rVl) {
-            if (machInst.vtype8.vta) {
+            if (agnostic_ei >= rVl) {
+                if (machInst.vtype8.vta) {
+                    std::memset(
+                        vd_bytes + vdElemIdx * elem_bytes,
+                        0xff,
+                        elem_bytes);
+                }
+            } else if (!this->vm &&
+                    !elem_mask(v0, agnostic_ei) &&
+                    machInst.vtype8.vma) {
                 std::memset(
                     vd_bytes + vdElemIdx * elem_bytes,
                     0xff,
                     elem_bytes);
             }
-        } else if (!this->vm &&
-                   !elem_mask(v0, agnostic_ei) &&
-                   machInst.vtype8.vma) {
-            std::memset(
-                vd_bytes + vdElemIdx * elem_bytes,
-                0xff,
-                elem_bytes);
         }
-    }
+    }    }
+
 '''
 
     microiop = InstObjParams(name + '_micro',
@@ -156,7 +258,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             'vfof_set_code' : vfof_set_code,
             'vfof_zero_idx_check_code' : vfof_zero_idx_check_code,
             'vfof_get_code' : vfof_get_code,
-
+            'vfof_adjust_mem_size_code' : vfof_adjust_mem_size_code,
             'calc_memsize_code' : calc_memsize_code,
             'is_vecWhole'   : is_vecWhole,
             'is_vecIndex'   : is_vecIndex,

--- a/src/arch/riscv/isa/vector/base/vector_mem.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.isa
@@ -111,6 +111,40 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     else:
         divrVl = ''
 
+    agnostic_load_code = ''
+    if base_type.startswith('Vl') and not vecWhole:
+        agnostic_load_code = '''
+    // Fill RVV tail-agnostic and mask-agnostic load elements with ones.
+    const size_t reg_elem_base =
+        (vmi.rs / elem_num_per_vreg) * elem_num_per_vreg;
+    const size_t elem_bytes = VLENB / elem_num_per_vreg;
+    auto vd_bytes =
+        tmp_d0.as<uint8_t>();
+
+    for (size_t vdElemIdx = 0;
+         vdElemIdx < elem_num_per_vreg;
+         ++vdElemIdx) {
+        const size_t agnostic_ei =
+            reg_elem_base + vdElemIdx;
+
+        if (agnostic_ei >= rVl) {
+            if (machInst.vtype8.vta) {
+                std::memset(
+                    vd_bytes + vdElemIdx * elem_bytes,
+                    0xff,
+                    elem_bytes);
+            }
+        } else if (!this->vm &&
+                   !elem_mask(v0, agnostic_ei) &&
+                   machInst.vtype8.vma) {
+            std::memset(
+                vd_bytes + vdElemIdx * elem_bytes,
+                0xff,
+                elem_bytes);
+        }
+    }
+'''
+
     microiop = InstObjParams(name + '_micro',
         Name + 'Micro',
         exec_template_base + 'MicroInst',
@@ -128,6 +162,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             'is_vecIndex'   : is_vecIndex,
 
             'wb_elem_mask'  : wb_elem_mask,
+            'agnostic_load_code' : agnostic_load_code,
 
             'divrVl'        : divrVl
         },

--- a/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
@@ -172,6 +172,8 @@ Fault
         %(memacc_code)s;
     }
 
+
+
     %(op_wb)s;
     return fault;
 }
@@ -300,6 +302,12 @@ Fault
     }
 
     %(vfof_get_code)s;
+
+
+    %(agnostic_load_code)s
+
+
+
     %(op_wb)s;
     return NoFault;
 }

--- a/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_mem.temp.isa
@@ -283,9 +283,19 @@ Fault
     uint32_t eewb = eew_ / 8;
     uint32_t mem_size = %(calc_memsize_code)s;
     mem_size = vm_zero ? 0 : mem_size;
+
+    // For a fault-only-first load, the completion packet represents only
+    // the successfully translated prefix of this micro-op. A null packet
+    // means this micro-op completed zero elements after an earlier element
+    // of the architectural instruction had already succeeded.
+    %(vfof_adjust_mem_size_code)s
+
     if (pkt) {
-        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
-        assert(mem_size == pkt->getSize());
+        // A VLEFF partial fault may return a packet representing the full
+        // split request, while only the prefix before the fault is valid
+        // architecturally.  Copy exactly the successful prefix.
+        assert(mem_size <= pkt->getSize());
+        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), mem_size);
     } else {
         assert(mem_size == 0);
     }
@@ -658,7 +668,12 @@ template<typename ElemType>
             if (vmi.microVd >= 32) {
                 break;
             }
-            microop = new %(class_name)sMicro<ElemType>(machInst, i * fn, vmi);
+            // RVV indexed-load unique micro-op index fix.
+            microop =
+                new %(class_name)sMicro<ElemType>(
+                    machInst,
+                    i * nf + fn,
+                    vmi);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsLoad);
 
@@ -749,12 +764,33 @@ Fault
 
     uint32_t vdElemIdx = vmi.rs % (VLENB / elem_size);
     size_t ei = vmi.rs;
-    if (machInst.vm || elem_mask(v0, ei)) {
+    if ((ei < rVl) && (machInst.vm || elem_mask(v0, ei))) {
         fault = xc->readMem(EA, Mem.as<uint8_t>(), mem_size,
                                 memAccessFlags, byte_enable);
         if (fault != NoFault)
             return fault;
         %(memacc_code)s;
+    }
+
+    // RVV indexed-load atomic agnostic fix.
+    if ((ei < rVl) &&
+        !machInst.vm &&
+        !elem_mask(v0, ei) &&
+        machInst.vtype8.vma) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                vdElemIdx * sizeof(vu),
+            0xff,
+            sizeof(vu));
+    } else if (
+        (rVl != 0) &&
+        (ei >= rVl) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                vdElemIdx * sizeof(vu),
+            0xff,
+            sizeof(vu));
     }
 
     %(op_wb)s;

--- a/src/arch/riscv/isa/vector/simple/decoder.isa
+++ b/src/arch/riscv/isa/vector/simple/decoder.isa
@@ -28,7 +28,7 @@ decode QUADRANT {
                     }}, inst_flags=VectorUnitStrideMaskLoadOp);
                     0x10: VleffOp::vle8ff_v({{
                         Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei8_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -67,7 +67,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle16ff_v({{
                         Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei16_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -106,7 +106,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle32ff_v({{
                         Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei32_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -145,7 +145,7 @@ decode QUADRANT {
                     }
                     0x10: VleffOp::vle64ff_v({{
                         Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
-                    }}, inst_flags=VectorUnitStrideLoadOp);
+                    }}, inst_flags=VectorUnitStrideFaultOnlyFirstLoadOp);
                 }
                 0x1: VlIndexOp::vluxei64_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -1899,8 +1899,22 @@ decode QUADRANT {
                         0x1: VectorNonSplitFormat::vfmv_s_f({{
                             auto fd = ftype_freg<et>(freg(Fs1_bits));
                             std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
+
+                            // RVV vfmv.s.f tail-agnostic fix.
+                            //
+                            // When vl is nonzero, element 0 receives the
+                            // scalar floating-point value. All remaining
+                            // elements are tail elements.
                             if (rVl) {
                                 Vd_vu[0] = fd.v;
+
+                                if (machInst.vtype8.vta) {
+                                    for (uint32_t i = 1;
+                                         i < RiscvISA::VLENB / sizeof(Vd_vu[0]);
+                                         ++i) {
+                                        Vd_vu[i] = ~vu(0);
+                                    }
+                                }
                             }
                         }}, OPFVV, VectorMiscOp);
                     }
@@ -2164,6 +2178,16 @@ decode QUADRANT {
                             std::memcpy(Vd_vu, Vd_merger, RiscvISA::VLENB);
                             if (rVl) {
                                 Vd_vu[0] = Rs1_vu;
+
+                                // vmv.s.x only writes element 0. The remaining
+                                // destination elements are tail elements and
+                                // follow the vta policy.
+                                if (machInst.vtype8.vta) {
+                                    std::memset(
+                                        Vd_vu + 1,
+                                        0xff,
+                                        RiscvISA::VLENB - sizeof(vu));
+                                }
                             }
                         }}, OPMVX, VectorMiscOp);
                     }

--- a/src/arch/riscv/isa/vector/simple/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.isa
@@ -83,14 +83,14 @@ let {{
                     %s
                 } else if (machInst.vtype8.vma) {
                     std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
                 }
-            } else if (machInst.vtype8.vta) {
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
                 std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
@@ -100,12 +100,73 @@ let {{
             return """
             if (ei < rVl) {
                 %s
-            } else if (machInst.vtype8.vta) {
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
                 std::memset(
-                        reinterpret_cast<uint8_t *>(Vd) +
+                        tmp_d0.as<uint8_t>() +
                             i * sizeof(ElemType),
                         0xff,
                         sizeof(ElemType));
+            }
+            """ % code
+
+
+    def wideningAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    std::memset(
+                        tmp_d0.as<uint8_t>() +
+                            i * sizeof(vwu),
+                        0xff,
+                        sizeof(vwu));
+                }
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
+                std::memset(
+                    tmp_d0.as<uint8_t>() +
+                        i * sizeof(vwu),
+                    0xff,
+                    sizeof(vwu));
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            } else if ((rVl != 0) && machInst.vtype8.vta) {
+                std::memset(
+                    tmp_d0.as<uint8_t>() +
+                        i * sizeof(vwu),
+                    0xff,
+                    sizeof(vwu));
+            }
+            """ % code
+
+    def narrowingAgnosticWrapper(code):
+        return """
+            // Narrowing operations write the destination element at
+            // i + offset. Handle active, mask-agnostic and
+            // tail-agnostic destination elements consistently.
+            if (rVl != 0) {
+                if (ei < rVl) {
+                    if (this->vm || elem_mask(v0, ei)) {
+                        %s
+                    } else if (machInst.vtype8.vma) {
+                        std::memset(
+                            tmp_d0.as<uint8_t>() +
+                                (i + offset) * sizeof(ElemType),
+                            0xff,
+                            sizeof(ElemType));
+                    }
+                } else if (machInst.vtype8.vta) {
+                    std::memset(
+                        tmp_d0.as<uint8_t>() +
+                            (i + offset) * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+                }
             }
             """ % code
 
@@ -117,7 +178,7 @@ let {{
                     %s
                 } else if (machInst.vtype8.vma) {
                     const uint32_t agnostic_bit = offset + i;
-                    reinterpret_cast<uint8_t *>(Vd)[agnostic_bit / 8] |=
+                    tmp_d0.as<uint8_t>()[agnostic_bit / 8] |=
                         static_cast<uint8_t>(
                             1U << (agnostic_bit %% 8));
                 }
@@ -290,7 +351,7 @@ def format VectorIntExtFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
 
-    code = maskCondWrapper(code)
+    code = regularAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     vm_decl_rd = vmDeclAndReadData()
@@ -351,7 +412,7 @@ def format VectorIntWideningFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = wideningAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
 
@@ -411,7 +472,7 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     # code
-    code = maskCondWrapper(code)
+    code = narrowingAgnosticWrapper(code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = narrowingOpRegisterConstraintChecks(code)
@@ -642,7 +703,7 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = regularAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -706,7 +767,7 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = wideningAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -754,7 +815,30 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = """
+    // RVV widening-conversion agnostic fix.
+    if (ei < rVl) {
+        if (this->vm ||
+            elem_mask(v0, ei)) {
+            %s
+        } else if (
+            machInst.vtype8.vma) {
+            std::memset(
+                tmp_d0.as<uint8_t>() +
+                    i * sizeof(vwu),
+                0xff,
+                sizeof(vwu));
+        }
+    } else if (
+        (rVl != 0) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                i * sizeof(vwu),
+            0xff,
+            sizeof(vwu));
+    }
+    """ % (code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -798,7 +882,7 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setOldDestWrapper(dest_reg_id)
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
-    code = maskCondWrapper(code)
+    code = narrowingAgnosticWrapper(code)
     code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -1057,6 +1141,26 @@ def format VectorMaskFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
     code = loopWrapper(code, micro_inst = False)
+    code += """
+    // Mask logical instructions always have an
+    // agnostic tail.  Match the reference model by
+    // choosing all ones for tail bits.
+    //
+    // Prestart bits remain undisturbed, and when
+    // vstart >= vl (including vl == 0), vd is not
+    // modified.
+    const uint64_t mask_vstart =
+        xc->readMiscReg(MISCREG_VSTART);
+
+    if (mask_vstart < rVl) {
+        for (uint32_t bit = rVl;
+             bit < VLEN;
+             ++bit) {
+            Vd_ub[bit / 8] =
+                ASSIGN_VD_BIT(bit, true);
+        }
+    }
+    """
 
     iop = InstObjParams(name,
         Name,
@@ -1087,7 +1191,7 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
@@ -1101,6 +1205,16 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     code = """
     if (microIdx * elem_num_per_vreg < rVl) {
         %s
+
+        // Integer reduction writes only destination element 0.
+        // Match the reference model by filling the remaining
+        // tail elements with ones under the tail-agnostic policy.
+        if (machInst.vtype8.vta) {
+            std::memset(
+                tmp_d0.as<uint8_t>() + sizeof(ElemType),
+                0xff,
+                RiscvISA::VLENB - sizeof(ElemType));
+        }
     }
     """ % (code)
 
@@ -1130,16 +1244,25 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     iop = InstObjParams(name, Name, 'VectorArithMacroInst', {'code': code},
                         flags)
     inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
+    dest_reg_id = "RegId(VecRegClass, VecTempReg0)"
     src1_reg_id = "RegId(VecRegClass, _machInst.vs1)"
     src2_reg_id = "RegId(VecRegClass, _machInst.vs2 + _microIdx)"
     old_dest_reg_id = "RegId(VecRegClass, _machInst.vd)"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
-    set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
+    set_src_reg_idx += """
+        // Carry the ordered-reduction accumulator through a renamed
+        // internal vector temporary register.
+        if (_microIdx != 0) {
+            accSrcIdx = _numSrcRegs;
+            setSrcRegIdx(
+                _numSrcRegs++,
+                RegId(VecRegClass, VecTempReg0));
+        }
+    """
     set_src_reg_idx += setSrcVL()
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
@@ -1167,8 +1290,11 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
         VectorReduceMicroDeclare.subst(microiop) + \
         VectorReduceMicroConstructor.subst(microiop) + \
         VectorReduceFloatMicroExecute.subst(microiop) + \
+        VectorReduceFloatFinalMicroDeclare.subst(iop) + \
+        VectorReduceFloatFinalMicroConstructor.subst(iop) + \
+        VectorReduceFloatFinalMicroExecute.subst(iop) + \
         VectorReduceMacroDeclare.subst(iop) + \
-        VectorReduceMacroConstructor.subst(iop)
+        VectorReduceFloatMacroConstructor.subst(iop)
     decode_block = VectorFloatDecodeBlock.subst(iop)
 }};
 
@@ -1183,7 +1309,7 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()
@@ -1283,7 +1409,7 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    # Treat tail undisturbed/agnostic as the same
+    # Old vd is required for reduction chaining and tail-undisturbed
     # We always need old rd as src vreg
     set_src_reg_idx += setOldDestWrapper(old_dest_reg_id)
     set_src_reg_idx += setSrcVL()

--- a/src/arch/riscv/isa/vector/simple/vector_arith.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.isa
@@ -74,6 +74,62 @@ let {{
             }
             """ % (code)
 
+
+    def regularAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+                }
+            } else if (machInst.vtype8.vta) {
+                std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            } else if (machInst.vtype8.vta) {
+                std::memset(
+                        reinterpret_cast<uint8_t *>(Vd) +
+                            i * sizeof(ElemType),
+                        0xff,
+                        sizeof(ElemType));
+            }
+            """ % code
+
+    def maskResultAgnosticWrapper(code, withvm = True):
+        if withvm:
+            return """
+            if (ei < rVl) {
+                if (this->vm || elem_mask(v0, ei)) {
+                    %s
+                } else if (machInst.vtype8.vma) {
+                    const uint32_t agnostic_bit = offset + i;
+                    reinterpret_cast<uint8_t *>(Vd)[agnostic_bit / 8] |=
+                        static_cast<uint8_t>(
+                            1U << (agnostic_bit %% 8));
+                }
+            }
+            """ % code
+        else:
+            return """
+            if (ei < rVl) {
+                %s
+            }
+            """ % code
+
     def eiDeclarePrefix(code, widening = False):
         if widening:
             return '''
@@ -183,7 +239,7 @@ def format VectorIntFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = regularAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
 
@@ -420,7 +476,7 @@ def format VectorIntMaskFormat(code, category, *flags) {{
         set_src_reg_idx += setSrcVm()
 
     #code
-    code = maskCondWrapper(code, mask_cond)
+    code = maskResultAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
 
@@ -540,7 +596,7 @@ def format VectorFloatFormat(code, category, *flags) {{
     if v0_required:
         set_src_reg_idx += setSrcVm()
     # code
-    code = maskCondWrapper(code, mask_cond)
+    code = regularAgnosticWrapper(code, mask_cond)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
@@ -797,7 +853,7 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
 
-    code = maskCondWrapper(code)
+    code = maskResultAgnosticWrapper(code)
     code = eiDeclarePrefix(code)
     code = loopWrapper(code)
     code = fflags_wrapper(code)

--- a/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
@@ -359,8 +359,12 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     }
 
-    const int32_t t_micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    const int32_t micro_vlmax = vlmul < 0 ? t_micro_vlmax : t_micro_vlmax / 2;
+    // Each widening micro-op writes one physical destination vector
+    // register. Since the destination element width is 2 * SEW, the
+    // number of destination elements handled by one micro-op is
+    // independent of LMUL. LMUL is represented by the number of
+    // generated micro-ops.
+    const int32_t micro_vlmax = VLEN / (2 * sew);
     [[maybe_unused]] const size_t offset =
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
     uint32_t elem_num_per_vreg = micro_vlmax;
@@ -586,8 +590,12 @@ Fault
 
     VRM_REQUIRED;
 
-    const int32_t t_micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
-    const int32_t micro_vlmax = vlmul < 0 ? t_micro_vlmax : t_micro_vlmax / 2;
+    // Each widening micro-op writes one physical destination vector
+    // register. Since the destination element width is 2 * SEW, the
+    // number of destination elements handled by one micro-op is
+    // independent of LMUL. LMUL is represented by the number of
+    // generated micro-ops.
+    const int32_t micro_vlmax = VLEN / (2 * sew);
     [[maybe_unused]] const size_t offset =
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
     uint32_t elem_num_per_vreg = micro_vlmax;
@@ -1307,6 +1315,172 @@ template<typename ElemType>
 
 }};
 
+
+def template VectorReduceFloatMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+{
+    const uint32_t num_reduce_microops =
+        vflmul < 1 ? 1 : vflmul;
+
+    StaticInstPtr microop;
+
+    // Reduction data micro-ops only update VecTempReg0.
+    for (uint32_t i = 0; i < num_reduce_microops; ++i) {
+        microop =
+            new %(class_name)sMicro<ElemType>(_machInst, i);
+        microop->setDelayedCommit();
+        this->microops.push_back(microop);
+    }
+
+    // Write architectural vd only after every source-register
+    // chunk has been renamed and consumed.
+    microop =
+        new %(class_name)sFinalMicro<ElemType>(
+            _machInst, num_reduce_microops);
+    microop->setDelayedCommit();
+    this->microops.push_back(microop);
+
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+}};
+
+
+def template VectorReduceFloatFinalMicroDeclare {{
+
+template<typename ElemType>
+class %(class_name)sFinalMicro : public VectorArithMicroInst
+{
+  private:
+    RegId srcRegIdxArr[3];
+    RegId destRegIdxArr[1];
+
+  public:
+    %(class_name)sFinalMicro(
+        ExtMachInst _machInst,
+        uint8_t _microIdx);
+
+    Fault execute(
+        ExecContext *xc,
+        Trace::InstRecord *traceData) const override;
+
+    using VectorArithMicroInst::generateDisassembly;
+};
+
+}};
+
+
+def template VectorReduceFloatFinalMicroConstructor {{
+
+template<typename ElemType>
+%(class_name)sFinalMicro<ElemType>::%(class_name)sFinalMicro(
+    ExtMachInst _machInst,
+    uint8_t _microIdx)
+    : VectorArithMicroInst(
+          "%(mnemonic)s_final_micro",
+          _machInst,
+          %(op_class)s,
+          _microIdx)
+{
+    setRegIdxArrays(
+        reinterpret_cast<RegIdArrayPtr>(
+            &std::remove_pointer_t<decltype(this)>::srcRegIdxArr),
+        reinterpret_cast<RegIdArrayPtr>(
+            &std::remove_pointer_t<decltype(this)>::destRegIdxArr));
+
+    _numSrcRegs = 0;
+    _numDestRegs = 0;
+
+    // Architectural destination.
+    setDestRegIdx(
+        _numDestRegs++,
+        RegId(VecRegClass, _machInst.vd));
+    _numTypedDestRegs[VecRegClass]++;
+
+    // Final renamed accumulator value.
+    setSrcRegIdx(
+        _numSrcRegs++,
+        RegId(VecRegClass, VecTempReg0));
+
+    // Original architectural destination. Because the reduction
+    // data micro-ops do not write vd, this remains the pre-instruction
+    // value even when vd overlaps the vs2 register group.
+    setSrcRegIdx(
+        _numSrcRegs++,
+        RegId(VecRegClass, _machInst.vd));
+
+    SET_VL_SRC();
+}
+
+}};
+
+
+def template VectorReduceFloatFinalMicroExecute {{
+
+template<typename ElemType>
+Fault
+%(class_name)sFinalMicro<ElemType>::execute(
+    ExecContext *xc,
+    Trace::InstRecord *traceData) const
+{
+    using et = ElemType;
+    using vu = decltype(et::v);
+
+    if (machInst.vill) {
+        return std::make_shared<IllegalInstFault>(
+            "VILL is set", machInst);
+    }
+
+    auto &tmp_d0 =
+        *(RiscvISAInst::VecRegContainer *)
+        xc->getWritableRegOperand(this, 0);
+    auto Vd = tmp_d0.as<vu>();
+
+    // Begin with the original destination so vl=0 and
+    // tail-undisturbed behavior preserve the previous contents.
+    RiscvISAInst::VecRegContainer tmp_old;
+    xc->getRegOperand(this, 1, &tmp_old);
+    auto OldVd = tmp_old.as<vu>();
+
+    for (uint32_t i = 0; i < VLEN / sew; ++i) {
+        Vd[i] = OldVd[i];
+    }
+
+    RiscvISAInst::VecRegContainer tmp_acc;
+    xc->getRegOperand(this, 0, &tmp_acc);
+    auto Acc = tmp_acc.as<vu>();
+
+    uint64_t rVl = 0;
+    assert(vlsrcIdx > 0);
+    rVl = xc->getRegOperand(this, vlsrcIdx);
+
+    if (rVl != 0) {
+        // A vector reduction writes only element zero.
+        Vd[0] = Acc[0];
+
+        if (machInst.vtype8.vta) {
+            for (uint32_t i = 1; i < VLEN / sew; ++i) {
+                Vd[i] = ~vu(0);
+            }
+        }
+    }
+
+    xc->setRegOperand(this, 0, &tmp_d0);
+
+    if (traceData) {
+        traceData->setData(tmp_d0);
+    }
+
+    return NoFault;
+}
+
+}};
+
+
 def template VectorReduceMicroDeclare {{
 
 template<typename ElemType>
@@ -1316,6 +1490,7 @@ private:
     // vs2, vs1, vd, vm
     RegId srcRegIdxArr[8];
     RegId destRegIdxArr[1];
+    int8_t accSrcIdx = -1;
 public:
     %(class_name)s(ExtMachInst _machInst,
                    uint8_t _microIdx);
@@ -1384,37 +1559,63 @@ Fault
 
 def template VectorReduceFloatMicroExecute {{
 
-template <typename ElemType>
+template<typename ElemType>
 Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  Trace::InstRecord* traceData) const
+%(class_name)s<ElemType>::execute(
+    ExecContext *xc,
+    Trace::InstRecord *traceData) const
 {
     softfloat_roundingMode = 0;
     %(type_def)s;
+
     if (machInst.vill) {
-        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+        return std::make_shared<IllegalInstFault>(
+            "VILL is set", machInst);
     }
 
     %(op_decl)s;
     %(op_rd)s;
     %(vm_decl_rd)s;
-    COPY_OLD_VD();
 
-    uint32_t micro_vlmax = VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+    const uint32_t micro_vlmax =
+        VLEN / sew * (vflmul > 0 ? 1 : vflmul);
+
+    // The first data micro-op starts with vs1[0].
+    // Later data micro-ops continue from the previous renamed
+    // VecTempReg0 version.
+    vu accumulator = Vs1[0];
+
+    if (accSrcIdx >= 0) {
+        RiscvISAInst::VecRegContainer tmp_acc;
+        xc->getRegOperand(this, accSrcIdx, &tmp_acc);
+        accumulator = tmp_acc.as<vu>()[0];
+    }
+
+    // Every statically generated micro-op must produce a new temp
+    // version, including chunks that are inactive because of vl.
+    Vd[0] = accumulator;
+
     if (micro_vlmax * this->microIdx < rVl) {
-        Vd[0] = this->microIdx != 0 ? old_Vd[0] : Vs1[0];
-
         auto reduce_loop =
-            [&, this](const auto& f, const auto* _, const auto* vs2) {
+            [&, this](
+                const auto& f,
+                const auto *,
+                const auto *vs2) {
                 vu tmp_val = Vd[0];
-                for (uint32_t i = 0; i < micro_vlmax; i++) {
-                    uint32_t ei = i + micro_vlmax * this->microIdx;
-                    if ((ei < rVl) && (this->vm || elem_mask(v0, ei))) {
-                        tmp_val = f(tmp_val, Vs2[i]).v;
+
+                for (uint32_t i = 0; i < micro_vlmax; ++i) {
+                    const uint32_t ei =
+                        i + micro_vlmax * this->microIdx;
+
+                    if ((ei < rVl) &&
+                        (this->vm || elem_mask(v0, ei))) {
+                        tmp_val = f(tmp_val, vs2[i]).v;
                     }
                 }
+
                 return tmp_val;
             };
+
         %(code)s;
     }
 
@@ -1423,6 +1624,7 @@ Fault
 }
 
 }};
+
 
 def template VectorReduceFloatWideningMicroExecute {{
 
@@ -1595,6 +1797,60 @@ Fault
     uint32_t elem_num_per_vreg = VLENB / std::max(vd_eewb, vs1_eewb);
 
     %(code)s;
+
+    // RVV gather final agnostic fix.
+    //
+    // A gather instruction can contain multiple micro-ops
+    // for different vs2 source registers. Apply destination
+    // agnostic policy only after the last source-register
+    // micro-op for this destination chunk.
+    const uint64_t gather_vstart =
+        xc->readMiscReg(MISCREG_VSTART);
+
+    // Only architectural destination-register chunks may
+    // receive tail/mask agnostic updates. Gather decomposition
+    // can create extra micro-ops beyond the current LMUL group.
+    const uint32_t gather_vd_vregs =
+        vflmul < 1 ? 1 : vflmul;
+
+    if ((vd_idx < gather_vd_vregs) &&
+        (vs2_idx + 1 == vs2_vregs) &&
+        (gather_vstart < rVl)) {
+        for (uint32_t gather_i = 0;
+             gather_i < elem_num_per_vreg;
+             ++gather_i) {
+            // Tail and mask policies are properties of
+            // destination elements, not the vs1 index chunk.
+            const uint32_t gather_ei =
+                gather_i +
+                vd_idx * elem_num_per_vreg +
+                vd_bias;
+
+            const uint32_t gather_vd_i =
+                gather_i + vd_bias;
+
+            if (gather_vd_i >= vd_elems) {
+                continue;
+            }
+
+            const bool gather_is_tail =
+                gather_ei >= rVl;
+
+            const bool gather_is_inactive =
+                (gather_ei >= gather_vstart) &&
+                (gather_ei < rVl) &&
+                !this->vm &&
+                !elem_mask(v0, gather_ei);
+
+            if ((gather_is_tail &&
+                 machInst.vtype8.vta) ||
+                (gather_is_inactive &&
+                 machInst.vtype8.vma)) {
+                Vd[gather_vd_i] = ~vu(0);
+            }
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;
@@ -1739,6 +1995,19 @@ Fault
             };
 
         %(code)s;
+    }
+
+    // A reduction only writes destination element 0. All remaining
+    // destination elements are tail elements. Apply tail-agnostic
+    // filling only on the final micro-op, after the reduction result
+    // has been accumulated.
+    if ((rVl != 0) &&
+        this->isLastMicroop() &&
+        machInst.vtype8.vta) {
+        std::memset(
+            reinterpret_cast<uint8_t *>(Vd) + sizeof(Vd[0]),
+            0xff,
+            VLEN / 8 - sizeof(Vd[0]));
     }
 
     %(op_wb)s;

--- a/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_arith.temp.isa
@@ -1937,6 +1937,30 @@ Fault
     %(vm_decl_rd)s;
     COPY_OLD_VD();
     %(code)s;
+
+    // Fill RVV tail-agnostic and mask-agnostic slide elements with ones.
+    for (uint32_t agnostic_i = 0;
+         agnostic_i < elem_num_per_vreg;
+         ++agnostic_i) {
+        const uint32_t agnostic_ei =
+            vmi.rs + agnostic_i;
+
+        const bool is_tail = agnostic_ei >= rVl;
+        const bool is_masked_off =
+            agnostic_ei < rVl &&
+            !this->vm &&
+            !elem_mask(v0, agnostic_ei);
+
+        if ((is_tail && machInst.vtype8.vta) ||
+            (is_masked_off && machInst.vtype8.vma)) {
+            std::memset(
+                reinterpret_cast<uint8_t *>(Vd) +
+                    agnostic_i * sizeof(ElemType),
+                0xff,
+                sizeof(ElemType));
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;
@@ -1965,6 +1989,30 @@ Fault
     %(vm_decl_rd)s;
     COPY_OLD_VD();
     %(code)s;
+
+    // Fill RVV tail-agnostic and mask-agnostic slide elements with ones.
+    for (uint32_t agnostic_i = 0;
+         agnostic_i < elem_num_per_vreg;
+         ++agnostic_i) {
+        const uint32_t agnostic_ei =
+            vmi.rs + agnostic_i;
+
+        const bool is_tail = agnostic_ei >= rVl;
+        const bool is_masked_off =
+            agnostic_ei < rVl &&
+            !this->vm &&
+            !elem_mask(v0, agnostic_ei);
+
+        if ((is_tail && machInst.vtype8.vta) ||
+            (is_masked_off && machInst.vtype8.vma)) {
+            std::memset(
+                reinterpret_cast<uint8_t *>(Vd) +
+                    agnostic_i * sizeof(ElemType),
+                0xff,
+                sizeof(ElemType));
+        }
+    }
+
     %(op_wb)s;
 
     return NoFault;

--- a/src/arch/riscv/isa/vector/simple/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_conf.isa
@@ -95,6 +95,24 @@ def template VConfExecute {{
     {
         auto tc = xc->tcBase();
 
+        // All vector configuration instructions are illegal when the
+        // vector context is disabled. This check must happen before
+        // writing vstart, vtype or vl, because those writes may mark
+        // the vector context Dirty.
+        STATUS status = xc->readMiscReg(MISCREG_STATUS);
+        if (status.vs == 0) {
+            return std::make_shared<IllegalInstFault>(
+                "Vector state is off", machInst);
+        }
+
+        if (xc->readMiscReg(MISCREG_VIRMODE) == 1) {
+            VSSTATUS vsstatus = xc->readMiscReg(MISCREG_VSSTATUS);
+            if (vsstatus.vs == 0) {
+                return std::make_shared<IllegalInstFault>(
+                    "Vector state is off in virtual mode", machInst);
+            }
+        }
+
         %(op_decl)s;
         %(op_rd)s;
         %(code)s;

--- a/src/arch/riscv/isa/vector/simple/vector_mem.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_mem.isa
@@ -63,9 +63,9 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     vfof_set_code = ''
     vfof_zero_idx_check_code = ''
     vfof_get_code = ''
+    vfof_adjust_mem_size_code = ''
     if vfof:
         vfof_set_code = '''
-        auto base_addr = Rs1;
         uint32_t elem_size = (eew / 8);
         if (fault != NoFault) {
             auto addr_fault = dynamic_cast<AddressFault*>(fault.get());
@@ -73,18 +73,43 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             if (addr_fault) {
                 auto fault_addr = addr_fault->trap_value();
                 assert(fault_addr >= EA);
-                *fault_elem_idx = (fault_addr - base_addr) / elem_size;
+                // This value is consumed by VleffEnd as the number of
+                // successful elements in this micro-op, so it must be local
+                // to this micro-op's effective address.
+                *fault_elem_idx = (fault_addr - EA) / elem_size;
             }
         } else {
             *fault_elem_idx = mem_size / elem_size;
         }
         '''
         vfof_zero_idx_check_code = '''
-        if (fault != NoFault && *fault_elem_idx == 0)
-            return fault;
+        // Only a fault on architectural element zero traps.
+        // A later fault terminates fault-only-first normally.
+        if (fault != NoFault) {
+            if ((vmi.rs + *fault_elem_idx) == 0)
+                return fault;
+
+            // Suppress the architectural exception.  The successful prefix
+            // will be completed and VleffEnd will shorten VL.
+            fault = NoFault;
+        }
         '''
         vfof_get_code = '''
         Vfof_ud[0] = *fault_elem_idx;
+        '''
+        vfof_adjust_mem_size_code = '''
+        if (pkt) {
+            // fault_elem_idx was calculated during initiateAcc relative
+            // to this micro-op's EA.  It is the successful prefix length.
+            mem_size = std::min<uint32_t>(
+                mem_size,
+                static_cast<uint32_t>(*fault_elem_idx * eewb));
+        } else {
+            // A later micro-op whose first local element faults contributes
+            // zero elements to the fault-only-first result.
+            mem_size = 0;
+        }
+        *fault_elem_idx = mem_size / eewb;
         '''
 
     vecWhole = base_type == 'VlWhole' or base_type == 'VsWhole'
@@ -114,6 +139,78 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     agnostic_load_code = ''
     if base_type.startswith('Vl') and not vecWhole:
         agnostic_load_code = '''
+    using RvvLoadMicroType =
+        std::remove_cv_t<
+            std::remove_pointer_t<
+                decltype(this)>>;
+
+    if constexpr (
+        std::is_base_of_v<
+            VlIndexMicroInst,
+            RvvLoadMicroType>) {
+
+    // RVV indexed-load per-element agnostic fix.
+    //
+    // Each indexed-load micro-op processes one destination
+    // element. Filling every tail element from each micro-op
+    // can corrupt unread indices when vd overlaps vs2.
+    const size_t agnostic_ei = vmi.rs;
+    const size_t agnostic_vd_elem =
+        vmi.rs % elem_num_per_vreg;
+    const size_t agnostic_elem_bytes =
+        VLENB / elem_num_per_vreg;
+
+    auto agnostic_vd_bytes =
+        tmp_d0.as<uint8_t>();
+
+    if ((agnostic_ei < rVl) &&
+        !this->vm &&
+        !elem_mask(v0, agnostic_ei) &&
+        machInst.vtype8.vma) {
+        std::memset(
+            agnostic_vd_bytes +
+                agnostic_vd_elem *
+                    agnostic_elem_bytes,
+            0xff,
+            agnostic_elem_bytes);
+    } else if (
+        (rVl != 0) &&
+        (agnostic_ei >= rVl) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            agnostic_vd_bytes +
+                agnostic_vd_elem *
+                    agnostic_elem_bytes,
+            0xff,
+            agnostic_elem_bytes);
+    }
+    // RVV indexed-load fractional-LMUL physical tail fix.
+    //
+    // For fractional LMUL, architectural VLMAX occupies only
+    // part of one physical vector register. No micro-op exists
+    // for elements beyond VLMAX, so the final indexed-load
+    // micro-op must apply tail-agnostic policy to that region.
+    //
+    // Do this only after every index has been consumed, avoiding
+    // corruption when vd overlaps the index register group.
+    if ((machInst.nf == 0) &&
+        this->isLastMicroop() &&
+        (rVl != 0) &&
+        (vflmul < 1) &&
+        machInst.vtype8.vta) {
+        const size_t physical_tail_begin =
+            vmi.re * agnostic_elem_bytes;
+
+        if (physical_tail_begin < VLENB) {
+            std::memset(
+                agnostic_vd_bytes + physical_tail_begin,
+                0xff,
+                VLENB - physical_tail_begin);
+        }
+    }
+
+} else {
+
     // Fill RVV tail-agnostic and mask-agnostic load elements with ones.
     const size_t reg_elem_base =
         (vmi.rs / elem_num_per_vreg) * elem_num_per_vreg;
@@ -121,28 +218,33 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     auto vd_bytes =
         tmp_d0.as<uint8_t>();
 
-    for (size_t vdElemIdx = 0;
-         vdElemIdx < elem_num_per_vreg;
-         ++vdElemIdx) {
-        const size_t agnostic_ei =
-            reg_elem_base + vdElemIdx;
+    // When vl is zero, no destination elements may be updated,
+    // including tail-agnostic and mask-agnostic elements.
+    if (rVl != 0) {
+        for (size_t vdElemIdx = 0;
+            vdElemIdx < elem_num_per_vreg;
+            ++vdElemIdx) {
+            const size_t agnostic_ei =
+                reg_elem_base + vdElemIdx;
 
-        if (agnostic_ei >= rVl) {
-            if (machInst.vtype8.vta) {
+            if (agnostic_ei >= rVl) {
+                if (machInst.vtype8.vta) {
+                    std::memset(
+                        vd_bytes + vdElemIdx * elem_bytes,
+                        0xff,
+                        elem_bytes);
+                }
+            } else if (!this->vm &&
+                    !elem_mask(v0, agnostic_ei) &&
+                    machInst.vtype8.vma) {
                 std::memset(
                     vd_bytes + vdElemIdx * elem_bytes,
                     0xff,
                     elem_bytes);
             }
-        } else if (!this->vm &&
-                   !elem_mask(v0, agnostic_ei) &&
-                   machInst.vtype8.vma) {
-            std::memset(
-                vd_bytes + vdElemIdx * elem_bytes,
-                0xff,
-                elem_bytes);
         }
-    }
+    }    }
+
 '''
 
     microiop = InstObjParams(name + '_micro',
@@ -156,7 +258,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             'vfof_set_code' : vfof_set_code,
             'vfof_zero_idx_check_code' : vfof_zero_idx_check_code,
             'vfof_get_code' : vfof_get_code,
-
+            'vfof_adjust_mem_size_code' : vfof_adjust_mem_size_code,
             'calc_memsize_code' : calc_memsize_code,
             'is_vecWhole'   : is_vecWhole,
             'is_vecIndex'   : is_vecIndex,

--- a/src/arch/riscv/isa/vector/simple/vector_mem.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_mem.isa
@@ -111,6 +111,40 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
     else:
         divrVl = ''
 
+    agnostic_load_code = ''
+    if base_type.startswith('Vl') and not vecWhole:
+        agnostic_load_code = '''
+    // Fill RVV tail-agnostic and mask-agnostic load elements with ones.
+    const size_t reg_elem_base =
+        (vmi.rs / elem_num_per_vreg) * elem_num_per_vreg;
+    const size_t elem_bytes = VLENB / elem_num_per_vreg;
+    auto vd_bytes =
+        tmp_d0.as<uint8_t>();
+
+    for (size_t vdElemIdx = 0;
+         vdElemIdx < elem_num_per_vreg;
+         ++vdElemIdx) {
+        const size_t agnostic_ei =
+            reg_elem_base + vdElemIdx;
+
+        if (agnostic_ei >= rVl) {
+            if (machInst.vtype8.vta) {
+                std::memset(
+                    vd_bytes + vdElemIdx * elem_bytes,
+                    0xff,
+                    elem_bytes);
+            }
+        } else if (!this->vm &&
+                   !elem_mask(v0, agnostic_ei) &&
+                   machInst.vtype8.vma) {
+            std::memset(
+                vd_bytes + vdElemIdx * elem_bytes,
+                0xff,
+                elem_bytes);
+        }
+    }
+'''
+
     microiop = InstObjParams(name + '_micro',
         Name + 'Micro',
         exec_template_base + 'MicroInst',
@@ -128,6 +162,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
             'is_vecIndex'   : is_vecIndex,
 
             'wb_elem_mask'  : wb_elem_mask,
+            'agnostic_load_code' : agnostic_load_code,
 
             'divrVl'        : divrVl
         },

--- a/src/arch/riscv/isa/vector/simple/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_mem.temp.isa
@@ -172,6 +172,8 @@ Fault
         %(memacc_code)s;
     }
 
+
+
     %(op_wb)s;
     return fault;
 }
@@ -300,6 +302,12 @@ Fault
     }
 
     %(vfof_get_code)s;
+
+
+    %(agnostic_load_code)s
+
+
+
     %(op_wb)s;
     return NoFault;
 }

--- a/src/arch/riscv/isa/vector/simple/vector_mem.temp.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_mem.temp.isa
@@ -283,9 +283,19 @@ Fault
     uint32_t eewb = eew_ / 8;
     uint32_t mem_size = %(calc_memsize_code)s;
     mem_size = vm_zero ? 0 : mem_size;
+
+    // For a fault-only-first load, the completion packet represents only
+    // the successfully translated prefix of this micro-op. A null packet
+    // means this micro-op completed zero elements after an earlier element
+    // of the architectural instruction had already succeeded.
+    %(vfof_adjust_mem_size_code)s
+
     if (pkt) {
-        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
-        assert(mem_size == pkt->getSize());
+        // A VLEFF partial fault may return a packet representing the full
+        // split request, while only the prefix before the fault is valid
+        // architecturally.  Copy exactly the successful prefix.
+        assert(mem_size <= pkt->getSize());
+        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), mem_size);
     } else {
         assert(mem_size == 0);
     }
@@ -656,7 +666,12 @@ template<typename ElemType>
             if (vmi.microVd >= 32) {
                 break;
             }
-            microop = new %(class_name)sMicro<ElemType>(machInst, i * fn, vmi);
+            // RVV indexed-load unique micro-op index fix.
+            microop =
+                new %(class_name)sMicro<ElemType>(
+                    machInst,
+                    i * nf + fn,
+                    vmi);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsLoad);
 
@@ -747,12 +762,33 @@ Fault
 
     uint32_t vdElemIdx = vmi.rs % (VLENB / elem_size);
     size_t ei = vmi.rs;
-    if (machInst.vm || elem_mask(v0, ei)) {
+    if ((ei < rVl) && (machInst.vm || elem_mask(v0, ei))) {
         fault = xc->readMem(EA, Mem.as<uint8_t>(), mem_size,
                                 memAccessFlags, byte_enable);
         if (fault != NoFault)
             return fault;
         %(memacc_code)s;
+    }
+
+    // RVV indexed-load atomic agnostic fix.
+    if ((ei < rVl) &&
+        !machInst.vm &&
+        !elem_mask(v0, ei) &&
+        machInst.vtype8.vma) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                vdElemIdx * sizeof(vu),
+            0xff,
+            sizeof(vu));
+    } else if (
+        (rVl != 0) &&
+        (ei >= rVl) &&
+        machInst.vtype8.vta) {
+        std::memset(
+            tmp_d0.as<uint8_t>() +
+                vdElemIdx * sizeof(vu),
+            0xff,
+            sizeof(vu));
     }
 
     %(op_wb)s;

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -274,8 +274,8 @@ struct TlbEntry : public Serializable
 inline Addr VADDR_SEXT(uint8_t addrXlateMode, Addr vaddr) {
     switch(addrXlateMode){
         case AddrXlateMode::BARE : return Addr(sext<SV48_VADDR_BITS>(vaddr));
-        case AddrXlateMode::SV39 : return Addr(sext<SV39_VADDR_BITS>(vaddr));
-        case AddrXlateMode::SV48 : return Addr(sext<SV48_VADDR_BITS>(vaddr));
+        case AddrXlateMode::SV39 : return Addr(szext<SV39_VADDR_BITS>(vaddr));
+        case AddrXlateMode::SV48 : return Addr(szext<SV48_VADDR_BITS>(vaddr));
         default: panic("addrXlateMode should be BARE/SV39/SV48.");
     }
 }

--- a/src/base/bitfield.hh
+++ b/src/base/bitfield.hh
@@ -125,9 +125,15 @@ template <int N>
 constexpr uint64_t
 sext(uint64_t val)
 {
-    bool sign_bit = bits(val, N - 1);
-    if (sign_bit)
-        val |= ~mask(N);
+    static_assert(
+        N > 0 && N <= 64,
+        "sext<N>: N must be between 1 and 64"
+    );
+    if constexpr (N < 64) {
+        val &= mask(N);
+        if (bits(val, N - 1))
+            val |= ~mask(N);
+    }
     return val;
 }
 

--- a/src/base/bitfield.hh
+++ b/src/base/bitfield.hh
@@ -125,15 +125,9 @@ template <int N>
 constexpr uint64_t
 sext(uint64_t val)
 {
-    static_assert(
-        N > 0 && N <= 64,
-        "sext<N>: N must be between 1 and 64"
-    );
-    if constexpr (N < 64) {
-        val &= mask(N);
-        if (bits(val, N - 1))
-            val |= ~mask(N);
-    }
+    bool sign_bit = bits(val, N - 1);
+    if (sign_bit)
+        val |= ~mask(N);
     return val;
 }
 

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1393,6 +1393,20 @@ Commit::commitInsts()
                             return;
                         }
 
+                      // Vector loads write architectural vector registers.
+                      // Mark mstatus.VS dirty when the instruction commits.
+                      if (head_inst->isVector() && head_inst->isLoad()) {
+                          RiscvISA::STATUS status =
+                              cpu->readMiscRegNoEffect(
+                                  RiscvISA::MiscRegIndex::MISCREG_STATUS,
+                                  tid);
+                          status.sd = 1;
+                          status.vs = 3;
+                          cpu->setMiscRegNoEffect(
+                              RiscvISA::MiscRegIndex::MISCREG_STATUS,
+                              (RegVal)status, tid);
+                      }
+
                     if (head_inst->isUpdateVsstatusSd()) {
                         auto v = cpu->readMiscRegNoEffect(
                             RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -3204,12 +3204,27 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
     bool cacheHit = LSQRequest::_inst->getCpuPtr()->ticksToCycles(curTick() - pkt->sendTick) <= 1;
     // Dump inst num, request addr, and packet addr
     if (debug::LSQ) {
-        char buffer[8];
-        std::memcpy(buffer, pkt->getPtr<char>(), pkt->getSize());
-        DPRINTF(LSQ, "Single Req::recvTimingResp: inst: %llu, pkt: %#lx, isLoad: %d, "
-                    "isLLSC: %d, isUncache: %d, isCachehit: %d, data: %d\n",
-                    pkt->req->getReqInstSeqNum(), pkt->getAddr(), isLoad(), mainReq()->isLLSC(),
-                    mainReq()->isUncacheable(), cacheHit, *((uint64_t*)buffer));
+        uint64_t firstWord = 0;
+        const size_t copySize =
+            std::min<size_t>(pkt->getSize(), sizeof(firstWord));
+
+        std::memcpy(
+            &firstWord,
+            pkt->getPtr<uint8_t>(),
+            copySize);
+
+        DPRINTF(LSQ,
+                "Single Req::recvTimingResp: inst: %llu, pkt: %#lx, "
+                "size: %u, isLoad: %d, isLLSC: %d, isUncache: %d, "
+                "isCachehit: %d, firstData: %#llx\n",
+                pkt->req->getReqInstSeqNum(),
+                pkt->getAddr(),
+                pkt->getSize(),
+                isLoad(),
+                mainReq()->isLLSC(),
+                mainReq()->isUncacheable(),
+                cacheHit,
+                static_cast<unsigned long long>(firstWord));
     }
 
     if (isLoad()) {
@@ -3506,11 +3521,35 @@ LSQ::SplitDataRequest::sendPacketToCache()
     bool mshr_alias_fail = false;
     bool hit_in_write_buffer = false;
     while (numReceivedPackets + _numOutstandingPackets < _packets.size()) {
-        bool success = lsqUnit()->trySendPacket(isLoad(), _packets.at(numReceivedPackets + _numOutstandingPackets),
-                                                bank_conflict, tag_read_fail, mshr_used,
-                                                mshr_alias_fail, hit_in_write_buffer);
+        const size_t pkt_idx =
+            numReceivedPackets + _numOutstandingPackets;
+        PacketPtr pkt = _packets.at(pkt_idx);
+
+        bool success = lsqUnit()->trySendPacket(
+            isLoad(), pkt,
+            bank_conflict, tag_read_fail, mshr_used,
+            mshr_alias_fail, hit_in_write_buffer);
+
+        DPRINTF(LSQ,
+                "Split send observe [sn:%llu] idx:%llu addr:%#lx "
+                "success:%d bankConflict:%d tagReadFail:%d "
+                "mshrUsed:%d mshrAliasFail:%d writeBuffer:%d "
+                "received:%llu outstanding:%llu total:%llu\n",
+                _inst->seqNum,
+                static_cast<unsigned long long>(pkt_idx),
+                pkt->getAddr(),
+                success,
+                bank_conflict,
+                tag_read_fail,
+                mshr_used,
+                mshr_alias_fail,
+                hit_in_write_buffer,
+                static_cast<unsigned long long>(numReceivedPackets),
+                static_cast<unsigned long long>(_numOutstandingPackets),
+                static_cast<unsigned long long>(_packets.size()));
+
         if (success) {
-            _packets[numReceivedPackets + _numOutstandingPackets]->setLSQPtr(lsqUnit()->getLsq());
+            pkt->setLSQPtr(lsqUnit()->getLsq());
             _numOutstandingPackets++;
         } else {
             break;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1168,6 +1168,9 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
 
         bool done_checking_load = false;
         for (auto req0 : inst_request->_reqs) {
+            if (!req0 || !req0->hasPaddr()) {
+                continue;
+            }
             Addr inst_eff_addr1 = req0->getPaddr() >> depCheckShift;
             Addr inst_eff_addr2 =
                 (req0->getPaddr() + req0->getSize() - 1) >> depCheckShift;
@@ -1176,6 +1179,9 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                     inst->seqNum, req0->getPaddr());
 
             for (auto req1 : load_request->_reqs) {
+                    if (!req1 || !req1->hasPaddr()) {
+                        continue;
+                    }
                 Addr ld_eff_addr1 = req1->getPaddr() >> depCheckShift;
                 Addr ld_eff_addr2 = (req1->getPaddr() + req1->getSize() - 1) >> depCheckShift;
 
@@ -3362,12 +3368,30 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         }
     }
 
-    if (load_inst->getFault() != NoFault) {
-        // If the instruction has an outstanding fault, we cannot complete
-        // the access as this discards the current fault.
-        DPRINTF(LoadPipeline, "Not completing instruction [sn:%lli] access "
-                "due to pending fault.\n", load_inst->seqNum);
+    /*
+     * A split load can have a PartialFault: an earlier fragment translated
+     * successfully while a later fragment faulted.  The translated prefix
+     * must still be sent to memory.  Keep the architectural fault attached
+     * to the instruction, but do not block the successful fragments here.
+     */
+    const bool partial_fault_load =
+        request->isSplit() && request->isPartialFault();
+
+    if (load_inst->getFault() != NoFault &&
+        !partial_fault_load) {
+        // A full translation fault has no valid memory fragment to access.
+        DPRINTF(LoadPipeline,
+                "Not completing instruction [sn:%lli] access "
+                "due to pending fault.\n",
+                load_inst->seqNum);
         return load_inst->getFault();
+    }
+
+    if (partial_fault_load) {
+        DPRINTF(LoadPipeline,
+                "Continuing partial-fault split load [sn:%lli]; "
+                "sending successfully translated prefix fragments.\n",
+                load_inst->seqNum);
     }
 
     load_entry.setRequest(request);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RISC-V floating-point rounding and immediate-load instructions.
  * Improved support for vector fault-only-first loads and vector configuration handling.
* **Bug Fixes**
  * Corrected illegal-instruction trap details and address sign extension.
  * Fixed vector tail-agnostic and mask-agnostic behavior across arithmetic, moves, reductions, slides, gathers, and loads.
  * Improved handling of split memory faults and indexed vector loads.
  * Corrected vector-load status updates and floating-point reduction results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->