### PR TITLE
Revert "arch-riscv: Cover fractional LMUL tails in vector gather"

### DIFF
--- a/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
+++ b/src/arch/riscv/isa/vector/base/vector_arith.temp.isa
@@ -1815,13 +1815,8 @@ Fault
     if ((vd_idx < gather_vd_vregs) &&
         (vs2_idx + 1 == vs2_vregs) &&
         (gather_vstart < rVl)) {
-        // With fractional LMUL, the unused portion of the physical
-        // destination register also belongs to the tail.
-        const uint32_t gather_agnostic_elems =
-            vflmul < 1 ? vd_elems : elem_num_per_vreg;
-
         for (uint32_t gather_i = 0;
-             gather_i < gather_agnostic_elems;
+             gather_i < elem_num_per_vreg;
              ++gather_i) {
             // Tail and mask policies are properties of
             // destination elements, not the vs1 index chunk.


### PR DESCRIPTION
Reverts OpenXiangShan/GEM5#1013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vector gather handling for agnostic elements to ensure consistent processing across vector register configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->