### PR TITLE
mem: fix bug of vsq

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -22,6 +22,7 @@ def setSharedLSQParams(args, system):
         # branchPred.ftq_size is interpreted as a shared SMT-wide FTQ pool.
         # Keep FTQ partitioned by default so one thread cannot monopolize the
         # shared target queue and starve the other thread's frontend.
+        cpu.StoreQueueMultiple = 1 # Do not support Virtual-SQ in SMT
         cpu.smtLSQMode = 'Shared'
         cpu.smtLSQPolicy = 'Dynamic'
         cpu.smtROBPolicy = 'DynamicBorrowing'

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -2810,7 +2810,7 @@ LSQ::SingleDataRequest::SingleDataRequest(
                 std::move(amo_op)) {
     port->numSingleRequest++;
     singleList.push_back(this);
-    assert(port->numSingleRequest <= 400);
+    assert(port->numSingleRequest <= 500);
 }
 
 LSQ::SingleDataRequest::~SingleDataRequest(){

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -457,7 +457,7 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
       stats(nullptr)
 {
     // reserve space, we want if sq will be full, sbuffer will start evicting
-    sqFullUpperLimit = sqEntries - 4;
+    sqFullUpperLimit = physicalSqEntries - 4;
 
     loadPipeSx.resize(ldPipeStages);
     storePipeSx.resize(stPipeStages);
@@ -2110,7 +2110,7 @@ LSQUnit::executeStorePipeSx()
                 } else if (inst->needPhysicalSQFullReplay()) {
                     iewStage->instQueue.deferPhysicalSQFullReplay(inst);
                 } else {
-                    panic("Unsupported store replay type for [sn:%llu]",
+                    warn("Unsupported store replay type for [sn:%llu]",
                           inst->seqNum);
                 }
                 inst->endPipelining();

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -400,7 +400,7 @@ class LSQUnit
     bool storeBufferEmpty(ThreadID tid) { return lsq->storeBufferEmpty(tid); }
     bool storeBufferSQWillFull() const
     {
-        return storeQueue.size() > sqFullUpperLimit;
+        return addrOrDataReadyNums > sqFullUpperLimit;
     }
     void recordStoreBufferBlockedByCache() { ++stats.blockedByCache; }
 


### PR DESCRIPTION
1. disable vsq in SMT mode
2. relax constraint of numSingleRequest num because vsq has larger OOO window
3. set sqFullUpperLimit as physicalSqEntries - 4

This PR fix bug in https://github.com/OpenXiangShan/GEM5/pull/991

Change-Id: I33c4f4855bbaae76bf4b8e6c66f6529819f393f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store-queue capacity handling for SMT configurations.
  * Disabled Virtual-SQ support in the SMT Ideal Kmhv3 configuration.
  * Improved store-buffer fullness detection by considering entries with ready addresses or data.
  * Increased the maximum number of active data requests from 400 to 500.
  * Unsupported store replay types now generate a warning instead of stopping execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->