### PR TITLE
configs: raise default maxinsts for OpenSBI/Linux raw-cpt boots

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -321,9 +321,21 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         default='3GHz',
                         help="Clock for blocks running at CPU speed")
 
-    parser.add_argument("-I", "--maxinsts", action="store", type=int,
+    # Default 40M matches typical checkpoint slices. Cold-boot raw binaries
+    # (OpenSBI + Linux hello) often need far more; config_xiangshan_inputs()
+    # raises this automatically for --raw-cpt unless the user overrides -I.
+    # Track whether -I was on the CLI so an explicit `-I 40000000` is not
+    # treated as "unspecified default" and silently bumped.
+    class _StoreMaxinsts(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values)
+            setattr(namespace, "maxinsts_user_set", True)
+
+    parser.set_defaults(maxinsts_user_set=False)
+    parser.add_argument("-I", "--maxinsts", action=_StoreMaxinsts, type=int,
                         default=40*10**6, help="""Total number of instructions to
-                                            simulate (default: run forever)""")
+                                            simulate (default: 40M; raised for
+                                            --raw-cpt full-system boots)""")
 
     parser.add_argument("--enable-riscv-vector", action="store_true", default=False,
             help="enable riscv vector extension (need vector-supported gcpt restore and diff-ref-so)")

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -331,6 +331,37 @@ def get_xiangshan_cpu_class(args: argparse.Namespace):
     return XiangshanCore
 
 
+# Default --maxinsts from Options.py; used when the user did not pass -I.
+_DEFAULT_MAXINSTS = 40 * 10**6
+# OpenSBI + Linux cold boot (hello) routinely exceeds 40M retired insts on O3.
+_RAW_CPT_DEFAULT_MAXINSTS = 200 * 10**6
+
+
+def is_xiangshan_linux_raw_cpt(path: str) -> bool:
+    """True for OpenSBI/Linux cold-boot raw images (by filename only).
+
+    Name-only keeps the auto-raise conservative: large bare-metal binaries are
+    not bumped. Callers that need size heuristics can extend later.
+    """
+    if not path:
+        return False
+    name = os.path.basename(path).lower()
+    return name == "linux.bin" or any(
+        k in name for k in ("linux", "fw_payload", "fw_jump", "opensbi"))
+
+
+def _should_raise_raw_cpt_maxinsts(args: argparse.Namespace) -> bool:
+    """Raise -I only for named cold-boot images when -I was not on the CLI."""
+    if not getattr(args, "raw_cpt", False):
+        return False
+    # Explicit `-I` (even `-I 40000000`) must win over the auto bump.
+    if getattr(args, "maxinsts_user_set", False):
+        return False
+    if args.maxinsts != _DEFAULT_MAXINSTS:
+        return False
+    return is_xiangshan_linux_raw_cpt(getattr(args, "generic_rv_cpt", None))
+
+
 def config_xiangshan_inputs(args: argparse.Namespace, sys):
     ref_so = None
 
@@ -338,6 +369,17 @@ def config_xiangshan_inputs(args: argparse.Namespace, sys):
         ref_so = resolve_xiangshan_ref_so(args)
 
     args.difftest_ref_so = ref_so
+
+    # Issue #393: default -I=40M is sized for checkpoints, not OpenSBI+Linux
+    # cold boot. Only named linux/opensbi raw images get the bump; coremark
+    # and other AM bins keep 40M. Explicit -I always wins.
+    if _should_raise_raw_cpt_maxinsts(args):
+        warn(
+            f"--raw-cpt with default --maxinsts={_DEFAULT_MAXINSTS}: "
+            f"raising to {_RAW_CPT_DEFAULT_MAXINSTS} for cold-boot workloads "
+            f"(OpenSBI/Linux). Pass -I explicitly to override."
+        )
+        args.maxinsts = _RAW_CPT_DEFAULT_MAXINSTS
 
     if args.gcpt_restorer is None:
         if args.raw_cpt:


### PR DESCRIPTION
## Summary

- Fixes the primary symptom of #393: `--raw-cpt` OpenSBI/Linux cold boots exit with `max instruction count` before userspace Hello because the global default `-I=40M` is sized for checkpoints.
- When `--raw-cpt` uses a linux/opensbi/fw_* named image and the user did **not** pass `-I`, auto-raise to 200M and warn. Explicit `-I` always wins.
- Correct `--maxinsts` help text (was “run forever”).

## Scope (per review)

This PR is intentionally slimmed down:

| Kept | Dropped / moved |
|------|-----------------|
| maxinsts auto-raise + help text | `xiangshan.py` → `idealkmhv3.py` shim (not added) |
| filename-only Linux/OpenSBI classifier | Sv39 DTB advertise (Sv48 is supported) |
| | UARTLite changes → separate PR |
| | kmhv3/idealkmhv3 DTB matcher expansion |

## Test plan

- [ ] `idealkmhv3.py --raw-cpt --generic-rv-cpt=linux.bin --disable-difftest` without `-I` prints the auto-raise warning and reaches userspace Hello
- [ ] Explicit `-I 40000000` is **not** bumped
- [ ] coremark-sized raw bin (no linux/opensbi in name) keeps default 40M
- [ ] CI Coremark / difftest smoke

Fixes #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic instruction-limit handling for supported Xiangshan raw checkpoint boots.
  * Increased the default limit from 40 million to 200 million instructions for qualifying full-system cold boots.

* **Bug Fixes**
  * Explicit instruction limits are now preserved without automatic adjustment.
  * Added clearer command-line help describing default and workload-specific limits.
  * Added warnings when the instruction limit is automatically increased.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->