### PR TITLE
Implement new MDP algorithm called PHAST

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -991,14 +991,14 @@ def xiangshan_system_init():
     )
     parser.add_argument(
         "--enable-phast-mdp",
-        action="store_true",
-        default=False,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Use PHAST memory dependence prediction instead of StoreSets.",
     )
     parser.add_argument(
         "--phast-num-rows",
         type=int,
-        default=128,
+        default=64,
         help="Rows per PHAST history table.",
     )
     parser.add_argument(

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -989,6 +989,36 @@ def xiangshan_system_init():
         help="ROB misprediction-recovery walk policy. NaiveCpt enables the "
               "RAT-checkpoint recovery-cost model.",
     )
+    parser.add_argument(
+        "--enable-phast-mdp",
+        action="store_true",
+        default=False,
+        help="Use PHAST memory dependence prediction instead of StoreSets.",
+    )
+    parser.add_argument(
+        "--phast-num-rows",
+        type=int,
+        default=128,
+        help="Rows per PHAST history table.",
+    )
+    parser.add_argument(
+        "--phast-associativity",
+        type=int,
+        default=4,
+        help="PHAST table associativity.",
+    )
+    parser.add_argument(
+        "--phast-tag-bits",
+        type=int,
+        default=16,
+        help="PHAST tag width.",
+    )
+    parser.add_argument(
+        "--phast-max-counter",
+        type=int,
+        default=16,
+        help="PHAST confidence counter maximum value.",
+    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -989,36 +989,6 @@ def xiangshan_system_init():
         help="ROB misprediction-recovery walk policy. NaiveCpt enables the "
               "RAT-checkpoint recovery-cost model.",
     )
-    parser.add_argument(
-        "--enable-phast-mdp",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Use PHAST memory dependence prediction instead of StoreSets.",
-    )
-    parser.add_argument(
-        "--phast-num-rows",
-        type=int,
-        default=64,
-        help="Rows per PHAST history table.",
-    )
-    parser.add_argument(
-        "--phast-associativity",
-        type=int,
-        default=4,
-        help="PHAST table associativity.",
-    )
-    parser.add_argument(
-        "--phast-tag-bits",
-        type=int,
-        default=16,
-        help="PHAST tag width.",
-    )
-    parser.add_argument(
-        "--phast-max-counter",
-        type=int,
-        default=16,
-        help="PHAST confidence counter maximum value.",
-    )
 
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -53,6 +53,11 @@ def setKmhV3IdealParams(args, system):
         cpu.renameWidth = 8
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
+        cpu.EnablePHASTMDP = args.enable_phast_mdp
+        cpu.phast_num_rows = args.phast_num_rows
+        cpu.phast_associativity = args.phast_associativity
+        cpu.phast_tag_bits = args.phast_tag_bits
+        cpu.phast_max_counter = args.phast_max_counter
 
         # dispatch
         cpu.enableDispatchStage = False

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -53,11 +53,7 @@ def setKmhV3IdealParams(args, system):
         cpu.renameWidth = 8
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
-        cpu.EnablePHASTMDP = args.enable_phast_mdp
-        cpu.phast_num_rows = args.phast_num_rows
-        cpu.phast_associativity = args.phast_associativity
-        cpu.phast_tag_bits = args.phast_tag_bits
-        cpu.phast_max_counter = args.phast_max_counter
+        cpu.EnablePHASTMDP = True
 
         # dispatch
         cpu.enableDispatchStage = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -54,6 +54,11 @@ def setKmhV3Params(args, system):
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
         cpu.enable_storeSet_train = True
+        cpu.EnablePHASTMDP = args.enable_phast_mdp
+        cpu.phast_num_rows = args.phast_num_rows
+        cpu.phast_associativity = args.phast_associativity
+        cpu.phast_tag_bits = args.phast_tag_bits
+        cpu.phast_max_counter = args.phast_max_counter
 
         # dispatch
         cpu.enableDispatchStage = False

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -54,11 +54,7 @@ def setKmhV3Params(args, system):
         cpu.numPhysIntRegs = 224
         cpu.numPhysFloatRegs = 256
         cpu.enable_storeSet_train = True
-        cpu.EnablePHASTMDP = args.enable_phast_mdp
-        cpu.phast_num_rows = args.phast_num_rows
-        cpu.phast_associativity = args.phast_associativity
-        cpu.phast_tag_bits = args.phast_tag_bits
-        cpu.phast_max_counter = args.phast_max_counter
+        cpu.EnablePHASTMDP = False
 
         # dispatch
         cpu.enableDispatchStage = False

--- a/docs/Gem5_Docs/lsu/PHAST_MDP_handoff.md
+++ b/docs/Gem5_Docs/lsu/PHAST_MDP_handoff.md
@@ -185,16 +185,11 @@ load 如果确实拿到了有效 PHAST 预测，并且后来 commit 时可以验
 
 ## 5. 参数和默认值
 
-### 5.1 运行时开关
+### 5.1 配置入口
 
-在 `configs/common/xiangshan.py` 和 `configs/example/kmhv3.py` 里，PHAST 的入口是：
-
-- `--enable-phast-mdp`
-- `--no-enable-phast-mdp`
-- `--phast-num-rows`
-- `--phast-associativity`
-- `--phast-tag-bits`
-- `--phast-max-counter`
+PHAST 参数定义在 `src/cpu/o3/BaseO3CPU.py`。配置脚本可以直接给 CPU
+SimObject 赋值；当前 `kmhv3.py` 固定关闭 PHAST，`idealkmhv3.py` 固定开启
+PHAST，均使用 `BaseO3CPU` 中的表参数默认值。
 
 ### 5.2 默认值
 
@@ -207,12 +202,17 @@ load 如果确实拿到了有效 PHAST 预测，并且后来 commit 时可以验
 | `phast_associativity` | `4` | 组相联路数 |
 | `phast_tag_bits` | `16` | tag 位宽 |
 | `phast_max_counter` | `16` | confidence counter 上限 |
+| `phast_counter_threshold` | `1` | 发出 PHAST 预测所需的最小 confidence |
+| `phast_counter_increment` | `0` | 正确预测后的置信度增量；`0` 保持原有的直接恢复上限语义 |
+| `phast_counter_decrement` | `1` | 错误预测后的置信度减量 |
+| `phast_selected_target_bits` | `5` | 参与 path hash 的 target 地址低位数 |
+| `phast_history_lengths` | `[0, 2, 4, 6, 8, 12, 16, 32]` | 每张 path table 对应的 branch history 长度，必须从 `0` 开始且严格递增 |
+| `phast_second_target_max_distance` | `0` | 第二个 store distance 的排他上限；`0` 表示虚拟 SQ 容量的一半 |
 
 ### 5.3 当前需要注意的脚本
 
-`configs/example/kmhv3.py` 和 `configs/example/idealkmhv3.py` 已经把 PHAST 参数接到 CPU 上。
-
-如果以后改用其它入口脚本，要确认它也把这些参数传到了 CPU，否则即使命令行有参数，模拟里也可能仍然是 `EnablePHASTMDP=true` 这套默认值，或者被脚本覆盖成别的值。
+如果其它入口脚本覆盖了 PHAST 参数，要确认其值被赋给每个 CPU 的对应
+SimObject 属性；否则会继续使用 `BaseO3CPU.py` 的默认值。
 
 ## 6. 计数器口径
 

--- a/docs/Gem5_Docs/lsu/PHAST_MDP_handoff.md
+++ b/docs/Gem5_Docs/lsu/PHAST_MDP_handoff.md
@@ -1,0 +1,334 @@
+# PHAST MDP 交付说明
+
+本文档用于交接 XS-GEM5 中的 PHAST memory dependence predictor 实现。
+目标是让接手者在不依赖上下文聊天记录的情况下，快速知道：
+
+1. PHAST 学的是什么
+2. 代码落在哪些文件
+3. 怎么开关和调参
+4. 新增 stats 应该怎么看
+5. 目前已知的风险和后续工作点
+
+本文档对应的代码状态以 `2026-07-31` 为准。
+
+## 1. PHAST 解决的问题
+
+XS 里原本的 MDP 是 StoreSets：
+
+`Load PC -> StoreSet -> 当前最新 Store`
+
+它能减少重复的 store-load violation，但粒度比较粗，容易把不同路径上的 load 合并到同一组里，形成假依赖。
+
+PHAST 的思路是：
+
+`Load PC + path history -> store distance -> 当前 Store Queue 中的具体动态 Store`
+
+也就是说，PHAST 不再预测“属于哪个 StoreSet”，而是直接预测“这个 load 应该等当前 SQ 中第几个更老的 store”。
+
+## 2. 当前实现状态
+
+PHAST 已经接入 XS-GEM5 的 O3 内核，不再是纯实验代码。
+
+已接入的主路径：
+
+- `src/cpu/o3/phast.hh`
+- `src/cpu/o3/phast.cc`
+- `src/cpu/o3/mem_dep_unit.hh`
+- `src/cpu/o3/mem_dep_unit.cc`
+- `src/cpu/o3/lsq_unit.cc`
+- `src/cpu/o3/iew.cc`
+- `src/cpu/o3/commit.cc`
+- `src/cpu/o3/dyn_inst.hh`
+- `src/cpu/o3/BaseO3CPU.py`
+- `configs/common/xiangshan.py`
+- `configs/example/kmhv3.py`
+
+当前行为：
+
+- `EnablePHASTMDP=true` 是当前默认
+- `--no-enable-phast-mdp` 可以显式关闭 PHAST
+- PHAST 预测结果会先映射成当前 SQ 中的动态 store，再走现有 replay-based MDP 路径
+- RAW violation 现在会在 IEW 违例点立即训练 PHAST，commit 阶段还有一次兜底训练，但已用 `violationTrained` 去重
+
+## 3. 算法语义
+
+### 3.1 查表 key
+
+PHAST 查表使用：
+
+- `Load PC`
+- `path history`
+
+其中 `path history` 取的是 load 之前的分歧分支历史。当前实现里会先按 `seqNum < load_seq_num` 过滤，再按历史长度并行查多张表。
+
+当前历史长度表是：
+
+`0, 2, 4, 6, 8, 12, 16, 32`
+
+### 3.2 表项含义
+
+表项里保存的是：
+
+- `store_distance`
+- `confidence counter`
+- `tag`
+
+`store_distance` 是一个相对距离，不是 store seqNum，也不是 store PC。
+
+含义示例：
+
+```text
+S5  distance = 0
+S4  distance = 1
+S3  distance = 2
+S2  distance = 3
+```
+
+如果 load 真正依赖 `S3`，预测值应该是 `store_distance = 2`。
+
+### 3.3 从 distance 到动态 store
+
+PHAST 命中后，不会直接拿 distance 去喂 LSQ，而是先在当前 store queue 里把它换成具体的动态 store seqNum。
+
+换算方式本质是：
+
+`load.sqIt - (distance + 1)`
+
+如果这个位置已经不在当前 SQ 范围内，或者 iterator 无效，预测会被丢弃。
+
+### 3.4 训练
+
+PHAST 仍然是 violation-driven training。
+
+当真实 RAW violation 发生时，会用：
+
+- load PC
+- filtered branch history
+- violating store 的 SQ distance
+
+来更新对应表项。
+
+### 3.5 commit-time confidence update
+
+load 如果确实拿到了有效 PHAST 预测，并且后来 commit 时可以验证该预测对应的 store 地址与 load 地址是否冲突，就会更新 PHAST 表的 confidence。
+
+这个更新的作用是压 alias 和错误预测，不是重新学习 distance。
+
+## 4. 代码地图
+
+### 4.1 核心 predictor
+
+`src/cpu/o3/phast.hh/.cc`
+
+负责：
+
+- 多历史长度表
+- hash/index/tag
+- confidence counter
+- 路径历史 hash
+- distance 预测和训练
+
+### 4.2 依赖单位集成
+
+`src/cpu/o3/mem_dep_unit.cc`
+
+负责：
+
+- 选择 StoreSets 或 PHAST
+- PHAST distance -> current SQ store 映射
+- replay-based MDP 依赖表填写
+- PHAST 违例训练
+- commit-time confidence update
+- 新增 stats
+
+### 4.3 LSQ replay
+
+`src/cpu/o3/lsq_unit.cc`
+
+负责：
+
+- 用 `mdpProducingStores` 挡住 load replay
+- 在 load commit 时把预测信息交给 `InstQueue::commit()`
+
+### 4.4 违例路径
+
+`src/cpu/o3/iew.cc`
+
+负责：
+
+- 发现 RAW violation
+- 把 violation 交给 `MemDepUnit::violation()`
+
+`src/cpu/o3/commit.cc`
+
+负责：
+
+- squash 后的 load 退役兜底训练
+- 用 `violationTrained` 避免重复训练
+
+### 4.5 per-load 元数据
+
+`src/cpu/o3/dyn_inst.hh`
+
+`MemDepInfo` 里现在保存：
+
+- `predicted`
+- `predStoreAddrs`
+- `predStoreSizes`
+- `predBranchHistLength`
+- `predictorHash`
+- `violatingStoreSeqNum`
+- `violatingStorePC`
+- `storeQueueDistance`
+- `violationCounted`
+- `violationTrained`
+
+## 5. 参数和默认值
+
+### 5.1 运行时开关
+
+在 `configs/common/xiangshan.py` 和 `configs/example/kmhv3.py` 里，PHAST 的入口是：
+
+- `--enable-phast-mdp`
+- `--no-enable-phast-mdp`
+- `--phast-num-rows`
+- `--phast-associativity`
+- `--phast-tag-bits`
+- `--phast-max-counter`
+
+### 5.2 默认值
+
+默认值定义在 `src/cpu/o3/BaseO3CPU.py`：
+
+| 参数 | 默认值 | 含义 |
+|---|---:|---|
+| `EnablePHASTMDP` | `True` | 默认开启 PHAST |
+| `phast_num_rows` | `64` | 每张历史表的行数 |
+| `phast_associativity` | `4` | 组相联路数 |
+| `phast_tag_bits` | `16` | tag 位宽 |
+| `phast_max_counter` | `16` | confidence counter 上限 |
+
+### 5.3 当前需要注意的脚本
+
+`configs/example/kmhv3.py` 和 `configs/example/idealkmhv3.py` 已经把 PHAST 参数接到 CPU 上。
+
+如果以后改用其它入口脚本，要确认它也把这些参数传到了 CPU，否则即使命令行有参数，模拟里也可能仍然是 `EnablePHASTMDP=true` 这套默认值，或者被脚本覆盖成别的值。
+
+## 6. 计数器口径
+
+### 6.1 PHAST 相关
+
+| 计数器 | 含义 |
+|---|---|
+| `phastTableHits` | PHAST 查表命中，且返回了非零 / 有效 `store_distance` |
+| `phastEffectivePreds` | 命中的 `store_distance` 成功映射到当前 SQ 中的动态 store，并真的给 load 建了依赖 |
+| `phastDropInvalidSQDistance` | 命中后因为 `store_distance` 非法、SQ 游标无效或目标 store 找不到，预测被丢弃 |
+| `phastViolationUpdates` | PHAST 违例训练次数 |
+| `phastCommitUpdates` | PHAST commit-time confidence update 次数 |
+
+### 6.2 通用 MDP 违例口径
+
+| 计数器 | 含义 |
+|---|---|
+| `mdpUnpredictedViolations` | load 没被 MDP 预测，但后来发生真实 RAW violation |
+| `mdpPredictedViolations` | load 已经有 MDP 预测，但后来仍发生真实 RAW violation |
+| `mdpFalseDepAtCommit` | load 曾被预测依赖某个 store，但 commit 时确认预测 store 地址与 load 地址不冲突 |
+
+### 6.3 现有计数器的关系
+
+现在 `phastPredictions` 还保留着，主要是兼容旧分析脚本。
+
+它和 `phastEffectivePreds` 目前表达的是同一个成功映射事件，接手时不要把它们当成两类独立语义。
+
+如果做新分析，建议优先看：
+
+1. `phastTableHits`
+2. `phastEffectivePreds`
+3. `phastDropInvalidSQDistance`
+4. `mdpUnpredictedViolations`
+5. `mdpPredictedViolations`
+6. `mdpFalseDepAtCommit`
+
+## 7. 怎么看结果
+
+### 7.1 读法建议
+
+如果 `phastTableHits` 很低：
+
+- 说明表项根本没学到，或者 path hash / history length 不对
+
+如果 `phastTableHits` 高，但 `phastEffectivePreds` 低：
+
+- 说明表是命中的，但 distance 没法映射成当前 SQ 里的动态 store
+
+如果 `phastEffectivePreds` 高，但 `phastViolationUpdates` 仍然很低：
+
+- 说明预测虽然落地了，但 violation 反馈没打通，或者 workload 本身很少真的触发 RAW violation
+
+如果 `mdpUnpredictedViolations` 很高：
+
+- 说明漏预测多，false negative 多
+
+如果 `mdpPredictedViolations` 很高，同时 `mdpFalseDepAtCommit` 也高：
+
+- 说明预测到了一些 store，但依赖对象不准，或过度保守导致假依赖
+
+### 7.2 SPEC 的统计口径
+
+SPEC CPU 06 的输出目录里通常是多个 slice，每个 slice 下面都有自己的 `stats.txt`。
+
+比较 PHAST 时，建议先看单个代表 slice 的趋势，再决定是否做整 benchmark 汇总。
+
+如果要做整 benchmark 级比较，优先按 slice 聚合后再做加权，而不是直接把不同 slice 的原始计数当成同一个事件流。
+
+## 8. 验证方式
+
+### 8.1 编译
+
+```bash
+scons build/RISCV/gem5.opt --gold-linker -j64
+```
+
+或者至少编 touched 的 O3 对象：
+
+```bash
+scons build/RISCV/cpu/o3/dyn_inst.o \
+      build/RISCV/cpu/o3/mem_dep_unit.o \
+      build/RISCV/cpu/o3/inst_queue.o \
+      build/RISCV/cpu/o3/iew.o \
+      build/RISCV/cpu/o3/commit.o \
+      build/RISCV/cpu/o3/lsq_unit.o -j64
+```
+
+### 8.2 运行
+
+```bash
+./build/RISCV/gem5.fast ./configs/example/kmhv3.py \
+  --generic-rv-cpt=<checkpoint>
+```
+
+### 8.3 建议先看的 slice
+
+```text
+spec_all/perlbench_checkspam_24678
+```
+
+这个 slice 是对store-load违例较多次数的slice.
+
+开发时曾发现一个问题：PHAST 已经打开，但 `phastViolationUpdates` 一直是 0。根因是 IEW 的 RAW violation 路径曾经把 PHAST 训练挡掉了；当前代码已经改成在 violation 点直接训练，并用 `violationTrained` 去重。
+
+## 9. 已知风险
+
+1. 现在 `phastPredictions` 和 `phastEffectivePreds` 语义有重叠，后续如果要做长期维护，建议保留一个主口径，另一个做兼容或删掉。
+2. `mdpFalseDepAtCommit` 依赖 load commit 时已经记录过的预测 store 地址；如果没记录到地址，它不会被算成 false positive。
+3. PHAST 的效果强依赖 branch history 质量和 table 参数，特别是 `phast_num_rows` 和 `phast_tag_bits`。
+4. 如果改用别的 config 入口，要检查 PHAST 参数是否也被传到了 CPU。
+5. 最近一次代码变更后，建议重新跑一次代表 slice，确认新增的 `phast*` 和 `mdp*` 计数器都按预期增长。
+
+## 10. 给接手者的建议
+
+1. 先用 `perlbench_checkspam_24678` 做最小回归。
+2. 看 `phastTableHits -> phastEffectivePreds -> phastViolationUpdates` 这条链路是否闭环。
+3. 如果 `phastDropInvalidSQDistance` 偏高，优先查 SQ iterator / distance 映射，而不是先怀疑 hash。
+4. 如果 `mdpFalseDepAtCommit` 偏高，再看 commit-time overlap 判定和 `LSQDepCheckShift`。
+5. 如果要做参数搜索，优先扫 `phast_num_rows`、`phast_tag_bits`，其次才是 `phast_associativity` 和 `phast_max_counter`。

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -218,6 +218,21 @@ class BaseO3CPU(BaseCPU):
     phast_associativity = Param.Unsigned(4, "PHAST table associativity")
     phast_tag_bits = Param.Unsigned(16, "PHAST tag bits")
     phast_max_counter = Param.Unsigned(16, "PHAST confidence counter max")
