### PR TITLE
arch-riscv: Add H-mode L1 TLB compression

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -434,9 +434,21 @@ Walker::doL2TLBHitSchedule(const RequestPtr &req, ThreadContext *tc, BaseMMU::Tr
     l2state.translation = translation;
     l2state.mode = mode;
     l2state.Paddr = Paddr;
-    l2state.entry = entry;
-    l2state.entryVsstage = entryVsstage;
-    l2state.entryGstage = entryGstage;
+    l2state.hasEntry = entry != nullptr;
+    l2state.hasEntryVsstage = entryVsstage != nullptr;
+    l2state.hasEntryGstage = entryGstage != nullptr;
+    if (entry) {
+        l2state.entry = *entry;
+        l2state.entry.trieHandle = nullptr;
+    }
+    if (entryVsstage) {
+        l2state.entryVsstage = *entryVsstage;
+        l2state.entryVsstage.trieHandle = nullptr;
+    }
+    if (entryGstage) {
+        l2state.entryGstage = *entryGstage;
+        l2state.entryGstage.trieHandle = nullptr;
+    }
     L2TLBrequestors.push_back(l2state);
 }
 
@@ -720,23 +732,40 @@ Walker::dol2TLBHit()
         //assert(l2tlbFault == NoFault);
         if (l2tlbFault == NoFault) {
             if (enableL1L2replace){ //write back entry from L2 to L1
-                if (dol2TLBHitrequestors.entry != nullptr) {
+                if (dol2TLBHitrequestors.hasEntry) {
+                    TlbEntry &entry = dol2TLBHitrequestors.entry;
                     TlbEntry l1_entry;
                     if (tlb->isL1DirectCompressionEnabled() &&
                         tlb->buildSingleL1CompressedEntry(dol2TLBHitrequestors.req->getVaddr(),
-                                                          *dol2TLBHitrequestors.entry, direct, l1_entry)) {
+                                                          entry, direct, l1_entry)) {
                         tlb->insert(l1_entry.vaddr, l1_entry, false, direct);
                         tlb->recordL1CompressedEntry(l1_entry);
                     } else if (!tlb->isL1DirectCompressionEnabled()) {
-                        tlb->insert(dol2TLBHitrequestors.entry->vaddr, *dol2TLBHitrequestors.entry, false, direct);
+                        tlb->insert(entry.vaddr, entry, false, direct);
                     }
                 }
-                if (dol2TLBHitrequestors.entryVsstage != nullptr)
-                    tlb->insert(dol2TLBHitrequestors.entryVsstage->vaddr, *dol2TLBHitrequestors.entryVsstage, false,
-                            vsstage);
-                if (dol2TLBHitrequestors.entryGstage != nullptr)
-                    tlb->insert(dol2TLBHitrequestors.entryGstage->gpaddr, *dol2TLBHitrequestors.entryGstage, false,
-                            gstage);
+                if (dol2TLBHitrequestors.hasEntryVsstage) {
+                    TlbEntry &entry = dol2TLBHitrequestors.entryVsstage;
+                    TlbEntry l1_entry;
+                    if (tlb->isL1DirectCompressionEnabled() &&
+                        tlb->buildSingleL1CompressedEntry(entry.vaddr, entry, vsstage, l1_entry)) {
+                        tlb->insert(l1_entry.vaddr, l1_entry, false, vsstage);
+                        tlb->recordL1CompressedEntry(l1_entry);
+                    } else if (!tlb->isL1DirectCompressionEnabled()) {
+                        tlb->insert(entry.vaddr, entry, false, vsstage);
+                    }
+                }
+                if (dol2TLBHitrequestors.hasEntryGstage) {
+                    TlbEntry &entry = dol2TLBHitrequestors.entryGstage;
+                    TlbEntry l1_entry;
+                    if (tlb->isL1DirectCompressionEnabled() &&
+                        tlb->buildSingleL1CompressedEntry(entry.gpaddr, entry, gstage, l1_entry)) {
+                        tlb->insert(l1_entry.vaddr, l1_entry, false, gstage);
+                        tlb->recordL1CompressedEntry(l1_entry);
+                    } else if (!tlb->isL1DirectCompressionEnabled()) {
+                        tlb->insert(entry.gpaddr, entry, false, gstage);
+                    }
+                }
             }
             dol2TLBHitrequestors.translation->finish(
                 l2tlbFault, dol2TLBHitrequestors.req, dol2TLBHitrequestors.tc,
@@ -1027,7 +1056,29 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
             DPRINTF(PageTableWalkerTwoStage, "twoStageStepWalk(G): found the leaf pte.\n");
 
             if (finishGVA && (!isVsatp0Mode)) {
-                walker->tlb->insert(entry.gpaddr, entry, false, gstage);
+                if (walker->tlb->isL1DirectCompressionEnabled()) {
+                    TlbEntry compressed_entry;
+                    bool inserted_compressed = false;
+                    if (!tlbHit) {
+                        std::array<PTE, l2tlbLineSize> l1_compress_ptes;
+                        for (int compress_i = 0; compress_i < l2tlbLineSize; compress_i++) {
+                            l1_compress_ptes[compress_i] = read->getLE_l2tlb<uint64_t>(compress_i);
+                        }
+                        if (walker->tlb->buildL1CompressedEntry(entry.gpaddr, entry, l1_compress_ptes, gstage,
+                                                                 twoStageLevel, compressed_entry)) {
+                            walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, gstage);
+                            walker->tlb->recordL1CompressedEntry(compressed_entry);
+                            inserted_compressed = true;
+                        }
+                    }
+                    if (!inserted_compressed &&
+                        walker->tlb->buildSingleL1CompressedEntry(entry.gpaddr, entry, gstage, compressed_entry)) {
+                        walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, gstage);
+                        walker->tlb->recordL1CompressedEntry(compressed_entry);
+                    }
+                } else {
+                    walker->tlb->insert(entry.gpaddr, entry, false, gstage);
+                }
                 int l2_level = twoStageLevel;
                 inl2Entry.gpaddr = entry.gpaddr;
                 inl2Entry.pte = pte;
@@ -1234,7 +1285,30 @@ Walker::WalkerState::twoStageWalk(PacketPtr &write)
                         gPaddr = gPaddr | (entry.vaddr & PGMASK);
 
                         entry.paddr = (gPaddr >> 12) << 12;
-                        walker->tlb->insert(entry.vaddr, entry, false, vsstage);
+                        if (walker->tlb->isL1DirectCompressionEnabled()) {
+                            TlbEntry compressed_entry;
+                            bool inserted_compressed = false;
+                            if (!tlbHit) {
+                                std::array<PTE, l2tlbLineSize> l1_compress_ptes;
+                                for (int compress_i = 0; compress_i < l2tlbLineSize; compress_i++) {
+                                    l1_compress_ptes[compress_i] = read->getLE_l2tlb<uint64_t>(compress_i);
+                                }
+                                if (walker->tlb->buildL1CompressedEntry(entry.vaddr, entry, l1_compress_ptes, vsstage,
+                                                                         level, compressed_entry)) {
+                                    walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, vsstage);
+                                    walker->tlb->recordL1CompressedEntry(compressed_entry);
+                                    inserted_compressed = true;
+                                }
+                            }
+                            if (!inserted_compressed &&
+                                walker->tlb->buildSingleL1CompressedEntry(entry.vaddr, entry, vsstage,
+                                                                           compressed_entry)) {
+                                walker->tlb->insert(compressed_entry.vaddr, compressed_entry, false, vsstage);
+                                walker->tlb->recordL1CompressedEntry(compressed_entry);
+                            }
+                        } else {
+                            walker->tlb->insert(entry.vaddr, entry, false, vsstage);
+                        }
                         if (!tlbHit) {
                             int l2_level = level;
                             inl2Entry.gpaddr = gPaddr;

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -630,6 +630,9 @@ Walker::WalkerState::tryCoalesce(ThreadContext *_tc, BaseMMU::Translation *trans
                                  BaseMMU::Mode _mode, bool from_l2tlb, Addr asid, bool from_forward_pre_req,
                                  bool from_back_pre_req)
 {
+    if (nextlineOnly)
+        return std::make_pair(false, NoFault);
+
 
     SATP _satp = _tc->readMiscReg(MISCREG_SATP);
     bool priv_match;
@@ -907,6 +910,91 @@ Walker::WalkerState::startFunctional(Addr &addr, unsigned &logBytes,
 }
 
 Fault
+Walker::WalkerState::twoStageNextlineWalk(PacketPtr &write)
+{
+    write = nullptr;
+    const Addr nextlineBasicGpaddr = nextlineEntry.gpaddr;
+
+    for (int i = 0; i < l2tlbLineSize; i++) {
+        nextlineEntry.gpaddr =
+            (((nextlineBasicGpaddr >> (PageShift + L2TLB_BLK_OFFSET))
+              << L2TLB_BLK_OFFSET) + i)
+            << PageShift;
+        nextlineEntry.vaddr = nextlineEntry.gpaddr;
+        nextlineEntry.pte = read->getLE_l2tlb<uint64_t>(i);
+        nextlineEntry.paddr = nextlineEntry.pte.ppn;
+        nextlineEntry.index =
+            (nextlineEntry.gpaddr >> (PageShift + L2TLB_BLK_OFFSET)) &
+            walker->tlb->L2TLB_L0_MASK;
+        walker->tlb->L2TLBInsert(nextlineEntry.gpaddr, nextlineEntry, 0,
+                                 L_L2L0, i, false, gstage);
+    }
+
+    DPRINTF(PageTableWalkerTwoStage,
+            "H nextline: refill G-stage L2L0 base %#lx\n",
+            nextlineBasicGpaddr);
+    nextline = false;
+    endWalk();
+    return NoFault;
+}
+
+bool
+Walker::WalkerState::startTwoStageNextline(PacketPtr oldRead,
+                                            unsigned readSize,
+                                            Request::Flags flags)
+{
+    if (twoStageLevel != 0 || !timing || !openNextline ||
+        !autoNextlineSign || fromPre || fromBackPre)
+        return false;
+
+    const Addr nextRead = oldRead->getAddr() + readSize;
+    if ((oldRead->getAddr() >> PageShift) != (nextRead >> PageShift))
+        return false;
+
+    TlbEntry prefetchedEntry = entry;
+    prefetchedEntry.gpaddr = entry.gpaddr +
+        (l2tlbLineSize << PageShift);
+    prefetchedEntry.vaddr = prefetchedEntry.gpaddr;
+    prefetchedEntry.asid = vsatp.asid;
+    prefetchedEntry.vmid = hgatp.vmid;
+    prefetchedEntry.logBytes = PageShift;
+    prefetchedEntry.level = 0;
+    prefetchedEntry.isSquashed = false;
+    prefetchedEntry.used = false;
+    prefetchedEntry.isPre = true;
+    prefetchedEntry.fromForwardPreReq = false;
+    prefetchedEntry.fromBackPreReq = false;
+    prefetchedEntry.preSign = false;
+    prefetchedEntry.trieHandle = nullptr;
+
+    RequestPtr request = std::make_shared<Request>(
+        nextRead, readSize, flags, walker->requestorId);
+    WalkerState *nextlineState = new WalkerState(walker, nullptr, mainReq);
+    nextlineState->state = Waiting;
+    nextlineState->nextState = Translate;
+    nextlineState->timing = true;
+    nextlineState->started = true;
+    nextlineState->translateMode = twoStageMode;
+    nextlineState->nextline = true;
+    nextlineState->nextlineOnly = true;
+    nextlineState->finishDefaultTranslate = true;
+    nextlineState->nextlineEntry = prefetchedEntry;
+    if (!walker->reservePtwLevel(nextlineState, 0)) {
+        delete nextlineState;
+        return false;
+    }
+    nextlineState->read = new Packet(request, MemCmd::ReadReq);
+    nextlineState->read->allocate();
+    walker->currStates.push_back(nextlineState);
+    nextlineState->sendPackets();
+
+    DPRINTF(PageTableWalkerTwoStage,
+            "H nextline: issue G-stage L0 read %#lx for gpaddr %#lx\n",
+            nextRead, prefetchedEntry.gpaddr);
+    return true;
+}
+
+Fault
 Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
 {
     assert(state != Ready && state != Waiting);
@@ -1153,6 +1241,8 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
             walker->tlb->insert(entry.vaddr, entry, false, allstage);
 
 
+            walker->releasePtwLevel(this);
+            startTwoStageNextline(oldRead, oldSize, flags);
             endWalk();
             return NoFault;
         } else if ((!doEndWalk) || (doLLwalk)) {
@@ -1164,6 +1254,8 @@ Walker::WalkerState::twoStageStepWalk(PacketPtr &write)
                 entry.level = twoStageLevel;
                 entry.gpaddr = entry.vaddr;
                 walker->tlb->insert(entry.vaddr, entry, false, gstage);
+                walker->releasePtwLevel(this);
+                startTwoStageNextline(oldRead, oldSize, flags);
                 endWalk();
                 return NoFault;
             }
@@ -2144,9 +2236,9 @@ Walker::WalkerState::setupWalk(Addr ppn, Addr vaddr, int f_level, bool from_l2tl
     Fault fault = NoFault;
     if (translateMode == twoStageMode) {
         nextline = false;
-        autoNextlineSign = false;
+        openNextline = open_nextline;
+        autoNextlineSign = auto_open_nextline;
         preHitInPtw = false;
-        nextline = false;
         topAddr = (vsatp.ppn << PageShift) + (idx * sizeof(PTE));
         gPaddr = (vsatp.ppn << PageShift) + (idx_f * sizeof(PTE));
         if ((mainReq->get_level() != top_level) && (mainReq->getgPaddr() != 0)) {
@@ -2320,7 +2412,11 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
         nextState = Ready;
         PacketPtr write = NULL;
         read = pkt;
-        if ((translateMode == twoStageMode) && (inGstage)) {
+        if ((translateMode == twoStageMode) && nextlineOnly) {
+            DPRINTF(PageTableWalker,
+                    "recvPacket in twoStageMode: G-stage nextline.\n");
+            mainFault = twoStageNextlineWalk(write);
+        } else if ((translateMode == twoStageMode) && (inGstage)) {
             DPRINTF(PageTableWalker, "recvPacket in twoStageMode: Gstage.\n");
             mainFault = twoStageStepWalk(write);
         } else if ((translateMode == twoStageMode) && (!inGstage)) {
@@ -2355,6 +2451,11 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
     if (waitingForPtwLevel)
         return false;
 
+    if (nextlineOnly && inflight == 0 && read == NULL && writes.size() == 0) {
+        state = Ready;
+        nextState = Waiting;
+        return true;
+    }
     if ((inflight == 0 && read == NULL && writes.size() == 0) && (translateMode == twoStageMode)) {
         state = Ready;
         nextState = Waiting;

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -184,6 +184,7 @@ namespace RiscvISA
             int translateMode;
             bool inGstage;
             bool finishGVA;
+            bool nextlineOnly;
             int gpaddrMode;
             bool finishGPA;
             bool GstageFault;
@@ -211,7 +212,7 @@ namespace RiscvISA
                 tlbSizePte(0), openNextline(false), autoNextlineSign(false),
                 finishDefaultTranslate(false), preHitInPtw(false), fromPre(false),
                 fromBackPre(false),virt(0),translateMode(0),inGstage(false),finishGVA(false),
-                gpaddrMode(0),finishGPA(false),GstageFault(false),
+                nextlineOnly(false), gpaddrMode(0),finishGPA(false),GstageFault(false),
                 tlbHit(false),tlbHitPte(0),tlbflags(Request::PHYSICAL),
                 waitingForPtwLevel(false), reservedPtwLevel(-1),
                 blockedPtwLevel(-1), blockedPtwRead(0), blockedPtwReadSize(0),
@@ -257,6 +258,10 @@ namespace RiscvISA
             Fault startTwoStageWalkFromTLBInG(Addr ppn, Addr vaddr);
 
             Fault twoStageStepWalk(PacketPtr &write);
+            Fault twoStageNextlineWalk(PacketPtr &write);
+            bool startTwoStageNextline(PacketPtr oldRead,
+                                       unsigned readSize,
+                                       Request::Flags flags);
             Fault twoStageWalk(PacketPtr &write);
             Fault stepWalk(PacketPtr &write);
             void sendPackets();

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -285,9 +285,12 @@ namespace RiscvISA
               BaseMMU::Translation *translation;
               BaseMMU::Mode mode;
               Addr Paddr;
-              TlbEntry *entry;
-              TlbEntry *entryVsstage;
-              TlbEntry *entryGstage;
+              bool hasEntry;
+              bool hasEntryVsstage;
+              bool hasEntryGstage;
+              TlbEntry entry;
+              TlbEntry entryVsstage;
+              TlbEntry entryGstage;
         };
         std::list<L2TlbState> L2TLBrequestors;
 

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -2117,7 +2117,7 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
 
 
                 walker->doL2TLBHitSchedule(req, tc, translation, mode, gPaddr, e_l2tlb, e_l2tlbVsstage, e_l2tlbGstage,
-                                           3);
+                                           1);
                 return std::make_pair(hit_type,NoFault);
             } else {
                 DPRINTF(TLB, "l1tlb miss in Gstage, set TwoStagePageTableWalk\n");

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -103,6 +103,27 @@ l1CompressedBlockBase(Addr vaddr)
 }
 
 static bool
+isL1CompressionMode(uint8_t translateMode)
+{
+    return translateMode == direct || translateMode == vsstage ||
+           translateMode == gstage;
+}
+
+static uint16_t
+l1CompressionContextId(const TlbEntry &entry, uint8_t translateMode)
+{
+    return translateMode == gstage ? entry.vmid : entry.asid;
+}
+
+static bool
+sameL1CompressionContext(const TlbEntry &entry, uint16_t asid,
+                         uint8_t translateMode)
+{
+    return entry.translateMode == translateMode &&
+           l1CompressionContextId(entry, translateMode) == asid;
+}
+
+static bool
 isCompressibleLeafPte(PTE pte)
 {
     return pte.v && !(!pte.r && pte.w) && (pte.r || pte.x);
@@ -689,11 +710,11 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
             vpn, translateMode == gstage ? entry.vmid : entry.asid, entry.paddr, entry.pte, entry.size());
 
     if (!squashed_update && enableL1DirectCompression &&
-        translateMode == direct && !entry.isCompressed) {
+        isL1CompressionMode(translateMode) && !entry.isCompressed) {
         TlbEntry compressed_entry;
         panic_if(!buildSingleL1CompressedEntry(vpn, entry, translateMode,
                                                compressed_entry),
-                 "normal direct L1 entry inserted while compression is "
+                 "normal L1 entry inserted while compression is "
                  "enabled: vpn %#x pte %#x level %d\n",
                  vpn, entry.pte, (int)entry.level);
         return insert(compressed_entry.vaddr, compressed_entry, false,
@@ -701,7 +722,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     }
 
     if (!squashed_update && enableL1DirectCompression &&
-        translateMode == direct) {
+        isL1CompressionMode(translateMode)) {
         TlbEntry *merged_entry = prepareL1CompressedInsert(
             entry, translateMode);
         if (merged_entry) {
@@ -734,7 +755,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
     }
 
     if (newEntry) {
-        if (entry.isCompressed && translateMode == direct &&
+        if (entry.isCompressed && isL1CompressionMode(translateMode) &&
             newEntry->isCompressed && newEntry->l1CompressedNarrow)
             newEntry = nullptr;
     }
@@ -781,21 +802,23 @@ TLB::insert(Addr vpn, const TlbEntry &entry,bool squashed_update,uint8_t transla
         return newEntry;
     }
 
+    Addr key = buildKey(vpn, entry.asid, translateMode);
+    if (translateMode == gstage)
+        key = buildKey(vpn, entry.vmid, translateMode);
+    const unsigned trie_width =
+        TlbEntryTrie::MaxBits - entry.logBytes + PGSHFT;
+
     if (freeList.empty())
         evictLRU();
 
     newEntry = freeList.front();
     freeList.pop_front();
 
-    Addr key = buildKey(vpn, entry.asid, translateMode);
-    if (translateMode == gstage)
-        key = buildKey(vpn, entry.vmid, translateMode);
     *newEntry = entry;
     newEntry->translateMode = translateMode;
     newEntry->lruSeq = nextSeq();
     newEntry->vaddr = vpn;
-    newEntry->trieHandle = trie.insert(
-        key, TlbEntryTrie::MaxBits - entry.logBytes + PGSHFT, newEntry);
+    newEntry->trieHandle = trie.insert(key, trie_width, newEntry);
     DPRINTF(TLBVerbosel2, "trie insert key %#x logbytes %#x paddr %#x\n", key,
             entry.logBytes, newEntry->paddr);
     // stats all insert number
@@ -1356,6 +1379,23 @@ TLB::getEntryPaddr(const TlbEntry *entry, Addr vaddr) const
     return (ppn << PageShift) | (vaddr & mask(PageShift));
 }
 
+PTE
+TLB::getEntryPte(const TlbEntry *entry, Addr vaddr) const
+{
+    assert(entry != nullptr);
+
+    PTE pte = entry->pte;
+    if (!entry->isCompressed || entry->level != 0)
+        return pte;
+
+    const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
+    assert(entry->validIdx & (1 << sub_idx));
+
+    pte.ppn = (entry->paddr << L2TLB_BLK_OFFSET) |
+              entry->ppnLow[sub_idx];
+    return pte;
+}
+
 bool
 TLB::refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
                           BaseMMU::Mode mode, const TlbEntry &entry,
@@ -1419,7 +1459,7 @@ TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
                                 uint8_t translateMode,
                                 const TlbEntry *missed_entry)
 {
-    if (!enableL1DirectCompression || translateMode != direct)
+    if (!enableL1DirectCompression || !isL1CompressionMode(translateMode))
         return nullptr;
 
     const uint8_t sub_idx = (vaddr >> PageShift) & VADDR_CHOOSE_MASK;
@@ -1430,10 +1470,10 @@ TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
         TlbEntry &entry = tlb[i];
         if (&entry == missed_entry || !entry.trieHandle)
             continue;
-        if (!entry.isCompressed || entry.translateMode != direct)
+        if (!entry.isCompressed ||
+            !sameL1CompressionContext(entry, asid, translateMode))
             continue;
-        if (entry.asid != asid ||
-            l1CompressedBlockBase(entry.vaddr) != block_base ||
+        if (l1CompressedBlockBase(entry.vaddr) != block_base ||
             entry.level != 0)
             continue;
         if (!(entry.validIdx & (1 << sub_idx)))
@@ -1449,7 +1489,7 @@ TLB::lookupL1CompressedFallback(Addr vaddr, uint16_t asid,
 TlbEntry *
 TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
 {
-    if (!entry.isCompressed || translateMode != direct)
+    if (!entry.isCompressed || !isL1CompressionMode(translateMode))
         return nullptr;
 
     TlbEntry *merged_entry = nullptr;
@@ -1457,8 +1497,8 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
         tlbKeyComparablePageBase(entry.vaddr, entry.logBytes);
     const Addr block_limit = block_base + entry.size();
 
-    auto reinsert_narrow = [this](TlbEntry &narrow_entry,
-                                  size_t entry_idx) {
+    auto reinsert_narrow = [this, translateMode](TlbEntry &narrow_entry,
+                                                 size_t entry_idx) {
         const int narrow_idx = firstValidIdx(narrow_entry.validIdx);
         panic_if(narrow_idx < 0,
                  "compressed TLB entry has no valid subentry\n");
@@ -1468,6 +1508,9 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
             narrow_entry.trieHandle = nullptr;
         }
         narrow_entry.l1CompressedNarrow = true;
+        const uint8_t keep_idx = 1 << narrow_idx;
+        narrow_entry.validIdx &= keep_idx;
+        narrow_entry.pteIdx &= keep_idx;
 
         const Addr narrow_base =
             tlbKeyComparablePageBase(narrow_entry.vaddr,
@@ -1480,10 +1523,20 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
                 continue;
 
             TlbEntry &other_entry = tlb[j];
-            if (!other_entry.trieHandle || !other_entry.isCompressed ||
-                !other_entry.l1CompressedNarrow ||
-                other_entry.translateMode != direct ||
-                other_entry.asid != narrow_entry.asid)
+            if (!other_entry.trieHandle ||
+                other_entry.translateMode != translateMode ||
+                l1CompressionContextId(other_entry, translateMode) !=
+                l1CompressionContextId(narrow_entry, translateMode))
+                continue;
+
+            if (!other_entry.isCompressed) {
+                if (other_entry.logBytes == PageShift &&
+                    other_entry.vaddr == narrow_vaddr)
+                    remove(j);
+                continue;
+            }
+
+            if (!other_entry.l1CompressedNarrow)
                 continue;
 
             const int other_idx = firstValidIdx(other_entry.validIdx);
@@ -1501,8 +1554,10 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
                 remove(j);
         }
 
-        const Addr narrow_key =
-            buildKey(narrow_vaddr, narrow_entry.asid, direct);
+        const Addr narrow_key = buildKey(
+            narrow_vaddr, l1CompressionContextId(narrow_entry, translateMode),
+            translateMode);
+
         narrow_entry.trieHandle =
             trie.insert(narrow_key, TlbEntryTrie::MaxBits, &narrow_entry);
     };
@@ -1511,9 +1566,10 @@ TLB::prepareL1CompressedInsert(const TlbEntry &entry, uint8_t translateMode)
         TlbEntry &old_entry = tlb[i];
         if (!old_entry.trieHandle)
             continue;
-        if (old_entry.translateMode != direct)
+        if (old_entry.translateMode != translateMode)
             continue;
-        if (old_entry.asid != entry.asid)
+        if (l1CompressionContextId(old_entry, translateMode) !=
+            l1CompressionContextId(entry, translateMode))
             continue;
 
         const Addr old_base =
@@ -1577,7 +1633,7 @@ TLB::buildL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
                             uint8_t translateMode, int level,
                             TlbEntry &compressed_entry) const
 {
-    if (translateMode != direct || level != 0)
+    if (!isL1CompressionMode(translateMode) || level != 0)
         return false;
 
     if (!isCompressibleLeafPte(base_entry.pte))
@@ -1628,7 +1684,7 @@ TLB::buildSingleL1CompressedEntry(Addr vaddr, const TlbEntry &base_entry,
                                   uint8_t translateMode,
                                   TlbEntry &compressed_entry) const
 {
-    if (translateMode != direct)
+    if (!isL1CompressionMode(translateMode))
         return false;
 
     if (!isCompressibleLeafPte(base_entry.pte))
@@ -1681,7 +1737,7 @@ TLB::recordL1CompressionPotential(Addr vaddr, PTE base_pte,
                                   const std::array<PTE, l2tlbLineSize> &ptes,
                                   uint8_t translateMode, int level)
 {
-    if (translateMode != direct || level != 0)
+    if (!isL1CompressionMode(translateMode) || level != 0)
         return;
 
     stats.l1CompressPotentialAttempts++;
@@ -2012,28 +2068,29 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
         e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage,
                       is_prefetch);
         if (e[0]){
-            req->setPte(e[0]->pte);
+            PTE vs_pte = getEntryPte(e[0], vaddr);
+            req->setPte(vs_pte);
             hit_type = h_l1VSstageHit;
-            gPaddr = e[0]->pte.ppn <<12;
-            DPRINTF(TLB, "l1tlb hit in VSstage: level %d, ppn %#x\n", e[0]->level, e[0]->pte.ppn);
+            gPaddr = vs_pte.ppn <<12;
+            DPRINTF(TLB, "l1tlb hit in VSstage: level %d, ppn %#x\n", e[0]->level, vs_pte.ppn);
             if (e[0]->level >0){
                 pg_mask =  (1ULL << (12 + 9 * e[0]->level)) - 1;
-                gPaddr = ((e[0]->pte.ppn << 12) & ~pg_mask) | (vaddr & pg_mask & ~PGMASK);
+                gPaddr = ((vs_pte.ppn << 12) & ~pg_mask) | (vaddr & pg_mask & ~PGMASK);
             }
             gPaddr = gPaddr | (vaddr & PGMASK);
-            if (mode == BaseMMU::Write && !e[0]->pte.d) {
+            if (mode == BaseMMU::Write && !vs_pte.d) {
                 fault = createPagefault(vaddr, 0, mode, false);
                 //return fault;
                 return std::make_pair(hit_type,fault);
             } else {
-                fault = checkPermissions(vstatus, pmode, vaddr, mode, e[0]->pte, 0, false);
+                fault = checkPermissions(vstatus, pmode, vaddr, mode, vs_pte, 0, false);
                 if (fault != NoFault) {
                     return std::make_pair(hit_type, fault);
                 }
             }
             req->setPaddr(gPaddr);
-            ppn = e[0]->pte.ppn;
-            pte = e[0]->pte;
+            ppn = vs_pte.ppn;
+            pte = vs_pte;
 
             DPRINTFR(TLB, "\tpass check, try to lookup for Gstage pte\n");
 
@@ -2041,14 +2098,15 @@ TLB::checkHL1Tlb(const RequestPtr &req, ThreadContext *tc,
                           is_prefetch);
             if (e[0]) {
                 hit_type = h_l1GstageHit;
-                DPRINTF(TLB, "l1tlb hit in Gstage: level %d, ppn %#x\n", e[0]->level, e[0]->pte.ppn);
+                PTE g_pte = getEntryPte(e[0], gPaddr);
+                DPRINTF(TLB, "l1tlb hit in Gstage: level %d, ppn %#x\n", e[0]->level, g_pte.ppn);
                 std::pair(continuePtw, fault) =
-                    checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                    checkGPermissions(status, vaddr, gPaddr, mode, g_pte, req->get_h_inst());
                 if (e[0]->level >0){
                     pg_mask = (1ULL << (12 + 9 * e[0]->level)) - 1;
-                    pgBase = ((e[0]->pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
+                    pgBase = ((g_pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
                 } else {
-                    pgBase = e[0]->pte.ppn << 12;
+                    pgBase = g_pte.ppn << 12;
                 }
                 gPaddr = pgBase |(gPaddr & PGMASK);
 
@@ -2133,12 +2191,13 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
         if (e[0]) {
             e_l2tlbGstage = e[0];
             gPaddr = req->getgPaddr();
+            PTE g_pte = getEntryPte(e[0], gPaddr);
             std::pair<bool, Fault> result =
-                checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                checkGPermissions(status, vaddr, gPaddr, mode, g_pte, req->get_h_inst());
             continuePtw = result.first;
             fault = result.second;
             DPRINTF(TLB, "l2tlb hit in Gstage: "
-                    "level %d, hit_flag %d, ppn %#x\n", hit_level, hit_flag, e[0]->pte.ppn);
+                    "level %d, hit_flag %d, ppn %#x\n", hit_level, hit_flag, g_pte.ppn);
             if (fault != NoFault) {
                 return std::make_pair(hit_type, fault);
             } else if (continuePtw) {
@@ -2149,7 +2208,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     assert(0);
                 }
                 DPRINTFR(TLB, "\tneed continue to PTW(h_l2GstageHitContinue)\n");
-                req->setTwoPtwWalk(true, 0, e[0]->level-1, e[0]->pte.ppn, true);
+                req->setTwoPtwWalk(true, 0, e[0]->level-1, g_pte.ppn, true);
                 req->setgPaddr(gPaddr);
                 return std::make_pair(hit_type, fault);
             } else {
@@ -2157,10 +2216,10 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                 DPRINTFR(TLB, "\tfind the leaf pte(h_l2GstageHitEnd)\n");
                 if (e[0]->level > 0) {
                     pg_mask = (1ULL << (12 + 9 * e[0]->level)) - 1;
-                    pgBase = ((e[0]->pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
+                    pgBase = ((g_pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
                 }
                 else {
-                    pgBase = e[0]->pte.ppn << 12;
+                    pgBase = g_pte.ppn << 12;
                 }
                 gPaddr = pgBase | (gPaddr & PGMASK);
                 walker->doL2TLBHitSchedule(req, tc, translation, mode, gPaddr, e_l2tlb, e_l2tlbVsstage, e_l2tlbGstage,
@@ -2178,6 +2237,7 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
         DPRINTF(TLB, "l1tlb miss, lookup l2tlb at VSstage.\n");
         e[0] = lookup(vaddr, vsatp.asid, mode, false, true, vsstage,
                       is_prefetch);
+        bool vs_hit_l1 = e[0] != nullptr;
         hit_level = PTW_TOP_LEVEL(vsatp.mode);
         if (!e[0]) {
             for (int i_e = 1; i_e < L_L2SUM; i_e++) {
@@ -2195,25 +2255,27 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
         }
         if (e[0]) {
             DPRINTF(TLB, "l2 tlb hit in VSstage (h_l2VSstageHitContinue).\n");
-            e_l2tlbVsstage = e[0];
+            if (!vs_hit_l1)
+                e_l2tlbVsstage = e[0];
             hit_type = h_l2VSstageHitContinue;
             level = e[0]->level;
-            fault = L2TLBCheck(e[0]->pte, e[0]->level, vstatus, pmode, vaddr, mode, req, false, false);
+            PTE vs_pte = getEntryPte(e[0], vaddr);
+            fault = L2TLBCheck(vs_pte, e[0]->level, vstatus, pmode, vaddr, mode, req, false, false);
             finishgva = hitInSp;
-            req->setPte(e[0]->pte);
+            req->setPte(vs_pte);
             uint64_t hit_vaddr = e[0]->vaddr;
             if (fault != NoFault) {
                 DPRINTF(TLB, "l2 tlb pte check with fault, return. (h_l2VSstageHitContinue).\n");
                 return std::make_pair(hit_type, fault);
             } else {
                 DPRINTF(TLB, "l2 tlb pte pass check: level %d, isLeaf? %d, ppn %#x. (h_l2VSstageHitEnd).\n",
-                        level, hitInSp, e[0]->pte.ppn);
+                        level, hitInSp, vs_pte.ppn);
                 hit_type = h_l2VSstageHitEnd;
-                gPaddr = e[0]->pte.ppn << 12;
+                gPaddr = vs_pte.ppn << 12;
                 if (finishgva) {
                     if (e[0]->level > 0) {
                         pg_mask = (1ULL << (12 + 9 * e[0]->level)) - 1;
-                        gPaddr = ((e[0]->pte.ppn << 12) & ~pg_mask) | (vaddr & pg_mask & ~PGMASK);
+                        gPaddr = ((vs_pte.ppn << 12) & ~pg_mask) | (vaddr & pg_mask & ~PGMASK);
                     }
                     gPaddr = gPaddr | (vaddr & PGMASK);
                 } else {
@@ -2221,13 +2283,14 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     Addr shift = (PageShift + LEVEL_BITS * level);
                     Addr idx_f = (vaddr >> shift) & LEVEL_MASK;
                     Addr idx = (idx_f >> L2TLB_BLK_OFFSET) << L2TLB_BLK_OFFSET;
-                    gPaddr = (e[0]->pte.ppn << PageShift) + (idx_f * l2tlbLineSize);
+                    gPaddr = (vs_pte.ppn << PageShift) + (idx_f * l2tlbLineSize);
                 }
 
                 DPRINTFR(TLB, "\tlookup (gPaddr: %#x) in l1tlb again for Gstage.\n", gPaddr);
                 e[0] = nullptr;
                 e[0] = lookup(gPaddr, hgatp.vmid, mode, false, true, gstage,
                               is_prefetch);
+                bool g_hit_l1 = e[0] != nullptr;
                 if (!e[0]) {
                     DPRINTF(TLB, "l1tlb miss, lookup (gPaddr: %#x) l2tlb for Gstage.\n", gPaddr);
                     hit_level = PTW_TOP_LEVEL(hgatp.mode);
@@ -2247,22 +2310,24 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                     }
                 }
                 if (e[0]) {
-                    e_l2tlbGstage = e[0];
+                    if (!g_hit_l1)
+                        e_l2tlbGstage = e[0];
                     twoStageLevel = e[0]->level;
                     req->setgPaddr(gPaddr);
-                    auto check_res = checkGPermissions(status, vaddr, gPaddr, mode, e[0]->pte, req->get_h_inst());
+                    PTE g_pte = getEntryPte(e[0], gPaddr);
+                    auto check_res = checkGPermissions(status, vaddr, gPaddr, mode, g_pte, req->get_h_inst());
                     continuePtw = check_res.first;
                     fault = check_res.second;
                     DPRINTF(TLB, "found pte for gPaddr: %#x in Gstage -> "
                             "level:%d, ppn:%#x, pte.(v:%d, r:%d, w:%d, x:%d).\n",
-                            gPaddr, e[0]->level, e[0]->pte.ppn, e[0]->pte.v, e[0]->pte.r, e[0]->pte.w, e[0]->pte.x);
+                            gPaddr, e[0]->level, g_pte.ppn, g_pte.v, g_pte.r, g_pte.w, g_pte.x);
                     if (fault != NoFault) {
                         return std::make_pair(hit_type, fault);
                     } else if (continuePtw) {
                         DPRINTFR(TLB, "\tneed to continue PageTableWalk, setTwoStagePtW. "
                                  "(h_l2GstageHitContinue)\n");
                         hit_type = h_l2GstageHitContinue;
-                        req->setTwoPtwWalk(true, level, twoStageLevel-1, e[0]->pte.ppn, hitInSp);
+                        req->setTwoPtwWalk(true, level, twoStageLevel-1, g_pte.ppn, hitInSp);
                         req->setgPaddr(gPaddr);
                         return std::make_pair(hit_type, fault);
                     } else {
@@ -2272,9 +2337,9 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                         if (finishgva) {
                             if (e[0]->level > 0) {
                                 pg_mask = (1ULL << (12 + 9 * e[0]->level)) - 1;
-                                pgBase = ((e[0]->pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
+                                pgBase = ((g_pte.ppn << 12) & ~pg_mask) | (gPaddr & pg_mask & ~PGMASK);
                             } else {
-                                pgBase = (e[0]->pte.ppn << 12);
+                                pgBase = (g_pte.ppn << 12);
                             }
                             gPaddr = pgBase | (gPaddr & PGMASK);
                             DPRINTFR(TLB, "GVA finish, got HPA %#x, "
@@ -2284,9 +2349,9 @@ TLB::checkHL2Tlb(const RequestPtr &req, ThreadContext *tc, BaseMMU::Translation 
                         } else {
                             DPRINTFR(TLB, "GVA not finish, "
                                      "still need to setTwoStagePTW. (h_l2VSstageHitContinue)\n");
-                            uint64_t ppppn = e[0]->pte.ppn;
+                            uint64_t ppppn = g_pte.ppn;
                             hit_type = h_l2VSstageHitContinue;
-                            req->setTwoPtwWalk(false, level, e[0]->level, e[0]->pte.ppn, hitInSp);
+                            req->setTwoPtwWalk(false, level, e[0]->level, g_pte.ppn, hitInSp);
                         }
                         return std::make_pair(hit_type, NoFault);
                     }
@@ -3095,7 +3160,7 @@ void
 TLB::serialize(CheckpointOut &cp) const
 {
     // Only store the entries in use.
-    printf("serialize\n");
+    DPRINTF(TLB, "serialize\n");
     uint32_t _size = size - freeList.size();
     SERIALIZE_SCALAR(_size);
     SERIALIZE_SCALAR(lruSeq);
@@ -3111,7 +3176,7 @@ void
 TLB::unserialize(CheckpointIn &cp)
 {
     // Do not allow to restore with a smaller tlb.
-    printf("unserialize\n");
+    DPRINTF(TLB, "unserialize\n");
     uint32_t _size;
     UNSERIALIZE_SCALAR(_size);
     if (_size > size) {
@@ -3135,7 +3200,9 @@ TLB::unserialize(CheckpointIn &cp)
             key_vaddr += static_cast<Addr>(narrow_idx) << PageShift;
             trie_width = TlbEntryTrie::MaxBits;
         }
-        Addr key = buildKey(key_vaddr, newEntry->asid, 0);
+        const uint16_t key_id =
+            l1CompressionContextId(*newEntry, newEntry->translateMode);
+        Addr key = buildKey(key_vaddr, key_id, newEntry->translateMode);
         newEntry->trieHandle = trie.insert(key, trie_width, newEntry);
     }
 }

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -249,6 +249,7 @@ class TLB : public BaseTLB
     Port *getTableWalkerPort() override;
 
     Addr getEntryPaddr(const TlbEntry *entry, Addr vaddr) const;
+    PTE getEntryPte(const TlbEntry *entry, Addr vaddr) const;
     bool refillHintMaySatisfy(const RequestPtr &req, ThreadContext *tc,
                               BaseMMU::Mode mode, const TlbEntry &entry,
                               uint8_t translateMode) const;

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -2810,7 +2810,10 @@ LSQ::SingleDataRequest::SingleDataRequest(
                 std::move(amo_op)) {
     port->numSingleRequest++;
     singleList.push_back(this);
-    assert(port->numSingleRequest <= 500);
+    if (port->numSingleRequest > 500) {
+        warn_once("LSQ single data requests exceed debug threshold: %llu\n",
+                  port->numSingleRequest);
+    }
 }
 
 LSQ::SingleDataRequest::~SingleDataRequest(){
@@ -2864,7 +2867,10 @@ LSQ::SplitDataRequest::SplitDataRequest(LSQUnit* port, const DynInstPtr& inst, b
       _mainPacket(nullptr)
 {
     port->numSplitRequest++;
-    assert(port->numSplitRequest <= 400);
+    if (port->numSplitRequest > 400) {
+        warn_once("LSQ split data requests exceed debug threshold: %llu\n",
+                  port->numSplitRequest);
+    }
     flags.set(Flag::IsSplit);
 }
 


### PR DESCRIPTION
## Motivation

Add L1 TLB compression support for H-mode VS-stage and G-stage translations.

## Changes

- Add H-mode L1 VS/G-stage TLB compression.
- Fix an LSQ debug threshold abort exposed by H-mode checkpoints.
- Fix the H L1 VS/G split-hit completion path: it previously modeled a
  three-cycle L2-like delay despite performing no L2 lookup; retain the
  completion callback and reduce the delay to one cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Expanded RISC-V translation caching and compression across direct and multi-stage translations.
  * Improved translation hit handling, address calculations, and fallback behavior.
  * Added two-stage next-line prefetching to reduce translation latency.

* **Reliability**
  * Improved permission checks and checkpoint restoration for compressed translations.
  * Enhanced handling of cached translation entries and page-table walk responses.
  * Excessive data-request activity now produces a warning instead of stopping execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->