### PR TITLE
cpu-o3: Make decoded uop cache opt-in

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -347,6 +347,11 @@ def addCommonOptions(parser, configure_xiangshan=False):
     parser.add_argument("--ideal-kmhv3", action= "store_true",
                         help="Use KunminghuV3 ideal params, which take priority over command-line arguments.")
 
+    parser.add_argument("--enable-uop-cache", action="store_true",
+                        default=False,
+                        help=("Enable the single-thread O3 frontend decoded "
+                              "uop cache. This option is incompatible with "
+                              "SMT until bypass arbitration is validated."))
 
     # for warmup without switching cpu
     parser.add_argument("--warmup-insts-no-switch", action="store", type=int,

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -31,6 +31,10 @@ def setPtwLevelLimitParams(args, tlb):
     tlb.walker.ptw_miss_queue_size = args.ptw_miss_queue_size
 
 def setKmhV3IdealParams(args, system):
+    if args.enable_uop_cache and args.smt:
+        fatal("--enable-uop-cache currently requires a single hardware "
+              "thread; disable --smt for this experiment")
+
     for cpu in system.cpu:
 
         # fetch
@@ -43,6 +47,13 @@ def setKmhV3IdealParams(args, system):
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4  # maybe we need to change iewToFetchDelay to 4, but now we use commit update bpu
         cpu.fetchQueueSize = 64
+        cpu.hasUopCache = args.enable_uop_cache
+        cpu.uopCacheWayNum = 4
+        cpu.uopCacheSetNum = 384
+        cpu.uopCacheMaxInstBytesPerEntry = 4
+        # Keep the ideal configuration's bypass storage explicit so capacity
+        # changes remain attributable in performance experiments.
+        cpu.uopCacheBypassQueueSize = 64
 
         # decode
         cpu.fetchToDecodeDelay = 3
@@ -162,6 +173,12 @@ if __name__ == '__m5_main__':
     FutureClass = None
 
     args = xiangshan_system_init()
+
+    # Keep the experimental fast path single-threaded until its shared cache
+    # build/stream state has a verified SMT ownership model.
+    if args.enable_uop_cache and args.smt:
+        fatal("--enable-uop-cache currently requires a single hardware "
+              "thread; disable --smt for this experiment")
 
     assert not args.external_memory_system
 

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -31,6 +31,10 @@ def setPtwLevelLimitParams(args, tlb):
     tlb.walker.ptw_miss_queue_size = args.ptw_miss_queue_size
 
 def setKmhV3Params(args, system):
+    if args.enable_uop_cache and args.smt:
+        fatal("--enable-uop-cache currently requires a single hardware "
+              "thread; disable --smt for this experiment")
+
     for cpu in system.cpu:
 
         # fetch (idealfetch not care)
@@ -43,6 +47,11 @@ def setKmhV3Params(args, system):
         cpu.iewToFetchDelay = 4 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4
         cpu.fetchQueueSize = 64
+        cpu.hasUopCache = args.enable_uop_cache
+        # Finite per-thread buffering for decoded instructions that bypass the
+        # ordinary Fetch-to-Decode time buffer.  SMT plus uop cache is rejected
+        # by the CPU until the combined path has dedicated validation.
+        cpu.uopCacheBypassQueueSize = 64
 
         # decode
         cpu.fetchToDecodeDelay = 3
@@ -195,6 +204,13 @@ if __name__ == '__m5_main__':
     FutureClass = None
 
     args = xiangshan_system_init()
+
+    # Reject the unsupported combination before checkpoint/restorer setup so
+    # users receive the uop-cache diagnostic rather than an unrelated SMT
+    # environment error.
+    if args.enable_uop_cache and args.smt:
+        fatal("--enable-uop-cache currently requires a single hardware "
+              "thread; disable --smt for this experiment")
 
     assert not args.external_memory_system
 

--- a/docs/design-docs/frontend/README.md
+++ b/docs/design-docs/frontend/README.md
@@ -14,6 +14,7 @@
 6. `ubtb_design.md`
 7. `abtb_design.md`
 8. `microtage_design.md`
+9. `uop_cache_design.md`
 
 各文档当前大致分工如下：
 
@@ -25,6 +26,7 @@
 - `ubtb_design.md`：最前级 taken-target predictor
 - `abtb_design.md`：ahead pipeline 下的较大容量早期 target predictor
 - `microtage_design.md`：放在 `S1` 的轻量方向预测器
+- `uop_cache_design.md`：O3 uop cache 的动机、实现、bypass 时序与理想化边界
 
 当前暂未单独展开的模块包括：
 

--- a/docs/design-docs/frontend/uop_cache_design.md
+++ b/docs/design-docs/frontend/uop_cache_design.md
@@ -1,0 +1,549 @@
+# gem5 O3 uop cache 设计与实现
+
+## 1. 文档目的
+
+本文解释当前 gem5 O3 CPU 中 uop cache 的设计、数据流和时序模型。目标读者不需要
+预先了解 uop cache，但应当知道处理器前端会取指、译码，再把指令送往后端执行。
+
+这里的“uop cache”更准确地说是 **decoded-instruction cache**：它按 PC 保存 gem5 已经
+译码得到的 `StaticInstPtr`。再次遇到相同代码时，Fetch 可以直接复用译码结果，不再从
+I-cache 取得指令字节并调用 decoder；条件允许时，还可以直接把动态指令送到 Decode
+内部的 bypass 队列，绕过普通 Fetch-to-Decode time buffer。
+
+当前实现适合回答以下性能问题：
+
+- 如果热点指令的译码结果能够被缓存，I-cache 和普通译码路径的压力能降低多少？
+- 如果命中指令还能绕过普通 Fetch-to-Decode 延迟，前端供给能力能提高多少？
+- 哪些 workload 对重复执行的小段代码、I-cache 等待或前端延迟更敏感？
+
+它还不是一份可直接映射到 RTL 的精确硬件模型。第 10 节会集中说明其中偏理想的部分。
+
+## 2. 为什么需要 uop cache
+
+普通前端反复执行一段热点代码时，每次都要完成相似的工作：
+
+1. 分支预测器给出下一段 fetch target。
+2. Fetch 向 I-cache 请求包含目标 PC 的指令字节。
+3. I-cache 返回数据并填充 fetch buffer。
+4. decoder 根据 16/32-bit RISC-V 编码生成 `StaticInst`。
+5. Fetch 创建 `DynInst`，经 fetch queue 和时序 buffer 送往 Decode。
+
+循环会让同一批指令字节被反复读取和译码。uop cache 在首次正常译码后保存结果，后续
+命中时直接从第 4 步之后继续。它可能带来四类优势：
+
+### 2.1 缩短前端延迟
+
+当前配置的普通 Fetch-to-Decode 延迟为 3 cycle。成功进入 bypass 队列的命中指令在
+下一 cycle 就能被 Decode 看到，因此在无其他阻塞时，固定缩短 2 cycle。完整推导见
+第 8 节。
+
+### 2.2 避免 I-cache 等待
+
+当整个预测 fetch block 都在 uop cache 中时，Fetch 可以跳过该 block 的 I-cache 请求。
+I-cache hit 时，这主要减少访问和前端流水工作；I-cache miss、MSHR 冲突或端口繁忙时，
+还可能避免不定长的等待。这部分收益不是固定拍数，取决于 cache 和内存系统状态。
+
+### 2.3 降低重复译码工作
+
+命中后直接复用 `StaticInstPtr`，不再把指令字节送入 RISC-V decoder。这可以表达真实
+硬件中“decoded uop 被重复使用”的方向性收益，也能减少模拟器自身的译码工作。
+
+### 2.4 提高热点代码的前端供给稳定性
+
+紧循环、频繁调用的小函数和稳定控制流通常有较高的时间局部性。只要 working set 能
+留在 uop cache 中，它们对 I-cache 状态的敏感度会降低，Decode 更容易连续获得指令。
+收益最终仍受分支预测、Decode 宽度、Rename/后端背压和错误路径浪费限制。
+
+## 3. 建模合同
+
+理解统计结果前，应先明确当前模型保证什么、不保证什么。
+
+### 3.1 输入和输出
+
+- 输入是 FTQ 当前预测 block、待取指 PC、线程的执行上下文，以及正常 Decode 得到的
+  `DynInst`。
+- cache 命中输出是保存的 `StaticInstPtr`、原 PC 和是否为压缩指令。
+- Fetch 仍然创建新的 `DynInst`，分配新的 sequence number，并保留预测、squash、融合
+  和后端执行所需状态。uop cache 不缓存动态执行结果。
+
+### 3.2 功能约束
+
+- 只有整个预测 block 从 `startPC` 到实际 `target_end` 的每条指令都存在时，block 才
+  算命中；部分命中不会供给该 block。
+- 命中必须同时满足 **PC 匹配** 和 **`UopCacheContext` 匹配**。PC 只说明“正在取哪一
+  个虚拟地址”，而不一定说明这个地址当前映射到哪段代码、以什么特权权限执行；因此
+  不能只用 PC 做 key。
+- macro-op 和 micro-op 不会写入本实现的 `UopCache::cache`，也不会作为命中结果从该
+  cache 读出。它们仍沿用普通 Fetch/decoder 路径处理。
+- trace mode 不使用 uop cache。
+- 命中不改变分支预测结果；Fetch 仍以 FTQ 给出的 block 边界和预测 taken target 为准。
+
+### 3.3 `UopCacheContext` 为什么必须参与匹配
+
+每个 `UopEntry` 都保存一个 `UopCacheContext`。当前上下文包含五个值：
+
+| 字段 | 表示的执行环境 |
+| --- | --- |
+| `prv` | 当前 RISC-V 特权级，例如 U/S/M |
+| `virt` | 是否处于虚拟化执行模式 |
+| `satp` | 当前 host/普通地址翻译上下文（包含页表根和地址转换模式） |
+| `vsatp` | guest 地址翻译上下文 |
+| `hgatp` | hypervisor 对 guest 物理地址的二级翻译上下文 |
+
+例如，两个执行片段可能使用同一个虚拟 PC，但由于进程切换、页表切换、guest 切换或
+特权级变化，PC 最终对应的物理代码和权限检查不同。如果只比较 PC，旧环境中译码的
+`StaticInstPtr` 就可能被错误地复用到新环境。查询时 `UopCache::findWay()` 会同时
+比较 entry 的 tag、首条指令 PC 和完整 `UopCacheContext`；任何一个字段不同都视为
+miss。这样做的目的不是判断指令是否“执行过”，而是把译码结果绑定到生成它时的地址
+翻译和权限环境。
+
+需要注意，这只是当前模型选择的上下文保护集合，不等于完整的硬件一致性协议。当前已
+在 `fence.i`、TLB/page-table invalidation 和 PMP 更新时失效 cache；外部 I-cache
+coherence 和未遵守 `fence.i` 合同的代码修改仍不在模型保证范围内，详见第 10.8 节。
+
+### 3.4 性能因果链
+
+模型表达的因果关系是：
+
+```text
+重复执行已译码代码
+    -> block/PC/context 命中
+    -> 跳过 I-cache 字节供给和 decoder
+    -> bypass 队列有空间且不破坏程序顺序
+    -> 绕过普通 fetch queue 到 FetchStruct 的延迟
+    -> Decode 更早获得指令
+    -> 在前端确为瓶颈时降低总周期数
+```
+
+命中率高并不必然等于 IPC 提升。若瓶颈在错误分支、执行单元、数据 cache 或提交带宽，
+提前供给的指令可能只是在队列中等待。
+
+## 4. Cache 组织与参数
+
+主要参数定义在 `src/cpu/o3/BaseO3CPU.py`：
+
+| 参数 | 默认值 | 含义 |
+| --- | ---: | --- |
+| `hasUopCache` | `False` | 是否启用 decoded uop cache；关闭时 Decode 使用原有队列、背压与 SMT 仲裁 |
+| `uopCacheWayNum` | `4` | 组相联 way 数，必须为 2 的幂 |
+| `uopCacheSetNum` | `384` | set 数，可以不是 2 的幂 |
+| `uopCacheMaxInstBytesPerEntry` | `4` | 单 entry 名义指令字节容量，必须至少为 4B |
+| `uopCacheBypassQueueSize` | `64` | 每线程 Decode bypass 队列容量 |
+
+`kmhv3.py` 和 `idealkmhv3.py` 现在默认关闭 uop cache。只有显式传入
+`--enable-uop-cache` 时才开启：
+
+```text
+--enable-uop-cache
+```
+
+两种配置当前都把 `fetchQueueSize` 设为 64、`fetchToDecodeDelay` 设为 3、
+`decodeWidth` 设为 8。`idealkmhv3.py` 还显式设置 4 way、384 set、每 entry 4B；
+`kmhv3.py` 使用 `BaseO3CPU.py` 中相同的默认值。
+
+当前配置合同明确禁止同时启用 SMT 和 uop cache。关闭 uop cache 时保留原有 Decode
+buffer 深度、feedback backpressure、`SmtActiveThreadArbiter` 和逐线程统计更新；开启
+后虽仍使用 per-thread bypass deque 和原有 SMT arbiter，但 Fetch/FTQ fast path 尚未
+完成足够的双线程正确性验证，因此 CPU 会在 `numThreads > 1` 时拒绝该组合，而不是
+静默运行一个可能错误的模型。
+
+### 4.1 索引和 tag
+
+PC 先右移一位，以 RISC-V 最小 2B 指令粒度形成 halfword address：
+
+```text
+halfword_addr = virtual_PC >> 1
+```
+
+- set 数为 2 的幂时，用 mask 取 set、用 shift 取 tag。
+- set 数不是 2 的幂时，用 `% setNum` 取 set、用 `/ setNum` 取 tag。
+
+默认总共有 `4 * 384 = 1536` 个 entry。当前每个 entry 实际只保存 **一条** 指令，
+因此它不是常见的“一个 entry 保存一串 uop”的 trace/block uop cache。
+
+### 4.1.1 `uopCacheMaxInstBytesPerEntry` 的实际语义
+
+这个参数容易被误解为“一个 cache 存储块最多可以放多少字节，超过后就自动拆分”。
+当前代码并不是这样实现的：
+
+1. `UopCache::addInst()` 每次只把当前的一条普通指令写入
+   `currentRefillEntry`。
+2. 该函数随后调用 `setCurrentUopEntryDone()`，立即把这个单指令 entry 放入
+   `refillEntryBuffer`，并新建下一个空 entry。
+3. `UopCache::tick()` 再把每个单指令 entry 独立写入 set/way。
+
+因此，在当前实现中，一个 entry 的实际大小只能是：
+
+- 普通 RISC-V 指令：4B；
+- compressed 指令：2B；
+- macro-op/micro-op：不创建 entry。
+
+不会出现“一个 entry 内指令数超过配置 4B”的运行时场景，也不存在超限后的自动分割、
+拒绝写入或溢出告警。`uopCacheMaxInstBytesPerEntry` 当前主要被
+`UopCacheStats` 用来表示每个 entry 的**名义容量**，计算 `entryCapacityBytesTotal`
+和 `entryByteUtilization`，并设置 `entryBytes` 分布的上界。默认值 4B 下，4B 普通指令
+的利用率为 100%，2B compressed 指令的利用率为 50%。
+
+如果未来把 entry 改成真正的多指令 block/trace entry，则必须额外实现容量判断：当累计
+字节数加上下一条指令大小超过该参数时，应先结束当前 entry、再开始新的 entry，并明确
+分支边界、跨 block 指令、压缩指令和 refill 带宽的处理。目前这些行为尚不存在，不能
+根据该参数推断 cache 会自动保存“最多 4B 的多条指令”。
+
+### 4.2 Entry 内容
+
+`UCInstDesc` 保存：
+
+- 已译码的 `StaticInstPtr`
+- 指令 PC
+- 是否为 16-bit compressed instruction
+- 进入 refill buffer 的 cycle
+
+`UopEntry` 还保存 tag、valid、首次指令 PC、覆盖字节数、写入 cache 的 cycle 和上下文。
+
+### 4.3 地址空间上下文
+
+`UopCacheContext` 比较以下 RISC-V 状态：
+
+- `prv`：当前特权级
+- `virt`：虚拟化模式
+- `satp`：主地址翻译上下文
+- `vsatp`：guest 地址翻译上下文
+- `hgatp`：hypervisor 地址翻译上下文
+
+这避免相同虚拟 PC 在不同地址空间或特权环境中错误复用同一个译码结果。不过它不是
+完整的指令一致性机制，见第 10.8 节。
+
+### 4.4 替换策略和复杂度
+
+替换优先选择空 way，否则使用 per-set tree-PLRU。命中后和 refill 后都会更新 PLRU。
+
+- 单条指令 lookup 会线性扫描所有 way，复杂度为 `O(wayNum)`。
+- block lookup 会按 2B/4B 指令长度遍历整个预测 block，每条指令再扫描 way，复杂度为
+  `O(blockInstCount * wayNum)`。
+- PLRU victim 选择和更新为 `O(log2(wayNum))`。
+
+这些是模拟器宿主机的算法复杂度，当前没有转换成被模拟 CPU 的额外 cycle。
+
+## 5. Refill 路径
+
+cache 由正常路径的 Decode 结果建立：
+
+```text
+I-cache/fetch buffer -> decoder -> DynInst -> Decode::decodeInsts()
+    -> UopCache::addInst()
+    -> refillEntryBuffer
+    -> 下一次 Decode::tick() 中 UopCache::tick()
+    -> set/way 中的 UopEntry
+```
+
+`Decode::tick()` 先调用 `UopCache::tick()`，随后才执行本拍的 `decodeInsts()`。因此本拍
+Decode 新加入 refill buffer 的 entry 最早在下一次 Decode tick 落入 cache。该行为表达
+了一个 1-cycle 的最小 fill 可见时间，但 `tick()` 会一次写完 refill buffer 中的所有
+entry，没有写端口数量限制。
+
+以下情况不会正常向 `UopCache::cache` refill：
+
+- uop cache 被关闭
+- 当前处于 stream mode，即正在消费 `UopCache::cache` 中的指令
+- 指令本身来自 `UopCache::cache`，防止自我 refill
+- 指令是 macro-op 或 micro-op；这两类对象不创建可供本 cache 复用的单条
+  `UCInstDesc` entry，仍由普通 decoder 的 macro-op/micro-op 逻辑处理
+
+Decode 根据当前指令来自正常路径还是 uop cache，在 build mode 和 stream mode 之间
+切换。squash、部分早期 redirect、taken 分支边界和 `quiesce` 会结束或清理当前 refill
+状态。由于当前 entry 只有一条指令，原本面向多指令 entry 的 build/stream 边界语义
+已经大幅退化。
+
+## 6. 命中与 I-cache bypass
+
+Fetch 查询分两层：
+
+1. `checkUopCacheBlockHit()` 验证预测 block 内每条 PC 都存在。
+2. `checkUopCacheHit()` / `findInst()` 查找当前 PC 对应的 entry 和指令描述。
+
+block 的结束位置为：
+
+- 预测 taken：预测分支 PC 加该分支指令长度。
+- 预测 not-taken：FTQ 的 `predEndPC`。
+
+只有 block 完整命中，`checkMemoryNeeds()` 才返回 `NoStall` 并跳过 fetch buffer 字节
+检查。`sendNextCacheRequest()` 也会在 block 起始 PC 命中时不发送流水化 I-cache
+请求。随后 `processSingleInstruction()` 直接取得保存的 `StaticInstPtr`，并根据
+compressed 标记推进 PC 状态。
+
+`PendingUopCacheLookup` 只是在同一 block/PC 的多次函数调用之间复用查询结果。当前
+查询、tag/context 比较和 `StaticInstPtr` 读取都发生在同步函数调用中，没有被模拟为
+独立的 lookup pipeline stage。
+
+## 7. Decode bypass 与顺序保证
+
+uop-cache hit 不一定成功 bypass。Fetch 首先询问 Decode 的 bypass deque 是否还有
+空间。容量由 `uopCacheBypassQueueSize` 参数控制，默认每线程 64 项：
+
+- 有空间：构造的 `DynInst` 不进入普通 `fetchQueue`，而是直接调用
+  `enqueueUopCacheBypassInst()`。
+- 无空间：仍然复用 uop-cache 的译码结果和 I-cache bypass，但指令回退到普通
+  `fetchQueue`，因此不获得固定的 Fetch-to-Decode 延迟收益。
+
+Decode 每拍最多按 `decodeWidth` 把普通路径和 bypass 路径的指令合并进
+`fixedbuffer`，再执行已有 Decode 逻辑。合并按 sequence number 排序。CPU 还跟踪最老
+的未译码普通指令，`uopCacheBypassOrderBlocked()` 会阻止较新的 bypass 指令越过较老的
+普通指令。这样做保证优化只改变到达时间，不改变程序顺序。
+
+squash 时，Decode 会清空相关线程的 bypass queue；每条指令还带 squash version，旧
+版本指令在移入 Decode buffer 时会被标记或丢弃。
+
+## 8. Bypass 成功到底节省多少拍
+
+### 8.1 结论
+
+在当前 `kmhv3.py` 和 `idealkmhv3.py` 配置中，相对于“同一 Fetch cycle 已经生成、并在
+本拍送入普通 FetchStruct 的指令”，成功 bypass 在无 backpressure、无更老普通指令
+阻塞时，**固定节省 2 cycle**。
+
+更一般地，若 `fetchToDecodeDelay = D`，由于当前 stage 调用顺序造成 bypass 至少等待
+1 cycle，固定缩短量为：
+
+```text
+max(D - 1, 0) cycle
+```
+
+当前 `D = 3`，所以为 `3 - 1 = 2 cycle`。
+
+### 8.2 逐拍推导
+
+`CPU::tick()` 的 stage 顺序是：
+
+```text
+commit -> iew -> rename -> decode -> fetch -> advance time buffers
+```
+
+设 Fetch 在 cycle `F` 创建一条指令：
+
+| Cycle | 普通路径 | bypass 路径 |
+| --- | --- | --- |
+| `F` | Fetch 写 `toDecode` 的 time-buffer wire | Fetch 在 Decode 已 tick 后写 bypass deque |
+| `F+1` | 尚未到 `getWire(-3)` | Decode 从 bypass deque 移入 `fixedbuffer`，可在本拍 decode |
+| `F+2` | 尚未到 `getWire(-3)` | 已经离开 Decode |
+| `F+3` | Decode 从普通输入移入 `fixedbuffer`，可在本拍 decode | 已经离开 Decode |
+
+因此 bypass 不是“同拍进入 Decode”。它绕过 3-cycle time buffer，但由于 Decode 在
+Fetch 之前 tick，仍花 1 cycle 到达 Decode，净节省 2 cycle。
+
+### 8.3 这个数字不包含什么
+
+- **I-cache miss latency**：完整 block 命中可能额外避免若干到很多 cycle，数量随运行
+  状态变化。
+- **I-cache hit/字节准备时间**：如果普通路径在 cycle `F` 尚不能生成指令，uop cache
+  会更早生成 `DynInst`，这也是可变或配置相关收益，不是上述固定 2 cycle。
+- **队列等待**：bypass queue 满、Decode blocked、`fixedbuffer` 满或存在更老普通指令
+  时，实际节省会小于 2 cycle，甚至只剩 I-cache/decoder 复用收益。
+- **后端性能**：早 2 cycle 到达 Decode 不保证程序早 2 cycle 完成，收益可能被后端
+  瓶颈覆盖。
+
+### 8.4 建议增加的直接时序统计
+
+当前 `uopCacheBypassInsts` 只数成功从 bypass queue 移到 Decode buffer 的指令，并不
+直接记录每条指令节省的拍数。若要用运行数据验证上述静态推导，建议后续为 `DynInst`
+记录：
+
+- Fetch 创建 cycle
+- 进入 Decode `fixedbuffer` 的 cycle
+- 正常路径与 bypass 路径分别统计该差值的 distribution
+
+这样可以区分理论固定延迟和真实队列/顺序阻塞后的有效延迟。
+
+## 9. 统计与结果解释
+
+### 9.1 现有统计
+
+Fetch 侧：
+
+| 统计 | 含义 |
+| --- | --- |
+| `uopCacheHits` | 在 block 起始 PC 统计的完整 block hit 次数 |
+| `uopCacheMisses` | 在 block 起始 PC 统计的 block miss 次数 |
+| `uopCacheHitInsts` | Fetch 从 uop cache 取得的动态指令数 |
+| `uopCacheBypassQueueFullEvents` | 命中但 bypass deque 满的次数 |
+| `uopCacheBypassOrderBlockedEvents` | 因更老普通指令未 decode 而阻塞的检查次数 |
+| `uopCacheBypassInsts` | 实际从 bypass deque 移入 Decode buffer 的非 squash 指令数 |
+| `uopCachePcMismatches` | 命中后无法按当前 PC 安全供给的异常次数 |
+
+uop cache 自身还记录 entry refill 数、每 entry 指令数/字节数和名义字节利用率。当前每
+entry 固定一条指令，因此 `avgEntryInsts` 应接近 1；2B 压缩指令会让 4B 名义容量利用
+率低于 100%。
+
+### 9.2 不能直接这样解释
+
+`uopCacheHitInsts` 是推测前端工作量，不是 retired instruction 数。错误路径、squash
+后的重新 fetch 和循环重复都会计数，所以它可以超过 `simInsts`。同理，不能只用
+`uopCacheHits / (hits + misses)` 就推导整机加速比。
+
+更可靠的 A/B 分析至少应同时比较：
+
+- `simTicks`、IPC 或 benchmark score
+- I-cache demand access/miss/stall
+- `uopCacheHitInsts`、`uopCacheBypassInsts`
+- queue-full 和 order-blocked 事件
+- branch misprediction、squashed instructions
+- 后端 stall，确认瓶颈是否已经转移
+
+### 9.3 当前 SPEC06 A/B 的方向性证据
+
+已有 CI 对比中，uop cache run `30421280436` 相对 base run `30418078641`：
+
+- `astar` 汇总运行时间约降低 7.04%，score 约提高 7.57%。
+- `bzip2` 汇总运行时间约降低 4.62%，score 约提高 4.85%。
+- SPEC06 Int score 约提高 2.24%，overall score 约提高 1.40%。
+
+单 checkpoint 中还观察到 I-cache demand access 大幅减少，这与“完整 block 命中后跳过
+I-cache 请求”的实现一致。这些数据说明 astar/bzip2 的热点前端路径确实能从当前模型
+获益，但不能单独证明真实硬件会获得相同幅度，原因包括下一节的理想化假设，以及两次
+CI 必须持续确认除 uop-cache 开关外没有其他配置或代码差异。
+
+## 10. 当前实现可能过于理想的地方
+
+以下限制会让模拟结果偏乐观，或者让它与真实 uop-cache 结构不同。
+
+### 10.1 Lookup 被建模为 0-cycle
+
+block 扫描、所有 way 的 tag/context 比较、PLRU 更新和 decoded instruction 读取都是
+同步函数调用。更大容量或高相联 cache 在真实硬件中可能需要一级或多级流水，命中也
+未必能在当前 Fetch cycle 直接供给。
+
+### 10.2 没有读端口、bank 和带宽限制
+
+一个 Fetch cycle 内可以查询并读取多条指令，没有 tag/data read port 数量、bank
+conflict、跨行读取或多路选择器时序限制。`fetchWidth=32` 时，这个假设尤其激进。
+
+### 10.3 Refill 带宽和读写冲突理想化
+
+refill 至少到下一 Decode tick 才可见，但一次 `tick()` 可以写完所有待填 entry。没有
+write port 上限，也没有 lookup 与 refill 同 set/bank 时的冲突。
+
+### 10.4 直接缓存 `StaticInstPtr`
+
+真实硬件需要保存编码后的 uop、操作数描述、控制位、边界信息和纠错元数据，并支付
+SRAM 面积与读出能耗。直接保存宿主对象指针既没有物理位宽，也没有面积、功耗或读出
+延迟，因此当前 1536-entry 配置不能直接换算成真实硬件容量。
+
+### 10.5 每 entry 仅一条指令
+
+典型 uop cache 常按 line、trace 或 fetch block 保存多条 uop，并处理对齐、跨 line、
+分支终止和内部 slot 利用率。当前逐指令 entry 简化了这些问题，同时让 4-way/384-set
+的容量和冲突行为不能直接对应某个真实设计。
+
+### 10.6 完整 block 查询本身没有代价
+
+模型为了决定是否跳过 I-cache，会先确认整个预测 block 的每条指令都命中。真实硬件
+通常不能在一个 cycle 内串行遍历未知数量、混合 2B/4B 长度的指令后再作决定。当前
+模型既拥有译码后长度信息，又不为遍历付出 timing cost。
+
+### 10.7 Context 读取和比较没有代价
+
+每次查询直接读取 `prv/virt/satp/vsatp/hgatp` 并全量比较，没有为寄存器分发、宽 tag
+或地址空间标识管理建模。真实实现可能使用更短的 ASID/VMID/tag，也可能在上下文切换
+时整体或选择性失效。
+
+### 10.8 指令一致性与失效边界
+
+cache 提供 `invalidateAll()` 和 `invalidateContext()`：二者都会处理已安装 entry 和
+尚未安装的 refill 状态，`invalidateAll()` 还会恢复 build mode。Fetch 的统一失效入口
+会同时取消所有 per-thread pending lookup，避免复用失效边界之前缓存的 block-hit 结论。
+
+当前接入点包括：
+
+- `fence.i`；
+- `sfence.vma`、`sinval.vma` 和现有页表 demap 路径；
+- `SATP` 变化触发的 `CPU::flushTLBs()`；
+- PMP configuration/address 更新。
+
+因此，遵守 RISC-V `fence.i` 和地址翻译失效合同的软件不会继续命中旧
+`StaticInstPtr`。尚未建模的是来自外部 agent 的指令侧 coherence 通知，以及软件未执行
+必要 `fence.i` 的非规范自修改代码；这些场景仍超出当前模型保证范围。
+
+### 10.9 I-cache bypass 边界偏乐观
+
+完整 block 命中会直接抑制 I-cache request。真实前端可能仍需完成权限检查、地址翻译、
+line/trace 对齐检查或与预测流水对拍。当前 context match 不能代表这些步骤的全部时序。
+
+### 10.10 Bypass 队列只建模容量
+
+每线程 bypass deque 容量由 `uopCacheBypassQueueSize` 参数化，默认 64；模型仍没有为其
+面积、读写端口或 bank 冲突建模。大队列会降低 queue-full 概率，从而放大固定 2-cycle
+bypass 收益。
+
+### 10.11 错误路径也享受优化
+
+模型会为预测路径查询 cache、创建指令和计 hit，即使这些指令后来被 squash。真实硬件
+当然也会推测执行，但错误路径的查询带宽、能耗、污染和恢复时序没有被完整约束。因此
+命中指令数和被避免的 I-cache access 可能显得非常大。
+
+### 10.12 替换与容量缺少物理校准
+
+tree-PLRU 本身合理，但其读取/更新没有 timing cost；默认 set/way/entry 数也尚未由某个
+RTL SRAM 宏、面积预算或目标处理器参数校准。结果更适合做机制上界探索，而非面积等价
+的产品预测。
+
+## 11. 推荐验证方法
+
+### 11.1 最小功能 A/B
+
+保持 binary、checkpoint、随机种子和所有 CPU 参数不变，只切换：
+
+```text
+# on
+--enable-uop-cache
+
+# off
+<不传 --enable-uop-cache>
+```
+
+先验证最终 committed instruction 数和架构结果一致，再比较周期和前端统计。
+
+### 11.2 时序验证
+
+用 `--debug-flags=UC,Decode,Fetch` 选择一个短小循环，检查同一 sequence number：
+
+1. Fetch 在 cycle `F` 打印 enqueue bypass。
+2. Decode 在 `F+1` 打印 moved to decode buffer。
+3. 普通路径对照在 `F+3` 从 FetchStruct 到达。
+
+为了做批量验证，优先实现第 8.4 节的 latency distribution，而不是解析大量日志。
+
+### 11.3 性能归因
+
+建议至少选择三类 workload：
+
+- 小热点循环：验证高命中和固定 bypass 延迟收益。
+- I-cache working set 较大：观察容量/冲突和 I-cache miss avoidance。
+- 后端受限 workload：验证高命中但低 IPC 收益的反例。
+
+逐步扫 `setNum`、`wayNum` 和一个未来可参数化的 lookup latency，可以得到容量、命中率
+和时序的敏感性曲线。若目标是与 RTL 对齐，还必须加入真实 entry 格式、bank/port、
+lookup stage、refill 带宽和失效协议后再比较。
+
+## 12. 代码导航
+
+- `src/cpu/o3/uop_cache.hh`：entry、context、cache 接口和 stats 声明。
+- `src/cpu/o3/uop_cache.cc`：索引、lookup、PLRU、refill 和 invalidation 实现。
+- `src/cpu/o3/fetch.cc`：block/PC 查询、I-cache bypass、DynInst 构造和命中统计。
+- `src/cpu/o3/decode.cc`：refill、bypass deque、顺序合并和 squash 清理。
+- `src/cpu/o3/cpu.cc`：stage tick 顺序和 Fetch/Decode bypass 转发接口。
+- `src/cpu/o3/dyn_inst.hh`：`fetchFromUopCache`、`uopCacheBypass` 等动态标记。
+- `src/cpu/o3/BaseO3CPU.py`：通用参数默认值。
+- `configs/common/Options.py`：`--enable-uop-cache` 命令行开关。
+- `configs/example/kmhv3.py`、`configs/example/idealkmhv3.py`：Kunminghu v3 配置。
+
+## 13. 总结
+
+当前实现把“缓存已译码指令”和“绕过普通 Fetch-to-Decode 延迟”组合在一起。对热点
+代码，它能够同时减少 I-cache/decoder 工作，并在 bypass 成功时把 Fetch 创建到 Decode
+消费的最短距离从 3 cycle 降到 1 cycle，固定净省 2 cycle；如果还避免了 I-cache miss，
+总收益可以更大但不固定。
+
+这个模型很适合探索 uop cache 的潜在上界和识别前端敏感 workload。解释 astar、bzip2
+等明显加速时也必须保留边界：0-cycle lookup、无限读写带宽、逐指令 entry、直接缓存
+`StaticInstPtr` 和大 bypass deque 都会使结果比可实现硬件更理想。下一
+阶段若要把性能数字用于硬件决策，最重要的工作是加入可参数化 lookup latency 与端口/
+bank 限制，并按目标 RTL 的 entry 格式和一致性规则重新校准容量。

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -866,6 +866,9 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 }
 
                 setMiscRegNoEffect(misc_reg, val);