+    phast_counter_threshold = Param.Unsigned(
+        1, "Minimum PHAST confidence required to issue a prediction")
+    phast_counter_increment = Param.Unsigned(
+        0,
+        "PHAST confidence increment after a correct prediction; 0 restores max confidence")
+    phast_counter_decrement = Param.Unsigned(
+        1, "PHAST confidence decrement after an incorrect prediction")
+    phast_selected_target_bits = Param.Unsigned(
+        5, "Target-address bits included in the PHAST path hash")
+    phast_history_lengths = VectorParam.Unsigned(
+        [0, 2, 4, 6, 8, 12, 16, 32],
+        "Branch-history lengths for PHAST path tables, shortest to longest")
+    phast_second_target_max_distance = Param.Unsigned(
+        0,
+        "Exclusive maximum SQ distance for a PHAST second target; 0 uses half of the virtual SQ capacity")
 
     BankConflictCheck = Param.Bool(True, "open Bank conflict check")
     sbufferBankWriteAccurately = Param.Bool(False, "Sbuffer write to memory with bank conflict check")

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -212,9 +212,9 @@ class BaseO3CPU(BaseCPU):
     LFSTEntrySize = Param.Unsigned(4,"The number of store table inst in every entry of LFST can contain")
     SSITSize = Param.Unsigned(1024, "Store set ID table size")
     enable_storeSet_train = Param.Bool(True, "Training store set predictor")
