### PR TITLE
cpu-o3:Fix bug in topdown measureFrontendBubbles where fetchBubbles_m…

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1565,6 +1565,9 @@ Fetch::sendInstructionsToDecode()
     if(tid == -1)
     {
         DPRINTF(Fetch, "All threads are stalled, no thread selected.\n");
+        for (int i = 0; i < numThreads; i++) {
+            measureFrontendBubbles(0, i);
+        }
         return;
     }
     DPRINTF(Fetch, "select Unstalled [tid:%i]\n",tid);


### PR DESCRIPTION
…ax is incorrectly calculated as 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend performance measurements during fully stalled CPU conditions.
  * Ensured bubble activity is recorded even when no unstalled thread is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->