+                // PMP changes can revoke instruction access without changing
+                // the virtual address or SATP value used by the uop-cache tag.
+                tc->getCpuPtr()->flushUopCache();
             }
             break;
           case MISCREG_MCOUNTEREN:
@@ -893,6 +896,7 @@ ISA::setMiscReg(int misc_reg, RegVal val)
                 mmu->getPMP()->pmpUpdateAddr(pmp_index, val);
 
                 setMiscRegNoEffect(misc_reg, write_val);
+                tc->getCpuPtr()->flushUopCache();
             }
             break;
             case MISCREG_HVIP: {

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -584,6 +584,11 @@ decode QUADRANT {
                 0x0: fence({{
                 }}, uint64_t, IsReadBarrier, IsWriteBarrier, MemReadOp);
                 0x1: fence_i({{
+                    // A decoded-instruction cache can otherwise reuse the old
+                    // StaticInst after software has made new instruction bytes
+                    // visible.  CPU models without such a cache implement this
+                    // hook as a no-op, preserving their existing fence.i path.
+                    xc->tcBase()->getCpuPtr()->flushUopCache();
                 }}, uint64_t, IsNonSpeculative, IsSerializeAfter, No_OpClass);
             }
         }
@@ -2551,6 +2556,11 @@ decode QUADRANT {
                                         machInst);
                         }
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        // The page-table root may be unchanged while the PTE or
+                        // execute permission for this virtual address changes.
+                        // A context tag containing SATP alone cannot detect that
+                        // case, so discard decoded instructions with the TLB.
+                        xc->tcBase()->getCpuPtr()->flushUopCache();
                     }}, IsNonSpeculative, IsSerializeBefore, IsSerializeAfter,
                         IsReadBarrier, IsWriteBarrier, No_OpClass);
                     0xb: sinval_vma({{
@@ -2571,6 +2581,7 @@ decode QUADRANT {
                                 machInst);
                         }
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        xc->tcBase()->getCpuPtr()->flushUopCache();
                     }}, IsNonSpeculative, IsSerializeBefore, IsSerializeAfter,
                         IsReadBarrier, IsWriteBarrier, No_OpClass);
                     0xc: decode RS2 {
@@ -2630,6 +2641,7 @@ decode QUADRANT {
                                 MISCREG_VIRMODE);
                         STATUS status = xc->readMiscReg(MISCREG_STATUS);
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        xc->tcBase()->getCpuPtr()->flushUopCache();
 
                         if(vir){
                             panic("add priv vir code\n");

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -400,6 +400,18 @@ class BaseCPU : public ClockedObject
     virtual void flushTLBs();
 
     /**
+     * Discard CPU-model-specific decoded-instruction cache state.
+     *
+     * Most CPU models do not cache decoded instructions, so the base
+     * implementation is intentionally a no-op.  Models which bypass normal
+     * instruction translation or byte fetch on a decoded-cache hit must
+     * override this hook.  RISC-V fence.i, address-translation invalidation,
+     * and instruction-access permission changes call it to prevent stale
+     * decoded instructions from surviving an architectural invalidation.
+     */
+    virtual void flushUopCache() {}
+
+    /**
      * Determine if the CPU is switched out.
      *
      * @return True if the CPU is switched out, false otherwise.

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -171,6 +171,16 @@ class BaseO3CPU(BaseCPU):
     trapLatency = Param.Cycles(13, "Trap latency")
     fetchTrapLatency = Param.Cycles(1, "Fetch trap latency")
 
+    # Keep the experimental decoded-instruction cache opt-in so configurations
+    # which do not mention it retain the established O3 frontend behavior.
+    hasUopCache = Param.Bool(False, "Enable decoded uop cache in the frontend")
+    uopCacheWayNum = Param.Unsigned(4, "Number of uop cache ways")
+    uopCacheSetNum = Param.Unsigned(384, "Number of uop cache sets")
+    uopCacheMaxInstBytesPerEntry = Param.Unsigned(
+        4, "Maximum instruction bytes covered by one uop cache entry")
+    uopCacheBypassQueueSize = Param.Unsigned(
+        64, "Per-thread decoded uop-cache bypass staging capacity")
+
     backComSize = Param.Unsigned(10,
             "Time buffer size for backwards communication")
     forwardComSize = Param.Unsigned(10,

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -60,6 +60,7 @@ if env['CONF']['TARGET_ISA'] != 'null':
     Source('thread_state.cc')
     Source('issue_queue.cc')
     Source('perfCCT.cc')
+    Source('uop_cache.cc')
 
     # Trace reader sources for trace-driven simulation
     Source('trace/TraceReader.cc')
@@ -93,6 +94,8 @@ if env['CONF']['TARGET_ISA'] != 'null':
     DebugFlag('LoadPipeline')
     DebugFlag('StorePipeline')
     DebugFlag('TraceReader')
+    DebugFlag('UC')
+    DebugFlag('UCSquash')
 
     CompoundFlag('O3CPUAll', [ 'Fetch', 'Decode', 'Rename', 'IEW', 'Commit',
         'IQ', 'ROB', 'FreeList', 'LSQ', 'LSQUnit', 'StoreSet', 'MemDepUnit',

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -129,12 +129,21 @@ CPU::CPU(const BaseO3CPUParams &params)
       ipc_r("ipc", "", 1000, archDBer),
       cpi_r("cpi", "", 1000, archDBer),
       issueWidth(params.decodeWidth),
+      enableUopCache(params.hasUopCache),
       enableMoveElimination(params.enableMoveElimination),
       enableConstantFolding(params.enableConstantFolding),
       enableMovImmElimination(params.enableMovImmElimination),
       cpuStats(this),
       valuePred(params.valuePred)
 {
+    // The normal O3 frontend supports SMT, but the initial uop-cache bypass
+    // implementation has shared build/stream state and has not established
+    // per-thread isolation.  Reject only that experimental combination so an
+    // opt-out configuration preserves the existing FS and SE SMT behavior.
+    fatal_if(params.hasUopCache && params.numThreads > 1,
+            "The O3 uop cache does not yet support SMT; disable the uop "
+            "cache or configure a single hardware thread.");
+
     if (!params.switched_out) {
         _status = Running;
     } else {
@@ -1356,8 +1365,50 @@ CPU::ListIt
 CPU::addInst(const DynInstPtr &inst)
 {
     instList.push_back(inst);
+    auto inst_it = --instList.end();
 
-    return --(instList.end());
+    if (enableUopCache) {
+        // Track only conventional Fetch instructions: bypass peers are already
+        // visible to Decode's merge logic and must not block one another here.
+        if (!inst->isDecoded() && !inst->isUopCacheBypass()) {
+            normalUndecodedSeqs[inst->threadNumber].insert(inst->seqNum);
+        }
+    }
+
+    return inst_it;
+}
+
+void
+CPU::enqueueUopCacheBypassInst(const DynInstPtr &inst)
+{
+    // Keep ownership of the bypass queue in Decode; CPU is the rendezvous
+    // point used by Fetch so the stages do not need a direct cross-reference.
+    decode.enqueueUopCacheBypassInst(inst);
+}
+
+bool
+CPU::canEnqueueUopCacheBypassInst(ThreadID tid) const
+{
+    return decode.canEnqueueUopCacheBypassInst(tid);
+}
+
+bool
+CPU::hasOlderNonBypassUndecodedInst(const DynInstPtr &inst)
+{
+    assert(enableUopCache);
+    const ThreadID tid = inst->threadNumber;
+    const auto &undecoded = normalUndecodedSeqs[tid];
+    return !undecoded.empty() && *undecoded.begin() < inst->seqNum;
+}
+
+void
+CPU::markInstDecoded(ThreadID tid, InstSeqNum seq_num)
+{
+    if (!enableUopCache) {
+        return;
+    }
+
+    normalUndecodedSeqs[tid].erase(seq_num);
 }
 
 void
@@ -1420,6 +1471,20 @@ CPU::removeFrontInst(const DynInstPtr &inst)
 
     removeInstsThisCycle = true;
 
+    // Fusion can retire the two source instructions from instList when it
+    // creates the fused replacement.  Commit may still hold one of those
+    // DynInst objects, so make repeated removal a harmless no-op instead of
+    // dereferencing an iterator invalidated by the Decode-side fusion path.
+    if (!inst->isInInstList()) {
+        DPRINTF(O3CPU, "Skipping already unlinked instruction [tid:%i] "
+                "PC %s [sn:%lli]\n",
+                inst->threadNumber, inst->pcState(), inst->seqNum);
+        return;
+    }
+
+    // Invalidate the DynInst's iterator before erase so any later owner can
+    // detect that CPU::instList no longer contains this instruction.
+    inst->clearInstListIt();
     instList.erase(inst->getInstListIt());
 }
 
@@ -1503,10 +1568,14 @@ CPU::squashInstIt(ListIt &instIt, ThreadID tid)
 
         // Mark it as squashed.
         (*instIt)->setSquashed();
+        markInstDecoded(tid, (*instIt)->seqNum);
 
         // @todo: Formulate a consistent method for deleting
         // instructions from the instruction list
         // Remove the instruction from the list.
+        // Squash owns this erase; invalidate the saved iterator so deferred
+        // cleanup cannot attempt to erase the same DynInst a second time.
+        (*instIt)->clearInstListIt();
         instIt = instList.erase(instIt);
     }
     return --instIt;
@@ -1517,6 +1586,21 @@ CPU::flushTLBs()
 {
     BaseCPU::flushTLBs();
     fetch.flushFetchBuffer();
+
+    // A uop-cache hit bypasses instruction translation, so entries decoded
+    // under the old translation/permission state cannot survive a TLB flush.
+    flushUopCache();
+}
+
+void
+CPU::flushUopCache()
+{
+    // Fetch must clear both installed entries and its memoized FTQ lookup.
+    // Do not touch any Fetch state when the feature is disabled; this keeps
+    // fence.i and translation-flush behavior identical to the legacy O3 path.
+    if (enableUopCache) {
+        fetch.invalidateUopCache();
+    }
 }
 
 void
@@ -1529,6 +1613,8 @@ CPU::cleanUpRemovedInsts()
                 (*removeList.front())->seqNum,
                 (*removeList.front())->pcState());
 
+        // Deferred retirement is the final owner of this iterator.
+        (*removeList.front())->clearInstListIt();
         instList.erase(removeList.front());
 
         removeList.pop_front();

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -43,7 +43,9 @@
 #ifndef __CPU_O3_CPU_HH__
 #define __CPU_O3_CPU_HH__
 
+#include <array>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <queue>
 #include <set>
@@ -398,6 +400,30 @@ class CPU : public BaseCPU
      */
     ListIt addInst(const DynInstPtr &inst);
 
+    /**
+     * Forward a decoded instruction from Fetch to Decode's bypass queue.
+     *
+     * CPU mediates this handoff to avoid coupling the two pipeline stages
+     * directly.  Decode remains responsible for capacity and ordering.
+     */
+    void enqueueUopCacheBypassInst(const DynInstPtr &inst);
+
+    /** Return whether Decode can accept another bypass instruction for tid. */
+    bool canEnqueueUopCacheBypassInst(ThreadID tid) const;
+
+    /**
+     * Return whether inst has an older undecoded instruction from the normal
+     * Fetch path.  Decode uses this stricter predicate to prevent a bypassed
+     * instruction from overtaking work still buffered in Fetch.
+     */
+    bool hasOlderNonBypassUndecodedInst(const DynInstPtr &inst);
+
+    /**
+     * Notify the sequence tracker that an instruction reached Decode or was
+     * squashed before Decode.  Both cases remove it as an ordering obstacle.
+     */
+    void markInstDecoded(ThreadID tid, InstSeqNum seq_num);
+
     /** Function to tell the CPU that an instruction has completed. */
     void instDone(ThreadID tid, const DynInstPtr &inst);
 
@@ -416,8 +442,15 @@ class CPU : public BaseCPU
     /** Removes the instruction pointed to by the iterator. */
     ListIt squashInstIt(ListIt &instIt, ThreadID tid);
 
-    // flush fetch buffer while flushing tlb
+    /** Flush translations and any frontend state derived from them. */
     void flushTLBs() override;
+
+    /**
+     * Invalidate decoded instructions after fence.i or permission/coherence
+     * changes.  Fetch owns both the cache array and memoized lookup state, so
+     * the CPU override delegates the complete operation to that stage.
+     */
+    void flushUopCache() override;
 
     /** Cleans up all instructions on the remove list. */
     void cleanUpRemovedInsts();
@@ -465,6 +498,14 @@ class CPU : public BaseCPU
      *  being retired or squashed.
      */
     bool removeInstsThisCycle;
+
+    /**
+     * Live normal-path instructions which have not crossed Decode, ordered by
+     * sequence number for each thread.  A set gives the bypass hot path an
+     * O(1) oldest-element lookup and O(log N) updates without scanning the
+     * CPU-wide instruction list after every squash or fusion event.
+     */
+    std::array<std::set<InstSeqNum>, MaxThreads> normalUndecodedSeqs;
 
   protected:
     /** The fetch stage. */
@@ -651,6 +692,13 @@ class CPU : public BaseCPU
 
     /** Issue Width, using for intel topdown stats */
     int issueWidth; // issueWidth = decodeWidth = renameWidth!!!
+
+    /**
+     * Whether the experimental decoded-instruction path is active.
+     * Sequence-order bookkeeping is skipped entirely when false so normal O3
+     * configurations retain the pre-uop-cache host and simulated behavior.
+     */
+    const bool enableUopCache;
 
     bool enableMoveElimination; // Control flag of register move elimination
     bool enableConstantFolding; // Control flag of Constant Folding (add-immediate elimination)

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -39,10 +39,15 @@
  */
 #include "cpu/o3/decode.hh"
 
+#include <cstring>
+#include <initializer_list>
+#include <limits>
 #include <queue>
+#include <utility>
 
 #include "arch/generic/pcstate.hh"
 #include "arch/riscv/insts/fusion.hh"
+#include "base/logging.hh"
 #include "base/trace.hh"
 #include "config/the_isa.hh"
 #include "cpu/inst_seq.hh"
@@ -53,6 +58,7 @@
 #include "debug/Decode.hh"
 #include "debug/DecoupleBP.hh"
 #include "debug/O3PipeView.hh"
+#include "debug/UC.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/full_system.hh"
 
@@ -66,6 +72,117 @@ namespace gem5
 namespace o3
 {
 
+namespace
+{
+
+enum FusionPairSource
+{
+    FusionNormalNormal,
+    FusionUopUopSameEntry,
+    FusionUopUopDifferentEntry,
+    FusionNormalToUop,
+    FusionUopToNormal,
+    NumFusionPairSources
+};
+
+const char *fusionPairSourceNames[] = {
+    "normal_normal",
+    "uop_uop_same_entry",
+    "uop_uop_different_entry",
+    "normal_to_uop",
+    "uop_to_normal",
+};
+
+enum FusionRejectReason
+{
+    FusionRejectMixedSource,
+    FusionRejectDifferentUopEntry,
+    FusionRejectFaulted,
+    FusionRejectLoadFusionDisabled,
+    FusionRejectIgnoredPC,
+    FusionRejectFirstMapMiss,
+    FusionRejectSecondMapMiss,
+    FusionRejectCreatorRejected,
+    NumFusionRejectReasons
+};
+
+const char *fusionRejectReasonNames[] = {
+    "mixed_source",
+    "different_uop_entry",
+    "faulted",
+    "load_fusion_disabled",
+    "ignored_pc",
+    "first_map_miss",
+    "second_map_miss",
+    "creator_rejected",
+};
+
+enum FusionDiagnosticPair
+{
+    FusionDiagOther,
+    FusionDiagSll4Add,
+    FusionDiagAddwByte,
+};
+
+std::type_index
+normalizedFusionType(const StaticInstPtr &inst)
+{
+    const StaticInst *static_inst = inst.get();
+    auto type = std::type_index(typeid(*static_inst));
+    auto it = RiscvISA::deCompressMap.find(type);
+    return it == RiscvISA::deCompressMap.end() ? type : it->second;
+}
+
+bool
+makeFusionKey(const StaticInstPtr &inst, RiscvISA::FusionKey &key)
+{
+    const auto *riscv_inst =
+        dynamic_cast<const RiscvISA::RiscvStaticInst *>(inst.get());
+    if (!riscv_inst) {
+        return false;
+    }
+
+    key = RiscvISA::FusionKey(
+        normalizedFusionType(inst), riscv_inst->getImm());
+    return true;
+}
+
+FusionDiagnosticPair
+classifyDiagnosticFusionPair(const DynInstPtr &first,
+                             const DynInstPtr &second)
+{
+    auto mnemonic_is = [](const StaticInstPtr &inst,
+                          std::initializer_list<const char *> names) {
+        const char *mnemonic = inst->getMnemonic();
+        for (const char *name : names) {
+            if (std::strcmp(mnemonic, name) == 0) {
+                return true;
+            }
+        }
+        return false;
+    };
+    auto imm_is = [](const StaticInstPtr &inst, int imm) {
+        RiscvISA::FusionKey key;
+        return makeFusionKey(inst, key) && key.imm == imm;
+    };
+
+    if (mnemonic_is(first->staticInst, {"slli", "c_slli"}) &&
+        mnemonic_is(second->staticInst, {"add", "c_add"}) &&
+        imm_is(first->staticInst, 4)) {
+        return FusionDiagSll4Add;
+    }
+
+    if (mnemonic_is(first->staticInst, {"addw", "c_addw"}) &&
+        mnemonic_is(second->staticInst, {"andi", "c_andi"}) &&
+        imm_is(second->staticInst, 255)) {
+        return FusionDiagAddwByte;
+    }
+
+    return FusionDiagOther;
+}
+
+} // namespace
+
 Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
     : cpu(_cpu),
       renameToDecodeDelay(params.renameToDecodeDelay),
@@ -74,28 +191,33 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
       fetchToDecodeDelay(params.fetchToDecodeDelay),
       decodeToFetchDelay(params.decodeToFetchDelay),
       decodeWidth(params.decodeWidth),
+      uopCacheBypassQueueSize(params.uopCacheBypassQueueSize),
+      enableUopCache(params.hasUopCache),
       numThreads(params.numThreads),
       enableLoadFusion(params.enable_loadFusion),
-      stats(_cpu)
+      stats(_cpu, params.numThreads)
 {
     if (decodeWidth > MaxWidth)
         fatal("decodeWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              decodeWidth, static_cast<int>(MaxWidth));
+    fatal_if(uopCacheBypassQueueSize == 0,
+             "uopCacheBypassQueueSize must be greater than zero");
 
     // @todo: Make into a parameter
     for (int i=0;i<numThreads;i++) {
         fixedbuffer[i] = boost::circular_buffer<DynInstPtr>(decodeWidth);
     }
-    // This buffer preserves the fetch->decode pipeline contents when decode
-    // stalls while TimeBuffer keeps advancing. Its depth matches the original
-    // forward pipeline window; fetch is backpressured before full to absorb
-    // both the decode->fetch feedback delay and the request already issued in
-    // the current cycle before decode computes backpressure.
-    const auto stallGroupDepth = fetchToDecodeDelay + 1;
+    // Preserve the pre-uop-cache pipeline capacity exactly when disabled.
+    // Enabled mode may hold normal bundles while an older bypass sequence is
+    // selected, so it needs bounded headroom up to the configured Fetch queue;
+    // that extra capacity is never present in the baseline A/B path.
+    const auto normal_fetch_buffer_groups = enableUopCache ?
+        params.fetchQueueSize + fetchToDecodeDelay + 1 :
+        fetchToDecodeDelay + 1;
     stallBuffer = boost::circular_buffer<DynInstPtr>(
-        decodeWidth * stallGroupDepth);
-    eachstallSize = boost::circular_buffer<int>(stallGroupDepth);
+        decodeWidth * normal_fetch_buffer_groups);
+    eachstallSize = boost::circular_buffer<int>(normal_fetch_buffer_groups);
 
 
     decodeStalls.resize(decodeWidth, StallReason::NoStall);
@@ -119,13 +241,28 @@ Decode::startupStage()
 void
 Decode::clearStates(ThreadID tid)
 {
-
+    if (enableUopCache) {
+        // The legacy path owns no per-thread Decode state here.  Fast-path
+        // queues must be cleared explicitly because they bypass TimeBuffer.
+        fixedbuffer[tid].clear();
+        uopCacheBypassQueue[tid].clear();
+        lastDecodeCycleTail[tid] = nullptr;
+    }
 }
 
 void
 Decode::resetStage()
 {
     _status = Inactive;
+    if (enableUopCache) {
+        stallBuffer.clear();
+        eachstallSize.clear();
+        for (ThreadID tid = 0; tid < numThreads; ++tid) {
+            fixedbuffer[tid].clear();
+            uopCacheBypassQueue[tid].clear();
+            lastDecodeCycleTail[tid] = nullptr;
+        }
+    }
 }
 
 std::string
@@ -134,18 +271,18 @@ Decode::name() const
     return cpu->name() + ".decode";
 }
 
-Decode::DecodeStats::DecodeStats(CPU *cpu)
+Decode::DecodeStats::DecodeStats(CPU *cpu, unsigned num_threads)
     : statistics::Group(cpu, "decode"),
       ADD_STAT(idleCycles, statistics::units::Cycle::get(),
                "Number of cycles decode is idle"),
       ADD_STAT(smtidleCycles, statistics::units::Cycle::get(),
-             "Number of cycles fetch was idle per tid"),           
+               "Number of idle cycles per thread"),
       ADD_STAT(blockedCycles, statistics::units::Cycle::get(),
                "Number of cycles decode is blocked"),
       ADD_STAT(smtblockedCycles, statistics::units::Cycle::get(),
-             "Number of cycles fetch has spent blocked per tid"),  
+               "Number of blocked cycles per thread"),
       ADD_STAT(smtnotactiveCycles, statistics::units::Cycle::get(),
-             "Number of cycles fetch no active per tid"),                
+               "Number of inactive cycles per thread"),
       ADD_STAT(runCycles, statistics::units::Cycle::get(),
                "Number of cycles decode is running"),
       ADD_STAT(unblockCycles, statistics::units::Cycle::get(),
@@ -160,6 +297,24 @@ Decode::DecodeStats::DecodeStats(CPU *cpu)
                "Number of fused instructions handled by decode"),
       ADD_STAT(fusedInsts, statistics::units::Count::get(),
                "Number of times decode fused instructions by type"),