-    EnablePHASTMDP = Param.Bool(False,
+    EnablePHASTMDP = Param.Bool(True,
         "Use PHAST memory dependence prediction instead of StoreSets")
-    phast_num_rows = Param.Unsigned(128, "PHAST rows per history table")
+    phast_num_rows = Param.Unsigned(64, "PHAST rows per history table")
     phast_associativity = Param.Unsigned(4, "PHAST table associativity")
     phast_tag_bits = Param.Unsigned(16, "PHAST tag bits")
     phast_max_counter = Param.Unsigned(16, "PHAST confidence counter max")

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -214,6 +214,10 @@ class BaseO3CPU(BaseCPU):
     enable_storeSet_train = Param.Bool(True, "Training store set predictor")
     EnablePHASTMDP = Param.Bool(True,
         "Use PHAST memory dependence prediction instead of StoreSets")
+    mdp_violation_timing = Param.String(
+        "atResolve",
+        "When to recover from and train a detected MDP RAW violation: "
+        "atResolve or atCommit")
     phast_num_rows = Param.Unsigned(64, "PHAST rows per history table")
     phast_associativity = Param.Unsigned(4, "PHAST table associativity")
     phast_tag_bits = Param.Unsigned(16, "PHAST tag bits")

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -212,6 +212,12 @@ class BaseO3CPU(BaseCPU):
     LFSTEntrySize = Param.Unsigned(4,"The number of store table inst in every entry of LFST can contain")
     SSITSize = Param.Unsigned(1024, "Store set ID table size")
     enable_storeSet_train = Param.Bool(True, "Training store set predictor")
+    EnablePHASTMDP = Param.Bool(False,
+        "Use PHAST memory dependence prediction instead of StoreSets")
+    phast_num_rows = Param.Unsigned(128, "PHAST rows per history table")
+    phast_associativity = Param.Unsigned(4, "PHAST table associativity")
+    phast_tag_bits = Param.Unsigned(16, "PHAST tag bits")
+    phast_max_counter = Param.Unsigned(16, "PHAST confidence counter max")
 
     BankConflictCheck = Param.Bool(True, "open Bank conflict check")
     sbufferBankWriteAccurately = Param.Bool(False, "Sbuffer write to memory with bank conflict check")

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -50,6 +50,7 @@ if env['CONF']['TARGET_ISA'] != 'null':
     Source('lsq.cc')
     Source('lsq_unit.cc')
     Source('mem_dep_unit.cc')
+    Source('phast.cc')
     Source('regfile.cc')
     Source('rename.cc')
     Source('rename_map.cc')

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -322,6 +322,7 @@ struct TimeStruct
         unsigned squashedLoopIter; // F
 
         bool isTrapSquash;
+        bool isDeferedMDPSquash;
         bool squash; // *F, D, R, I
         bool robSquashing; // *F, D, R, I
 

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1370,6 +1370,7 @@ Commit::commitInsts()
 
                 if (head_inst->isLoad() &&
                     head_inst->memDepInfo.violatingStoreSeqNum &&
+                    !head_inst->memDepInfo.violationTrained &&
                     iewStage->instQueue.usesPHAST(tid)) {
                     iewStage->instQueue.violation(
                         head_inst->memDepInfo.violatingStoreSeqNum,

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -146,6 +146,8 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
       commitToIEWDelay(params.commitToIEWDelay),
       renameToROBDelay(params.renameToROBDelay),
       fetchToCommitDelay(params.commitToFetchDelay),
+      mdpViolationAtCommit(params.mdp_violation_timing == "atCommit"),
+      enableStoreSetTrain(params.enable_storeSet_train),
       renameWidth(params.renameWidth),
       commitWidth(params.commitWidth),
       numThreads(params.numThreads),
@@ -162,6 +164,12 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
         fatal("commitWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              commitWidth, static_cast<int>(MaxWidth));
+
+    if (params.mdp_violation_timing != "atResolve" &&
+        params.mdp_violation_timing != "atCommit") {
+        fatal("mdp_violation_timing must be atResolve or atCommit, got %s\n",
+              params.mdp_violation_timing.c_str());
+    }
 
     _status = Active;
     _nextStatus = Inactive;
@@ -309,6 +317,8 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
                "Number of squash due to order violation"),
       ADD_STAT(squashDueToValuePrediction, statistics::units::Count::get(),
                "Number of squash due to value prediction"),
+      ADD_STAT(mdpViolationSquashes, statistics::units::Count::get(),
+               "Number of RAW MDP recoveries triggered at Commit"),
       ADD_STAT(squashDueToTrap, statistics::units::Count::get(),
                "Number of squash due to trap"),
       ADD_STAT(squashDueToTC, statistics::units::Count::get(),
@@ -1274,6 +1284,96 @@ Commit::updateMstatusSd(ThreadID tid){
 }
 
 void
+Commit::updateCommittedBranchHistory(ThreadID tid, const DynInstPtr &inst)
+{
+    if (!inst->isControl() ||
+        (inst->isDirectCtrl() && inst->isUncondCtrl())) {
+        return;
+    }
+
+    const auto &resolved_pc = inst->pcState().as<RiscvISA::PCState>();
+    branchInfo branch_info = {
+        inst->isIndirectCtrl(),
+        resolved_pc.branching(),
+        resolved_pc.npc(),
+        inst->seqNum,
+        resolved_pc.instAddr(),
+    };
+    committedBranchHistory[tid].push_front(branch_info);
+    if (committedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
+        committedBranchHistory[tid].pop_back();
+    }
+}
+
+bool
+Commit::handleMdpViolation(const DynInstPtr &head_inst, ThreadID tid)
+{
+    if (!mdpViolationAtCommit || !head_inst->isLoad() ||
+        !head_inst->memDepInfo.violationPending) {
+        return false;
+    }
+
+    const auto &mdp_info = head_inst->memDepInfo;
+    if (mdp_info.violatingStoreSeqNum == 0) {
+        // A malformed pending marker must not block the ROB forever.
+        head_inst->memDepInfo.violationPending = false;
+        return false;
+    }
+
+    DPRINTF(Commit,
+            "[tid:%i] [sn:%llu] Handling deferred RAW MDP violation at "
+            "Commit, store [sn:%llu] load PC %s\n",
+            tid, head_inst->seqNum, mdp_info.violatingStoreSeqNum,
+            head_inst->pcState());
+
+    // Commit-time PHAST training intentionally uses only resolved, committed
+    // branch outcomes. StoreSet training uses the same violation entry point.
+    if (iewStage->instQueue.usesPHAST(tid) || enableStoreSetTrain) {
+        iewStage->instQueue.violation(
+            mdp_info.violatingStoreSeqNum, mdp_info.violatingStorePC,
+            head_inst, committedBranchHistory[tid]);
+    }
+    head_inst->memDepInfo.violationPending = false;
+
+    // Do not retire the violating load. Keep the last older instruction in
+    // the ROB and refetch from the violating load's resolved PC.
+    const InstSeqNum squashed_inst = head_inst->seqNum - 1;
+    youngestSeqNum[tid] = squashed_inst;
+    rob->squash(squashed_inst, tid);
+    changedROBNumEntries[tid] = true;
+
+    if (valuePred) {
+        valuePred->squash(tid, squashed_inst);
+    }
+
+    toIEW->commitInfo[tid].doneSeqNum = squashed_inst;
+    toIEW->commitInfo[tid].doneMemSeqNum = squashed_inst;
+
+    traceUpdateSquashInfo(tid, squashed_inst);
+    toIEW->commitInfo[tid].isDeferedMDPSquash = true;
+    toIEW->commitInfo[tid].squash = true;
+    toIEW->commitInfo[tid].robSquashing = true;
+    toIEW->commitInfo[tid].mispredictInst = nullptr;
+    // Match the ordinary IEW order-violation path: squashInst identifies the
+    // last instruction retained in the ROB, while pc points at the load that
+    // must be refetched.  Passing the load itself would make Fetch treat the
+    // discarded instruction as the recovery anchor.
+    toIEW->commitInfo[tid].squashInst = rob->findInst(tid, squashed_inst);
+    toIEW->commitInfo[tid].squashedTargetId = head_inst->getFtqId();
+    toIEW->commitInfo[tid].squashedLoopIter = head_inst->getLoopIteration();
+    set(pc[tid], head_inst->pcState());
+    set(toIEW->commitInfo[tid].pc, pc[tid]);
+    squashInflightAndUpdateVersion(tid);
+
+    commitStatus[tid] = ROBSquashing;
+    ++stats.mdpViolationSquashes;
+    ++stats.squashDueToOrderViolation[tid];
+    wroteToTimeBuffer = true;
+    cpu->activityThisCycle();
+    return true;
+}
+
+void
 Commit::commitInsts()
 {
     ////////////////////////////////////
@@ -1359,6 +1459,11 @@ Commit::commitInsts()
                     "Trying to commit head instruction, [tid:%i] [sn:%llu]\n",
                     tid, head_inst->seqNum);
 
+            if (!head_inst->isSquashed() &&
+                handleMdpViolation(head_inst, tid)) {
+                break;
+            }
+
             // If the head instruction is squashed, it is ready to retire
             // (be removed from the ROB) at any time.
             if (head_inst->isSquashed()) {
@@ -1368,7 +1473,7 @@ Commit::commitInsts()
 
                 rob->drainSquashedHead(commit_thread);
 
-                if (head_inst->isLoad() &&
+                if (!mdpViolationAtCommit && head_inst->isLoad() &&
                     head_inst->memDepInfo.violatingStoreSeqNum &&
                     !head_inst->memDepInfo.violationTrained &&
                     iewStage->instQueue.usesPHAST(tid)) {
@@ -1376,6 +1481,9 @@ Commit::commitInsts()
                         head_inst->memDepInfo.violatingStoreSeqNum,
                         head_inst->memDepInfo.violatingStorePC,
                         head_inst, committedBranchHistory[tid]);
+                }
+                if (mdpViolationAtCommit) {
+                    head_inst->memDepInfo.violationPending = false;
                 }
 
                 ++stats.commitSquashedInsts;
@@ -1914,20 +2022,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
             head_inst->staticInst->disassemble(
                 head_inst->pcState().instAddr()).c_str(), inst_fault->name());
 
-        if (head_inst->isControl() &&
-            !(head_inst->isDirectCtrl() && head_inst->isUncondCtrl())) {
-            branchInfo branch_info = {
-                head_inst->isIndirectCtrl(),
-                head_inst->readPredTaken(),
-                head_inst->readPredTarg().instAddr(),
-                head_inst->seqNum,
-                head_inst->pcState().instAddr(),
-            };
-            committedBranchHistory[tid].push_front(branch_info);
-            if (committedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
-                committedBranchHistory[tid].pop_back();
-            }
-        }
+        updateCommittedBranchHistory(tid, head_inst);
 
 
         if (head_inst->traceData) {
@@ -2128,6 +2223,13 @@ Commit::moveInstsToBuffer()
         for (int i = 0; i < insts_from_rename; ++i) {
             const DynInstPtr &inst = fromRename->insts[i];
             assert(inst->threadNumber == tid);
+            // A Commit-time squash can be generated after this bundle has
+            // already left Rename.  Apply the same squash-version check used
+            // by Rename so that stale in-flight instructions cannot be
+            // inserted into the ROB after recovery completes.
+            if (localSquashVer[tid].largerThan(inst->getVersion())) {
+                inst->setSquashed();
+            }
             if (!inst->isSquashed()) {
                 fixedbuffer[tid].push_back(inst);
             }
@@ -2315,19 +2417,7 @@ Commit::updateComInstStats(const DynInstPtr &inst)
             }
             branchLog.push_back(temp);
         }
-        if (!(inst->isDirectCtrl() && inst->isUncondCtrl())) {
-            branchInfo branch_info = {
-                inst->isIndirectCtrl(),
-                inst->readPredTaken(),
-                inst->readPredTarg().instAddr(),
-                inst->seqNum,
-                inst->pcState().instAddr(),
-            };
-            committedBranchHistory[tid].push_front(branch_info);
-            if (committedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
-                committedBranchHistory[tid].pop_back();
-            }
-        }
+        updateCommittedBranchHistory(tid, inst);
         // tracing recent taken branches
         DPRINTF(DecoupleBP, "Control inst %lu, PC: %#lx -> target: %#lx\n",
                 inst->seqNum, inst->pcState().instAddr(),

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -576,6 +576,7 @@ Commit::clearStates(ThreadID tid)
     pc[tid].reset(cpu->tcBase(tid)->getIsaPtr()->newPCState());
     lastCommitedSeqNum[tid] = 0;
     squashAfterInst[tid] = NULL;
+    committedBranchHistory[tid].clear();
 }
 
 void Commit::drain() { drainPending = true; }
@@ -641,6 +642,7 @@ Commit::takeOverFrom()
         trapSquash[tid] = false;
         tcSquash[tid] = false;
         squashAfterInst[tid] = NULL;
+        committedBranchHistory[tid].clear();
     }
     rob->takeOverFrom();
 }
@@ -1366,6 +1368,15 @@ Commit::commitInsts()
 
                 rob->drainSquashedHead(commit_thread);
 
+                if (head_inst->isLoad() &&
+                    head_inst->memDepInfo.violatingStoreSeqNum &&
+                    iewStage->instQueue.usesPHAST(tid)) {
+                    iewStage->instQueue.violation(
+                        head_inst->memDepInfo.violatingStoreSeqNum,
+                        head_inst->memDepInfo.violatingStorePC,
+                        head_inst, committedBranchHistory[tid]);
+                }
+
                 ++stats.commitSquashedInsts;
                 // Notify potential listeners that this instruction is squashed
                 ppSquash->notify(head_inst);
@@ -1902,6 +1913,21 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
             head_inst->staticInst->disassemble(
                 head_inst->pcState().instAddr()).c_str(), inst_fault->name());
 
+        if (head_inst->isControl() &&
+            !(head_inst->isDirectCtrl() && head_inst->isUncondCtrl())) {
+            branchInfo branch_info = {
+                head_inst->isIndirectCtrl(),
+                head_inst->readPredTaken(),
+                head_inst->readPredTarg().instAddr(),
+                head_inst->seqNum,
+                head_inst->pcState().instAddr(),
+            };
+            committedBranchHistory[tid].push_front(branch_info);
+            if (committedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
+                committedBranchHistory[tid].pop_back();
+            }
+        }
+
 
         if (head_inst->traceData) {
             // We ignore ReExecution "faults" here as they are not real
@@ -2287,6 +2313,19 @@ Commit::updateComInstStats(const DynInstPtr &inst)
                 branchLog.pop_front();
             }
             branchLog.push_back(temp);
+        }
+        if (!(inst->isDirectCtrl() && inst->isUncondCtrl())) {
+            branchInfo branch_info = {
+                inst->isIndirectCtrl(),
+                inst->readPredTaken(),
+                inst->readPredTarg().instAddr(),
+                inst->seqNum,
+                inst->pcState().instAddr(),
+            };
+            committedBranchHistory[tid].push_front(branch_info);
+            if (committedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
+                committedBranchHistory[tid].pop_back();
+            }
         }
         // tracing recent taken branches
         DPRINTF(DecoupleBP, "Control inst %lu, PC: %#lx -> target: %#lx\n",

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -203,6 +203,7 @@ class Commit
     /** Mark the thread as processing a trap. */
     void processTrapEvent(ThreadID tid);
     LoadTripleCounter loadTripleCounter;
+    BranchHistory committedBranchHistory[MaxThreads];
 
     // --- Maps for "last time" tracking, keyed by static load PC ---
     std::unordered_map<Addr, Addr> lastLoadEA;
@@ -402,6 +403,11 @@ class Commit
 
     /** Sets the PC of a specific thread. */
     void pcState(const PCStateBase &val, ThreadID tid) { set(pc[tid], val); }
+
+    BranchHistory &getBranchHistory(ThreadID tid)
+    {
+        return committedBranchHistory[tid];
+    }
 
   private:
     /** Time buffer interface. */

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -374,6 +374,13 @@ class Commit
     bool hasExecutedYoungerInst(ThreadID tid, InstSeqNum seq_num) const;
     void updateMstatusSd(ThreadID tid);
 
+    /** Handle a deferred RAW MDP violation at the ROB head. */
+    bool handleMdpViolation(const DynInstPtr &head_inst, ThreadID tid);
+
+    /** Append a resolved control-flow outcome to committed history. */
+    void updateCommittedBranchHistory(ThreadID tid,
+                                      const DynInstPtr &inst);
+
     /** Tries to commit the head ROB instruction passed in.
      * @param head_inst The instruction to be committed.
      */
@@ -494,6 +501,12 @@ class Commit
     const Cycles renameToROBDelay;
 
     const Cycles fetchToCommitDelay;
+
+    /** Defer RAW MDP recovery/training until the violating load is at Commit. */
+    const bool mdpViolationAtCommit;
+
+    /** Whether StoreSet training is enabled for non-PHAST configurations. */
+    const bool enableStoreSetTrain;
 
     /** Rename width, in instructions.  Used so ROB knows how many
      *  instructions to get from the rename instruction queue.
@@ -651,6 +664,8 @@ class Commit
         statistics::Vector squashDueToBranch;
         statistics::Vector squashDueToOrderViolation;
         statistics::Vector squashDueToValuePrediction;
+        /** Number of Commit-triggered RAW MDP recoveries. */
+        statistics::Scalar mdpViolationSquashes;
         statistics::Vector squashDueToTrap;
         statistics::Vector squashDueToTC;
         statistics::Vector squashDueToSquashAfter;

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -433,6 +433,12 @@ class CPU : public BaseCPU
 
     uint32_t getIQInsts() { return iew.getIQInsts(); }
 
+    Fetch *getFetch() { return &fetch; }
+    Decode *getDecode() { return &decode; }
+    Rename *getRename() { return &rename; }
+    IEW *getIEW() { return &iew; }
+    Commit *getCommit() { return &commit; }
+
     /**
      * Return the oldest in-flight instruction sequence number.
      * If there are no in-flight instructions, returns the maximum value

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -122,7 +122,7 @@ Decode::startupStage()
 void
 Decode::clearStates(ThreadID tid)
 {
-
+    decodedBranchHistory[tid].clear();
 }
 
 void
@@ -305,6 +305,19 @@ Decode::fetchInstsValid()
 }
 
 void
+Decode::squashBranchHistory(ThreadID tid, InstSeqNum squash_seq_num,
+                            bool include_squash_inst)
+{
+    auto &branch_history = decodedBranchHistory[tid];
+    while (!branch_history.empty() &&
+           (include_squash_inst ?
+                branch_history.front().seqNum >= squash_seq_num :
+                branch_history.front().seqNum > squash_seq_num)) {
+        branch_history.pop_front();
+    }
+}
+
+void
 Decode::selfSquash(const DynInstPtr &inst, ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] [sn:%llu] Squashing due to incorrect branch "
@@ -347,6 +360,7 @@ Decode::selfSquash(const DynInstPtr &inst, ThreadID tid)
     stallSig->blockFetch[tid] = true; // tell fetch don't send new insts
 
     fixedbuffer[tid].clear();
+    squashBranchHistory(tid, squash_seq_num, false);
 
     // Clear per-thread stallBuffer for the squashed thread
     auto delIt = stallBuffer[tid].begin();
@@ -374,6 +388,7 @@ Decode::squash(ThreadID tid)
     DPRINTF(Decode, "[tid:%i] Squashing.\n",tid);
 
     fixedbuffer[tid].clear();
+    squashBranchHistory(tid, fromCommit->commitInfo[tid].doneSeqNum, false);
 
     // Clear per-thread stallBuffer for the squashed thread
     auto delIt = stallBuffer[tid].begin();
@@ -939,6 +954,21 @@ Decode::decodeInsts(ThreadID tid)
             npc->as<RiscvISA::PCState>().set(inst->pcState().getFallThruPC());
             inst->setPredTaken(false);
             inst->setPredTarg(*npc);
+        }
+
+        if (inst->isControl() &&
+            !(inst->isDirectCtrl() && inst->isUncondCtrl())) {
+            branchInfo branch_info = {
+                inst->isIndirectCtrl(),
+                inst->readPredTaken(),
+                inst->readPredTarg().instAddr(),
+                inst->seqNum,
+                inst->pcState().instAddr(),
+            };
+            decodedBranchHistory[tid].push_front(branch_info);
+            if (decodedBranchHistory[tid].size() > MAX_BRANCH_HISTORY) {
+                decodedBranchHistory[tid].pop_back();
+            }
         }
     }
     for (auto &fused_inst : fusionInst) {

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -123,7 +123,14 @@ class Decode
     bool isDrained() const;
 
     /** Takes over from another CPU's thread. */
-    void takeOverFrom() { resetStage(); }
+    void
+    takeOverFrom()
+    {
+        resetStage();
+        for (ThreadID tid = 0; tid < MaxThreads; ++tid) {
+            decodedBranchHistory[tid].clear();
+        }
+    }
 
     /** Ticks decode, processing all input signals and decoding as many
      * instructions as possible.
@@ -173,6 +180,14 @@ class Decode
      */
     unsigned squash(ThreadID tid);
 
+    BranchHistory &getBranchHistory(ThreadID tid)
+    {
+        return decodedBranchHistory[tid];
+    }
+
+    void squashBranchHistory(ThreadID tid, InstSeqNum squash_seq_num,
+                             bool include_squash_inst);
+
     void setFetchStage(Fetch *fetch_stage)
     {
         fetch_ptr = fetch_stage;
@@ -218,6 +233,9 @@ class Decode
 
     /** Queue of all instructions coming from fetch this cycle. */
     boost::circular_buffer<DynInstPtr> fixedbuffer[MaxThreads];
+
+    /** Speculative branch history used by path-sensitive MDP lookup. */
+    BranchHistory decodedBranchHistory[MaxThreads];
 
     /** Per-thread stall buffers to avoid contention in SMT mode.
      * Each thread has its own FIFO queue for backpressure isolation.

--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <ostream>
 
 #include "arch/riscv/insts/mem.hh"
 #include "arch/riscv/pcstate.hh"
@@ -59,6 +60,37 @@ namespace gem5
 
 namespace o3
 {
+
+std::ostream &
+operator<<(std::ostream &os, const branchInfo &b)
+{
+    os << "indirect: " << b.indirect
+       << ", taken: " << b.taken
+       << ", target: " << b.target
+       << ", seqNum: " << b.seqNum
+       << ", pc: " << b.pc;
+    return os;
+}
+
+bool
+operator==(const BranchHistory &a, const BranchHistory &b)
+{
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i].indirect != b[i].indirect ||
+            a[i].taken != b[i].taken ||
+            a[i].target != b[i].target ||
+            a[i].seqNum != b[i].seqNum ||
+            a[i].pc != b[i].pc) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 DynInst::DynInst(const Arrays &arrays, const StaticInstPtr &static_inst,
         const StaticInstPtr &_macroop, InstSeqNum seq_num, CPU *_cpu)

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -501,6 +501,9 @@ class DynInst : public ExecContext, public RefCounted
         /** True after the RAW violation has been counted once. */
         bool violationCounted = false;
 
+        /** True when a RAW violation is deferred until Commit. */
+        bool violationPending = false;
+
         /** True after the RAW violation has trained PHAST once. */
         bool violationTrained = false;
     } memDepInfo;

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -487,7 +487,7 @@ class DynInst : public ExecContext, public RefCounted
         /** Zero-based distance from the load to the violating older store. */
         std::ptrdiff_t storeQueueDistance = -1;
 
-        /** Store addresses/sizes used to validate a PHAST prediction. */
+        /** Store addresses/sizes used to validate an MDP prediction. */
         std::pair<Addr, Addr> predStoreAddrs = {0, 0};
         std::pair<unsigned, unsigned> predStoreSizes = {0, 0};
 
@@ -495,8 +495,11 @@ class DynInst : public ExecContext, public RefCounted
         unsigned predBranchHistLength = 0;
         uint64_t predictorHash = 0;
 
-        /** True when this load received a valid PHAST prediction. */
+        /** True when this load received a valid concrete MDP prediction. */
         bool predicted = false;
+
+        /** True after the RAW violation has been counted once. */
+        bool violationCounted = false;
 
         /** True after the RAW violation has trained PHAST once. */
         bool violationTrained = false;

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -497,6 +497,9 @@ class DynInst : public ExecContext, public RefCounted
 
         /** True when this load received a valid PHAST prediction. */
         bool predicted = false;
+
+        /** True after the RAW violation has trained PHAST once. */
+        bool violationTrained = false;
     } memDepInfo;
 
     /** Predicted producing stores (for replay-based MDP). */

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -44,12 +44,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdio>
 #include <deque>
 #include <list>
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "base/refcnt.hh"
 #include "base/trace.hh"
@@ -472,7 +474,32 @@ class DynInst : public ExecContext, public RefCounted
     ssize_t sqIdx = -1;
     typename LSQUnit::SQIterator sqIt;
 
