### PR TITLE
mem: Model multi-bank load conflicts

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1129,27 +1129,55 @@ LSQ::getDcacheDivBankSetKey(Addr vaddr) const
 }
 
 bool
-LSQ::loadBankConflictedCheck(Addr vaddr)
+LSQ::loadBankConflictedCheck(Addr vaddr, unsigned size)
 {
-    bool now_bank_conflict = false;
-    const unsigned bankIndex = bankNum(vaddr);
-    const unsigned div = getDcacheDiv(vaddr);
-    const uint64_t key = getDcacheDivBankSetKey(vaddr);
+    if (!enableBankConflictCheck || size == 0) {
+        return false;
+    }
 
-    if (enableBankConflictCheck) {
-        if (recentlyloadAddr.contains(key)) {
-            recentlyloadAddr.get(key);
-            return false;
-        }
-        if (bankOccupied[div][bankIndex]) {
-            now_bank_conflict = true;
+    struct TouchedBank
+    {
+        unsigned bankIndex;
+        unsigned div;
+        uint64_t key;
+        bool recentlyAccessed;
+    };
 
-        } else {
-            bankOccupied[div][bankIndex] = true;
-            recentlyloadAddr.insert(key, {});
+    // Collect all banks will be touched by the load request.
+    // Eg. Bank size = 2B, load size = 8B, address = 0x0, will touch bank 0,1,2,3.
+    std::vector<TouchedBank> touched_banks;
+    for (unsigned offset = 0; offset < size;) {
+        const Addr bank_vaddr = vaddr + offset;
+        touched_banks.push_back({
+            bankNum(bank_vaddr),
+            getDcacheDiv(bank_vaddr),
+            getDcacheDivBankSetKey(bank_vaddr),
+            false
+        });
+        // Take care of misaligned situation.
+        Addr offsetInc = dcacheBankBytes - (bank_vaddr & (dcacheBankBytes - 1));
+        offset += offsetInc;
+    }
+
+    // Probe every target bank before claiming any of them. A failed
+    // multi-bank load will not update bankOccupied and recentlyloadAddr.
+    for (auto &bank : touched_banks) {
+        bank.recentlyAccessed = recentlyloadAddr.contains(bank.key);
+        if (!bank.recentlyAccessed &&
+            bankOccupied[bank.div][bank.bankIndex]) {
+            return true;
         }
     }
-    return now_bank_conflict;
+
+    // Occupy the banks and insert new keys to recentlyloadAddr.
+    for (const auto &bank : touched_banks) {
+        bankOccupied[bank.div][bank.bankIndex] = true;
+        if (!bank.recentlyAccessed) {
+            recentlyloadAddr.insert(bank.key, {});
+        }
+    }
+
+    return false;
 }
 
 void

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1166,7 +1166,7 @@ class LSQ
         return (a >> dcacheBankOffsetBits) & (numBank - 1);
     }
 
-    bool loadBankConflictedCheck(Addr vaddr);
+    bool loadBankConflictedCheck(Addr vaddr, unsigned size);
 
     void setDcacheWriteStall(bool t) { dcacheWriteStall = t; }
     bool getDcacheWriteStall() { return dcacheWriteStall; }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -3010,7 +3010,8 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
     bool cache_got_blocked = false;
     LSQRequest *request = dynamic_cast<LSQRequest *>(data_pkt->senderState);
     if (isLoad) {
-        bank_conflict = lsq->loadBankConflictedCheck(data_pkt->req->getVaddr());
+        bank_conflict = lsq->loadBankConflictedCheck(
+            data_pkt->req->getVaddr(), data_pkt->req->getSize());
     }
     // Record the tick count at the time of sending to let
     // the subsequent cache understand the request's sending time.


### PR DESCRIPTION
## Motivation

**There are still some problems inside this PR: https://github.com/OpenXiangShan/GEM5/pull/988, some logic is missing. So this PR wants to fix it.**

The scenario where the problem occurs is:
Loads larger than a D-cache bank can touch multiple banks, but the conflict check previously reserved only the bank containing the starting virtual address.

## Approach

- Pass the packet size to the load-side bank conflict checker.
- Enumerate every bank overlapped by the packet, including unaligned endpoints.
- Probe all target banks before claiming any; a conflict leaves all occupancy and recent-address state unchanged.
- Claim every target bank only after the full probe succeeds.

## Scope

O3 LSQ load-side bank-conflict accounting. Split requests retain the existing per-packet arbitration semantics.

## Validation

- git diff --check
- git diff --cached --check
- Reviewed 2B-bank/8B-load and 8B-bank/4B-load boundary cases.
- Per request, no build or regression was run.