+      ADD_STAT(fusionPairsChecked, statistics::units::Count::get(),
+               "Number of adjacent instruction pairs checked for fusion"),
+      ADD_STAT(fusionPairSources, statistics::units::Count::get(),
+               "Source classes of adjacent instruction pairs checked for "
+               "fusion"),
+      ADD_STAT(fusionRejectReasons, statistics::units::Count::get(),
+               "Reasons adjacent instruction pairs did not fuse"),
+      ADD_STAT(fusionSourceBoundaryWouldFuse, statistics::units::Count::get(),
+               "Source-boundary rejects that would otherwise pass fusion"),
+      ADD_STAT(fusionCycleBoundaryPairsChecked, statistics::units::Count::get(),
+               "Pairs checked across adjacent decode cycles"),
+      ADD_STAT(fusionCycleBoundaryWouldFuse, statistics::units::Count::get(),
+               "Adjacent decode-cycle boundary pairs that would fuse if "
+               "decoded in the same cycle"),
+      ADD_STAT(fusionSll4AddRejectReasons, statistics::units::Count::get(),
+               "Reject reasons for opcode-level sll4add fusion candidates"),
+      ADD_STAT(fusionAddwByteRejectReasons, statistics::units::Count::get(),
+               "Reject reasons for opcode-level addwbyte fusion candidates"),
       ADD_STAT(controlMispred, statistics::units::Count::get(),
                "Number of times decode detected an instruction incorrectly "
                "predicted as a control"),
@@ -173,7 +328,10 @@ Decode::DecodeStats::DecodeStats(CPU *cpu)
                "Number of instructions that mispredicted due to npc")
 {
     idleCycles.prereq(idleCycles);
+    smtidleCycles.init(num_threads).flags(statistics::total);
     blockedCycles.prereq(blockedCycles);
+    smtblockedCycles.init(num_threads).flags(statistics::total);
+    smtnotactiveCycles.init(num_threads).flags(statistics::total);
     runCycles.prereq(runCycles);
     unblockCycles.prereq(unblockCycles);
     squashCycles.prereq(squashCycles);
@@ -185,16 +343,27 @@ Decode::DecodeStats::DecodeStats(CPU *cpu)
     mispredictedByPC.flags(statistics::total);
     mispredictedByNPC.flags(statistics::total);
     fusedInsts.init(128).flags(statistics::nozero);
-
-    smtidleCycles
-            .init(4)
-            .flags(statistics::total);
-    smtblockedCycles
-            .init(4)
-            .flags(statistics::total);    
-    smtnotactiveCycles
-            .init(4)
-            .flags(statistics::total);          
+    fusionPairSources.init(NumFusionPairSources).flags(statistics::nozero);
+    for (int i = 0; i < NumFusionPairSources; ++i) {
+        fusionPairSources.subname(i, fusionPairSourceNames[i]);
+    }
+    fusionRejectReasons.init(NumFusionRejectReasons)
+        .flags(statistics::nozero);
+    fusionSourceBoundaryWouldFuse.init(NumFusionRejectReasons)
+        .flags(statistics::nozero);
+    fusionSll4AddRejectReasons.init(NumFusionRejectReasons)
+        .flags(statistics::nozero);
+    fusionAddwByteRejectReasons.init(NumFusionRejectReasons)
+        .flags(statistics::nozero);
+    for (int i = 0; i < NumFusionRejectReasons; ++i) {
+        fusionRejectReasons.subname(i, fusionRejectReasonNames[i]);
+        fusionSourceBoundaryWouldFuse.subname(i, fusionRejectReasonNames[i]);
+        fusionSll4AddRejectReasons.subname(i, fusionRejectReasonNames[i]);
+        fusionAddwByteRejectReasons.subname(i, fusionRejectReasonNames[i]);
+    }
+    fusionPairsChecked.prereq(fusionPairsChecked);
+    fusionCycleBoundaryPairsChecked.prereq(fusionCycleBoundaryPairsChecked);
+    fusionCycleBoundaryWouldFuse.prereq(fusionCycleBoundaryWouldFuse);
 }
 
 void
@@ -240,6 +409,7 @@ Decode::drainSanityCheck() const
 {
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         assert(fixedbuffer[tid].empty());
+        assert(uopCacheBypassQueue[tid].empty());
     }
 }
 
@@ -247,10 +417,38 @@ bool
 Decode::isDrained() const
 {
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        if (!fixedbuffer[tid].empty())
+        if (!fixedbuffer[tid].empty() || !uopCacheBypassQueue[tid].empty())
             return false;
     }
     return true;