-    /** Store-set predicted producing stores (for replay-based MDP). */
+    /** PHAST metadata carried by each load. */
+    struct MemDepInfo
+    {
+        /** Store this load received forwarded data from, if any. */
+        InstSeqNum forwardedFrom = 0;
+
+        /** Store-load violation training target. */
+        InstSeqNum violatingStoreSeqNum = 0;
+        Addr violatingStorePC = 0;
+
+        /** Zero-based distance from the load to the violating older store. */
+        std::ptrdiff_t storeQueueDistance = -1;
+
+        /** Store addresses/sizes used to validate a PHAST prediction. */
+        std::pair<Addr, Addr> predStoreAddrs = {0, 0};
+        std::pair<unsigned, unsigned> predStoreSizes = {0, 0};
+
+        /** PHAST table metadata used for confidence updates. */
+        unsigned predBranchHistLength = 0;
+        uint64_t predictorHash = 0;
+
+        /** True when this load received a valid PHAST prediction. */
+        bool predicted = false;
+    } memDepInfo;
+
+    /** Predicted producing stores (for replay-based MDP). */
     std::vector<InstSeqNum> mdpProducingStores;
 
     /** Whether this load is predicted to strictly wait for prior store addrs. */

--- a/src/cpu/o3/dyn_inst_ptr.hh
+++ b/src/cpu/o3/dyn_inst_ptr.hh
@@ -42,7 +42,13 @@
 #ifndef __CPU_O3_DYN_INST_PTR_HH__
 #define __CPU_O3_DYN_INST_PTR_HH__
 
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <iosfwd>
+
 #include "base/refcnt.hh"
+#include "cpu/inst_seq.hh"
 
 namespace gem5
 {
@@ -54,6 +60,23 @@ class DynInst;
 
 using DynInstPtr = RefCountingPtr<DynInst>;
 using DynInstConstPtr = RefCountingPtr<const DynInst>;
+
+struct branchInfo
+{
+    bool indirect = false;
+    bool taken = false;
+    uint64_t target = 0;
+    InstSeqNum seqNum = 0;
+    uint64_t pc = 0;
+};
+
+std::ostream &operator<<(std::ostream &os, const branchInfo &b);
+
+using BranchHistory = std::deque<branchInfo>;
+
+bool operator==(const BranchHistory &a, const BranchHistory &b);
+
+constexpr size_t MAX_BRANCH_HISTORY = 128;
 
 } // namespace o3
 } // namespace gem5

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -96,6 +96,7 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       iewToCommitDelay(params.iewToCommitDelay),
       wbWidth(params.wbWidth),
       enableStoreSetTrain(params.enable_storeSet_train),
+      mdpViolationAtCommit(params.mdp_violation_timing == "atCommit"),
       numThreads(params.numThreads),
       iewStats(cpu)
 {
@@ -103,6 +104,12 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
         fatal("wbWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              wbWidth, static_cast<int>(MaxWidth));
+
+    if (params.mdp_violation_timing != "atResolve" &&
+        params.mdp_violation_timing != "atCommit") {
+        fatal("mdp_violation_timing must be atResolve or atCommit, got %s\n",
+              params.mdp_violation_timing.c_str());
+    }
 
     _status = Active;
     exeStatus = Running;
@@ -182,6 +189,8 @@ IEW::IEWStats::IEWStats(CPU *cpu)
              "Number of times the LSQ has become full, causing a stall"),
     ADD_STAT(memOrderViolationEvents, statistics::units::Count::get(),
              "Number of memory order violations"),
+    ADD_STAT(mdpViolationDeferred, statistics::units::Count::get(),
+             "RAW MDP violations deferred until Commit"),
     ADD_STAT(predictedTakenIncorrect, statistics::units::Count::get(),
              "Number of branches that were predicted taken incorrectly"),
     ADD_STAT(predictedNotTakenIncorrect, statistics::units::Count::get(),
@@ -1646,24 +1655,51 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
                     violator->pcState(), violator->seqNum,
                     inst->pcState(), inst->seqNum, inst->physEffAddr);
 
-            fetchRedirect[tid] = true;
-
-            // Tell the instruction queue that a violation has occured.
-            if (instQueue.usesPHAST(tid)) {
-                auto &mdp_history = cpu->getDecode()->getBranchHistory(tid);
-                instQueue.violation(inst->seqNum, inst->pcState().instAddr(),
-                                    violator, mdp_history);
-            } else if (enableStoreSetTrain) {
-                auto &mdp_history =
-                    cpu->getCommit()->getBranchHistory(tid);
-                instQueue.violation(inst->seqNum,
-                    inst->pcState().instAddr(), violator,
-                    mdp_history);
-            }
             violator->setProducerStorePC(inst->pcState().instAddr());
 
-            // Squash.
-            squashDueToMemOrder(violator, tid);
+            const bool raw_mdp_violation =
+                (inst->isStore() || inst->isAtomic()) &&
+                // Once a load has a deferred RAW violation, keep all
+                // subsequent producer observations on the deferred path.
+                // The first producer remains the training target captured by
+                // LSQUnit::checkViolations().
+                (violator->memDepInfo.violationPending ||
+                 violator->memDepInfo.violatingStoreSeqNum == inst->seqNum);
+            if (mdpViolationAtCommit && raw_mdp_violation) {
+                if (!violator->memDepInfo.violationPending) {
+                    // Preserve the first concrete producer observed before
+                    // Commit.  The load may overlap multiple younger stores
+                    // while recovery is deferred, but the original model
+                    // trains on the first violation that triggers recovery.
+                    violator->memDepInfo.violationPending = true;
+                    ++iewStats.mdpViolationDeferred;
+                }
+                DPRINTF(IEW,
+                        "Deferring RAW MDP violation to Commit: load PC %s "
+                        "[sn:%llu], store PC %s [sn:%llu].\n",
+                        violator->pcState(), violator->seqNum,
+                        inst->pcState(), inst->seqNum);
+            } else {
+                fetchRedirect[tid] = true;
+
+                // Tell the instruction queue that a violation has occured.
+                if (instQueue.usesPHAST(tid)) {
+                    auto &mdp_history =
+                        cpu->getDecode()->getBranchHistory(tid);
+                    instQueue.violation(inst->seqNum,
+                                        inst->pcState().instAddr(),
+                                        violator, mdp_history);
+                } else if (enableStoreSetTrain) {
+                    auto &mdp_history =
+                        cpu->getCommit()->getBranchHistory(tid);
+                    instQueue.violation(inst->seqNum,
+                                        inst->pcState().instAddr(),
+                                        violator, mdp_history);
+                }
+
+                // Squash.
+                squashDueToMemOrder(violator, tid);
+            }
 
             ++iewStats.memOrderViolationEvents;
         }
@@ -1983,8 +2019,9 @@ IEW::tick()
         DPRINTF(IEW,"Commit processing [tid:%i]\n",tid);
 
         if (fromCommit->commitInfo[tid].doneMemSeqNum != 0 &&
-            !fromCommit->commitInfo[tid].squash &&
-            !fromCommit->commitInfo[tid].robSquashing) {
+            (fromCommit->commitInfo[tid].isDeferedMDPSquash ||
+              (!fromCommit->commitInfo[tid].squash &&
+               !fromCommit->commitInfo[tid].robSquashing))) {
             recordThreadWork(tid);
 
             // Marks some of the entries in the store queue as canWB and

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1649,10 +1649,16 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             fetchRedirect[tid] = true;
 
             // Tell the instruction queue that a violation has occured.
-            if (enableStoreSetTrain && !instQueue.usesPHAST(tid)) {
+            if (instQueue.usesPHAST(tid)) {
+                auto &mdp_history = cpu->getDecode()->getBranchHistory(tid);
+                instQueue.violation(inst->seqNum, inst->pcState().instAddr(),
+                                    violator, mdp_history);
+            } else if (enableStoreSetTrain) {
+                auto &mdp_history =
+                    cpu->getCommit()->getBranchHistory(tid);
                 instQueue.violation(inst->seqNum,
                     inst->pcState().instAddr(), violator,
-                    cpu->getCommit()->getBranchHistory(tid));
+                    mdp_history);
             }
             violator->setProducerStorePC(inst->pcState().instAddr());
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -612,6 +612,8 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
                 toCommit->squashedLoopIter[tid]);
     }
 
+    cpu->getDecode()->squashBranchHistory(tid, inst->seqNum, true);
+
     stallSig->blockRename[tid] = true;
 }
 
@@ -650,6 +652,8 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
                 toCommit->squashedTargetId[tid],
                 toCommit->squashedLoopIter[tid]);
     }
+
+    cpu->getDecode()->squashBranchHistory(tid, inst->seqNum, true);
 
     stallSig->blockRename[tid] = true;
 }
@@ -690,6 +694,8 @@ IEW::squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid)
                 toCommit->squashedTargetId[tid],
                 toCommit->squashedLoopIter[tid]);
     }
+
+    cpu->getDecode()->squashBranchHistory(tid, inst->seqNum, true);
 
     stallSig->blockRename[tid] = true;
 }
@@ -1643,8 +1649,10 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             fetchRedirect[tid] = true;
 
             // Tell the instruction queue that a violation has occured.
-            if (enableStoreSetTrain) {
-                instQueue.violation(inst, violator);
+            if (enableStoreSetTrain && !instQueue.usesPHAST(tid)) {
+                instQueue.violation(inst->seqNum,
+                    inst->pcState().instAddr(), violator,
+                    cpu->getCommit()->getBranchHistory(tid));
             }
             violator->setProducerStorePC(inst->pcState().instAddr());
 

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -501,6 +501,9 @@ class IEW
 
     bool enableStoreSetTrain;
 
+    /** Defer RAW MDP recovery/training until the violating load is at Commit. */
+    const bool mdpViolationAtCommit;
+
     /** Number of active threads. */
     ThreadID numThreads;
 
@@ -538,6 +541,8 @@ class IEW
         statistics::Scalar lsqFullEvents;
         /** Stat for total number of memory ordering violation events. */
         statistics::Scalar memOrderViolationEvents;
+        /** RAW MDP violations deferred from IEW until Commit. */
+        statistics::Scalar mdpViolationDeferred;
         /** Stat for total number of incorrect predicted taken branches. */
         statistics::Scalar predictedTakenIncorrect;
         /** Stat for total number of incorrect predicted not taken branches. */

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -751,7 +751,28 @@ InstructionQueue::resolveMdpAddrReplayStoreAddr(const DynInstPtr &store_inst)
             continue;
         }
 
-        it->storeSeqNums.erase(store_sn);
+        auto store_it = it->storeSeqNums.find(store_sn);
+        if (store_it != it->storeSeqNums.end()) {
+            if (it->inst->memDepInfo.predicted) {
+                auto &info = it->inst->memDepInfo;
+                if (info.predStoreSizes.first != 0 &&
+                    info.predStoreAddrs.first == store_inst->effAddr &&
+                    info.predStoreSizes.first == store_inst->effSize) {
+                    // Already recorded.
+                } else if (info.predStoreSizes.second != 0 &&
+                           info.predStoreAddrs.second == store_inst->effAddr &&
+                           info.predStoreSizes.second == store_inst->effSize) {
+                    // Already recorded.
+                } else if (info.predStoreSizes.first == 0) {
+                    info.predStoreAddrs.first = store_inst->effAddr;
+                    info.predStoreSizes.first = store_inst->effSize;
+                } else if (info.predStoreSizes.second == 0) {
+                    info.predStoreAddrs.second = store_inst->effAddr;
+                    info.predStoreSizes.second = store_inst->effSize;
+                }
+            }
+            it->storeSeqNums.erase(store_it);
+        }
         if (it->pipeDone && it->storeSeqNums.empty()) {
             DPRINTF(IQ, "Load[sn:%llu] MDP addr replay ready (store[sn:%llu] addr ready)\n",
                     it->inst->seqNum, store_sn);
@@ -1189,11 +1210,18 @@ InstructionQueue::hasPhysicalSQFullReplayInsts() const
 }
 
 void
-InstructionQueue::violation(const DynInstPtr &store,
-        const DynInstPtr &faulting_load)
+InstructionQueue::violation(InstSeqNum store_seq_num, Addr store_pc,
+        const DynInstPtr &faulting_load, const BranchHistory &branchHistory)
 {
     iqIOStats.intInstQueueWrites++;
-    memDepUnit[store->threadNumber].violation(store, faulting_load);
+    memDepUnit[faulting_load->threadNumber].violation(
+        store_seq_num, store_pc, faulting_load, branchHistory);
+}
+
+void
+InstructionQueue::commit(const DynInstPtr &inst)
+{
+    memDepUnit[inst->threadNumber].commit(inst);
 }
 
 void
@@ -1221,6 +1249,7 @@ InstructionQueue::doSquash(ThreadID tid)
 
     DPRINTF(IQ, "[tid:%i] Squashing until sequence number %i!\n",
             tid, squashedSeqNum[tid]);
+    cpu->getDecode()->squashBranchHistory(tid, squashedSeqNum[tid], false);
     squashInfo.squashTid = tid;
     squashInfo.squashSn  = squashedSeqNum[tid];
     scheduler->doSquash(squashInfo);

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -290,7 +290,14 @@ class InstructionQueue
     void cacheUnblocked();
 
     /** Indicates an ordering violation between a store and a load. */
-    void violation(const DynInstPtr &store, const DynInstPtr &faulting_load);
+    void violation(InstSeqNum store_seq_num, Addr store_pc,
+                   const DynInstPtr &faulting_load,
+                   const BranchHistory &branchHistory);
+
+    bool usesPHAST(ThreadID tid) const { return memDepUnit[tid].usesPHAST(); }
+
+    /** Updates the memory dependence predictor when a load commits. */
+    void commit(const DynInstPtr &inst);
 
     /**
      * Squashes instructions for a thread. Squashing information is obtained

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1,5 +1,6 @@
 #include "cpu/o3/issue_queue.hh"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
@@ -1060,7 +1061,8 @@ IssueQue::insert(const DynInstPtr& inst)
      */
     if (inst->isMemRef()) {
         // insert and check memDep
-        scheduler->memDepUnit[inst->threadNumber].insert(inst);
+        scheduler->memDepUnit[inst->threadNumber].insert(
+            inst, cpu->getDecode()->getBranchHistory(inst->threadNumber));
     } else {
         addIfReady(inst);
     }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -39,6 +39,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <cassert>
 
 #include "arch/generic/debugfaults.hh"
@@ -1261,6 +1262,15 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                                 "[sn:%lli] at address %#x\n",
                                 inst->seqNum, ld_inst->seqNum, ld_eff_addr1);
                         memDepViolator = ld_inst;
