### PR TITLE
configs: Align KMH V3 ITLB entries

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -33,7 +33,6 @@ def setKmhV3IdealParams(args, system):
     for cpu in system.cpu:
 
         # fetch
-        cpu.mmu.itb.size = 96
         #cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
         #cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
         setPtwLevelLimitParams(args, cpu.mmu.itb)

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -32,7 +32,7 @@ def setKmhV3Params(args, system):
     for cpu in system.cpu:
 
         # fetch (idealfetch not care)
-        cpu.mmu.itb.size = 96
+        cpu.mmu.itb.size = 48
         cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
         cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
         setPtwLevelLimitParams(args, cpu.mmu.itb)

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -32,7 +32,6 @@ def setKmhV3Params(args, system):
     for cpu in system.cpu:
 
         # fetch (idealfetch not care)
-        cpu.mmu.itb.size = 48
         cpu.mmu.itb.enable_l1_direct_compression = args.enable_l1_direct_compression
         cpu.mmu.dtb.enable_l1_direct_compression = args.enable_l1_direct_compression
         setPtwLevelLimitParams(args, cpu.mmu.itb)


### PR DESCRIPTION
Change-Id: I96e215ce314496f74299061ab9b6d4ab69f2abef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a fixed instruction TLB size from example configurations, allowing the system to use the appropriate configuration instead.
  * Preserved existing processor, memory-management, and performance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->