+}
+
+void
+Decode::enqueueUopCacheBypassInst(const DynInstPtr &inst)
+{
+    assert(enableUopCache);
+    ThreadID tid = inst->threadNumber;
+    assert(tid < numThreads);
+    assert(inst->isFetchFromUopCache());
+    assert(canEnqueueUopCacheBypassInst(tid));
+
+    uopCacheBypassQueue[tid].push_back(inst);
+    DPRINTF(UC, "[tid:%i] Enqueued uop-cache bypass inst [sn:%llu] pc=%#lx "
+            "queue=%d\n",
+            tid, inst->seqNum, inst->getPC(), uopCacheBypassQueue[tid].size());
+
+    if (_status == Inactive) {
+        _status = Active;
+        cpu->activateStage(CPU::DecodeIdx);
+    }
+    cpu->activityThisCycle();
+}
+
+bool
+Decode::canEnqueueUopCacheBypassInst(ThreadID tid) const
+{
+    assert(tid < numThreads);
+    return uopCacheBypassQueue[tid].size() < uopCacheBypassQueueSize;
 }
 
 bool
@@ -311,6 +509,8 @@ Decode::selfSquash(const DynInstPtr &inst, ThreadID tid)
     stallSig->blockFetch[tid] = true; // tell fetch don't send new insts
 
     fixedbuffer[tid].clear();
+    uopCacheBypassQueue[tid].clear();
+    lastDecodeCycleTail[tid] = nullptr;
 
     auto delIt = stallBuffer.begin();
     for (auto it0 = eachstallSize.begin(); it0 != eachstallSize.end();) {
@@ -337,6 +537,8 @@ Decode::squash(ThreadID tid)
     DPRINTF(Decode, "[tid:%i] Squashing.\n",tid);
 
     fixedbuffer[tid].clear();
+    uopCacheBypassQueue[tid].clear();
+    lastDecodeCycleTail[tid] = nullptr;
 
     auto delIt = stallBuffer.begin();
     for (auto it0 = eachstallSize.begin(); it0 != eachstallSize.end();) {
@@ -394,48 +596,148 @@ Decode::updateActivate()
     }
 }
 