+                        if (iewStage->instQueue.usesPHAST(
+                                ld_inst->threadNumber)) {
+                            ld_inst->memDepInfo.violatingStoreSeqNum =
+                                inst->seqNum;
+                            ld_inst->memDepInfo.violatingStorePC =
+                                inst->pcState().instAddr();
+                            ld_inst->memDepInfo.storeQueueDistance =
+                                (ld_inst->sqIt - inst->sqIt) - 1;
+                        }
 
                         ++stats.memOrderViolation;
                         if (inst->isStore() && !countedStLdViolationThisCycle) {
@@ -2254,6 +2264,10 @@ LSQUnit::commitLoad()
 
     DPRINTF(LSQUnit, "Committing head load instruction, PC %s, [sn:%lu]\n",
             inst->pcState(), inst->seqNum);
+
+    if (inst->memDepInfo.predicted) {
+        iewStage->instQueue.commit(inst);
+    }
 
     // Update histogram with memory latency from load
     // Only take latency from load demand that where issued and did not fault
@@ -3603,6 +3617,30 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
         } else {
             std::vector<InstSeqNum> wait_stores;
             wait_stores.reserve(load_inst->mdpProducingStores.size());
+            auto rememberPredStore = [&](const DynInstPtr &st_inst) {
+                if (!load_inst->memDepInfo.predicted) {
+                    return;
+                }
+                auto &info = load_inst->memDepInfo;
+                if (info.predStoreSizes.first != 0 &&
+                    info.predStoreAddrs.first == st_inst->effAddr &&
+                    info.predStoreSizes.first == st_inst->effSize) {
+                    return;
+                }
+                if (info.predStoreSizes.second != 0 &&
+                    info.predStoreAddrs.second == st_inst->effAddr &&
+                    info.predStoreSizes.second == st_inst->effSize) {
+                    return;
+                }
+                if (info.predStoreSizes.first == 0) {
+                    info.predStoreAddrs.first = st_inst->effAddr;
+                    info.predStoreSizes.first = st_inst->effSize;
+                } else if (info.predStoreSizes.second == 0) {
+                    info.predStoreAddrs.second = st_inst->effAddr;
+                    info.predStoreSizes.second = st_inst->effSize;
+                }
+            };
+
             for (auto st_it = storeQueue.begin(); st_it != storeQueue.end(); ++st_it) {
                 if (!st_it->valid() || !st_it->instruction()) {
                     continue;
@@ -3611,14 +3649,20 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                 if (st_inst->seqNum >= load_inst->seqNum) {
                     break;
                 }
-                if (st_it->addrReady()) {
+
+                const bool predicted_store =
+                    std::find(load_inst->mdpProducingStores.begin(),
+                              load_inst->mdpProducingStores.end(),
+                              st_inst->seqNum) !=
+                    load_inst->mdpProducingStores.end();
+                if (!predicted_store) {
                     continue;
                 }
-                if (std::find(load_inst->mdpProducingStores.begin(),
-                              load_inst->mdpProducingStores.end(),
-                              st_inst->seqNum) != load_inst->mdpProducingStores.end()) {
-                    wait_stores.push_back(st_inst->seqNum);
+                if (st_it->addrReady()) {
+                    rememberPredStore(st_inst);
+                    continue;
                 }
+                wait_stores.push_back(st_inst->seqNum);
             }
 
             if (!wait_stores.empty()) {
@@ -3863,6 +3907,8 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
                 // Don't need to do anything special for split loads.
                 ++stats.forwLoads;
                 load_inst->setProducerStorePC(store_it->instruction()->pcState().instAddr());
+                load_inst->memDepInfo.forwardedFrom =
+                    store_it->instruction()->seqNum;
 
                 return NoFault;
             } else if (

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1262,8 +1262,10 @@ LSQUnit::checkViolations(typename LoadQueue::iterator& loadIt,
                                 "[sn:%lli] at address %#x\n",
                                 inst->seqNum, ld_inst->seqNum, ld_eff_addr1);
                         memDepViolator = ld_inst;
-                        if (iewStage->instQueue.usesPHAST(
-                                ld_inst->threadNumber)) {
+                        // Preserve the concrete RAW target for both MDP
+                        // implementations. PHAST additionally consumes the
+                        // SQ distance and path metadata captured at issue.
+                        if (!ld_inst->memDepInfo.violationPending) {
                             ld_inst->memDepInfo.violatingStoreSeqNum =
                                 inst->seqNum;
                             ld_inst->memDepInfo.violatingStorePC =
@@ -2750,6 +2752,10 @@ LSQUnit::squash(const InstSeqNum &squashed_num)
             DPRINTF(HtmCpu, ">> htmStarts (%d) : htmStops-- (%d)\n",
               htmStarts, htmStops);
         }
+
+        // A deferred MDP violation only applies while this dynamic load
+        // remains on the architecturally valid path.
+        loadQueue.back().instruction()->memDepInfo.violationPending = false;
 
         // Clear the smart pointer to make sure it is decremented.
         loadQueue.back().instruction()->setSquashed();

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -66,6 +66,7 @@ MemDepUnit::MemDepUnit(const BaseO3CPUParams &params)
       enableReplayBasedMDP(params.EnableReplayBasedMDP),
       enableMDPStrictWait(params.EnableMDPStrictWait),
       enablePHASTMDP(params.EnablePHASTMDP),
+      depCheckShift(params.LSQDepCheckShift),
       stats(nullptr)
 {
     DPRINTF(MemDepUnit, "Creating MemDepUnit object.\n");
@@ -107,6 +108,7 @@ MemDepUnit::init(const BaseO3CPUParams &params, ThreadID tid, CPU *cpu)
             params.LFSTSize, params.LFSTEntrySize);
     phastPred.init(params);
 
+    depCheckShift = params.LSQDepCheckShift;
     enableReplayBasedMDP = params.EnableReplayBasedMDP;
     enableMDPStrictWait = params.EnableMDPStrictWait;
     enablePHASTMDP = params.EnablePHASTMDP;
@@ -132,10 +134,22 @@ MemDepUnit::MemDepUnitStats::MemDepUnitStats(statistics::Group *parent)
                "Number of PHAST predictions mapped to in-flight stores."),
       ADD_STAT(phastMappedStores, statistics::units::Count::get(),
                "Number of in-flight stores mapped from PHAST distances."),
+      ADD_STAT(phastTableHits, statistics::units::Count::get(),
+               "Number of PHAST table hits returning a valid distance."),
+      ADD_STAT(phastEffectivePreds, statistics::units::Count::get(),
+               "Number of PHAST hits that mapped to an in-flight store."),
+      ADD_STAT(phastDropInvalidSQDistance, statistics::units::Count::get(),
+               "Number of PHAST hits dropped because the target store could not be located."),
       ADD_STAT(phastViolationUpdates, statistics::units::Count::get(),
                "Number of PHAST violation-driven updates."),
       ADD_STAT(phastCommitUpdates, statistics::units::Count::get(),
-               "Number of PHAST commit-time confidence updates.")
+               "Number of PHAST commit-time confidence updates."),
+      ADD_STAT(mdpUnpredictedViolations, statistics::units::Count::get(),
+               "Number of RAW violations with no MDP prediction."),
+      ADD_STAT(mdpPredictedViolations, statistics::units::Count::get(),
+               "Number of RAW violations with an MDP prediction."),
+      ADD_STAT(mdpFalseDepAtCommit, statistics::units::Count::get(),
+               "Number of predicted loads that turned out not to conflict at commit.")
 {
 }
 
@@ -230,6 +244,7 @@ MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
     std::vector<InstSeqNum> producing_stores;
     bool mdp_pred = false;
     bool strict_wait = false;
+    bool phast_table_hit = false;
     PHASTPredictionResult phast_pred;
 
     auto mapDistanceToStore = [&](std::ptrdiff_t distance) {
@@ -283,20 +298,16 @@ MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
             phast_pred = phastPred.checkInst(inst->pcState().instAddr(),
                                              inst->seqNum, branchHistory,
                                              inst->isLoad());
+            phast_table_hit = phast_pred.storeQueueDistances.first >= 0 ||
+                              phast_pred.storeQueueDistances.second >= 0;
+            if (phast_table_hit) {
+                ++stats.phastTableHits;
+            }
             bool first_mapped =
                 mapDistanceToStore(phast_pred.storeQueueDistances.first);
             bool second_mapped =
                 mapDistanceToStore(phast_pred.storeQueueDistances.second);
             mdp_pred = first_mapped || second_mapped;
-            if (mdp_pred) {
-                inst->memDepInfo.predicted = true;
-                inst->memDepInfo.predBranchHistLength =
-                    phast_pred.predBranchHistLength;
-                inst->memDepInfo.predictorHash = phast_pred.predictorHash;
-                ++stats.phastPredictions;
-            } else {
-                inst->memDepInfo.predicted = false;
-            }
         } else {
             mdp_pred = true;
             producing_stores = depPred.checkInst(inst->pcState().instAddr());
@@ -328,7 +339,26 @@ MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
         }
     }
 
+    const bool concrete_prediction = inst->isLoad() && mdp_pred &&
+        !producing_stores.empty() && !store_entries.empty();
+    if (inst->isLoad()) {
+        inst->memDepInfo.predicted = concrete_prediction;
+        if (enablePHASTMDP && concrete_prediction) {
+            inst->memDepInfo.predBranchHistLength =
+                phast_pred.predBranchHistLength;
+            inst->memDepInfo.predictorHash = phast_pred.predictorHash;
+            ++stats.phastEffectivePreds;
+            ++stats.phastPredictions;
+        } else if (!concrete_prediction) {
+            inst->memDepInfo.predBranchHistLength = 0;
+            inst->memDepInfo.predictorHash = 0;
+        }
+    }
+
     if (store_entries.empty()) {
+        if (enablePHASTMDP && phast_table_hit) {
+            ++stats.phastDropInvalidSQDistance;
+        }
         DPRINTF(MemDepUnit, "No dependency for inst PC "
                 "%s [sn:%lli].\n", inst->pcState(), inst->seqNum);
 
@@ -663,6 +693,18 @@ MemDepUnit::violation(InstSeqNum store_seq_num, Addr store_pc,
             " load: %#x, store: %#x [sn:%lli]\n",
             violating_load->pcState().instAddr(), store_pc, store_seq_num);
 
+    const bool had_mdp_prediction = violating_load->memDepInfo.predicted ||
+                                    violating_load->mdpPredStrictWait ||
+                                    !violating_load->mdpProducingStores.empty();
+    if (!violating_load->memDepInfo.violationCounted) {
+        if (had_mdp_prediction) {
+            ++stats.mdpPredictedViolations;
+        } else {
+            ++stats.mdpUnpredictedViolations;
+        }
+        violating_load->memDepInfo.violationCounted = true;
+    }
+
     if (enablePHASTMDP) {
         if (violating_load->memDepInfo.violationTrained ||
             violating_load->memDepInfo.storeQueueDistance < 0) {
@@ -699,16 +741,44 @@ MemDepUnit::issue(const DynInstPtr &inst)
 void
 MemDepUnit::commit(const DynInstPtr &inst)
 {
-    if (!enablePHASTMDP || !inst->isLoad() || !inst->memDepInfo.predicted) {
+    if (!inst->isLoad() || !inst->memDepInfo.predicted) {
         return;
     }
 
-    phastPred.commit(inst->pcState().instAddr(), inst->effAddr, inst->effSize,
-            inst->memDepInfo.predStoreAddrs,
-            inst->memDepInfo.predStoreSizes,
-            inst->memDepInfo.predBranchHistLength,
-            inst->memDepInfo.predictorHash);
-    ++stats.phastCommitUpdates;
+    auto overlaps = [this](Addr a0, unsigned s0, Addr a1, unsigned s1) {
+        if (s0 == 0 || s1 == 0) {
+            return false;
+        }
+        const Addr l0 = a0 >> depCheckShift;
+        const Addr l1 = (a0 + s0 - 1) >> depCheckShift;
+        const Addr r0 = a1 >> depCheckShift;
+        const Addr r1 = (a1 + s1 - 1) >> depCheckShift;
+        return r1 >= l0 && r0 <= l1;
+    };
+
+    const bool has_predicted_store =
+        inst->memDepInfo.predStoreSizes.first != 0 ||
+        inst->memDepInfo.predStoreSizes.second != 0;
+    const bool false_dep = has_predicted_store &&
+        !overlaps(inst->effAddr, inst->effSize,
+                  inst->memDepInfo.predStoreAddrs.first,
+                  inst->memDepInfo.predStoreSizes.first) &&
+        !overlaps(inst->effAddr, inst->effSize,
+                  inst->memDepInfo.predStoreAddrs.second,
+                  inst->memDepInfo.predStoreSizes.second);
+
+    if (false_dep) {
+        ++stats.mdpFalseDepAtCommit;
+    }
+
+    if (enablePHASTMDP) {
+        phastPred.commit(inst->pcState().instAddr(), inst->effAddr,
+                         inst->effSize, inst->memDepInfo.predStoreAddrs,
+                         inst->memDepInfo.predStoreSizes,
+                         inst->memDepInfo.predBranchHistLength,
+                         inst->memDepInfo.predictorHash);
+        ++stats.phastCommitUpdates;
+    }
 }
 
 MemDepUnit::MemDepEntryPtr &

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -664,12 +664,17 @@ MemDepUnit::violation(InstSeqNum store_seq_num, Addr store_pc,
             violating_load->pcState().instAddr(), store_pc, store_seq_num);
 
     if (enablePHASTMDP) {
+        if (violating_load->memDepInfo.violationTrained ||
+            violating_load->memDepInfo.storeQueueDistance < 0) {
+            return;
+        }
         phastPred.violation(violating_load->pcState().instAddr(),
                 violating_load->seqNum, store_seq_num, store_pc,
                 violating_load->memDepInfo.storeQueueDistance,
                 violating_load->memDepInfo.predicted,
                 violating_load->memDepInfo.predBranchHistLength,
                 violating_load->memDepInfo.predictorHash, branchHistory);
+        violating_load->memDepInfo.violationTrained = true;
         ++stats.phastViolationUpdates;
     } else {
         depPred.violation(store_pc, violating_load->pcState().instAddr());

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -28,6 +28,8 @@
 
 #include "cpu/o3/mem_dep_unit.hh"
 
+#include <algorithm>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <vector>
@@ -59,7 +61,11 @@ MemDepUnit::MemDepUnit(const BaseO3CPUParams &params)
     : _name(params.name + ".memdepunit"),
       depPred(params.store_set_clear_period, params.SSITSize,
               params.LFSTSize,params.store_set_clear_thres,params.LFSTEntrySize),
+      phastPred(params),
       iqPtr(NULL),
+      enableReplayBasedMDP(params.EnableReplayBasedMDP),
+      enableMDPStrictWait(params.EnableMDPStrictWait),
+      enablePHASTMDP(params.EnablePHASTMDP),
       stats(nullptr)
 {
     DPRINTF(MemDepUnit, "Creating MemDepUnit object.\n");
@@ -99,9 +105,11 @@ MemDepUnit::init(const BaseO3CPUParams &params, ThreadID tid, CPU *cpu)
 
     depPred.init(params.store_set_clear_period, params.store_set_clear_thres, params.SSITSize,
             params.LFSTSize, params.LFSTEntrySize);
+    phastPred.init(params);
 
     enableReplayBasedMDP = params.EnableReplayBasedMDP;
     enableMDPStrictWait = params.EnableMDPStrictWait;
+    enablePHASTMDP = params.EnablePHASTMDP;
 
     std::string stats_group_name = csprintf("MemDepUnit__%i", tid);
     cpu->addStatGroup(stats_group_name.c_str(), &stats);
@@ -119,7 +127,15 @@ MemDepUnit::MemDepUnitStats::MemDepUnitStats(statistics::Group *parent)
       ADD_STAT(conflictingStores, statistics::units::Count::get(),
                "Number of conflicting stores."),
       ADD_STAT(dependentLoads, statistics::units::Count::get(),
-               "Number of  predicted conflicting loads.")
+               "Number of  predicted conflicting loads."),
+      ADD_STAT(phastPredictions, statistics::units::Count::get(),
+               "Number of PHAST predictions mapped to in-flight stores."),
+      ADD_STAT(phastMappedStores, statistics::units::Count::get(),
+               "Number of in-flight stores mapped from PHAST distances."),
+      ADD_STAT(phastViolationUpdates, statistics::units::Count::get(),
+               "Number of PHAST violation-driven updates."),
+      ADD_STAT(phastCommitUpdates, statistics::units::Count::get(),
+               "Number of PHAST commit-time confidence updates.")
 {
 }
 
@@ -153,6 +169,7 @@ MemDepUnit::takeOverFrom()
     loadBarrierSNs.clear();
     storeBarrierSNs.clear();
     depPred.clear();
+    phastPred.clear();
 }
 
 void
@@ -194,7 +211,7 @@ MemDepUnit::insertBarrierSN(const DynInstPtr &barr_inst)
 }
 
 void
-MemDepUnit::insert(const DynInstPtr &inst)
+MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
 {
     ThreadID tid = inst->threadNumber;
 
@@ -208,14 +225,47 @@ MemDepUnit::insert(const DynInstPtr &inst)
 #endif
 
     instList[tid].push_back(inst);
-
     inst_entry->listIt = --(instList[tid].end());
 
-    // Check any barriers and the dependence predictor for any
-    // producing memrefs/stores.
-    std::vector<InstSeqNum>  producing_stores;
-    bool store_set_pred = false;
+    std::vector<InstSeqNum> producing_stores;
+    bool mdp_pred = false;
     bool strict_wait = false;
+    PHASTPredictionResult phast_pred;
+
+    auto mapDistanceToStore = [&](std::ptrdiff_t distance) {
+        if (distance < 0 || inst->sqIt._cq == nullptr) {
+            return false;
+        }
+
+        const auto offset = static_cast<std::ptrdiff_t>(distance + 1);
+        if (inst->sqIt.idx() < inst->sqIt._cq->head() +
+                                   static_cast<size_t>(offset)) {
+            return false;
+        }
+
+        auto sq_it = inst->sqIt - offset;
+        if (!sq_it.dereferenceable() || !sq_it->valid() ||
+            !sq_it->instruction()) {
+            return false;
+        }
+
+        const auto &store_inst = sq_it->instruction();
+        if (store_inst->seqNum >= inst->seqNum) {
+            return false;
+        }
+
+        if (std::find(producing_stores.begin(), producing_stores.end(),
+                      store_inst->seqNum) != producing_stores.end()) {
+            return true;
+        }
+
+        producing_stores.push_back(store_inst->seqNum);
+        ++stats.phastMappedStores;
+        return true;
+    };
+
+    // Check any barriers and the dependence predictor for any producing
+    // memrefs/stores.
     if ((inst->isLoad() || inst->isAtomic()) && hasLoadBarrier()) {
         DPRINTF(MemDepUnit, "%d load barriers in flight\n",
                 loadBarrierSNs.size());
@@ -228,9 +278,27 @@ MemDepUnit::insert(const DynInstPtr &inst)
         producing_stores.insert(std::end(producing_stores),
                                 std::begin(storeBarrierSNs),
                                 std::end(storeBarrierSNs));
-    } else {
-        if (inst->isLoad()) {
-            store_set_pred = true;
+    } else if (inst->isLoad()) {
+        if (enablePHASTMDP) {
+            phast_pred = phastPred.checkInst(inst->pcState().instAddr(),
+                                             inst->seqNum, branchHistory,
+                                             inst->isLoad());
+            bool first_mapped =
+                mapDistanceToStore(phast_pred.storeQueueDistances.first);
+            bool second_mapped =
+                mapDistanceToStore(phast_pred.storeQueueDistances.second);
+            mdp_pred = first_mapped || second_mapped;
+            if (mdp_pred) {
+                inst->memDepInfo.predicted = true;
+                inst->memDepInfo.predBranchHistLength =
+                    phast_pred.predBranchHistLength;
+                inst->memDepInfo.predictorHash = phast_pred.predictorHash;
+                ++stats.phastPredictions;
+            } else {
+                inst->memDepInfo.predicted = false;
+            }
+        } else {
+            mdp_pred = true;
             producing_stores = depPred.checkInst(inst->pcState().instAddr());
             if (enableMDPStrictWait) {
                 strict_wait = depPred.checkInstStrict(inst->pcState().instAddr());
@@ -239,7 +307,7 @@ MemDepUnit::insert(const DynInstPtr &inst)
     }
 
     if (enableReplayBasedMDP && inst->isLoad()) {
-        if (store_set_pred) {
+        if (mdp_pred) {
             inst->mdpProducingStores = producing_stores;
             inst->mdpPredStrictWait = strict_wait;
         } else {
@@ -249,8 +317,6 @@ MemDepUnit::insert(const DynInstPtr &inst)
     }
 
     std::vector<MemDepEntryPtr> store_entries;
-
-    // If there is a producing store, try to find the entry.
     for (auto producing_store : producing_stores) {
         DPRINTF(MemDepUnit, "Searching for producer [sn:%lli]\n",
                             producing_store);
@@ -262,8 +328,6 @@ MemDepUnit::insert(const DynInstPtr &inst)
         }
     }
 
-    // If no store entry, then instruction can issue as soon as the registers
-    // are ready.
     if (store_entries.empty()) {
         DPRINTF(MemDepUnit, "No dependency for inst PC "
                 "%s [sn:%lli].\n", inst->pcState(), inst->seqNum);
@@ -271,9 +335,7 @@ MemDepUnit::insert(const DynInstPtr &inst)
         assert(inst_entry->memDeps == 0);
 
         inst->issueQue->markMemDepDone(inst);
-    } else if (enableReplayBasedMDP && inst->isLoad() && store_set_pred) {
-        // Replay-based MDP: do not stall loads in IQ. Carry the prediction
-        // to load pipe and potentially replay there.
+    } else if (enableReplayBasedMDP && inst->isLoad() && mdp_pred) {
         DPRINTF(MemDepUnit, "Replay-based MDP: bypass IQ stall for load PC "
                 "%s [sn:%lli], predicted producers: %lu, strict: %d\n",
                 inst->pcState(), inst->seqNum, producing_stores.size(),
@@ -283,13 +345,11 @@ MemDepUnit::insert(const DynInstPtr &inst)
 
         ++stats.conflictingLoads;
     } else {
-        // Otherwise make the instruction dependent on the store/barrier.
         DPRINTF(MemDepUnit, "Adding to dependency list\n");
         for ([[maybe_unused]] auto producing_store : producing_stores)
             DPRINTF(MemDepUnit, "\tinst PC %s is dependent on [sn:%lli].\n",
                 inst->pcState(), producing_store);
 
-        // Add this instruction to the list of dependents.
         for (auto store_entry : store_entries)
             store_entry->dependInsts.push_back(inst_entry);
 
@@ -309,8 +369,13 @@ MemDepUnit::insert(const DynInstPtr &inst)
         DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n",
                 inst->pcState(), inst->seqNum);
 
-        depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
-                inst->threadNumber, cpu->curCycle());
+        if (enablePHASTMDP) {
+            phastPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
+                                  inst->threadNumber);
+        } else {
+            depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
+                    inst->threadNumber, cpu->curCycle());
+        }
 
         ++stats.insertedStores;
     } else if (inst->isLoad()) {
@@ -331,8 +396,13 @@ MemDepUnit::insertNonSpec(const DynInstPtr &inst)
         DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n",
                 inst->pcState(), inst->seqNum);
 
-        depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
-                inst->threadNumber, cpu->curCycle());
+        if (enablePHASTMDP) {
+            phastPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
+                                  inst->threadNumber);
+        } else {
+            depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
+                    inst->threadNumber, cpu->curCycle());
+        }
 
         ++stats.insertedStores;
     } else if (inst->isLoad()) {
@@ -480,6 +550,19 @@ MemDepUnit::wakeDependents(const DynInstPtr &inst)
                 "[sn:%lli].\n",
                 woken_inst->inst->seqNum);
 
+        if (woken_inst->inst->memDepInfo.predicted && inst->isStore()) {
+            auto &info = woken_inst->inst->memDepInfo;
+            if (info.predStoreSizes.first == 0) {
+                info.predStoreAddrs.first = inst->effAddr;
+                info.predStoreSizes.first = inst->effSize;
+            } else if (info.predStoreSizes.second == 0 &&
+                       (info.predStoreAddrs.first != inst->effAddr ||
+                        info.predStoreSizes.first != inst->effSize)) {
+                info.predStoreAddrs.second = inst->effAddr;
+                info.predStoreSizes.second = inst->effSize;
+            }
+        }
+
         assert(woken_inst->memDeps > 0);
         woken_inst->memDeps -= 1;
 
@@ -565,19 +648,32 @@ MemDepUnit::squash(const InstSeqNum &squashed_num, ThreadID tid)
     }
 
     // Tell the dependency predictor to squash as well.
-    depPred.squash(squashed_num, tid);
+    if (enablePHASTMDP) {
+        phastPred.squash(squashed_num, tid);
+    } else {
+        depPred.squash(squashed_num, tid);
+    }
 }
 
 void
-MemDepUnit::violation(const DynInstPtr &store_inst,
-        const DynInstPtr &violating_load)
+MemDepUnit::violation(InstSeqNum store_seq_num, Addr store_pc,
+        const DynInstPtr &violating_load, const BranchHistory &branchHistory)
 {
-    DPRINTF(MemDepUnit, "Passing violating PCs to store sets,"
-            " load: %#x, store: %#x\n", violating_load->pcState().instAddr(),
-            store_inst->pcState().instAddr());
-    // Tell the memory dependence unit of the violation.
-    depPred.violation(store_inst->pcState().instAddr(),
-            violating_load->pcState().instAddr());
+    DPRINTF(MemDepUnit, "Passing violating PCs to mem dep predictor,"
+            " load: %#x, store: %#x [sn:%lli]\n",
+            violating_load->pcState().instAddr(), store_pc, store_seq_num);
+
+    if (enablePHASTMDP) {
+        phastPred.violation(violating_load->pcState().instAddr(),
+                violating_load->seqNum, store_seq_num, store_pc,
+                violating_load->memDepInfo.storeQueueDistance,
+                violating_load->memDepInfo.predicted,
+                violating_load->memDepInfo.predBranchHistLength,
+                violating_load->memDepInfo.predictorHash, branchHistory);
+        ++stats.phastViolationUpdates;
+    } else {
+        depPred.violation(store_pc, violating_load->pcState().instAddr());
+    }
 }
 
 void
@@ -586,7 +682,28 @@ MemDepUnit::issue(const DynInstPtr &inst)
     DPRINTF(MemDepUnit, "Issuing instruction PC %#x [sn:%lli].\n",
             inst->pcState().instAddr(), inst->seqNum);
 
-    depPred.issued(inst->pcState().instAddr(), inst->seqNum, inst->isStore());
+    if (enablePHASTMDP) {
+        phastPred.issued(inst->pcState().instAddr(), inst->seqNum,
+                         inst->isStore());
+    } else {
+        depPred.issued(inst->pcState().instAddr(), inst->seqNum,
+                       inst->isStore());
+    }
+}
+
+void
+MemDepUnit::commit(const DynInstPtr &inst)
+{
+    if (!enablePHASTMDP || !inst->isLoad() || !inst->memDepInfo.predicted) {
+        return;
+    }
+
+    phastPred.commit(inst->pcState().instAddr(), inst->effAddr, inst->effSize,
+            inst->memDepInfo.predStoreAddrs,
+            inst->memDepInfo.predStoreSizes,
+            inst->memDepInfo.predBranchHistLength,
+            inst->memDepInfo.predictorHash);
+    ++stats.phastCommitUpdates;
 }
 
 MemDepUnit::MemDepEntryPtr &

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -140,6 +140,8 @@ MemDepUnit::MemDepUnitStats::MemDepUnitStats(statistics::Group *parent)
                "Number of PHAST hits that mapped to an in-flight store."),
       ADD_STAT(phastDropInvalidSQDistance, statistics::units::Count::get(),
                "Number of PHAST hits dropped because the target store could not be located."),
+      ADD_STAT(phastInvalidSQDistanceFeedback, statistics::units::Count::get(),
+               "Number of PHAST confidence updates after an SQ distance mapping failure."),
       ADD_STAT(phastViolationUpdates, statistics::units::Count::get(),
                "Number of PHAST violation-driven updates."),
       ADD_STAT(phastCommitUpdates, statistics::units::Count::get(),
@@ -245,28 +247,37 @@ MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
     bool mdp_pred = false;
     bool strict_wait = false;
     bool phast_table_hit = false;
+    bool phast_sq_mapping_failed = false;
     PHASTPredictionResult phast_pred;
 
+    auto markPHASTMappingFailure = [&]() {
+        phast_sq_mapping_failed = true;
+        return false;
+    };
+
     auto mapDistanceToStore = [&](std::ptrdiff_t distance) {
-        if (distance < 0 || inst->sqIt._cq == nullptr) {
+        if (distance < 0) {
             return false;
+        }
+        if (inst->sqIt._cq == nullptr) {
+            return markPHASTMappingFailure();
         }
 
         const auto offset = static_cast<std::ptrdiff_t>(distance + 1);
         if (inst->sqIt.idx() < inst->sqIt._cq->head() +
                                    static_cast<size_t>(offset)) {
-            return false;
+            return markPHASTMappingFailure();
         }
 
         auto sq_it = inst->sqIt - offset;
         if (!sq_it.dereferenceable() || !sq_it->valid() ||
             !sq_it->instruction()) {
-            return false;
+            return markPHASTMappingFailure();
         }
 
         const auto &store_inst = sq_it->instruction();
         if (store_inst->seqNum >= inst->seqNum) {
-            return false;
+            return markPHASTMappingFailure();
         }
 
         if (std::find(producing_stores.begin(), producing_stores.end(),
@@ -337,6 +348,14 @@ MemDepUnit::insert(const DynInstPtr &inst, const BranchHistory &branchHistory)
             store_entries.push_back((*hash_it).second);
             DPRINTF(MemDepUnit, "Producer found\n");
         }
+    }
+
+    if (enablePHASTMDP && phast_table_hit &&
+        (phast_sq_mapping_failed || store_entries.empty())) {
+        phastPred.invalidSQDistance(inst->pcState().instAddr(),
+                                    phast_pred.predBranchHistLength,
+                                    phast_pred.predictorHash);
+        ++stats.phastInvalidSQDistanceFeedback;
     }
 
     const bool concrete_prediction = inst->isLoad() && mdp_pred &&

--- a/src/cpu/o3/mem_dep_unit.hh
+++ b/src/cpu/o3/mem_dep_unit.hh
@@ -313,6 +313,9 @@ class MemDepUnit
         /** PHAST hits dropped because the target store could not be located. */
         statistics::Scalar phastDropInvalidSQDistance;
 
+        /** PHAST confidence updates after a distance-to-store mapping failure. */
+        statistics::Scalar phastInvalidSQDistanceFeedback;
+
         /** PHAST updates from committed memory-order violations. */
         statistics::Scalar phastViolationUpdates;
 

--- a/src/cpu/o3/mem_dep_unit.hh
+++ b/src/cpu/o3/mem_dep_unit.hh
@@ -46,11 +46,13 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "base/statistics.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/phast.hh"
 #include "cpu/o3/store_set.hh"
 #include "debug/MemDepUnit.hh"
 
@@ -120,8 +122,10 @@ class MemDepUnit
     /** Sets the pointer to the IQ. */
     void setIQ(InstructionQueue *iq_ptr);
 
+    bool usesPHAST() const { return enablePHASTMDP; }
+
     /** Inserts a memory instruction. */
-    void insert(const DynInstPtr &inst);
+    void insert(const DynInstPtr &inst, const BranchHistory &branchHistory);
 
     /** Inserts a non-speculative memory instruction. */
     void insertNonSpec(const DynInstPtr &inst);
@@ -152,11 +156,15 @@ class MemDepUnit
     void squash(const InstSeqNum &squashed_num, ThreadID tid);
 
     /** Indicates an ordering violation between a store and a younger load. */
-    void violation(const DynInstPtr &store_inst,
-                   const DynInstPtr &violating_load);
+    void violation(InstSeqNum store_seq_num, Addr store_pc,
+                   const DynInstPtr &violating_load,
+                   const BranchHistory &branchHistory);
 
     /** Issues the given instruction */
     void issue(const DynInstPtr &inst);
+
+    /** Updates predictor state when a load commits. */
+    void commit(const DynInstPtr &inst);
 
     /** Debugging function to dump the lists of instructions. */
     void dumpLists();
@@ -237,6 +245,7 @@ class MemDepUnit
      *  upon.
      */
     StoreSet depPred;
+    PHAST phastPred;
 
     /** Sequence numbers of outstanding load barriers. */
     std::unordered_set<InstSeqNum> loadBarrierSNs;
@@ -262,6 +271,9 @@ class MemDepUnit
     /** If true, MDP uses StoreSet strict-wait flag (checkInstStrict). */
     bool enableMDPStrictWait = false;
 
+    /** If true, use PHAST rather than StoreSets. */
+    bool enablePHASTMDP = false;
+
     /** The thread id of this memory dependence unit. */
     int id;
     struct MemDepUnitStats : public statistics::Group
@@ -281,6 +293,18 @@ class MemDepUnit
         /** Stat for number of predicted conflicting loads
          */
         statistics::Scalar dependentLoads;
+
+        /** PHAST lookup hits with at least one mapped in-flight store. */
+        statistics::Scalar phastPredictions;
+
+        /** Number of dynamic stores mapped from PHAST store distances. */
+        statistics::Scalar phastMappedStores;
+
+        /** PHAST updates from committed memory-order violations. */
+        statistics::Scalar phastViolationUpdates;
+
+        /** PHAST confidence updates from predicted load commit. */
+        statistics::Scalar phastCommitUpdates;
     } stats;
 };
 

--- a/src/cpu/o3/mem_dep_unit.hh
+++ b/src/cpu/o3/mem_dep_unit.hh
@@ -276,6 +276,10 @@ class MemDepUnit
 
     /** The thread id of this memory dependence unit. */
     int id;
+
+    /** Address compare shift used for commit-time false-dependency checks. */
+    unsigned depCheckShift = 0;
+
     struct MemDepUnitStats : public statistics::Group
     {
         MemDepUnitStats(statistics::Group *parent);
@@ -300,11 +304,29 @@ class MemDepUnit
         /** Number of dynamic stores mapped from PHAST store distances. */
         statistics::Scalar phastMappedStores;
 
+        /** PHAST table hits returning a valid store distance. */
+        statistics::Scalar phastTableHits;
+
+        /** PHAST hits that became effective in-flight dependencies. */
+        statistics::Scalar phastEffectivePreds;
+
+        /** PHAST hits dropped because the target store could not be located. */
+        statistics::Scalar phastDropInvalidSQDistance;
+
         /** PHAST updates from committed memory-order violations. */
         statistics::Scalar phastViolationUpdates;
 
         /** PHAST confidence updates from predicted load commit. */
         statistics::Scalar phastCommitUpdates;
+
+        /** RAW violations without any MDP prediction. */
+        statistics::Scalar mdpUnpredictedViolations;
+
+        /** RAW violations with an MDP prediction in place. */
+        statistics::Scalar mdpPredictedViolations;
+
+        /** Predicted loads that turned out not to conflict at commit. */
+        statistics::Scalar mdpFalseDepAtCommit;
     } stats;
 };
 