+unsigned
+Decode::moveUopCacheBypassInstsToBuffer(ThreadID tid,
+                                        InstSeqNum stopBeforeSeq)
+{
+    auto &bypass_queue = uopCacheBypassQueue[tid];
+    if (bypass_queue.empty()) {
+        return 0;
+    }
+    if (bypass_queue.front()->seqNum >= stopBeforeSeq) {
+        return 0;
+    }
+    if (uopCacheBypassOrderBlocked(bypass_queue.front())) {
+        if (fetch_ptr) {
+            fetch_ptr->recordUopCacheBypassOrderBlockedEvent();
+        }
+        return 0;
+    }
+
+    int moved = 0;
+    unsigned bypassed = 0;
+    while (!bypass_queue.empty() &&
+           bypass_queue.front()->seqNum < stopBeforeSeq &&
+           !fixedbuffer[tid].full() && moved < decodeWidth) {
+        if (uopCacheBypassOrderBlocked(bypass_queue.front())) {
+            if (fetch_ptr) {
+                fetch_ptr->recordUopCacheBypassOrderBlockedEvent();
+            }
+            break;
+        }
+        auto inst = bypass_queue.front();
+        bypass_queue.pop_front();
+        if (inst->isSquashed()) {
+            cpu->markInstDecoded(tid, inst->seqNum);
+            continue;
+        }
+        if (localSquashVer[tid].largerThan(inst->getVersion())) {
+            inst->setSquashed();
+            cpu->markInstDecoded(tid, inst->seqNum);
+            continue;
+        } else {
+            bypassed++;
+        }
+        fixedbuffer[tid].push_back(inst);
+        moved++;
+    }
+
+    DPRINTF(UC, "[tid:%i] Moved %d uop-cache bypass insts to decode buffer, "
+            "remaining=%d\n",
+            tid, moved, bypass_queue.size());
+
+    if (bypassed && fetch_ptr) {
+        fetch_ptr->recordUopCacheBypassInsts(bypassed);
+    }
+
+    return bypassed;
+}
+
+bool
+Decode::uopCacheBypassOrderBlocked(const DynInstPtr &inst) const
+{
+    const ThreadID tid = inst->threadNumber;
+    assert(tid < numThreads);
+
+    if (!cpu->hasOlderNonBypassUndecodedInst(inst)) {
+        return false;
+    }
+
+    const auto &buffer = fixedbuffer[tid];
+    if (buffer.empty()) {
+        return true;
+    }
+
+    // Normal-path instructions moved into fixedbuffer in this same cycle are
+    // still globally "undecoded" until decodeInsts() consumes them.  If the
+    // bypass instruction is the next sequence after the buffer tail, all older
+    // instructions that can block it are already ahead of it in decode order.
+    return buffer.back()->seqNum + 1 != inst->seqNum;
+}
+
 void
 Decode::moveInstsToBuffer()
 {
-    auto tryMoveHeadGroupToFixedBuffer = [&]() -> bool {
-        if (stallBuffer.empty()) {
-            return false;
-        }
-
-        // stallbuffer moves to fixedbuffer in strict FIFO order.
-        ThreadID tid = stallBuffer.front()->threadNumber;
-        if (!fixedbuffer[tid].empty()) {
-            return false;
-        }
-
-        int insts_from_stall = eachstallSize.front();
-        eachstallSize.pop_front();
-        for (int i = 0; i < insts_from_stall; ++i) {
-            const DynInstPtr &inst = stallBuffer.front();
-            assert(tid == inst->threadNumber);
-            if (localSquashVer[tid].largerThan(inst->getVersion())) {
-                inst->setSquashed();
+    if (!enableUopCache) {
+        // This is the pre-uop-cache algorithm verbatim.  Keeping a dedicated
+        // disabled branch prevents bypass ordering and capacity choices from
+        // perturbing normal Fetch-to-Decode timing or SMT arbitration.
+        auto try_move_head_group = [&]() -> bool {
+            if (stallBuffer.empty()) {
+                return false;
             }
-            assert(!fixedbuffer[inst->threadNumber].full());
-            fixedbuffer[inst->threadNumber].push_back(inst);
-            stallBuffer.pop_front();
+            ThreadID tid = stallBuffer.front()->threadNumber;
+            if (!fixedbuffer[tid].empty()) {
+                return false;
+            }
+            int group_size = eachstallSize.front();
+            eachstallSize.pop_front();
+            for (int i = 0; i < group_size; ++i) {
+                const DynInstPtr &inst = stallBuffer.front();
+                assert(tid == inst->threadNumber);
+                if (localSquashVer[tid].largerThan(inst->getVersion())) {
+                    inst->setSquashed();
+                }
+                assert(!fixedbuffer[tid].full());
+                fixedbuffer[tid].push_back(inst);
+                stallBuffer.pop_front();
+            }
+            return true;
+        };
+
+        const bool moved_group = try_move_head_group();
+        const int insts_from_fetch = fromFetch->size;
+        if (insts_from_fetch != 0) {
+            panic_if(eachstallSize.full(),
+                     "Decode stallbuffer overflow, has %d stalls\n",
+                     eachstallSize.size() + 1);
+            eachstallSize.push_back(insts_from_fetch);
+            for (int i = 0; i < insts_from_fetch; ++i) {
+                stallBuffer.push_back(fromFetch->insts[i]);
+            }
         }
+        DPRINTF(Decode, "Decode stall buffer has %d stalls\n",
+                eachstallSize.size());
+        if (!stallBuffer.empty() && !moved_group) {
+            try_move_head_group();
+        }
+        return;
+    }
 
-        return true;
-    };
-
-    // Model one stage advance before latching the next cycle's input so a
-    // full stall buffer can still accept a new fetch bundle when its head
-    // group moves forward in the same cycle.
-    const bool moved_group = tryMoveHeadGroupToFixedBuffer();
-
+    // Enabled mode merges normal and bypass traffic by sequence number.  A
+    // fixedbuffer is filled from only one thread per cycle, preserving the
+    // existing per-cycle Decode ownership rule even though queues are per-TID.
     // do not support mixed thread instructions in one fetch group
     int insts_from_fetch = fromFetch->size;
     if (insts_from_fetch != 0) {
         ThreadID tid = fromFetch->insts[0]->threadNumber;
 
         // move to stallbuffer
-        panic_if(eachstallSize.full(), "Decode stallbuffer overflow, has %d stalls\n", eachstallSize.size() + 1);
+        panic_if(eachstallSize.full() ||
+                 stallBuffer.size() + insts_from_fetch > stallBuffer.capacity(),
+                 "Decode stallbuffer overflow, has %d stalls and %d insts\n",
+                 eachstallSize.size() + 1,
+                 stallBuffer.size() + insts_from_fetch);
         eachstallSize.push_back(insts_from_fetch);
         for (int i = 0; i < insts_from_fetch; i++) {
             stallBuffer.push_back(fromFetch->insts[i]);
@@ -445,14 +747,114 @@ Decode::moveInstsToBuffer()
     DPRINTF(Decode, "Decode stall buffer has %d stalls\n",
             eachstallSize.size());
 
-    if (stallBuffer.empty()) {
-        return;
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        if (!fixedbuffer[tid].empty()) {
+            return;
+        }
     }
 
-    // If nothing advanced before latching new input, allow the current head
-    // (possibly the just-arrived group) to fill an empty stage this cycle.
-    if (!moved_group) {
-        tryMoveHeadGroupToFixedBuffer();
+    ThreadID fill_tid = InvalidThreadID;
+    unsigned moved_total = 0;
+
+    auto get_oldest_bypass = [&]() {
+        ThreadID bypass_tid = InvalidThreadID;
+        InstSeqNum bypass_seq = std::numeric_limits<InstSeqNum>::max();
+        for (ThreadID tid = 0; tid < numThreads; ++tid) {
+            if (!uopCacheBypassQueue[tid].empty() &&
+                (fill_tid == InvalidThreadID || tid == fill_tid) &&
+                uopCacheBypassQueue[tid].front()->seqNum < bypass_seq) {
+                bypass_tid = tid;
+                bypass_seq = uopCacheBypassQueue[tid].front()->seqNum;
+            }
+        }
+        return std::make_pair(bypass_tid, bypass_seq);
+    };
+
+    auto move_normal_insts = [&](InstSeqNum stop_before_seq) {
+        if (stallBuffer.empty()) {
+            return 0U;
+        }
+
+        ThreadID tid = stallBuffer.front()->threadNumber;
+        if (fill_tid != InvalidThreadID && fill_tid != tid) {
+            return 0U;
+        }
+
+        int group_remaining = eachstallSize.front();
+        unsigned moved = 0;
+        while (group_remaining > 0 &&
+               moved_total < decodeWidth &&
+               !fixedbuffer[tid].full() &&
+               !stallBuffer.empty() &&
+               stallBuffer.front()->seqNum < stop_before_seq) {
+            const DynInstPtr &inst = stallBuffer.front();
+            assert(tid == inst->threadNumber);
+            if (localSquashVer[tid].largerThan(inst->getVersion())) {
+                inst->setSquashed();
+            }
+
+            assert(!fixedbuffer[inst->threadNumber].full());
+            fixedbuffer[inst->threadNumber].push_back(inst);
+            stallBuffer.pop_front();
+            group_remaining--;
+            moved++;
+            moved_total++;
+            fill_tid = tid;
+        }
+
+        if (moved == 0) {
+            return 0U;
+        }
+        if (group_remaining == 0) {
+            eachstallSize.pop_front();
+        } else {
+            eachstallSize.front() = group_remaining;
+        }
+
+        return moved;
+    };
+
+    while (moved_total < decodeWidth) {
+        auto [bypass_tid, bypass_seq] = get_oldest_bypass();
+        const bool has_bypass = bypass_tid != InvalidThreadID;
+        const bool has_normal =
+            !stallBuffer.empty() &&
+            (fill_tid == InvalidThreadID ||
+             stallBuffer.front()->threadNumber == fill_tid);
+
+        if (!has_bypass && !has_normal) {
+            break;
+        }
+
+        if (has_bypass &&
+            (!has_normal || bypass_seq < stallBuffer.front()->seqNum)) {
+            const unsigned before_queue =
+                uopCacheBypassQueue[bypass_tid].size();
+            const unsigned before_buffer = fixedbuffer[bypass_tid].size();
+            const unsigned bypassed =
+                moveUopCacheBypassInstsToBuffer(
+                    bypass_tid,
+                    has_normal ? stallBuffer.front()->seqNum :
+                                 std::numeric_limits<InstSeqNum>::max());
+            const unsigned after_queue =
+                uopCacheBypassQueue[bypass_tid].size();
+            const unsigned after_buffer = fixedbuffer[bypass_tid].size();
+            if (after_buffer > before_buffer) {
+                moved_total += after_buffer - before_buffer;
+                fill_tid = bypass_tid;
+            }
+            if (!bypassed && after_queue == before_queue &&
+                after_buffer == before_buffer) {
+                break;
+            }
+            continue;
+        }
+
+        const unsigned moved = move_normal_insts(
+            has_bypass ? bypass_seq : std::numeric_limits<InstSeqNum>::max());
+        if (!moved) {
+            break;
+        }
     }
 }
 
@@ -468,6 +870,11 @@ Decode::checkSquash()
                 fromCommit->commitInfo[i].squashVersion.getVersion());
             DPRINTF(Decode, "Updating squash version to %u\n",
                     localSquashVer[i].getVersion());
+            if (enableUopCache) {
+                auto *uop_cache = fetch_ptr ? fetch_ptr->getUopCache() : nullptr;
+                assert(uop_cache);
+                uop_cache->flushCurUopEntry();
+            }
         }
     }
 }
@@ -475,6 +882,12 @@ Decode::checkSquash()
 void
 Decode::tick()
 {
+    if (enableUopCache) {
+        auto *uop_cache = fetch_ptr ? fetch_ptr->getUopCache() : nullptr;
+        assert(uop_cache);
+        uop_cache->tick();
+    }
+
     toRename->fetchStallReason = fromFetch->fetchStallReason;
     wroteToTimeBuffer = false;
     toRenameIndex = 0;
@@ -485,56 +898,57 @@ Decode::tick()
 
     checkSquash();
 
-    // check threads stall & status
+    // Preserve the established SMT arbiter for both modes.  Uop-cache bypass
+    // only changes how a selected thread obtains instructions; it must not
+    // replace fairness and borrow-priority policy at the stage boundary.
     ThreadID blocked_tid = InvalidThreadID;
     SmtActiveThreadArbiter active_arbiter;
-    auto freezeActiveThread = [this](ThreadID tid) {
+    auto freeze_active_thread = [this](ThreadID tid) {
         stallSig->blockFetch[tid] = true;
         stallSig->fetchBlockReason[tid] = StallReason::OtherFragStall;
         toFetch->decodeInfo[tid].blockReason =
             stallSig->fetchBlockReason[tid];
     };
-    const auto fetchFeedbackReserve =
+    const auto fetch_feedback_reserve =
         numThreads > 1 ? fetchToDecodeDelay : decodeToFetchDelay + 1;
-    const bool fifoBackpressured =
+    const bool fifo_backpressured =
         !stallBuffer.empty() &&
-        eachstallSize.size() + fetchFeedbackReserve >=
+        eachstallSize.size() + fetch_feedback_reserve >=
             eachstallSize.capacity();
-    const ThreadID fifoHeadTid =
-        !stallBuffer.empty() ? stallBuffer.front()->threadNumber : InvalidThreadID;
-    const StallReason fifoBlockReason =
-        (fifoBackpressured && fifoHeadTid != InvalidThreadID &&
-         stallSig->blockDecode[fifoHeadTid]) ?
-            stallSig->decodeBlockReason[fifoHeadTid] :
-            (fifoBackpressured ? StallReason::OtherFragStall :
+    const ThreadID fifo_head_tid =
+        !stallBuffer.empty() ? stallBuffer.front()->threadNumber :
+                               InvalidThreadID;
+    const StallReason fifo_block_reason =
+        (fifo_backpressured && fifo_head_tid != InvalidThreadID &&
+         stallSig->blockDecode[fifo_head_tid]) ?
+            stallSig->decodeBlockReason[fifo_head_tid] :
+            (fifo_backpressured ? StallReason::OtherFragStall :
                                  StallReason::NoStall);
     for (int i = 0; i < numThreads; i++) {
         bool block = stallSig->blockDecode[i];
         bool active = !block && !fixedbuffer[i].empty();
 
-        if(block){
+        if (block) {
             ++stats.smtblockedCycles[i];
         }
-
-        if(!active)
-        {
+        if (!active) {
             ++stats.smtnotactiveCycles[i];
         }
 
-        stallSig->blockFetch[i] = block || fifoBackpressured;
+        stallSig->blockFetch[i] = block || fifo_backpressured;
         stallSig->fetchBlockReason[i] =
             stallSig->blockFetch[i] ?
-                (block ? stallSig->decodeBlockReason[i] : fifoBlockReason) :
+                (block ? stallSig->decodeBlockReason[i] : fifo_block_reason) :
                 StallReason::NoStall;
         toFetch->decodeInfo[i].blockReason = stallSig->fetchBlockReason[i];
         if (active) {
             const auto freeze = active_arbiter.observe(
                 i, smtBorrowPriority(fromIEW->iewInfo[i]));
             if (freeze.previousActive != InvalidThreadID) {
-                freezeActiveThread(freeze.previousActive);
+                freeze_active_thread(freeze.previousActive);
             }
             if (freeze.freezeCurrent) {
-                freezeActiveThread(i);
+                freeze_active_thread(i);
             }
         } else if (block && blocked_tid == InvalidThreadID) {
             blocked_tid = i;
@@ -630,6 +1044,11 @@ Decode::decodeInsts(ThreadID tid)
     }
 
     auto& insts_to_decode = fixedbuffer[tid];
+    auto *uop_cache = enableUopCache && fetch_ptr ?
+        fetch_ptr->getUopCache() : nullptr;
+    if (cpu->isTraceMode()) {
+        uop_cache = nullptr;
+    }
 
     DPRINTF(Decode, "[tid:%i] Sending instruction to rename.\n",tid);
 
@@ -659,6 +1078,9 @@ Decode::decodeInsts(ThreadID tid)
                     "squashed, skipping.\n",
                     tid, inst->seqNum, inst->pcState());
 
+            if (enableUopCache) {
+                cpu->markInstDecoded(tid, inst->seqNum);
+            }
             ++stats.squashedInsts;
 
             --insts_available;
@@ -668,12 +1090,42 @@ Decode::decodeInsts(ThreadID tid)
             continue;
         }
 
+        if (enableUopCache) {
+            // Fetch's bypass-order trackers cover both sources while the
+            // feature is enabled; the legacy path does not need this state.
+            inst->setDecoded();
+            cpu->markInstDecoded(tid, inst->seqNum);
+        }
+
         // Also check if instructions have no source registers.  Mark
         // them as ready to issue at any time.  Not sure if this check
         // should exist here or at a later stage; however it doesn't matter
         // too much for function correctness.
         if (inst->numSrcRegs() == 0) {
             inst->setCanIssue();
+        }
+
+        if (uop_cache) {
+            if (inst->isFetchFromUopCache() && uop_cache->isBuildMode()) {
+                uop_cache->switchToStreamMode();
+            } else if (!inst->isFetchFromUopCache() &&
+                       uop_cache->isStreamMode()) {
+                uop_cache->switchToBuildMode();
+            }
+        }
+
+        DynInstPtr uop_cache_refill_inst = inst;
+
+        if (fusionInst.empty()) {
+            auto &prev_tail = lastDecodeCycleTail[tid];
+            if (prev_tail && !prev_tail->isSquashed() &&
+                prev_tail->seqNum + 1 == inst->seqNum) {
+                stats.fusionCycleBoundaryPairsChecked++;
+                if (wouldFuseInstPair(prev_tail, inst, true)) {
+                    stats.fusionCycleBoundaryWouldFuse++;
+                }
+            }
+            prev_tail = nullptr;
         }
 
         // This current instruction is valid, so add it into the decode
@@ -699,6 +1151,10 @@ Decode::decodeInsts(ThreadID tid)
             inst->setSerializeAfter();
             decode_stalls.push(StallReason::SerializeStall);
             breakDecode = StallReason::SerializeStall;
+            if (uop_cache) {
+                uop_cache->addInst(uop_cache_refill_inst);
+                uop_cache->setCurrentUopEntryDone();
+            }
             DPRINTF(Decode,
                     "[tid:%i] [sn:%llu] Vector config decoded, set serialize barrier and stop decoding younger "
                     "instructions.\n",
@@ -719,6 +1175,10 @@ Decode::decodeInsts(ThreadID tid)
 
             decode_stalls.push(StallReason::InstMisPred);
             breakDecode = StallReason::InstMisPred;
+            if (uop_cache) {
+                DPRINTF(UC, "Predicted-taken non-control inst, flush UC refill\n");
+                uop_cache->flushCurUopEntry();
+            }
 
             break;
         }
@@ -782,6 +1242,10 @@ Decode::decodeInsts(ThreadID tid)
 
                 decode_stalls.push(StallReason::InstMisPred);
                 breakDecode = StallReason::InstMisPred;
+                if (uop_cache) {
+                    DPRINTF(UC, "Direct branch target mismatch, flush UC refill\n");
+                    uop_cache->flushCurUopEntry();
+                }
 
                 DPRINTF(Decode,
                         "[tid:%i] [sn:%llu] Updating predictions:"
@@ -808,6 +1272,10 @@ Decode::decodeInsts(ThreadID tid)
             inst->setPredTarg(*target);
             // must squash after setting inst real target because it cannot be computed from static inst
             selfSquash(inst, inst->threadNumber);
+            if (uop_cache) {
+                DPRINTF(UC, "Unpredicted return, flush UC refill\n");
+                uop_cache->flushCurUopEntry();
+            }
             break;
         }
         if (inst->isNonSpeculative() && inst->readPredTaken()) {
@@ -817,9 +1285,21 @@ Decode::decodeInsts(ThreadID tid)
             inst->setPredTaken(false);
             inst->setPredTarg(*npc);
         }
+        if (uop_cache) {
+            uop_cache->addInst(uop_cache_refill_inst);
+            if (uop_cache_refill_inst->isQuiesce()) {
+                uop_cache->flushCurUopEntry();
+            }
+            if (uop_cache_refill_inst->readPredTaken()) {
+                uop_cache->setCurrentUopEntryDone();
+            }
+        }
     }
     for (auto &fused_inst : fusionInst) {
         toRename->insts[toRename->size++] = fused_inst;
+    }
+    if (!fusionInst.empty()) {
+        lastDecodeCycleTail[tid] = fusionInst.back();
     }
 
     if (insts_available) {
@@ -851,16 +1331,111 @@ Decode::decodeInsts(ThreadID tid)
     }
 }
 
+bool
+Decode::wouldFuseInstPair(const DynInstPtr &first_inst,
+                          const DynInstPtr &second_inst,
+                          bool enforceSourceBoundary) const
+{
+    const bool first_from_uop_cache = first_inst->isFetchFromUopCache();
+    const bool second_from_uop_cache = second_inst->isFetchFromUopCache();
+
+    if (enforceSourceBoundary) {
+        if (first_from_uop_cache != second_from_uop_cache) {
+            return false;
+        }
+    }
+
+    if (first_inst->faulted() || second_inst->faulted()) {
+        return false;
+    }
+    if (!enableLoadFusion && (first_inst->isLoad() || second_inst->isLoad())) {
+        return false;
+    }
+    if (first_inst->getPC() >= ignoreFusionPC &&
+        first_inst->getPC() < ignoreFusionPC + 8 &&
+        cpu->ticksToCycles(curTick() - lastSetIgnoreTick) <=
+            keepIgnoreFusionCycles) {
+        return false;
+    }
+
+    RiscvISA::FusionKey first_key;
+    if (!makeFusionKey(first_inst->staticInst, first_key)) {
+        return false;
+    }
+
+    auto finder = RiscvISA::fusionMap.find(first_key);
+    if (finder == RiscvISA::fusionMap.end()) {
+        return false;
+    }
+
+    assert(finder->second.index() == 1);
+    auto map = std::get<1>(finder->second);
+    RiscvISA::FusionKey second_key;
+    if (!makeFusionKey(second_inst->staticInst, second_key)) {
+        return false;
+    }
+    finder = map->find(second_key);
+    if (finder == map->end()) {
+        return false;
+    }
+
+    assert(finder->second.index() == 0);
+    auto creator = std::get<0>(finder->second);
+    const std::vector<DynInstPtr> inst_pair = {first_inst, second_inst};
+    return static_cast<bool>(creator(inst_pair));
+}
+
 void
 Decode::checkAndFuseInsts(std::vector<DynInstPtr> &vec, DynInstPtr& cur)
 {
     if (vec.empty()) {
         return;
     }
+    const bool first_from_uop_cache = vec.back()->isFetchFromUopCache();
+    const bool second_from_uop_cache = cur->isFetchFromUopCache();
+    const FusionDiagnosticPair diag_pair =
+        classifyDiagnosticFusionPair(vec.back(), cur);
+    auto record_reject = [&](FusionRejectReason reason) {
+        stats.fusionRejectReasons[reason]++;
+        if (diag_pair == FusionDiagSll4Add) {
+            stats.fusionSll4AddRejectReasons[reason]++;
+        } else if (diag_pair == FusionDiagAddwByte) {
+            stats.fusionAddwByteRejectReasons[reason]++;
+        }
+    };
+    auto would_fuse_without_source_boundary = [&]() {
+        return wouldFuseInstPair(vec.back(), cur, false);
+    };
+
+    stats.fusionPairsChecked++;
+    if (first_from_uop_cache && second_from_uop_cache) {
+        if (vec.back()->getUopCacheFetchAddr() ==
+            cur->getUopCacheFetchAddr()) {
+            stats.fusionPairSources[FusionUopUopSameEntry]++;
+        } else {
+            stats.fusionPairSources[FusionUopUopDifferentEntry]++;
+        }
+    } else if (first_from_uop_cache) {
+        stats.fusionPairSources[FusionUopToNormal]++;
+    } else if (second_from_uop_cache) {
+        stats.fusionPairSources[FusionNormalToUop]++;
+    } else {
+        stats.fusionPairSources[FusionNormalNormal]++;
+    }
+
+    if (first_from_uop_cache != second_from_uop_cache) {
+        if (would_fuse_without_source_boundary()) {
+            stats.fusionSourceBoundaryWouldFuse[FusionRejectMixedSource]++;
+        }
+        record_reject(FusionRejectMixedSource);
+        return;
+    }
     if (vec.back()->faulted() || cur->faulted()) {
+        record_reject(FusionRejectFaulted);
         return;
     }
     if (!enableLoadFusion && (vec.back()->isLoad() || cur->isLoad())) {
+        record_reject(FusionRejectLoadFusionDisabled);
         return;
     }
     if (vec.back()->getPC() >= ignoreFusionPC && vec.back()->getPC() < ignoreFusionPC + 8) {
@@ -868,42 +1443,48 @@ Decode::checkAndFuseInsts(std::vector<DynInstPtr> &vec, DynInstPtr& cur)
         if (cpu->ticksToCycles(curTick() - lastSetIgnoreTick) > keepIgnoreFusionCycles) {
             ignoreFusionPC = 0;
         }
+        record_reject(FusionRejectIgnoredPC);
         return;
     }
 
     // first search
-    auto first = (StaticInst*)vec.back()->staticInst.get();
-    std::type_index first_type = typeid(0);
-    auto it = RiscvISA::deCompressMap.find(typeid(*first));
-    if (it != RiscvISA::deCompressMap.end()) {
-        first_type = it->second;
-    } else {
-        first_type = typeid(*first);
+    RiscvISA::FusionKey first_key;
+    if (!makeFusionKey(vec.back()->staticInst, first_key)) {
+        record_reject(FusionRejectFirstMapMiss);
+        return; // no fusion
     }
-    auto finder = RiscvISA::fusionMap.find(RiscvISA::FusionKey(first_type, first->getImm()));
-    if (finder == RiscvISA::fusionMap.end()) return ; // no fusion
+
+    auto finder = RiscvISA::fusionMap.find(first_key);
+    if (finder == RiscvISA::fusionMap.end()) {
+        record_reject(FusionRejectFirstMapMiss);
+        return; // no fusion
+    }
 
     // second search
     assert(finder->second.index() == 1);
 
-    auto second = cur->staticInst.get();
-    std::type_index typeid_second = typeid(0);
-    auto it_second = RiscvISA::deCompressMap.find(typeid(*second));
-    if (it_second != RiscvISA::deCompressMap.end()) {
-        typeid_second = it_second->second;
-    } else {
-        typeid_second = typeid(*second);
-    }
     auto map = std::get<1>(finder->second);
-    finder = map->find(RiscvISA::FusionKey(typeid_second, second->getImm()));
-    if (finder == map->end()) return; // no fusion
+    RiscvISA::FusionKey second_key;
+    if (!makeFusionKey(cur->staticInst, second_key)) {
+        record_reject(FusionRejectSecondMapMiss);
+        return; // no fusion
+    }
+
+    finder = map->find(second_key);
+    if (finder == map->end()) {
+        record_reject(FusionRejectSecondMapMiss);
+        return; // no fusion
+    }
 
     assert(finder->second.index() == 0);
     auto creator = std::get<0>(finder->second);
 
     const std::vector<DynInstPtr> inst_pair = {vec.back(), cur};
     auto fused_inst = creator(inst_pair);
-    if (!fused_inst) return;
+    if (!fused_inst) {
+        record_reject(FusionRejectCreatorRejected);
+        return;
+    }
     vec.pop_back();
 
     DynInst::Arrays arrays;
@@ -923,13 +1504,25 @@ Decode::checkAndFuseInsts(std::vector<DynInstPtr> &vec, DynInstPtr& cur)
 
 
     instruction->setVersion(inst_pair[1]->getVersion());
+    instruction->setDecoded();
     instruction->setTid(inst_pair[1]->threadNumber);
     instruction->thread = inst_pair[1]->thread;
     instruction->setFtqId(inst_pair[1]->ftqId);
+    if (first_from_uop_cache) {
+        instruction->setFetchFromUopCache(true);
+        instruction->setUopCacheBypass(
+            inst_pair[0]->isUopCacheBypass() &&
+            inst_pair[1]->isUopCacheBypass());
+        instruction->setUopCacheFetchAddr(inst_pair[0]->getUopCacheFetchAddr());
+    }
 
-    instruction->instListIt = cpu->instList.insert(inst_pair[0]->instListIt, instruction);
-    cpu->instList.erase(inst_pair[0]->instListIt);
-    cpu->instList.erase(inst_pair[1]->instListIt);
+    auto first_it = inst_pair[0]->getInstListIt();
+    auto second_it = inst_pair[1]->getInstListIt();
+    instruction->setInstListIt(cpu->instList.insert(first_it, instruction));
+    inst_pair[0]->clearInstListIt();
+    inst_pair[1]->clearInstListIt();
+    cpu->instList.erase(first_it);
+    cpu->instList.erase(second_it);
 
     dynamic_cast<RiscvISA::FusionInst*>(fused_inst.get())->setFusedInst(instruction);
 

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -41,6 +41,10 @@
 #ifndef __CPU_O3_DECODE_HH__
 #define __CPU_O3_DECODE_HH__
 
+#include <deque>
+#include <limits>
+#include <string>
+
 #include <boost/circular_buffer.hpp>
 
 #include "base/statistics.hh"
@@ -137,11 +141,23 @@ class Decode
      */
     void decodeInsts(ThreadID tid);
 
+    /**
+     * Enqueue one cache-sourced DynInst into its thread's finite fast-path
+     * queue.  Fetch allocates the sequence number before this call; Decode
+     * later merges it with normal traffic without violating that order.
+     */
+    void enqueueUopCacheBypassInst(const DynInstPtr &inst);
+    /** Return whether the addressed thread has one bypass queue slot free. */
+    bool canEnqueueUopCacheBypassInst(ThreadID tid) const;
+
     void setIgnoreNextFusion(Addr pc) { ignoreFusionPC = pc; lastSetIgnoreTick = curTick(); }
 
   private:
 
     void checkAndFuseInsts(std::vector<DynInstPtr> &vec, DynInstPtr& cur);
+    bool wouldFuseInstPair(const DynInstPtr &first,
+                           const DynInstPtr &second,
+                           bool enforceSourceBoundary) const;
 
     /** Updates overall decode status based on all of the threads' statuses. */
     void updateActivate();
@@ -150,6 +166,18 @@ class Decode
      * sorted by thread.
      */
     void moveInstsToBuffer();
+
+    /**
+     * Move cache-sourced instructions into the per-thread Decode buffer up to
+     * a normal-path sequence boundary.  Squashed/version-stale entries are
+     * consumed but never forwarded.
+     */
+    unsigned moveUopCacheBypassInstsToBuffer(
+        ThreadID tid,
+        InstSeqNum stopBeforeSeq = std::numeric_limits<InstSeqNum>::max());
+
+    /** True when an older ordinary Fetch instruction must decode first. */
+    bool uopCacheBypassOrderBlocked(const DynInstPtr &inst) const;
 
     void checkSquash();
 
@@ -216,8 +244,14 @@ class Decode
     /** Queue of all instructions coming from fetch this cycle. */
     boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
 
+    /** FIFO preserving ordinary FetchStruct bundles while Decode stalls. */
     boost::circular_buffer<DynInstPtr> stallBuffer;
+    /** Bundle sizes aligned one-for-one with groups stored in stallBuffer. */
     boost::circular_buffer<int> eachstallSize;
+    /** Per-thread fast-path queues; cross-source ordering uses seqNum. */
+    std::deque<DynInstPtr> uopCacheBypassQueue[MaxThreads];
+    /** Previous cycle tail used only for fusion-boundary diagnostics. */
+    DynInstPtr lastDecodeCycleTail[MaxThreads];
 
     /** Variable that tracks if decode has written to the time buffer this
      * cycle. Used to tell CPU if there is activity this cycle.
@@ -242,6 +276,14 @@ class Decode
     /** The width of decode, in instructions. */
     unsigned decodeWidth;
 
+    /**
+     * Per-thread bypass capacity.  It models finite fast-path buffering and
+     * never changes the capacity of the ordinary Fetch-to-Decode pipeline.
+     */
+    unsigned uopCacheBypassQueueSize;
+    /** Construction-time gate used to keep the disabled path unchanged. */
+    bool enableUopCache;
+
     /** Index of instructions being sent to rename. */
     unsigned toRenameIndex;
 
@@ -255,7 +297,7 @@ class Decode
 
     struct DecodeStats : public statistics::Group
     {
-        DecodeStats(CPU *cpu);
+        DecodeStats(CPU *cpu, unsigned num_threads);
 
         /** Stat for total number of idle cycles. */
         statistics::Scalar idleCycles;
@@ -278,6 +320,14 @@ class Decode
 
         statistics::Scalar numFusedInsts;
         statistics::Vector fusedInsts;
+        statistics::Scalar fusionPairsChecked;
+        statistics::Vector fusionPairSources;
+        statistics::Vector fusionRejectReasons;
+        statistics::Vector fusionSourceBoundaryWouldFuse;
+        statistics::Scalar fusionCycleBoundaryPairsChecked;
+        statistics::Scalar fusionCycleBoundaryWouldFuse;
+        statistics::Vector fusionSll4AddRejectReasons;
+        statistics::Vector fusionAddwByteRejectReasons;
         /** Stat for number of times decode detected a non-control instruction
          * incorrectly predicted as a branch.
          */

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -202,6 +202,9 @@ class DynInst : public ExecContext, public RefCounted
 
         // load/store pipe state end
 
+        // Bypass instructions enter Decode outside the normal time buffer, so
+        // explicit decode completion is needed for cross-path age ordering.
+        Decoded,                 /// Instruction has reached decode
         Executed,                /// Instruction has executed
         CanCommit,               /// Instruction can commit
         AtCommit,                /// Instruction has reached commit
@@ -426,6 +429,14 @@ class DynInst : public ExecContext, public RefCounted
     /** Iterator pointing to this BaseDynInst in the list of all insts. */
     ListIt instListIt;
 
+    /**
+     * Whether instListIt still refers to this instruction in CPU::instList.
+     * Bypass fusion and deferred cleanup can unlink instructions through
+     * different paths; tracking ownership prevents a second erase through a
+     * stale iterator.
+     */
+    bool linkedInInstList = false;
+
     ////////////////////// Branch Data ///////////////
     /** Predicted PC state after this instruction. */
     std::unique_ptr<PCStateBase> predPC;
@@ -437,6 +448,15 @@ class DynInst : public ExecContext, public RefCounted
     unsigned ftqId;
     /** The number of loop iteration within an fsq entry of the instruction. */
     unsigned loopIteration;
+
+    /** True when the static instruction was supplied by the uop cache. */
+    bool fetchFromUopCache = false;
+
+    /** True when this instruction used the direct Fetch-to-Decode path. */
+    bool uopCacheBypass = false;
+
+    /** Virtual fetch address used to validate the cached instruction stream. */
+    Addr uopCacheFetchAddr = 0;
 
     /** The Macroop if one exists */
     const StaticInstPtr macroop;
@@ -1052,6 +1072,12 @@ class DynInst : public ExecContext, public RefCounted
 
     /** Scheduler state end */
 
+    /** Mark this instruction as no longer pending at the Decode boundary. */
+    void setDecoded() { status.set(Decoded); }
+
+    /** Return whether this instruction has crossed the Decode boundary. */
+    bool isDecoded() const { return status[Decoded]; }
+
 
     /** load/store pipe state begin */
 
@@ -1401,7 +1427,18 @@ class DynInst : public ExecContext, public RefCounted
     ListIt &getInstListIt() { return instListIt; }
 
     /** Sets iterator for this instruction in the list of all insts. */
-    void setInstListIt(ListIt _instListIt) { instListIt = _instListIt; }
+    void
+    setInstListIt(ListIt _instListIt)
+    {
+        instListIt = _instListIt;
+        linkedInInstList = true;
+    }
+
+    /** Return whether getInstListIt() is currently safe to erase. */
+    bool isInInstList() const { return linkedInInstList; }
+
+    /** Invalidate the saved instruction-list iterator after unlinking. */
+    void clearInstListIt() { linkedInInstList = false; }
 
   public:
 
@@ -1714,6 +1751,24 @@ class DynInst : public ExecContext, public RefCounted
         RiscvISA::PCState rpc = pc->as<RiscvISA::PCState>();
         return rpc.compressed() ? 2 : 4;
     }
+
+    /** Return whether Fetch obtained the decoded form from the uop cache. */
+    bool isFetchFromUopCache() const { return fetchFromUopCache; }
+
+    /** Record the origin of the decoded static instruction. */
+    void setFetchFromUopCache(bool is) { fetchFromUopCache = is; }
+
+    /** Return whether the instruction bypassed the normal Fetch queue. */
+    bool isUopCacheBypass() const { return uopCacheBypass; }
+
+    /** Record whether Decode receives this instruction via its bypass queue. */
+    void setUopCacheBypass(bool is) { uopCacheBypass = is; }
+
+    /** Save the virtual address associated with the uop-cache lookup. */
+    void setUopCacheFetchAddr(Addr pc) { uopCacheFetchAddr = pc; }
+
+    /** Return the virtual address associated with the uop-cache lookup. */
+    Addr getUopCacheFetchAddr() const { return uopCacheFetchAddr; }
 
   protected:
     SquashVersion squashVer;

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -71,6 +71,7 @@
 #include "debug/O3CPU.hh"
 #include "debug/O3PipeView.hh"
 #include "debug/TraceReader.hh"
+#include "debug/UC.hh"
 #include "mem/packet.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/full_system.hh"
@@ -93,6 +94,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       branchPred(nullptr),
       dbpbtb(nullptr),
       resolveQueueSize(params.resolveQueueSize),
+      uopCache(std::make_unique<UopCache>(_cpu, params)),
       decodeToFetchDelay(params.decodeToFetchDelay),
       renameToFetchDelay(params.renameToFetchDelay),
       iewToFetchDelay(params.iewToFetchDelay),
@@ -117,6 +119,15 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         fatal("fetchWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              fetchWidth, static_cast<int>(MaxWidth));
+
+    // The bypass queue is currently a single-thread resource in Decode.  Do
+    // not silently run an unsafe configuration: ordinary SMT remains fully
+    // supported when the cache is disabled, while decoded-cache SMT can be
+    // enabled later only after its arbitration and squash ordering are made
+    // explicitly per-thread.
+    fatal_if(uopCache->enabled() && numThreads > 1,
+             "The uop cache bypass path does not yet support SMT; disable "
+             "the uop cache when numThreads=%u\n", numThreads);
 
     smtBorrowThrottleHoldCycles = params.smtBorrowThrottleCycles;
     // IEW reports an early redirect before the formal Commit squash reaches
@@ -238,11 +249,11 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
     ADD_STAT(idleCycles, statistics::units::Cycle::get(),
              "Number of cycles fetch was idle"),
     ADD_STAT(smtidleCycles, statistics::units::Cycle::get(),
-             "Number of cycles fetch was idle per tid"),         
+             "Number of cycles fetch was idle per tid"),
     ADD_STAT(blockedCycles, statistics::units::Cycle::get(),
              "Number of cycles fetch has spent blocked"),
     ADD_STAT(smtblockedCycles, statistics::units::Cycle::get(),
-             "Number of cycles fetch has spent blocked per tid"),         
+             "Number of cycles fetch has spent blocked per tid"),
     ADD_STAT(miscStallCycles, statistics::units::Cycle::get(),
              "Number of cycles fetch has spent waiting on interrupts, or bad "
              "addresses, or out of MSHRs"),
@@ -279,9 +290,9 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
     ADD_STAT(decodeStalls, statistics::units::Count::get(),
              "Number of decode stalls"),
     ADD_STAT(smtdecodeStalls, statistics::units::Count::get(),
-             "Number of decode stalls per tid"),  
+             "Number of decode stalls per tid"),
     ADD_STAT(smtftqempty, statistics::units::Count::get(),
-             "Number of ftq empty per tid"),                  
+             "Number of ftq empty per tid"),
     ADD_STAT(decodeStallRate, statistics::units::Rate<
                     statistics::units::Count, statistics::units::Cycle>::get(),
              "Number of decode stalls per cycle",
@@ -316,6 +327,22 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "Number of FTQ heads skipped because IEW reported a pending redirect"),
     ADD_STAT(redirectPendingOnlyFetchCycles, statistics::units::Count::get(),
              "Number of fetch attempts blocked because all FTQ heads were redirect-pending"),
+    ADD_STAT(uopCacheHits, statistics::units::Count::get(),
+             "Number of complete FTQ spans supplied by the uop cache"),
+    ADD_STAT(uopCacheMisses, statistics::units::Count::get(),
+             "Number of FTQ spans that miss in the uop cache"),
+    ADD_STAT(uopCacheHitInsts, statistics::units::Count::get(),
+             "Number of instructions supplied by the uop cache"),
+    ADD_STAT(uopCacheBypassQueueFullEvents, statistics::units::Count::get(),
+             "Number of uop-cache hits sent through the normal queue because "
+             "the bypass queue is full"),
+    ADD_STAT(uopCacheBypassOrderBlockedEvents, statistics::units::Count::get(),
+             "Number of bypass instructions delayed behind older normal-path "
+             "instructions"),
+    ADD_STAT(uopCacheBypassInsts, statistics::units::Count::get(),
+             "Number of uop-cache instructions accepted through bypass"),
+    ADD_STAT(uopCachePcMismatches, statistics::units::Count::get(),
+             "Number of inconsistent uop-cache entries invalidated at lookup"),
     ADD_STAT(traceMetaStores, statistics::units::Count::get(),
              "Number of stored trace metadata records (seqNum -> traceInst)"),
     ADD_STAT(traceMetaCleanupSquashCalls, statistics::units::Count::get(),
@@ -383,7 +410,7 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .prereq(decodeStalls);
         smtdecodeStalls
             .init(fetch->numThreads)
-            .flags(statistics::total);  
+            .flags(statistics::total);
         smtftqempty
             .init(fetch->numThreads)
             .flags(statistics::total);
@@ -392,7 +419,7 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .flags(statistics::total);
         smtblockedCycles
             .init(fetch->numThreads)
-            .flags(statistics::total);     
+            .flags(statistics::total);
         decodeStallRate
             .flags(statistics::total);
         fetchBubbles
@@ -413,6 +440,20 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .prereq(redirectPendingFetchSkips);
         redirectPendingOnlyFetchCycles
             .prereq(redirectPendingOnlyFetchCycles);
+        uopCacheHits
+            .prereq(uopCacheHits);
+        uopCacheMisses
+            .prereq(uopCacheMisses);
+        uopCacheHitInsts
+            .prereq(uopCacheHitInsts);
+        uopCacheBypassQueueFullEvents
+            .prereq(uopCacheBypassQueueFullEvents);
+        uopCacheBypassOrderBlockedEvents
+            .prereq(uopCacheBypassOrderBlockedEvents);
+        uopCacheBypassInsts
+            .prereq(uopCacheBypassInsts);
+        uopCachePcMismatches
+            .prereq(uopCachePcMismatches);
         traceMetaStores
             .prereq(traceMetaStores);
         traceMetaCleanupSquashCalls
@@ -443,14 +484,14 @@ Fetch::initDecodeScheduler()
     robCounter = new InstsCounter();
     DPRINTF(Fetch, "Initialized SMT Decode Scheduler: 0\n");
 
-    for (ThreadID tid = 0; tid < numThreads; tid++) 
+    for (ThreadID tid = 0; tid < numThreads; tid++)
     {
         lsqCounter->setCounter(tid, 0);
         iqCounter->setCounter(tid, 0);
         robCounter->setCounter(tid, 0);
     }
     DPRINTF(Fetch, "Initialized SMT Decode Scheduler: 1\n");
-    
+
     if (smtDecodePolicy == "icount") {
         // Use ROB as default counter for icount
         decodeScheduler = new ICountScheduler(numThreads, robCounter);
@@ -511,6 +552,7 @@ Fetch::clearStates(ThreadID tid)
     threads[tid].cacheReq.reset();
     threads[tid].reset();
     fetchQueue[tid].clear();
+    clearPendingUopCacheLookup(tid);
 
     // TODO not sure what to do with priorityList for now
     // priorityList.push_back(tid);
@@ -543,6 +585,7 @@ Fetch::resetStage()
         ftqEntryFetchedInsts[tid] = 0;
 
         fetchQueue[tid].clear();
+        clearPendingUopCacheLookup(tid);
 
         priorityList.push_back(tid);
         waitForVsetvl[tid] = false;
@@ -752,12 +795,40 @@ Fetch::processCacheCompletion(PacketPtr pkt)
                 "[TRACE] Icache completion: keep timing only; no trace bytes injection\n");
     }
 
-    // Verify fetchBufferPC alignment with the supplying FSQ entry.
-    if (threads[tid].valid && dbpbtb->ftqHasFetching(tid)) {
+    // Uop-cache hits can advance or consume the FTQ head while an older
+    // multi-line I-cache request is still in flight. Such a response belongs
+    // to the old head and must not populate the fetch buffer for the current
+    // head. Reset every piece of state derived from that request so Fetch can
+    // issue a fresh lookup/access for the current control-flow path.
+    const auto discardStaleCompletion = [&] {
+        ++fetchStats.icacheSquashes;
+        threads[tid].valid = false;
+        threads[tid].cacheReq.reset();
+        clearPendingUopCacheLookup(tid);
+        setThreadStatus(tid, Running);
+        setAllFetchStalls(StallReason::NoStall);
+        cpu->wakeCPU();
+        switchToActive();
+    };
+
+    if (threads[tid].valid && !isTraceMode()) {
+        if (!dbpbtb->ftqHasFetching(tid)) {
+            DPRINTF(Fetch,
+                    "[tid:%i] Dropping stale I-cache completion for "
+                    "fetchBufferPC %#lx because no FTQ head is fetching\n",
+                    tid, threads[tid].startPC);
+            discardStaleCompletion();
+            return;
+        }
+
         const auto &stream = dbpbtb->ftqFetchingTarget(tid);
         if (threads[tid].startPC != stream.startPC) {
-            panic("fetchBufferPC %#x should be aligned with FSQ startPC %#x",
-                  threads[tid].startPC, stream.startPC);
+            DPRINTF(Fetch,
+                    "[tid:%i] Dropping stale I-cache completion for "
+                    "fetchBufferPC %#lx; current FTQ head startPC is %#lx\n",
+                    tid, threads[tid].startPC, stream.startPC);
+            discardStaleCompletion();
+            return;
         }
     }
 
@@ -935,10 +1006,12 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
                                  inst->seqNum, tid, currentLoopIter);
         ftqEntryFetchedInsts[tid] = 0;
         threads[tid].valid = false;
+        clearPendingUopCacheLookup(tid);
     } else if (run_out) {
         dbpbtb->consumeFetchTarget(ftqEntryFetchedInsts[tid], tid);
         ftqEntryFetchedInsts[tid] = 0;
         threads[tid].valid = false;
+        clearPendingUopCacheLookup(tid);
         DPRINTF(DecoupleBP, "Used up fetch targets.\n");
     }
 
@@ -1252,6 +1325,9 @@ Fetch::doSquash(PCStateBase &new_pc, const DynInstPtr squashInst, const InstSeqN
 
     // Empty fetch queue
     fetchQueue[tid].clear();
+    // A squash may replace the FTQ head or architectural context.  Never let
+    // a lookup memoized on the wrong path authorize an I-cache bypass.
+    clearPendingUopCacheLookup(tid);
 
     // microops are being squashed, it is not known wheather the
     // youngest non-squashed microop was  marked delayed commit
@@ -1276,6 +1352,21 @@ Fetch::flushFetchBuffer()
 {
     for (ThreadID i = 0; i < numThreads; ++i) {
         threads[i].valid = false;
+    }
+}
+
+void
+Fetch::invalidateUopCache()
+{
+    if (uopCache->enabled()) {
+        uopCache->invalidateAll();
+    }
+
+    // Pending decisions are frontend state, not UopCache array state.  They
+    // must be discarded in the same operation so no thread can reuse a block
+    // hit computed before the invalidation boundary.
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        clearPendingUopCacheLookup(tid);
     }
 }
 
@@ -1534,7 +1625,7 @@ Fetch::sendInstructionsToDecode()
             any_thread_active = true;
             //break;
         }else{
-            fetchStats.smtdecodeStalls[i]++; 
+            fetchStats.smtdecodeStalls[i]++;
         }
     }
 