--- a/src/cpu/o3/phast.cc
+++ b/src/cpu/o3/phast.cc
@@ -230,6 +230,17 @@ PHAST::commit(Addr load_pc, Addr load_addr, unsigned load_size,
     paths[path_index].updateCommit(load_pc, predictor_hash, misprediction);
 }
 
+void
+PHAST::invalidSQDistance(Addr load_pc, unsigned path_index,
+                         uint64_t predictor_hash)
+{
+    if (path_index >= paths.size()) {
+        return;
+    }
+
+    paths[path_index].updateCommit(load_pc, predictor_hash, true);
+}
+
 int
 PHAST::SimplBlockCache::init(uint32_t set_bits, uint32_t _associativity,
                             uint32_t tag_bits, uint32_t max_counter_value,

--- a/src/cpu/o3/phast.cc
+++ b/src/cpu/o3/phast.cc
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ */
+
+#include "cpu/o3/phast.hh"
+
+#include <algorithm>
+#include <cassert>
+
+#include "base/intmath.hh"
+#include "params/BaseO3CPU.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+namespace
+{
+
+uint64_t
+hash_combine(uint64_t seed, uint64_t value)
+{
+    return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+}
+
+} // namespace
+
+void
+PHAST::init(const BaseO3CPUParams &params)
+{
+    assert(isPowerOf2(params.phast_num_rows));
+
+    depCheckShift = params.LSQDepCheckShift;
+    SQEntries = params.SQEntries;
+
+    unsigned set_bits = 0;
+    while ((1u << set_bits) < params.phast_num_rows) {
+        ++set_bits;
+    }
+
+    selectedTargetBits = 5;
+    selectedTargetMask = (selectedTargetBits == 64)
+        ? ~0ULL
+        : ((1ULL << selectedTargetBits) - 1);
+
+    historySizes = {0, 2, 4, 6, 8, 12, 16, 32};
+    paths.clear();
+    paths.resize(historySizes.size());
+    for (auto &path : paths) {
+        path.init(set_bits, params.phast_associativity,
+                  params.phast_tag_bits, params.phast_max_counter);
+    }
+}
+
+void
+PHAST::clear()
+{
+    for (auto &path : paths) {
+        path.clear();
+    }
+}
+
+BranchHistory
+PHAST::filteredHistory(InstSeqNum load_seq_num,
+                       const BranchHistory &branch_history) const
+{
+    BranchHistory filtered;
+    for (const auto &entry : branch_history) {
+        if (entry.seqNum >= load_seq_num) {
+            continue;
+        }
+        filtered.push_back(entry);
+    }
+    return filtered;
+}
+
+uint64_t
+PHAST::makePathHash(Addr load_pc, const BranchHistory &branch_history,
+                    unsigned history_len) const
+{
+    uint64_t hash = hash_combine(load_pc ^ (load_pc >> 11), history_len);
+    history_len =
+        std::min(history_len, static_cast<unsigned>(branch_history.size()));
+
+    for (unsigned i = 0; i < history_len; ++i) {
+        const auto &branch = branch_history[i];
+        uint64_t branch_bits = branch.pc ^ (branch.pc >> 7);
+        branch_bits ^= branch.target & selectedTargetMask;
+        branch_bits ^= static_cast<uint64_t>(branch.taken) << 1;
+        branch_bits ^= static_cast<uint64_t>(branch.indirect) << 2;
+        branch_bits ^= branch.target >> selectedTargetBits;
+        hash = hash_combine(hash, branch_bits);
+    }
+
+    return hash;
+}
+
+PHASTPredictionResult
+PHAST::checkInst(Addr load_pc, InstSeqNum load_seq_num,
+                 const BranchHistory &branch_history, bool is_load)
+{
+    PHASTPredictionResult result;
+    if (!is_load) {
+        return result;
+    }
+
+    BranchHistory filtered = filteredHistory(load_seq_num, branch_history);
+
+    for (int i = static_cast<int>(historySizes.size()) - 1; i >= 0; --i) {
+        const unsigned hist_len = historySizes[i];
+        if (hist_len > filtered.size()) {
+            continue;
+        }
+
+        const uint64_t hash = makePathHash(load_pc, filtered, hist_len);
+        const auto distances = paths[i].predict(load_pc, hash);
+        if (distances.first >= 0 || distances.second >= 0) {
+            result.storeQueueDistances = distances;
+            result.predBranchHistLength = static_cast<unsigned>(i);
+            result.predictorHash = hash;
+            return result;
+        }
+    }
+
+    return result;
+}
+
+void
+PHAST::violation(Addr load_pc, InstSeqNum load_seq_num,
+                 InstSeqNum store_seq_num, Addr,
+                 std::ptrdiff_t store_queue_distance, bool predicted,
+                 unsigned predicted_path_index, uint64_t predicted_hash,
+                 const BranchHistory &branch_history)
+{
+    BranchHistory filtered = filteredHistory(load_seq_num, branch_history);
+
+    unsigned available_branches = 0;
+    for (const auto &entry : filtered) {
+        ++available_branches;
+        if (entry.seqNum <= store_seq_num) {
+            break;
+        }
+    }
+
+    unsigned actual_index = 0;
+    for (unsigned i = 0; i < historySizes.size(); ++i) {
+        if (historySizes[i] <= available_branches) {
+            actual_index = i;
+        } else {
+            break;
+        }
+    }
+
+    const uint64_t actual_hash =
+        makePathHash(load_pc, filtered, historySizes[actual_index]);
+
+    if (predicted && predicted_path_index < paths.size() &&
+        (predicted_path_index != actual_index ||
+         predicted_hash != actual_hash)) {
+        paths[predicted_path_index].updateCommit(load_pc, predicted_hash, true);
+    }
+
+    if (store_queue_distance >= 0) {
+        paths[actual_index].update(load_pc, actual_hash, store_queue_distance,
+                                   SQEntries);
+    }
+}
+
+void
+PHAST::commit(Addr load_pc, Addr load_addr, unsigned load_size,
+              const std::pair<Addr, Addr> &store_addrs,
+              const std::pair<unsigned, unsigned> &store_sizes,
+              unsigned path_index, uint64_t predictor_hash)
+{
+    if (path_index >= paths.size()) {
+        return;
+    }
+
+    auto overlaps = [this](Addr a0, unsigned s0, Addr a1, unsigned s1) {
+        if (s0 == 0 || s1 == 0) {
+            return false;
+        }
+        const Addr l0 = a0 >> depCheckShift;
+        const Addr l1 = (a0 + s0 - 1) >> depCheckShift;
+        const Addr r0 = a1 >> depCheckShift;
+        const Addr r1 = (a1 + s1 - 1) >> depCheckShift;
+        return r1 >= l0 && r0 <= l1;
+    };
+
+    bool misprediction = true;
+    if (overlaps(load_addr, load_size, store_addrs.first,
+                 store_sizes.first) ||
+        overlaps(load_addr, load_size, store_addrs.second,
+                 store_sizes.second)) {
+        misprediction = false;
+    }
+
+    paths[path_index].updateCommit(load_pc, predictor_hash, misprediction);
+}
+
+int
+PHAST::SimplBlockCache::init(uint32_t set_bits, uint32_t _associativity,
+                            uint32_t tag_bits, uint32_t max_counter_value)
+{
+    setBits = set_bits;
+    tagBits = tag_bits;
+    associativity = _associativity;
+    maxCounterValue = max_counter_value;
+    lruCounter = 0;
+
+    cache.clear();
+    cache.resize(1ULL << setBits);
+    for (auto &set : cache) {
+        set.resize(associativity);
+    }
+
+    return (1ULL << setBits) * associativity;
+}
+
+uint64_t
+PHAST::SimplBlockCache::xorFold(uint64_t pc, uint64_t history,
+                                unsigned size) const
+{
+    if (size == 0) {
+        return 0;
+    }
+
+    const uint64_t mask = (1ULL << size) - 1;
+    uint64_t fold = (history & mask) ^ (pc & mask);
+    history >>= size;
+
+    while (history) {
+        fold ^= (history & mask);
+        history >>= size;
+    }
+
+    return fold;
+}
+
+uint64_t
+PHAST::SimplBlockCache::getIndex(Addr pc, uint64_t history) const
+{
+    pc = (pc ^ (pc >> 2) ^ (pc >> 5));
+    return xorFold(pc, history, setBits);
+}
+
+uint64_t
+PHAST::SimplBlockCache::getTag(Addr pc, uint64_t history) const
+{
+    pc = (pc ^ (pc >> 3) ^ (pc >> 7));
+    return xorFold(pc, history, tagBits);
+}
+
+PHAST::SimplBlockCache::Entry *
+PHAST::SimplBlockCache::findEntry(Addr pc, uint64_t history)
+{
+    const auto set = getIndex(pc, history);
+    const auto tag = getTag(pc, history);
+    for (uint32_t i = 0; i < associativity; ++i) {
+        if (cache[set][i].valid && cache[set][i].tag == tag) {
+            return &cache[set][i];
+        }
+    }
+    return nullptr;
+}
+
+const PHAST::SimplBlockCache::Entry *
+PHAST::SimplBlockCache::findEntry(Addr pc, uint64_t history) const
+{
+    const auto set = getIndex(pc, history);
+    const auto tag = getTag(pc, history);
+    for (uint32_t i = 0; i < associativity; ++i) {
+        if (cache[set][i].valid && cache[set][i].tag == tag) {
+            return &cache[set][i];
+        }
+    }
+    return nullptr;
+}
+
+PHAST::SimplBlockCache::Entry *
+PHAST::SimplBlockCache::getLRUEntry(uint64_t set)
+{
+    for (uint32_t i = 0; i < associativity; ++i) {
+        if (!cache[set][i].valid) {
+            return &cache[set][i];
+        }
+    }
+
+    uint32_t lru_way = 0;
+    uint64_t lru_value = cache[set][0].lru;
+    for (uint32_t i = 1; i < associativity; ++i) {
+        if (cache[set][i].lru < lru_value) {
+            lru_way = i;
+            lru_value = cache[set][i].lru;
+        }
+    }
+    return &cache[set][lru_way];
+}
+
+void
+PHAST::SimplBlockCache::updateLRU(Entry *entry)
+{
+    entry->lru = lruCounter++;
+}
+
+std::pair<std::ptrdiff_t, std::ptrdiff_t>
+PHAST::SimplBlockCache::predict(Addr pc, uint64_t history) const
+{
+    const auto *entry = findEntry(pc, history);
+    if (entry == nullptr || entry->counter == 0 ||
+        (entry->distances.first < 0 && entry->distances.second < 0)) {
+        return {-1, -1};
+    }
+
+    return entry->distances;
+}
+
+void
+PHAST::SimplBlockCache::update(Addr pc, uint64_t history,
+                               std::ptrdiff_t distance, unsigned SQEntries)
+{
+    if (distance < 0) {
+        return;
+    }
+
+    const auto set = getIndex(pc, history);
+    auto *entry = findEntry(pc, history);
+    if (entry == nullptr) {
+        entry = getLRUEntry(set);
+        entry->valid = true;
+        entry->tag = getTag(pc, history);
+        entry->distances = {distance, -1};
+        entry->counter = maxCounterValue;
+    } else if (entry->distances.second < 0 &&
+               entry->distances.first != distance &&
+               distance < static_cast<std::ptrdiff_t>(SQEntries / 2) &&
+               entry->distances.first < static_cast<std::ptrdiff_t>(SQEntries / 2)) {
+        entry->distances.second = distance;
+        entry->counter = maxCounterValue;
+    } else {
+        entry->distances = {distance, -1};
+        entry->counter = maxCounterValue;
+    }
+
+    updateLRU(entry);
+}
+
+void
+PHAST::SimplBlockCache::updateCommit(Addr pc, uint64_t history,
+                                     bool prediction_wrong)
+{
+    auto *entry = findEntry(pc, history);
+    if (entry == nullptr || entry->counter == 0) {
+        return;
+    }
+
+    if (prediction_wrong) {
+        --entry->counter;
+    } else {
+        entry->counter = maxCounterValue;
+    }
+
+    updateLRU(entry);
+}
+
+void
+PHAST::SimplBlockCache::clear()
+{
+    for (auto &set : cache) {
+        for (auto &entry : set) {
+            entry.tag = 0;
+            entry.distances = {-1, -1};
+            entry.lru = 0;
+            entry.counter = 0;
+            entry.valid = false;
+        }
+    }
+    lruCounter = 0;
+}
+
+} // namespace o3
+} // namespace gem5