@@ -1560,14 +1651,13 @@ Fetch::sendInstructionsToDecode()
         return;
     }
 
-    ThreadID tid =selectUnstalledThread();
+    ThreadID tid = selectUnstalledThread();
 
-    if(tid == -1)
-    {
+    if (tid == -1) {
         DPRINTF(Fetch, "All threads are stalled, no thread selected.\n");
         return;
     }
-    DPRINTF(Fetch, "select Unstalled [tid:%i]\n",tid);
+    DPRINTF(Fetch, "select Unstalled [tid:%i]\n", tid);
 
     // fetch totally stalled
     if (stallSig->blockFetch[tid]) {
@@ -1890,7 +1980,8 @@ Fetch::handleDecodeSquash(ThreadID tid)
 DynInstPtr
 Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
         StaticInstPtr curMacroop, const PCStateBase &this_pc,
-        const PCStateBase &next_pc, bool trace)
+        const PCStateBase &next_pc, bool trace, bool enqueueToFetchQueue,
+        bool uopCacheBypass)
 {
     // Get a sequence number.
     InstSeqNum seq = cpu->getAndIncrementInstSeq();
@@ -1904,6 +1995,7 @@ Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
             arrays, staticInst, curMacroop, this_pc, next_pc, seq, cpu);
 
     instruction->setTid(tid);
+    instruction->setUopCacheBypass(uopCacheBypass);
 
     cpu->perfCCT->createMeta(instruction);
     cpu->perfCCT->updateInstPos(instruction->seqNum, PerfRecord::AtFetch);
@@ -1936,13 +2028,24 @@ Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
     // Add instruction to the CPU's list of instructions.
     instruction->setInstListIt(cpu->addInst(instruction));
 
-    // Write the instruction to the first slot in the queue
-    // that heads to decode.
     assert(numInst < fetchWidth);
-    fetchQueue[tid].push_back(instruction);
-    assert(fetchQueue[tid].size() <= fetchQueueSize);
-    DPRINTF(Fetch, "[tid:%i] Fetch queue entry created (%i/%i).\n",
-            tid, fetchQueue[tid].size(), fetchQueueSize);
+    if (enqueueToFetchQueue) {
+        // The normal path is intentionally unchanged: decoded-cache misses
+        // and disabled configurations use the same per-thread queue and SMT
+        // Decode arbitration as xs-dev.
+        fetchQueue[tid].push_back(instruction);
+        assert(fetchQueue[tid].size() <= fetchQueueSize);
+        DPRINTF(Fetch, "[tid:%i] Fetch queue entry created (%i/%i).\n",
+                tid, fetchQueue[tid].size(), fetchQueueSize);
+    } else {
+        // A bypass instruction is already decoded and is therefore handed to
+        // Decode's bounded bypass queue instead of occupying the ordinary
+        // Fetch-to-Decode queue.  Sequence-number ordering is enforced by CPU
+        // and Decode before it can overtake older normal-path instructions.
+        DPRINTF(UC, "[tid:%i] Uop-cache inst bypasses fetch queue "
+                "[sn:%llu] pc=%#lx\n",
+                tid, instruction->seqNum, instruction->getPC());
+    }
     //toDecode->insts[toDecode->size++] = instruction;
 
     // Keep track of if we can take an interrupt at this boundary
@@ -1964,6 +2067,151 @@ Fetch::checkDecoupledFrontend(ThreadID tid)
         return false;
     }
     return true;
+}
+
+bool
+Fetch::getUopCacheHit(ThreadID tid, Addr fetchAddr, int &hitWay,
+                      const UopCacheContext &context, bool countStats)
+{
+    hitWay = -1;
+    if (!uopCache->enabled() || isTraceMode() || ftqEmpty(tid)) {
+        return false;
+    }
+
+    assert(dbpbtb);
+    const auto &target = dbpbtb->ftqFetchingTarget(tid);
+    // A predicted-taken FTQ target ends immediately after its predicted CFI;
+    // bytes beyond that instruction belong to a different control-flow path.
+    const Addr target_end = target.predTaken ?
+        target.predBranchInfo.pc + target.predBranchInfo.size :
+        target.predEndPC;
+    if (target_end <= target.startPC) {
+        return false;
+    }
+
+    auto &pending = pendingUopCacheLookup[tid];
+    const bool same_block =
+        pending.blockValid && pending.startPC == target.startPC &&
+        pending.endPC == target_end && pending.context == context;
+    if (!same_block) {
+        // Cache the all-or-nothing result for this FTQ span.  Apart from
+        // avoiding repeated associative lookups, this ensures Fetch never
+        // starts a span on decoded instructions and then unexpectedly changes
+        // to raw bytes halfway through it.
+        pending = PendingUopCacheLookup();
+        pending.blockValid = true;
+        pending.startPC = target.startPC;
+        pending.endPC = target_end;
+        pending.context = context;
+        pending.blockHit = uopCache->checkUopCacheBlockHit(
+            target.startPC, target_end, context);
+    }
+
+    const bool same_inst =
+        pending.instValid && pending.instPC == fetchAddr &&
+        pending.context == context;
+    const auto inst_hit = same_inst ?
+        std::make_pair(true, pending.hitWay) :
+        uopCache->checkUopCacheHit(fetchAddr, context);
+    hitWay = inst_hit.second;
+
+    // Count one result per FTQ span rather than once per instruction.  The
+    // first PC is the unique point at which a span starts being consumed.
+    if (countStats && fetchAddr == target.startPC) {
+        if (pending.blockHit) {
+            fetchStats.uopCacheHits++;
+        } else {
+            fetchStats.uopCacheMisses++;
+        }
+    }
+
+    return pending.blockHit && inst_hit.first;
+}
+
+bool
+Fetch::getUopCacheInst(ThreadID tid, Addr instAddr, int &hitWay,
+                       const UCInstDesc *&instDesc, int *instIdx,
+                       bool countStats)
+{
+    instDesc = nullptr;
+    hitWay = -1;
+    if (!uopCache->enabled() || isTraceMode() || ftqEmpty(tid)) {
+        return false;
+    }
+
+    assert(dbpbtb);
+    const auto &target = dbpbtb->ftqFetchingTarget(tid);
+    const Addr target_end = target.predTaken ?
+        target.predBranchInfo.pc + target.predBranchInfo.size :
+        target.predEndPC;
+    const UopCacheContext context = uopCache->getContext(tid);
+    auto &pending = pendingUopCacheLookup[tid];
+
+    if (pending.blockValid && pending.blockHit &&
+        pending.startPC == target.startPC && pending.endPC == target_end &&
+        pending.context == context && pending.instValid &&
+        pending.instPC == instAddr) {
+        int matched_idx = -1;
+        instDesc = uopCache->findInst(instAddr, pending.hitWay, context,
+                                      &matched_idx);
+        if (!instDesc || matched_idx != pending.instIdx) {
+            clearPendingUopCacheLookup(tid);
+            return false;
+        }
+        hitWay = pending.hitWay;
+        if (instIdx) {
+            *instIdx = matched_idx;
+        }
+        return true;
+    }
+
+    if (!getUopCacheHit(tid, instAddr, hitWay, context, countStats)) {
+        clearPendingUopCacheLookup(tid);
+        return false;
+    }
+
+    int matched_idx = -1;
+    instDesc = uopCache->findInst(instAddr, hitWay, context, &matched_idx);
+    if (!instDesc || instDesc->inst->isMacroop() ||
+        instDesc->inst->isMicroop()) {
+        // Refill deliberately excludes macro/micro-ops.  Seeing one here, or
+        // failing to recover a PC that the block probe declared resident,
+        // means the entry is internally inconsistent and must not bypass the
+        // architectural decode path.
+        fetchStats.uopCachePcMismatches++;
+        warn("Invalid uop-cache entry: tid=%d startPC=%#lx instPC=%#lx "
+             "way=%d; invalidating entry\n",
+             tid, target.startPC, instAddr, hitWay);
+        uopCache->invalidateEntry(instAddr);
+        clearPendingUopCacheLookup(tid);
+        instDesc = nullptr;
+        return false;
+    }
+
+    pending.instValid = true;
+    pending.instPC = instAddr;
+    pending.hitWay = hitWay;
+    pending.instIdx = matched_idx;
+    if (instIdx) {
+        *instIdx = matched_idx;
+    }
+    return true;
+}
+
+void
+Fetch::clearPendingUopCacheLookup(ThreadID tid)
+{
+    pendingUopCacheLookup[tid] = PendingUopCacheLookup();
+}
+
+void
+Fetch::clearPendingUopCacheInstLookup(ThreadID tid)
+{
+    auto &pending = pendingUopCacheLookup[tid];
+    pending.instValid = false;
+    pending.instPC = 0;
+    pending.hitWay = -1;
+    pending.instIdx = -1;
 }
 
 ThreadID
@@ -2050,7 +2298,7 @@ Fetch::fetch(bool &status_change)
     }
     ++fetchStats.cycles;
     sendNextCacheRequest(tid, *threads[tid].fetchpc);
-    
+
 }
 
 StallReason
@@ -2070,6 +2318,19 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
     }
 
     Addr fetch_pc = this_pc.instAddr();