--- a/src/cpu/o3/phast.cc
+++ b/src/cpu/o3/phast.cc
@@ -6,9 +6,9 @@
 #include "cpu/o3/phast.hh"
 
 #include <algorithm>
-#include <cassert>
 
 #include "base/intmath.hh"
+#include "base/logging.hh"
 #include "params/BaseO3CPU.hh"
 
 namespace gem5
@@ -31,27 +31,57 @@ hash_combine(uint64_t seed, uint64_t value)
 void
 PHAST::init(const BaseO3CPUParams &params)
 {
-    assert(isPowerOf2(params.phast_num_rows));
+    fatal_if(params.phast_num_rows == 0 ||
+                 !isPowerOf2(params.phast_num_rows),
+             "PHAST rows per table must be a non-zero power of two.\n");
+    fatal_if(params.phast_associativity == 0,
+             "PHAST table associativity must be non-zero.\n");
+    fatal_if(params.phast_max_counter == 0,
+             "PHAST confidence counter maximum must be non-zero.\n");
+    fatal_if(params.phast_counter_threshold == 0 ||
+                 params.phast_counter_threshold > params.phast_max_counter,
+             "PHAST confidence threshold must be in [1, max counter].\n");
+    fatal_if(params.phast_tag_bits >= 64,
+             "PHAST tag bits must be less than 64.\n");
+    fatal_if(params.phast_selected_target_bits > 64,
+             "PHAST selected target bits must be at most 64.\n");
+    fatal_if(params.phast_history_lengths.empty(),
+             "PHAST must have at least one history table.\n");
+
+    for (unsigned i = 1; i < params.phast_history_lengths.size(); ++i) {
+        fatal_if(params.phast_history_lengths[i - 1] >=
+                     params.phast_history_lengths[i],
+                 "PHAST history lengths must be strictly increasing.\n");
+    }
 
     depCheckShift = params.LSQDepCheckShift;
-    SQEntries = params.SQEntries;
+    // PHAST stores distances in the virtual store queue used by MemDepUnit.
+    SQEntries = params.SQEntries * params.StoreQueueMultiple;
 
     unsigned set_bits = 0;
-    while ((1u << set_bits) < params.phast_num_rows) {
+    while ((1ULL << set_bits) < params.phast_num_rows) {
         ++set_bits;
     }
 
-    selectedTargetBits = 5;
+    selectedTargetBits = params.phast_selected_target_bits;
     selectedTargetMask = (selectedTargetBits == 64)
         ? ~0ULL
         : ((1ULL << selectedTargetBits) - 1);
 
-    historySizes = {0, 2, 4, 6, 8, 12, 16, 32};
+    historySizes = params.phast_history_lengths;
+    const unsigned second_target_max_distance =
+        params.phast_second_target_max_distance == 0
+            ? SQEntries / 2
+            : params.phast_second_target_max_distance;
     paths.clear();
     paths.resize(historySizes.size());
     for (auto &path : paths) {
         path.init(set_bits, params.phast_associativity,
-                  params.phast_tag_bits, params.phast_max_counter);
+                  params.phast_tag_bits, params.phast_max_counter,
+                  params.phast_counter_threshold,
+                  params.phast_counter_increment,
+                  params.phast_counter_decrement,
+                  second_target_max_distance);
     }
 }
 
@@ -164,8 +194,7 @@ PHAST::violation(Addr load_pc, InstSeqNum load_seq_num,
     }
 
     if (store_queue_distance >= 0) {
-        paths[actual_index].update(load_pc, actual_hash, store_queue_distance,
-                                   SQEntries);
+        paths[actual_index].update(load_pc, actual_hash, store_queue_distance);
     }
 }
 
@@ -203,12 +232,20 @@ PHAST::commit(Addr load_pc, Addr load_addr, unsigned load_size,
 
 int
 PHAST::SimplBlockCache::init(uint32_t set_bits, uint32_t _associativity,
-                            uint32_t tag_bits, uint32_t max_counter_value)
+                            uint32_t tag_bits, uint32_t max_counter_value,
+                            uint32_t counter_threshold,
+                            uint32_t counter_increment,
+                            uint32_t counter_decrement,
+                            unsigned second_target_max_distance)
 {
     setBits = set_bits;
     tagBits = tag_bits;
     associativity = _associativity;
     maxCounterValue = max_counter_value;
+    counterThreshold = counter_threshold;
+    counterIncrement = counter_increment;
+    counterDecrement = counter_decrement;
+    secondTargetMaxDistance = second_target_max_distance;
     lruCounter = 0;
 
     cache.clear();
@@ -310,7 +347,7 @@ std::pair<std::ptrdiff_t, std::ptrdiff_t>
 PHAST::SimplBlockCache::predict(Addr pc, uint64_t history) const
 {
     const auto *entry = findEntry(pc, history);
-    if (entry == nullptr || entry->counter == 0 ||
+    if (entry == nullptr || entry->counter < counterThreshold ||
         (entry->distances.first < 0 && entry->distances.second < 0)) {
         return {-1, -1};
     }
@@ -320,7 +357,7 @@ PHAST::SimplBlockCache::predict(Addr pc, uint64_t history) const
 
 void
 PHAST::SimplBlockCache::update(Addr pc, uint64_t history,
-                               std::ptrdiff_t distance, unsigned SQEntries)
+                               std::ptrdiff_t distance)
 {
     if (distance < 0) {
         return;
@@ -336,8 +373,9 @@ PHAST::SimplBlockCache::update(Addr pc, uint64_t history,
         entry->counter = maxCounterValue;
     } else if (entry->distances.second < 0 &&
                entry->distances.first != distance &&
-               distance < static_cast<std::ptrdiff_t>(SQEntries / 2) &&
-               entry->distances.first < static_cast<std::ptrdiff_t>(SQEntries / 2)) {
+               distance < static_cast<std::ptrdiff_t>(secondTargetMaxDistance) &&
+               entry->distances.first <
+                   static_cast<std::ptrdiff_t>(secondTargetMaxDistance)) {
         entry->distances.second = distance;
         entry->counter = maxCounterValue;
     } else {
@@ -358,9 +396,13 @@ PHAST::SimplBlockCache::updateCommit(Addr pc, uint64_t history,
     }
 
     if (prediction_wrong) {
-        --entry->counter;
-    } else {
+        entry->counter = entry->counter > counterDecrement
+            ? entry->counter - counterDecrement
+            : 0;
+    } else if (counterIncrement == 0) {
         entry->counter = maxCounterValue;
+    } else {
+        entry->counter = std::min(maxCounterValue, entry->counter + counterIncrement);
     }
 
     updateLRU(entry);

--- a/src/cpu/o3/phast.hh
+++ b/src/cpu/o3/phast.hh
@@ -79,6 +79,10 @@ class PHAST
         uint32_t associativity = 0;
         uint64_t lruCounter = 0;
         uint32_t maxCounterValue = 0;
+        uint32_t counterThreshold = 0;
+        uint32_t counterIncrement = 0;
+        uint32_t counterDecrement = 0;
+        unsigned secondTargetMaxDistance = 0;
         std::vector<std::vector<Entry>> cache;
 
         uint64_t xorFold(uint64_t pc, uint64_t history, unsigned size) const;
@@ -91,11 +95,13 @@ class PHAST
 
       public:
         int init(uint32_t set_bits, uint32_t _associativity, uint32_t tag_bits,
-                 uint32_t max_counter_value);
+                 uint32_t max_counter_value, uint32_t counter_threshold,
+                 uint32_t counter_increment,
+                 uint32_t counter_decrement,
+                 unsigned second_target_max_distance);
         std::pair<std::ptrdiff_t, std::ptrdiff_t> predict(Addr pc,
                                                           uint64_t history) const;
-        void update(Addr pc, uint64_t history, std::ptrdiff_t distance,
-                    unsigned SQEntries);
+        void update(Addr pc, uint64_t history, std::ptrdiff_t distance);
         void updateCommit(Addr pc, uint64_t history, bool prediction_wrong);
         void clear();
 

--- a/src/cpu/o3/phast.hh
+++ b/src/cpu/o3/phast.hh
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ */
+
+#ifndef __CPU_O3_PHAST_HH__
+#define __CPU_O3_PHAST_HH__
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "base/types.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+
+namespace gem5
+{
+
+struct BaseO3CPUParams;
+
+namespace o3
+{
+
+struct PHASTPredictionResult
+{
+    std::pair<std::ptrdiff_t, std::ptrdiff_t> storeQueueDistances{-1, -1};
+    unsigned predBranchHistLength = 0;
+    uint64_t predictorHash = 0;
+};
+
+class PHAST
+{
+  public:
+    PHAST() = default;
+    explicit PHAST(const BaseO3CPUParams &params) { init(params); }
+
+    void init(const BaseO3CPUParams &params);
+    void clear();
+
+    PHASTPredictionResult checkInst(Addr load_pc, InstSeqNum load_seq_num,
+                                    const BranchHistory &branch_history,
+                                    bool is_load);
+
+    void violation(Addr load_pc, InstSeqNum load_seq_num,
+                   InstSeqNum store_seq_num, Addr store_pc,
+                   std::ptrdiff_t store_queue_distance, bool predicted,
+                   unsigned predicted_path_index, uint64_t predicted_hash,
+                   const BranchHistory &branch_history);
+
+    void commit(Addr load_pc, Addr load_addr, unsigned load_size,
+                const std::pair<Addr, Addr> &store_addrs,
+                const std::pair<unsigned, unsigned> &store_sizes,
+                unsigned path_index, uint64_t predictor_hash);
+
+    void squash(InstSeqNum, ThreadID) {}
+    void issued(Addr, InstSeqNum, bool) {}
+    void insertStore(Addr, InstSeqNum, ThreadID) {}
+    void insertLoad(Addr, InstSeqNum) {}
+
+    unsigned selectedTargetBits = 5;
+    uint64_t selectedTargetMask = (1ULL << selectedTargetBits) - 1;
+
+  private:
+    class SimplBlockCache
+    {
+      private:
+        struct Entry
+        {
+            uint64_t tag = 0;
+            std::pair<std::ptrdiff_t, std::ptrdiff_t> distances{-1, -1};
+            uint64_t lru = 0;
+            uint32_t counter = 0;
+            bool valid = false;
+        };
+
+        uint32_t setBits = 0;
+        uint32_t tagBits = 0;
+        uint32_t associativity = 0;
+        uint64_t lruCounter = 0;
+        uint32_t maxCounterValue = 0;
+        std::vector<std::vector<Entry>> cache;
+
+        uint64_t xorFold(uint64_t pc, uint64_t history, unsigned size) const;
+        uint64_t getIndex(Addr pc, uint64_t history) const;
+        uint64_t getTag(Addr pc, uint64_t history) const;
+        Entry *findEntry(Addr pc, uint64_t history);
+        const Entry *findEntry(Addr pc, uint64_t history) const;
+        Entry *getLRUEntry(uint64_t set);
+        void updateLRU(Entry *entry);
+
+      public:
+        int init(uint32_t set_bits, uint32_t _associativity, uint32_t tag_bits,
+                 uint32_t max_counter_value);
+        std::pair<std::ptrdiff_t, std::ptrdiff_t> predict(Addr pc,
+                                                          uint64_t history) const;
+        void update(Addr pc, uint64_t history, std::ptrdiff_t distance,
+                    unsigned SQEntries);
+        void updateCommit(Addr pc, uint64_t history, bool prediction_wrong);
+        void clear();
+
+        unsigned getSetBits() const { return setBits; }
+        unsigned getTagBits() const { return tagBits; }
+    };
+
+    unsigned depCheckShift = 0;
+    unsigned SQEntries = 0;
+    std::vector<unsigned> historySizes;
+    std::vector<SimplBlockCache> paths;
+
+    uint64_t makePathHash(Addr load_pc, const BranchHistory &branch_history,
+                          unsigned history_len) const;
+    BranchHistory filteredHistory(InstSeqNum load_seq_num,
+                                  const BranchHistory &branch_history) const;
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_PHAST_HH__

--- a/src/cpu/o3/phast.hh
+++ b/src/cpu/o3/phast.hh
@@ -53,6 +53,10 @@ class PHAST
                 const std::pair<unsigned, unsigned> &store_sizes,
                 unsigned path_index, uint64_t predictor_hash);
 
+    /** Lower confidence after a predicted SQ distance has no producer. */
+    void invalidSQDistance(Addr load_pc, unsigned path_index,
+                           uint64_t predictor_hash);
+
     void squash(InstSeqNum, ThreadID) {}
     void issued(Addr, InstSeqNum, bool) {}
     void insertStore(Addr, InstSeqNum, ThreadID) {}

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -774,6 +774,8 @@ Rename::doSquash(const InstSeqNum &squashed_seq_num, ThreadID tid)
     if (ratSnapshotActive)
         squashSnapshot(squashed_seq_num, tid);
 
+    cpu->getDecode()->squashBranchHistory(tid, squashed_seq_num, false);
+
     auto hb_it = historyBuffer[tid].begin();
 
     // After a syscall squashes everything, the history buffer may be empty

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -624,7 +624,8 @@ ROB::getHeadGroupLastDoneSeq(ThreadID tid)
         InstSeqNum seqnum = 0;
         for (int i = 0; i < threadGroups[tid].front(); i++, it++) {
             auto& inst = *it;
-            if (!inst->readyToCommit() || !inst->isExecuted() || inst->faulted()) {
+            if (!inst->readyToCommit() || !inst->isExecuted() || inst->faulted() ||
+                 inst->memDepInfo.violationPending) {
                 break;
             }
             seqnum = inst->seqNum;


### PR DESCRIPTION
本 PR 将 XS-GEM5 的 PHAST memory dependence predictor 正式接入并补齐交付能力。主要改动包括：在 MemDepUnit 中完成 PHAST 查表、SQ  distance 到动态 store 的映射、RAW violation 训练和 commit-time confidence update；修复了原先 PHAST 打开后仍可能不进入训练路径的问题；新增 phastTableHits / phastEffectivePreds / phastDropInvalidSQDistance / mdpUnpredictedViolations / mdpPredictedViolations / mdpFalseDepAtCommit 等计数器，便于定位 PHAST 命中、落地、丢失和假依赖来源。与此同时，默认配置已调整为 PHAST 默认开启，phast_num_rows 默认值改为 64，并补充了 --no-enable-phast-mdp 以便显式关闭。另附带完成了 PHAST 交付文档，说明算法语义、代码落点、参数和 stats 口径。

结果：
在如今默认配置下，spec 06 1.0c分数18.3544->18.3916
https://github.com/OpenXiangShan/GEM5/actions/runs/30452710796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PHAST memory-dependence prediction for the out-of-order CPU pipeline.
  * Added configurable predictor settings for table sizing, history tracking, confidence behavior, and target selection.
  * Added branch-history tracking to improve dependency predictions across control-flow paths.
  * Added prediction, violation, forwarding, commit-time validation, and recovery statistics.
* **Configuration**
  * Added an option to perform memory-dependence violation recovery and training at resolve or commit time.
  * Enabled PHAST by default in ideal KHMv3 examples and disabled it in standard KHMv3 examples.
* **Documentation**
  * Added a Chinese guide covering PHAST behavior, configuration, statistics, validation, and known considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->