+
+    if (uopCache->enabled()) {
+        int hit_way = -1;
+        const UCInstDesc *inst_desc = nullptr;
+        if (getUopCacheInst(tid, fetch_pc, hit_way, inst_desc)) {
+            // A complete FTQ-span hit already provides the decoded StaticInst,
+            // so no ITLB/I-cache request or decoder byte feed is required.
+            // This branch is unreachable when the feature is disabled.
+            DPRINTF(UC, "[tid:%i] Bypassing I-cache for uop-cache hit "
+                    "at PC %#lx\n", tid, fetch_pc);
+            return StallReason::NoStall;
+        }
+    }
 
     // Check if fetch buffer is valid and contains this PC
     if (!threads[tid].valid) {
@@ -2102,20 +2363,86 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
 
 bool
 Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
-                               StaticInstPtr &curMacroop)
+                                StaticInstPtr &curMacroop, StallReason &stall)
 {
     auto *dec_ptr = decoder[tid];
     bool predictedBranch = false;
     bool newMacroop = false;
+    stall = StallReason::NoStall;
 
     // Create a copy of the current PC state to calculate the next PC.
     std::unique_ptr<PCStateBase> next_pc(pc.clone());
 
     // Decode the instruction, handling macro-op transitions.
     StaticInstPtr staticInst = nullptr;
+    bool uop_cache_hit = false;
+    bool uop_cache_bypass = false;
+    Addr uop_cache_fetch_addr = 0;
     if (!curMacroop) {
-        // Decode a new instruction if not currently in a macro-op.
-        staticInst = dec_ptr->decode(pc);
+        if (uopCache->enabled()) {
+            assert(dbpbtb && dbpbtb->ftqHasFetching(tid));
+            const auto &target = dbpbtb->ftqFetchingTarget(tid);
+            const Addr target_end = target.predTaken ?
+                target.predBranchInfo.pc + target.predBranchInfo.size :
+                target.predEndPC;
+            const auto &pending = pendingUopCacheLookup[tid];
+            const bool expected_cached_inst =
+                pending.blockValid && pending.blockHit &&
+                pending.startPC == target.startPC &&
+                pending.endPC == target_end && pending.instValid &&
+                pending.instPC == pc.instAddr();
+            int hit_way = -1;
+            int inst_idx = -1;
+            const UCInstDesc *inst_desc = nullptr;
+            uop_cache_hit = getUopCacheInst(
+                tid, pc.instAddr(), hit_way, inst_desc, &inst_idx, false);
+            if (uop_cache_hit) {
+                uop_cache_fetch_addr = inst_desc->pc;
+                staticInst = inst_desc->inst;
+                dec_ptr->setPCStateWithInstDesc(inst_desc->compressed, pc);
+                clearPendingUopCacheInstLookup(tid);
+
+                // Normal RISC-V decode updates speculative vtype state as a
+                // side effect.  A decoded-cache hit must reproduce that side
+                // effect or later vector instructions would be decoded with a
+                // stale vtype (and register-based vsetvl would fail to stall).
+                if (staticInst->isVectorConfig()) {
+                    auto &riscv_decoder =
+                        dec_ptr->as<RiscvISA::Decoder>();
+                    auto *vset = static_cast<RiscvISA::VConfOp *>(
+                        staticInst.get());
+                    if (vset->vtypeIsImm) {
+                        riscv_decoder.setVtype(vset->earlyVtype);
+                    } else {
+                        riscv_decoder.clearVtype();
+                    }
+                }
+
+                DPRINTF(UC, "[tid:%i] Supplying cached instruction "
+                        "pc=%#lx idx=%d compressed=%d %s\n",
+                        tid, inst_desc->pc, inst_idx, inst_desc->compressed,
+                        staticInst->disassemble(inst_desc->pc));
+            } else if (expected_cached_inst) {
+                // checkMemoryNeeds() did not feed decoder bytes on its earlier
+                // hit.  If the entry was invalidated between the two checks,
+                // leave PC untouched and restart through the ordinary cache
+                // path next cycle.
+                stall = StallReason::IcacheStall;
+                threads[tid].valid = false;
+                return false;
+            } else {
+                // The FTQ span missed during checkMemoryNeeds(), which has
+                // already supplied bytes to the decoder.  Continue through
+                // the exact normal decode path used when the feature is off.
+                staticInst = dec_ptr->decode(pc);
+            }
+        } else {
+            // Feature-off behavior is deliberately identical to xs-dev.
+            staticInst = dec_ptr->decode(pc);
+        }
+        panic_if(!staticInst, "Decoder returned no instruction for tid=%d "
+                 "pc=%#lx after Fetch supplied bytes\n",
+                 tid, pc.instAddr());
         ++fetchStats.insts;
 
         if (staticInst->isMacroop()) {
@@ -2131,9 +2458,27 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
         newMacroop = staticInst->isLastMicroop();
     }
 
+    if (uop_cache_hit) {
+        fetchStats.uopCacheHitInsts++;
+        uop_cache_bypass = cpu->canEnqueueUopCacheBypassInst(tid);
+        if (!uop_cache_bypass) {
+            // Queue-full fallback preserves progress and ordering by reusing
+            // the pre-existing normal Fetch-to-Decode queue.
+            fetchStats.uopCacheBypassQueueFullEvents++;
+        }
+    }
+
     // Build the dynamic instruction and add it to the fetch queue
     DynInstPtr instruction =
-        buildInst(tid, staticInst, curMacroop, pc, *next_pc, true);
+        buildInst(tid, staticInst, curMacroop, pc, *next_pc, true,
+                  !uop_cache_bypass, uop_cache_bypass);
+    instruction->setFetchFromUopCache(uop_cache_hit);
+    instruction->setUopCacheFetchAddr(uop_cache_fetch_addr);
+
+    if (uop_cache_bypass) {
+        cpu->enqueueUopCacheBypassInst(instruction);
+        wroteToTimeBuffer = true;
+    }
 
     o3::TraceInstruction traceForThisInst;
     if (isTraceMode()) {
@@ -2238,11 +2583,16 @@ Fetch::performInstructionFetch(ThreadID tid)
         // into multiple micro-ops.
         do {
             // Process a single instruction, from decoding to PC update.
-            predictedBranch = processSingleInstruction(tid, pc_state, curMacroop);
+            predictedBranch =
+                processSingleInstruction(tid, pc_state, curMacroop, stall);
+            if (stall != StallReason::NoStall) {
+                break;
+            }
 
         } while (curMacroop &&
                  numInst < fetchWidth &&
-                 fetchQueue[tid].size() < fetchQueueSize);
+                 fetchQueue[tid].size() < fetchQueueSize &&
+                 stall == StallReason::NoStall);
     }
 
     // Debug output for fetch queue contents
@@ -2307,6 +2657,21 @@ Fetch::sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state) {
                 "(previous PC %#lx outside [%#lx, %#lx))\n",
                 tid, *threads[tid].fetchpc, current_pc,
                 stream.startPC, stream.predEndPC);
+    }
+
+    if (uopCache->enabled()) {
+        int hit_way = -1;
+        const UCInstDesc *inst_desc = nullptr;
+        if (getUopCacheInst(tid, threads[tid].fetchpc->instAddr(),
+                            hit_way, inst_desc, nullptr, false)) {
+            // Keep cacheReq idle on a decoded-cache hit.  The normal I-cache
+            // issue/retry machinery below remains byte-for-byte equivalent to
+            // xs-dev whenever the feature is disabled or this span misses.
+            DPRINTF(UC, "[tid:%i] Skip pipelined I-cache request for "
+                    "uop-cache hit at PC %#lx\n",
+                    tid, threads[tid].fetchpc->instAddr());
+            return;
+        }
     }
 
     DPRINTF(Fetch, "[tid:%i] Issuing a pipelined I-cache access for new FSQ entry, "

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -55,6 +55,7 @@
 #include "cpu/o3/comm.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/uop_cache.hh"
 #include "cpu/pc_event.hh"
 #include "cpu/pred/bpred_unit.hh"
 #include "cpu/pred/btb/decoupled_bpred.hh"
@@ -520,6 +521,44 @@ class Fetch
 
     Addr getPreservedReturnAddr(const DynInstPtr &dynInst);
 
+    /**
+     * Return the decoded-instruction cache owned by Fetch.
+     *
+     * Decode uses this object to refill entries after normal-path decoding.
+     * Keeping ownership in Fetch makes lookup and I-cache-bypass policy local
+     * to the frontend while exposing refill through a narrow interface.
+     */
+    UopCache *getUopCache() { return uopCache.get(); }
+
+    /**
+     * Invalidate all decoded instructions and their memoized Fetch lookups.
+     *
+     * Translation, permission, fence.i, and executable-memory changes must
+     * use this wrapper instead of invalidating UopCache directly.  Clearing
+     * only the backing array would leave a pending FTQ block-hit decision in
+     * Fetch, which could incorrectly authorize an I-cache bypass after the
+     * architectural invalidation event.
+     */
+    void invalidateUopCache();
+
+    /** Return the normal Fetch-to-Decode queue occupancy for @p tid. */
+    size_t fetchQueueOccupancy(ThreadID tid) const
+    {
+        return tid < numThreads ? fetchQueue[tid].size() : 0;
+    }
+
+    /** Account instructions that Decode accepted through the bypass path. */
+    void recordUopCacheBypassInsts(unsigned count)
+    {
+        fetchStats.uopCacheBypassInsts += count;
+    }
+
+    /** Account a bypass instruction delayed behind older normal-path work. */
+    void recordUopCacheBypassOrderBlockedEvent()
+    {
+        fetchStats.uopCacheBypassOrderBlockedEvents++;
+    }
+
     /** Trace-driven simulation metadata accessors (used by CPU/Commit). */
     const o3::TraceInstruction* getTraceInstMetadata(InstSeqNum seqNum) const;
     bool isTraceInstruction(InstSeqNum seqNum) const;
@@ -531,7 +570,9 @@ class Fetch
   private:
     DynInstPtr buildInst(ThreadID tid, StaticInstPtr staticInst,
             StaticInstPtr curMacroop, const PCStateBase &this_pc,
-            const PCStateBase &next_pc, bool trace);
+            const PCStateBase &next_pc, bool trace,
+            bool enqueueToFetchQueue = true,
+            bool uopCacheBypass = false);
 
     /** Pipeline the next I-cache access to the current one. */
     void pipelineIcacheAccesses(ThreadID tid);
@@ -572,11 +613,13 @@ class Fetch
      * @param tid The thread ID of the instruction.
      * @param pc The current program counter state (will be updated).
      * @param curMacroop The current macro-op being processed (if any).
+     * @param stall Reports a late uop-cache lookup failure so Fetch can issue
+     *              the ordinary I-cache request without consuming the PC.
      * @return true if a branch was predicted.
      */
     bool
     processSingleInstruction(ThreadID tid, PCStateBase &pc,
-                             StaticInstPtr &curMacroop);
+                             StaticInstPtr &curMacroop, StallReason &stall);
 
     /**
      * Checks if the decoder requires more memory to proceed and fetches
@@ -600,6 +643,31 @@ class Fetch
     void
     lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc,
                          bool &predictedBranch, bool &newMacro);
+
+    /**
+     * Test whether the complete currently supplied FTQ span is resident.
+     * Requiring an all-or-nothing block hit prevents Fetch from switching
+     * between decoded instructions and I-cache bytes in the middle of one FTQ
+     * target, which would otherwise complicate PC and decoder-state recovery.
+     */
+    bool getUopCacheHit(ThreadID tid, Addr fetchAddr, int &hitWay,
+                        const UopCacheContext &context,
+                        bool countStats = true);
+
+    /**
+     * Return the decoded instruction for @p instAddr after validating the FTQ
+     * span, privilege/translation context, and unsupported macro-op cases.
+     */
+    bool getUopCacheInst(ThreadID tid, Addr instAddr, int &hitWay,
+                         const UCInstDesc *&instDesc,
+                         int *instIdx = nullptr,
+                         bool countStats = true);
+
+    /** Discard all cached lookup state for one hardware thread. */
+    void clearPendingUopCacheLookup(ThreadID tid);
+
+    /** Retain the block result but discard the per-instruction way/index. */
+    void clearPendingUopCacheInstLookup(ThreadID tid);
 
   private:
     /** Pointer to the O3CPU. */
@@ -637,6 +705,35 @@ class Fetch
 
     /** Trace-mode implementation owner (optional, enabled by params). */
     std::unique_ptr<TraceFetch> traceFetch;
+
+    /**
+     * Optional decoded-instruction cache.  When disabled, every call site is
+     * guarded before it can alter Fetch state, preserving the pre-uop-cache
+     * SMT, FTQ, redirect, and I-cache behavior exactly.
+     */
+    std::unique_ptr<UopCache> uopCache;
+
+    /**
+     * Memoized lookup state for the current FTQ target of each thread.
+     *
+     * Block validity is separate from instruction validity because one block
+     * decision is reused for all PCs in the FTQ span, while each instruction
+     * may reside in a different way.  Context is part of the key so privilege
+     * or address-space changes cannot reuse a stale decision.
+     */
+    struct PendingUopCacheLookup
+    {
+        bool blockValid = false;
+        Addr startPC = 0;
+        Addr endPC = 0;
+        bool blockHit = false;
+        UopCacheContext context;
+        bool instValid = false;
+        Addr instPC = 0;
+        int hitWay = -1;
+        int instIdx = -1;
+    };
+    PendingUopCacheLookup pendingUopCacheLookup[MaxThreads];
 
     /** PC of each thread. */
     // std::unique_ptr<PCStateBase> pc[MaxThreads];
@@ -1138,6 +1235,21 @@ class Fetch
         statistics::Scalar redirectPendingFetchSkips;
         /** Cycles where only redirect-pending FTQ heads were available to fetch. */
         statistics::Scalar redirectPendingOnlyFetchCycles;
+
+        /** FTQ spans completely supplied by the decoded-instruction cache. */
+        statistics::Scalar uopCacheHits;
+        /** FTQ spans that require the ordinary I-cache/decode path. */
+        statistics::Scalar uopCacheMisses;
+        /** Individual decoded instructions consumed on cache-hit spans. */
+        statistics::Scalar uopCacheHitInsts;
+        /** Hits routed through the normal queue because bypass is full. */
+        statistics::Scalar uopCacheBypassQueueFullEvents;
+        /** Bypass attempts held behind older normal-path instructions. */
+        statistics::Scalar uopCacheBypassOrderBlockedEvents;
+        /** Instructions actually accepted by Decode's bypass queue. */
+        statistics::Scalar uopCacheBypassInsts;
+        /** Structurally inconsistent entries invalidated during lookup. */
+        statistics::Scalar uopCachePcMismatches;
 
         // Trace metadata accounting (trace mode)
         /** Number of stored trace metadata records (seqNum -> traceInst). */

--- a/src/cpu/o3/uop_cache.cc
+++ b/src/cpu/o3/uop_cache.cc
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Copyright (c) 2004-2006 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/o3/uop_cache.hh"
+
+#include <algorithm>
+#include <sstream>
+
+#include "arch/riscv/regs/misc.hh"
+#include "base/bitfield.hh"
+#include "base/intmath.hh"
+#include "base/logging.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "cpu/o3/cpu.hh"
+#include "cpu/o3/dyn_inst.hh"
+#include "debug/UC.hh"
+#include "params/BaseO3CPU.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+UopCache::UopCache(CPU *_cpu, const BaseO3CPUParams &params)
+    : cpu(_cpu),
+      stats(_cpu, params.uopCacheMaxInstBytesPerEntry),
+      currentRefillEntry(nullptr),
+      enableUopCache(params.hasUopCache),
+      maxInstBytesPerEntry(params.uopCacheMaxInstBytesPerEntry),
+      setNum(params.uopCacheSetNum),
+      wayNum(params.uopCacheWayNum),
+      setNumIsPowerOf2(false),
+      setIdxMask(0),
+      setIdxShift(0),
+      isBuildMode_(true)
+{
+    fatal_if(setNum == 0, "uopCacheSetNum must be greater than zero");
+    fatal_if(wayNum == 0, "uopCacheWayNum must be greater than zero");
+    // RISC-V instructions are at most four bytes in this model.  A smaller
+    // nominal capacity would contradict the entry and utilization contracts.
+    fatal_if(maxInstBytesPerEntry < 4,
+             "uopCacheMaxInstBytesPerEntry must be at least 4 bytes");
+    fatal_if(!isPowerOf2(wayNum),
+             "uopCacheWayNum must be a power of two for tree-PLRU");
+    setNumIsPowerOf2 = isPowerOf2(setNum);
+    if (setNumIsPowerOf2) {
+        setIdxMask = mask(floorLog2(setNum));
+        setIdxShift = floorLog2(setNum);
+    }
+    cache.resize(wayNum);
+    for (auto &way : cache) {
+        way.resize(setNum);
+    }
+    plruTrees.resize(setNum, std::vector<uint8_t>(wayNum - 1, 0));
+    currentRefillEntry.reset(newEntry());
+}
+
+UopCache::UopCacheStats::UopCacheStats(
+        CPU *cpu, unsigned max_inst_bytes_per_entry)
+    : statistics::Group(cpu, "uop_cache"),
+      maxInstBytesPerEntry(max_inst_bytes_per_entry),
+      ADD_STAT(entryRefills, statistics::units::Count::get(),
+               "Number of uop-cache entries refilled into the cache"),
+      ADD_STAT(entryInstsTotal, statistics::units::Count::get(),
+               "Total decoded instructions stored by refilled uop-cache entries"),
+      ADD_STAT(entryBytesTotal, statistics::units::Byte::get(),
+               "Total instruction bytes covered by refilled uop-cache entries"),
+      ADD_STAT(entryCapacityBytesTotal, statistics::units::Byte::get(),
+               "Total nominal instruction-byte capacity of refilled "
+               "single-instruction uop-cache entries"),
+      ADD_STAT(entryInsts, statistics::units::Count::get(),
+               "Distribution of decoded instructions per refilled uop-cache "
+               "entry; single-instruction entries should sample one"),
+      ADD_STAT(entryBytes, statistics::units::Byte::get(),
+               "Distribution of instruction bytes covered per refilled "
+               "uop-cache entry"),
+      ADD_STAT(avgEntryInsts, statistics::units::Ratio::get(),
+               "Average decoded instructions per refilled uop-cache entry",
+               entryInstsTotal / entryRefills),
+      ADD_STAT(avgEntryBytes, statistics::units::Byte::get(),
+               "Average instruction bytes covered per refilled uop-cache entry",
+               entryBytesTotal / entryRefills),
+      ADD_STAT(entryByteUtilization, statistics::units::Ratio::get(),
+               "Average instruction-byte coverage of refilled "
+               "single-instruction uop-cache entries",
+               entryBytesTotal / entryCapacityBytesTotal)
+{
+}
+
+void
+UopCache::UopCacheStats::regStats()
+{
+    statistics::Group::regStats();
+
+    entryRefills.prereq(entryRefills);
+    entryInstsTotal.prereq(entryRefills);
+    entryBytesTotal.prereq(entryRefills);
+    entryCapacityBytesTotal.prereq(entryRefills);
+    entryInsts
+        .init(1, 1, 1)
+        .flags(statistics::pdf | statistics::total)
+        .prereq(entryRefills);
+    entryBytes
+        .init(1, maxInstBytesPerEntry, 1)
+        .flags(statistics::pdf | statistics::total)
+        .prereq(entryRefills);
+    avgEntryInsts.prereq(entryRefills);
+    avgEntryBytes.prereq(entryRefills);
+    entryByteUtilization.prereq(entryRefills);
+}
+
+UopEntry *
+UopCache::newEntry() const
+{
+    return new UopEntry();
+}
+
+Addr
+UopCache::getSetIdxFromVaddr(Addr vaddr) const
+{
+    // Index at halfword granularity so a compressed instruction in the upper
+    // half of a word does not alias solely because of four-byte alignment.
+    const Addr halfword_addr = vaddr >> 1;
+    return setNumIsPowerOf2 ? (halfword_addr & setIdxMask) :
+                              (halfword_addr % setNum);
+}
+
+Addr
+UopCache::getTagFromVaddr(Addr vaddr) const
+{
+    const Addr halfword_addr = vaddr >> 1;
+    return setNumIsPowerOf2 ? (halfword_addr >> setIdxShift) :
+                              (halfword_addr / setNum);
+}
+
+UopCacheContext
+UopCache::getContext(ThreadID tid) const
+{
+    UopCacheContext context;
+    context.prv = cpu->readMiscRegNoEffect(
+        RiscvISA::MiscRegIndex::MISCREG_PRV, tid);
+    context.virt = cpu->readMiscRegNoEffect(
+        RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);
+    context.satp = cpu->readMiscRegNoEffect(
+        RiscvISA::MiscRegIndex::MISCREG_SATP, tid);
+    context.vsatp = cpu->readMiscRegNoEffect(
+        RiscvISA::MiscRegIndex::MISCREG_VSATP, tid);
+    context.hgatp = cpu->readMiscRegNoEffect(
+        RiscvISA::MiscRegIndex::MISCREG_HGATP, tid);
+    return context;
+}
+
+void
+UopCache::addInst(const DynInstPtr &inst)
+{
+    if (!enableUopCache || isStreamMode() || inst->isFetchFromUopCache()) {
+        return;
+    }
+
+    // Macro/micro-op expansion depends on decoder-owned sequencing state.
+    // Only self-contained StaticInst objects are safe to replay here.
+    if (inst->isMacroop() || inst->isMicroop()) {
+        DPRINTF(UC, "skip macro/micro-op refill pc=%#lx inst=%s\n",
+                inst->getPC(), inst->staticInst->disassemble(inst->getPC()));
+        setCurrentUopEntryDone();
+        return;
+    }
+
+    currentRefillEntry->firstInstPC = inst->getPC();
+    currentRefillEntry->context = getContext(inst->threadNumber);
+
+    UCInstDesc instDesc;
+    instDesc.inst = inst->staticInst;
+    instDesc.compressed = inst->getInstBytes() == 2;
+    instDesc.pc = inst->getPC();
+    instDesc.enBufferTime = cpu->curCycle();
+
+    currentRefillEntry->bytesSize = instDesc.sizeBytes();
+    currentRefillEntry->inst = std::move(instDesc);
+    currentRefillEntry->valid = true;
+
+    DPRINTF(UC, "addInst: pc=%#lx compressed=%d bytes=%d ctx=%s inst=%s\n",
+            currentRefillEntry->inst.pc, currentRefillEntry->inst.compressed,
+            currentRefillEntry->bytesSize,
+            currentRefillEntry->context.toString().c_str(),
+            currentRefillEntry->inst.inst->disassemble(
+                currentRefillEntry->inst.pc));
+
+    setCurrentUopEntryDone();
+}
+
+void
+UopCache::tick()
+{
+    if (!enableUopCache) {
+        refillEntryBuffer.clear();
+        return;
+    }
+
+    // This models an ideal refill port: every completed entry can install in
+    // one tick.  It is a documented performance upper bound, not RTL timing.
+    for (auto &refillEntry : refillEntryBuffer) {
+        Addr setIdx = getSetIdxFromVaddr(refillEntry->firstInstPC);
+        Addr tag = getTagFromVaddr(refillEntry->firstInstPC);
+        const int existingWay =
+            findWay(refillEntry->firstInstPC, refillEntry->context);
+        const int replaceWayIdx =
+            existingWay >= 0 ? existingWay : chooseReplacementWay(setIdx);
+        auto &replaceWay = cache[replaceWayIdx];
+        const bool hasVictim = replaceWay[setIdx] != nullptr;
+
+        refillEntry->tag = tag;
+        refillEntry->enUopCacheTime = cpu->curCycle();
+
+        stats.entryRefills++;
+        stats.entryInstsTotal += 1;
+        stats.entryBytesTotal += refillEntry->bytesSize;
+        stats.entryCapacityBytesTotal += maxInstBytesPerEntry;
+        stats.entryInsts.sample(1);
+        stats.entryBytes.sample(refillEntry->bytesSize);
+
+        DPRINTF(UC,
+                "refill set=%d tag=%#lx way=%d victim=%d insts=1 "
+                "firstPC=%#lx ctx=%s\n",
+                setIdx, tag, replaceWayIdx, hasVictim,
+                refillEntry->firstInstPC,
+                refillEntry->context.toString().c_str());
+
+        replaceWay[setIdx] = std::move(refillEntry);
+        updatePlruOnAccess(setIdx, replaceWayIdx);
+    }
+
+    refillEntryBuffer.clear();
+}
+
+void
+UopCache::setCurrentUopEntryDone()
+{
+    if (!enableUopCache) {
+        flushCurUopEntry();
+        return;
+    }
+
+    if (!currentRefillEntry->valid) {
+        return;
+    }
+
+    refillEntryBuffer.push_back(std::move(currentRefillEntry));
+    currentRefillEntry.reset(newEntry());
+}
+
+void
+UopCache::flushCurUopEntry()
+{
+    DPRINTF(UC, "flushCurUopEntry\n");
+    currentRefillEntry.reset(newEntry());
+}
+
+int
+UopCache::findWay(Addr instAddr, const UopCacheContext &context) const
+{
+    const Addr setIdx = getSetIdxFromVaddr(instAddr);
+    const Addr tag = getTagFromVaddr(instAddr);
+
+    for (int way = 0; way < cache.size(); ++way) {
+        const UopEntry *entry = cache[way][setIdx].get();
+        if (entry && entry->valid && entry->tag == tag &&
+            entry->context == context &&
+            entry->firstInstPC == instAddr) {
+            return way;
+        }
+    }
+
+    return -1;
+}
+
+int
+UopCache::chooseReplacementWay(Addr setIdx) const
+{
+    for (int way = 0; way < cache.size(); ++way) {
+        if (!cache[way][setIdx]) {
+            return way;
+        }
+    }
+    return getPlruVictim(setIdx);
+}
+
+int
+UopCache::getPlruVictim(Addr setIdx) const
+{
+    assert(setIdx < plruTrees.size());
+    if (wayNum == 1) {
+        return 0;
+    }
+
+    const auto &tree = plruTrees[setIdx];
+    int node = 0;
+    int low = 0;
+    int high = wayNum;
+    while (node < wayNum - 1) {
+        const int mid = low + (high - low) / 2;
+        if (tree[node] == 0) {
+            node = 2 * node + 1;
+            high = mid;
+        } else {
+            node = 2 * node + 2;
+            low = mid;
+        }
+    }
+    return low;
+}
+
+void
+UopCache::updatePlruOnAccess(Addr setIdx, int way)
+{
+    assert(setIdx < plruTrees.size());
+    assert(way >= 0 && way < wayNum);
+    if (wayNum == 1) {
+        return;
+    }
+
+    auto &tree = plruTrees[setIdx];
+    int node = 0;
+    int low = 0;
+    int high = wayNum;
+    while (node < wayNum - 1) {
+        const int mid = low + (high - low) / 2;
+        if (way < mid) {
+            tree[node] = 1;
+            node = 2 * node + 1;
+            high = mid;
+        } else {
+            tree[node] = 0;
+            node = 2 * node + 2;
+            low = mid;
+        }
+    }
+}
+
+std::pair<bool, int>
+UopCache::checkUopCacheHit(Addr instAddr,
+                           const UopCacheContext &context)
+{
+    if (!enableUopCache) {
+        return std::make_pair(false, -1);
+    }
+
+    const int hitWay = findWay(instAddr, context);
+    if (hitWay >= 0) {
+        const Addr setIdx = getSetIdxFromVaddr(instAddr);
+        const auto &entry = cache[hitWay][setIdx];
+        DPRINTF(UC, "uop cache hit instAddr=%#lx way=%d ctx=%s %s\n",
+                instAddr, hitWay, context.toString().c_str(),
+                entry->toString().c_str());
+        updatePlruOnAccess(setIdx, hitWay);
+        return std::make_pair(true, hitWay);
+    }
+
+    return std::make_pair(false, -1);
+}
+
+bool
+UopCache::checkUopCacheBlockHit(Addr startAddr, Addr endAddr,
+                                const UopCacheContext &context)
+{
+    if (!enableUopCache || endAddr <= startAddr) {
+        return false;
+    }
+
+    for (Addr pc = startAddr; pc < endAddr;) {
+        const UCInstDesc *instDesc = findInst(pc, context);
+        if (!instDesc) {
+            DPRINTF(UC, "uop cache block miss start=%#lx end=%#lx "
+                    "missPC=%#lx ctx=%s\n", startAddr, endAddr, pc,
+                    context.toString().c_str());
+            return false;
+        }
+        pc += instDesc->sizeBytes();
+    }
+
+    DPRINTF(UC, "uop cache block hit start=%#lx end=%#lx ctx=%s\n",
+            startAddr, endAddr, context.toString().c_str());
+    return true;
+}
+
+const UCInstDesc *
+UopCache::findInst(Addr instPC, int hitWay,
+                   const UopCacheContext &context, int *instIdx)
+{
+    if (hitWay < 0 || hitWay >= cache.size()) {
+        return nullptr;
+    }
+
+    Addr setIdx = getSetIdxFromVaddr(instPC);
+    Addr tag = getTagFromVaddr(instPC);
+    const auto &way = cache[hitWay];
+    const UopEntry *entry = way[setIdx].get();
+    if (!entry || !entry->valid || entry->tag != tag ||
+        entry->context != context ||
+        entry->firstInstPC != instPC) {
+        return nullptr;
+    }
+
+    if (instIdx) {
+        *instIdx = 0;
+    }
+
+    return &entry->inst;
+}
+
+const UCInstDesc *
+UopCache::findInst(Addr instPC, const UopCacheContext &context,
+                   int *hitWay, int *instIdx)
+{
+    const int way = findWay(instPC, context);
+    if (way < 0) {
+        return nullptr;
+    }
+    if (hitWay) {
+        *hitWay = way;
+    }
+    return findInst(instPC, way, context, instIdx);
+}
+
+bool
+UopCache::invalidateEntry(Addr fetchAddr)
+{
+    if (!enableUopCache) {
+        return false;
+    }
+
+    Addr setIdx = getSetIdxFromVaddr(fetchAddr);
+    Addr tag = getTagFromVaddr(fetchAddr);
+    bool hasInvalid = false;
+
+    for (auto &way : cache) {
+        auto &entry = way[setIdx];
+        if (entry && entry->valid && entry->tag == tag &&
+            entry->firstInstPC == fetchAddr) {
+            entry.reset();
+            hasInvalid = true;
+        }
+    }
+
+    return hasInvalid;
+}
+
+void
+UopCache::invalidateAll()
+{
+    // Staged refills are part of the invalidation domain.  Otherwise a stale
+    // decoded instruction could be reinstalled immediately after fence.i.
+    for (auto &way : cache) {
+        for (auto &entry : way) {
+            entry.reset();
+        }
+    }
+    refillEntryBuffer.clear();
+    currentRefillEntry.reset(newEntry());
+    isBuildMode_ = true;
+    DPRINTF(UC, "invalidated all cached and in-flight uop entries\n");
+}
+
+void
+UopCache::invalidateContext(const UopCacheContext &context)
+{
+    for (auto &way : cache) {
+        for (auto &entry : way) {
+            if (entry && entry->context == context) {
+                entry.reset();
+            }
+        }
+    }
+
+    // Apply the same boundary to entries not installed yet so invalidation
+    // cannot be undone by the next idealized refill tick.
+    refillEntryBuffer.erase(
+        std::remove_if(refillEntryBuffer.begin(), refillEntryBuffer.end(),
+            [&context](const UopEntryPtr &entry) {
+                return entry && entry->context == context;
+            }),
+        refillEntryBuffer.end());
+    if (currentRefillEntry && currentRefillEntry->valid &&
+        currentRefillEntry->context == context) {
+        currentRefillEntry.reset(newEntry());
+    }
+    DPRINTF(UC, "invalidated uop entries for context %s\n",
+            context.toString().c_str());
+}
+
+void
+UopCache::switchToBuildMode()
+{
+    flushCurUopEntry();
+    isBuildMode_ = true;
+}
+
+void
+UopCache::switchToStreamMode()
+{
+    flushCurUopEntry();
+    isBuildMode_ = false;
+}
+
+std::string
+UopEntry::toString() const
+{
+    std::stringstream ss;
+    ss << "UopEntry: bytesSize=" << bytesSize
+       << " firstInstPC=0x" << std::hex << firstInstPC
+       << " enUopCacheTime=" << std::dec << enUopCacheTime
+       << " tag=0x" << std::hex << tag
+       << " ctx=" << context.toString()
+       << " inst=";
+    if (valid) {
+        ss << inst.toString();
+    } else {
+        ss << "<invalid>";
+    }
+    return ss.str();
+}
+
+bool
+UopCacheContext::operator==(const UopCacheContext &other) const
+{
+    return prv == other.prv &&
+           virt == other.virt &&
+           satp == other.satp &&
+           vsatp == other.vsatp &&
+           hgatp == other.hgatp;
+}
+
+std::string
+UopCacheContext::toString() const
+{
+    std::stringstream ss;
+    ss << "{prv=" << std::dec << prv
+       << ", virt=" << virt
+       << ", satp=0x" << std::hex << satp
+       << ", vsatp=0x" << vsatp
+       << ", hgatp=0x" << hgatp
+       << "}";
+    return ss.str();
+}
+
+std::string
+UCInstDesc::toString() const
+{
+    std::stringstream ss;
+    ss << "{pc=0x" << std::hex << pc << ", compressed=" << std::dec
+       << compressed << "}";
+    return ss.str();
+}
+
+} // namespace o3
+} // namespace gem5

--- a/src/cpu/o3/uop_cache.hh
+++ b/src/cpu/o3/uop_cache.hh
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Copyright (c) 2004-2006 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_O3_UOP_CACHE_HH__
+#define __CPU_O3_UOP_CACHE_HH__
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/op_class.hh"
+#include "cpu/static_inst.hh"
+
+namespace gem5
+{
+
+struct BaseO3CPUParams;
+
+namespace o3
+{
+
+class CPU;
+class DynInst;
+
+struct UCInstDesc
+{
+    /** Immutable decode result reused by a later fetch of the same context. */
+    StaticInstPtr inst;
+    Addr pc = 0;
+    bool compressed = false;
+    Cycles enBufferTime = Cycles(0);
+
+    int sizeBytes() const { return compressed ? 2 : 4; }
+    std::string toString() const;
+};
+
+struct UopCacheContext
+{
+    /** Translation and privilege identity under which decoding occurred. */
+    RegVal prv = 0;
+    RegVal virt = 0;
+    RegVal satp = 0;
+    RegVal vsatp = 0;
+    RegVal hgatp = 0;
+
+    bool operator==(const UopCacheContext &other) const;
+    bool operator!=(const UopCacheContext &other) const
+    {
+        return !(*this == other);
+    }
+    std::string toString() const;
+};
+
+struct UopEntry
+{
+    /** One self-contained decoded RISC-V instruction and its lookup tag. */
+    Addr tag = 0;
+    UopCacheContext context;
+    UCInstDesc inst;
+    bool valid = false;
+    Cycles enUopCacheTime = Cycles(0);
+    Addr firstInstPC = 0;
+    int bytesSize = 0;
+
+    std::string toString() const;
+};
+
+class UopCache
+{
+  public:
+    /** Build an optionally enabled set-associative decoded-instruction cache. */
+    UopCache(CPU *_cpu, const BaseO3CPUParams &params);
+
+    bool enabled() const { return enableUopCache; }
+
+    /** Stage a normally decoded instruction for refill at the next tick. */
+    void addInst(const DynInstPtr &inst);
+    /** Commit all staged refills; refill bandwidth is intentionally ideal. */
+    void tick();
+    /** Close the current single-instruction refill entry if it is valid. */
+    void setCurrentUopEntryDone();
+    /** Discard a partial refill without invalidating installed entries. */
+    void flushCurUopEntry();
+
+    /** Snapshot the privilege/translation identity used as part of the tag. */
+    UopCacheContext getContext(ThreadID tid) const;
+    /** Lookup one exact PC/context pair and update replacement state on hit. */
+    std::pair<bool, int> checkUopCacheHit(
+        Addr instAddr, const UopCacheContext &context);
+    /** Require a contiguous instruction description for the entire block. */
+    bool checkUopCacheBlockHit(Addr startAddr, Addr endAddr,
+                               const UopCacheContext &context);
+    /** Read from a selected way without transferring entry ownership. */
+    const UCInstDesc *findInst(Addr instPC, int hitWay,
+                               const UopCacheContext &context,
+                               int *instIdx = nullptr);
+    /** Lookup and read one instruction, optionally returning its way/index. */
+    const UCInstDesc *findInst(Addr instPC,
+                               const UopCacheContext &context,
+                               int *hitWay = nullptr,
+                               int *instIdx = nullptr);
+    /** Invalidate every way containing the exact virtual instruction PC. */
+    bool invalidateEntry(Addr fetchAddr);
+
+    /**
+     * Invalidate all installed and in-flight decoded instructions.
+     *
+     * The operation clears cache contents, staged refills, the current build
+     * entry, and restores build mode.  UopCache owns no fetch-side pending
+     * lookup, so a caller integrating fence.i must cancel that state too.
+     */
+    void invalidateAll();
+
+    /** Invalidate installed and in-flight entries for one exact context. */
+    void invalidateContext(const UopCacheContext &context);
+
+    /** Accept refills from ordinary Decode traffic. */
+    void switchToBuildMode();
+    /** Suppress refills while Decode consumes cache-sourced traffic. */
+    void switchToStreamMode();
+    bool isBuildMode() const { return isBuildMode_; }
+    bool isStreamMode() const { return !isBuildMode_; }
+
+  private:
+    using UopEntryPtr = std::unique_ptr<UopEntry>;
+    using Way = std::vector<UopEntryPtr>;
+
+    /** Map a virtual halfword address into a possibly non-power-of-two set. */
+    Addr getSetIdxFromVaddr(Addr vaddr) const;
+    /** Return the quotient/tag paired with getSetIdxFromVaddr(). */
+    Addr getTagFromVaddr(Addr vaddr) const;
+    /** Allocate a blank entry with all validity state cleared. */
+    UopEntry *newEntry() const;
+    /** Find the exact PC/context match by scanning the bounded way count. */
+    int findWay(Addr instAddr, const UopCacheContext &context) const;
+    /** Prefer an empty way, otherwise select the tree-PLRU victim. */
+    int chooseReplacementWay(Addr setIdx) const;
+    /** Decode the per-set PLRU tree into a victim way number. */
+    int getPlruVictim(Addr setIdx) const;
+    /** Update PLRU direction bits after either a hit or refill. */
+    void updatePlruOnAccess(Addr setIdx, int way);
+
+    CPU *cpu;
+
+    struct UopCacheStats : public statistics::Group
+    {
+        UopCacheStats(CPU *cpu, unsigned max_inst_bytes_per_entry);
+        void regStats() override;
+
+        const unsigned maxInstBytesPerEntry;
+        statistics::Scalar entryRefills;
+        statistics::Scalar entryInstsTotal;
+        statistics::Scalar entryBytesTotal;
+        statistics::Scalar entryCapacityBytesTotal;
+        statistics::Distribution entryInsts;
+        statistics::Distribution entryBytes;
+        statistics::Formula avgEntryInsts;
+        statistics::Formula avgEntryBytes;
+        statistics::Formula entryByteUtilization;
+    } stats;
+
+    /** Completed entries waiting for the next idealized refill tick. */
+    std::deque<UopEntryPtr> refillEntryBuffer;
+    /** Entry currently assembled by Decode; currently exactly one inst. */
+    UopEntryPtr currentRefillEntry;
+    /** Way-major cache storage. */
+    std::vector<Way> cache;
+    /** Per-set tree-PLRU direction bits. */
+    std::vector<std::vector<uint8_t>> plruTrees;
+
+    /** Construction-time feature gate; false keeps all lookup/refill inert. */
+    bool enableUopCache;
+    /** Nominal storage bytes charged to each single-instruction entry. */
+    int maxInstBytesPerEntry;
+    /** Number of index sets in each way. */
+    int setNum;
+    /** Bounded associativity and lookup scan width. */
+    int wayNum;
+    /** Select mask/shift indexing instead of modulo/division when possible. */
+    bool setNumIsPowerOf2;
+    /** Low halfword-address bits used as the set index for power-of-two sets. */
+    Addr setIdxMask;
+    /** Number of set-index bits removed to form the tag. */
+    unsigned setIdxShift;
+    /** True for normal-path refill, false for cache-stream consumption. */
+    bool isBuildMode_;
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_UOP_CACHE_HH__

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -50,7 +50,18 @@ public:
     inline FetchTarget& front(ThreadID tid) { return queue[tid].cap.front(); }
     inline FetchTarget& back(ThreadID tid) { return queue[tid].cap.back(); }
     inline FetchTarget& fetching(ThreadID tid) { return get(queue[tid].fetchptr, tid); }
+    // Uop-cache probes only inspect FTQ boundaries.  A const accessor makes
+    // that read-only contract explicit and prevents lookup code from
+    // accidentally changing predictor-owned state.
+    inline const FetchTarget& fetching(ThreadID tid) const { return get(queue[tid].fetchptr, tid); }
     inline FetchTarget& get(FetchTargetId targetId, ThreadID tid) {
+        assert(targetId >= queue[tid].baseTargetId &&
+               targetId < queue[tid].baseTargetId + queue[tid].cap.size());
+        return queue[tid].cap[targetId - queue[tid].baseTargetId];
+    }
+    // Const counterpart used by read-only frontend consumers such as decoded
+    // block lookup and diagnostics.
+    inline const FetchTarget& get(FetchTargetId targetId, ThreadID tid) const {
         assert(targetId >= queue[tid].baseTargetId &&
                targetId < queue[tid].baseTargetId + queue[tid].cap.size());
         return queue[tid].cap[targetId - queue[tid].baseTargetId];


### PR DESCRIPTION
Add the decoded uop cache to the O3 frontend with explicit refill, lookup, I-cache bypass, and Decode bypass behavior. Keep the feature disabled by default and enable it only with --enable-uop-cache so performance comparisons are intentional. Document the cache organization, UopCacheContext matching, entry-capacity semantics, bypass timing, observed benefits, and modeling limitations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in decoded-instruction (uop) cache for the O3 frontend, with configurable sizing, bypass handling, and refill behavior.
  * Added detailed hit, miss, bypass, invalidation, fusion, and utilization statistics.
* **Bug Fixes**
  * Prevented unsupported uop-cache and SMT configurations.
  * Improved cache consistency after instruction, address-translation, and permission changes.
* **Documentation**
  * Added comprehensive uop-cache design documentation covering behavior, performance, limitations, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->