### PR TITLE
cpu: Fix PopAndPush RAS update ordering

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -279,11 +279,11 @@ def template JumpConstructor {{
                     // If RD is link and RS1 is link and rd != rs1
                     else if (rs1_link) {
                         if (RS1 != RD) {
-                            // Both are link and RS1 == RD, pop then push
+                            // Both are link and RS1 != RD, pop then push
                             flags[IsReturn] = true;
                             flags[IsCall] = true;
                         } else {
-                            // Both are link and RS1 != RD, push RAS
+                            // Both are link and RS1 == RD, push RAS
                             flags[IsCall] = true;
                         }
                     }

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -216,7 +216,15 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
             predict_record.RASIndex = RAS[tid].topIdx();
             set(predict_record.RASTarget, ras_top);
 
+            // A branch that is both return and call (e.g. jalr with
+            // distinct link registers) must consume the old RAS entry
+            // before recording its new call return address.
             RAS[tid].pop();
+            if (inst->isCall()) {
+                RAS[tid].push(pc);
+                predict_record.pushedRAS = true;
+                predict_record.wasCall = true;
+            }
 
             DPRINTF(Branch, "[tid:%i] [sn:%llu] Instruction %s is a return, "
                     "RAS predicted target: %s, RAS index: %i\n",

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -137,13 +137,14 @@ BTBRAS::specUpdateState(FullBTBPrediction &pred)
     auto takenEntry = pred.getTakenEntry();
     DPRINTFR(RAS, "Do specUpdate for PC %lx pred target %lx ", pred.bbStart, pred.returnTarget);
 
-    if (takenEntry.isCall) {
-        Addr retAddr = takenEntry.pc + takenEntry.size;
-        push(tid, retAddr);
-    }
+    // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
     if (takenEntry.isReturn) {
         // do pop
         pop(tid);
+    }
+    if (takenEntry.isCall) {
+        Addr retAddr = takenEntry.pc + takenEntry.size;
+        push(tid, retAddr);
     }
     if (takenEntry.isCall) {
         DPRINTFR(RAS, "IsCall spec PC %lx\n", takenEntry.pc);
@@ -181,12 +182,13 @@ BTBRAS::recoverState(const FetchTarget &entry)
 
     // do push & pops on control squash
     if (entry.exeTaken) {
-        if (takenEntry.isCall) {
-            push(tid, retAddr);
-        }
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
         if (takenEntry.isReturn) {
             pop(tid);
             //TOSW = (TOSR + 1) % numInflightEntries;
+        }
+        if (takenEntry.isCall) {
+            push(tid, retAddr);
         }
     }
 
@@ -218,16 +220,17 @@ BTBRAS::update(const FetchTarget &entry)
         } else
             DPRINTF(RAS, "ssp and nsp match, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n",
                 meta_ptr->ssp, meta_ptr->sctr, state.nsp, state.stack[state.nsp].data.ctr);
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
+        if (takenEntry.isReturn) {
+            DPRINTF(RAS, "update ret entry PC %lx\n", entry.startPC);
+            pop_stack(tid);
+        }
         if (takenEntry.isCall) {
             DPRINTF(RAS, "real update call BTB hit %d meta TOSR %d TOSW %d\n entry PC %lx",
                 entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
             Addr retAddr = takenEntry.pc + takenEntry.size;
             push_stack(tid, retAddr);
             state.BOS = inflightPtrPlus1(meta_ptr->TOSW);
-        }
-        if (takenEntry.isReturn) {
-            DPRINTF(RAS, "update ret entry PC %lx\n", entry.startPC);
-            pop_stack(tid);
         }
     }
     if (takenEntry.isCall || takenEntry.isReturn) {
@@ -465,6 +468,7 @@ BTBRAS::getTopAddrFromMetas(const FetchTarget &stream)
     return meta_ptr->target;
 }
 
+#ifndef UNIT_TEST
 void
 BTBRAS::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
 {
@@ -486,6 +490,7 @@ BTBRAS::commitBranch(const FetchTarget &stream, const DynInstPtr &inst)
         }
     }
 }
+#endif
 
 #ifndef UNIT_TEST
 BTBRAS::RASStats::RASStats(statistics::Group *parent):

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -11,13 +11,6 @@
     #include "cpu/pred/btb/test/test_dprintf.hh"
     #include "cpu/pred/btb/timed_base_pred.hh"
 
-    // Test mode type definitions
-    namespace gem5 {
-        namespace o3 {
-            class DynInst;
-        }
-    }
-    using DynInstPtr = std::shared_ptr<gem5::o3::DynInst>;
 #else
     // Production mode includes
     #include "cpu/pred/btb/timed_base_pred.hh"
@@ -102,10 +95,8 @@ namespace btb_pred {
 
         void update(const FetchTarget &entry) override;
 
-        // commitBranch method - override only in production mode
-#ifdef UNIT_TEST
-        void commitBranch(const FetchTarget &stream, const DynInstPtr &inst);
-#else
+        // RAS prediction statistics require a concrete DynInst in production.
+#ifndef UNIT_TEST
         void commitBranch(const FetchTarget &stream, const DynInstPtr &inst) override;
 #endif
 

--- a/src/cpu/pred/btb/test/SConscript
+++ b/src/cpu/pred/btb/test/SConscript
@@ -60,8 +60,15 @@ GTest('history_manager.test',
 #     '../timed_base_pred.cc',
 # )
 
+GTest('ras_pop_push.test',
+    'ras_pop_push.test.cc',
+    '../ras.cc',
+    '../timed_base_pred.cc',
+)
+
 # Add the test to UNITTESTS target
 env.Append(UNITTESTS=['uras.test',
+        'ras_pop_push.test',
         'btb.test',
         'tage.test',
         'mgsc.test',

--- a/src/cpu/pred/btb/test/ras_pop_push.test.cc
+++ b/src/cpu/pred/btb/test/ras_pop_push.test.cc
@@ -19,22 +19,26 @@ class RASPopPushTest : public ::testing::Test
   protected:
     void SetUp() override {
         ras = std::make_unique<BTBRAS>(16, 2, 8);
-        checkReturnTarget(0, 0x80000000L);
+        check_return_target(0, 0x80000000L);
     }
 
-    void checkReturnTarget(Addr startAddr, Addr expectedTarget) {
+    void check_return_target(Addr startAddr, Addr expectedTarget) {
         boost::dynamic_bitset<> history(8, 0);
         std::vector<FullBTBPrediction> stagePreds(4);
         ras->putPCHistory(startAddr, history, stagePreds);
         EXPECT_EQ(stagePreds[0].returnTarget, expectedTarget);
     }
 
-    FullBTBPrediction createPrediction(Addr pc, Addr target, bool isCall, bool isReturn) {
+    FullBTBPrediction create_prediction(Addr pc, Addr target, bool isCall,
+                                        bool isReturn) {
         BTBEntry entry;
         entry.valid = true;
         entry.pc = pc;
         entry.target = target;
         entry.size = 4;
+        entry.isCond = false;
+        entry.isIndirect = isReturn;
+        entry.isDirect = !entry.isIndirect;
         entry.isCall = isCall;
         entry.isReturn = isReturn;
 
@@ -44,59 +48,55 @@ class RASPopPushTest : public ::testing::Test
         return pred;
     }
 
-    FetchTarget createStream(Addr pc, Addr target, bool isCall, bool isReturn,
-                             std::shared_ptr<void> meta) {
+    FetchTarget create_stream(Addr pc, Addr target, bool isCall, bool isReturn,
+                              std::shared_ptr<void> meta) {
         FetchTarget stream;
         stream.startPC = pc;
         stream.exeTaken = true;
         stream.exeBranchInfo.pc = pc;
         stream.exeBranchInfo.target = target;
         stream.exeBranchInfo.size = 4;
+        stream.exeBranchInfo.isCond = false;
+        stream.exeBranchInfo.isIndirect = isReturn;
+        stream.exeBranchInfo.isDirect = !stream.exeBranchInfo.isIndirect;
         stream.exeBranchInfo.isCall = isCall;
         stream.exeBranchInfo.isReturn = isReturn;
         stream.predMetas[0] = meta;
         return stream;
     }
 
-    void specAndCommitCall(Addr pc, Addr target) {
+    void spec_and_commit_call(Addr pc, Addr target) {
         auto meta = ras->getPredictionMeta();
-        auto pred = createPrediction(pc, target, true, false);
+        auto pred = create_prediction(pc, target, true, false);
         ras->specUpdateState(pred);
-        ras->update(createStream(pc, target, true, false, meta));
+        ras->update(create_stream(pc, target, true, false, meta));
     }
 
     std::unique_ptr<BTBRAS> ras;
 };
 
 TEST_F(RASPopPushTest, CallReturnPopsBeforePushingInAllPaths) {
-    specAndCommitCall(0x1000, 0x2000);
-    checkReturnTarget(0x2000, 0x1004);
-    specAndCommitCall(0x2000, 0x3000);
-    checkReturnTarget(0x3000, 0x2004);
+    spec_and_commit_call(0x1000, 0x2000);
+    check_return_target(0x2000, 0x1004);
+    spec_and_commit_call(0x2000, 0x3000);
+    check_return_target(0x3000, 0x2004);
 
     // JALR with distinct link registers must pop before pushing its return PC.
     auto popPushMeta = ras->getPredictionMeta();
-    auto popPush = createPrediction(0x3000, 0x2004, true, true);
+    auto popPush = create_prediction(0x3000, 0x2004, true, true);
     ras->specUpdateState(popPush);
-    checkReturnTarget(0x2004, 0x3004);
+    check_return_target(0x2004, 0x3004);
 
-    auto youngerCall = createPrediction(0x3004, 0x4000, true, false);
+    auto youngerCall = create_prediction(0x3004, 0x4000, true, false);
     ras->specUpdateState(youngerCall);
-    ras->recoverState(createStream(0x3000, 0x2004, true, true, popPushMeta));
-    checkReturnTarget(0x2004, 0x3004);
+    ras->recoverState(create_stream(0x3000, 0x2004, true, true, popPushMeta));
+    check_return_target(0x2004, 0x3004);
 
-    ras->update(createStream(0x3000, 0x2004, true, true, popPushMeta));
-    checkReturnTarget(0x2004, 0x3004);
+    ras->update(create_stream(0x3000, 0x2004, true, true, popPushMeta));
+    check_return_target(0x2004, 0x3004);
 }
 
 } // namespace test
 } // namespace btb_pred
 } // namespace branch_prediction
 } // namespace gem5
-
-int
-main(int argc, char **argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/src/cpu/pred/btb/test/ras_pop_push.test.cc
+++ b/src/cpu/pred/btb/test/ras_pop_push.test.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "base/types.hh"
+#include "cpu/pred/btb/common.hh"
+#include "cpu/pred/btb/ras.hh"
+
+namespace gem5 {
+namespace branch_prediction {
+namespace btb_pred {
+namespace test {
+
+class RASPopPushTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override {
+        ras = std::make_unique<BTBRAS>(16, 2, 8);
+        checkReturnTarget(0, 0x80000000L);
+    }
+
+    void checkReturnTarget(Addr startAddr, Addr expectedTarget) {
+        boost::dynamic_bitset<> history(8, 0);
+        std::vector<FullBTBPrediction> stagePreds(4);
+        ras->putPCHistory(startAddr, history, stagePreds);
+        EXPECT_EQ(stagePreds[0].returnTarget, expectedTarget);
+    }
+
+    FullBTBPrediction createPrediction(Addr pc, Addr target, bool isCall, bool isReturn) {
+        BTBEntry entry;
+        entry.valid = true;
+        entry.pc = pc;
+        entry.target = target;
+        entry.size = 4;
+        entry.isCall = isCall;
+        entry.isReturn = isReturn;
+
+        FullBTBPrediction pred;
+        pred.bbStart = pc;
+        pred.btbEntries.push_back(entry);
+        return pred;
+    }
+
+    FetchTarget createStream(Addr pc, Addr target, bool isCall, bool isReturn,
+                             std::shared_ptr<void> meta) {
+        FetchTarget stream;
+        stream.startPC = pc;
+        stream.exeTaken = true;
+        stream.exeBranchInfo.pc = pc;
+        stream.exeBranchInfo.target = target;
+        stream.exeBranchInfo.size = 4;
+        stream.exeBranchInfo.isCall = isCall;
+        stream.exeBranchInfo.isReturn = isReturn;
+        stream.predMetas[0] = meta;
+        return stream;
+    }
+
+    void specAndCommitCall(Addr pc, Addr target) {
+        auto meta = ras->getPredictionMeta();
+        auto pred = createPrediction(pc, target, true, false);
+        ras->specUpdateState(pred);
+        ras->update(createStream(pc, target, true, false, meta));
+    }
+
+    std::unique_ptr<BTBRAS> ras;
+};
+
+TEST_F(RASPopPushTest, CallReturnPopsBeforePushingInAllPaths) {
+    specAndCommitCall(0x1000, 0x2000);
+    checkReturnTarget(0x2000, 0x1004);
+    specAndCommitCall(0x2000, 0x3000);
+    checkReturnTarget(0x3000, 0x2004);
+
+    // JALR with distinct link registers must pop before pushing its return PC.
+    auto popPushMeta = ras->getPredictionMeta();
+    auto popPush = createPrediction(0x3000, 0x2004, true, true);
+    ras->specUpdateState(popPush);
+    checkReturnTarget(0x2004, 0x3004);
+
+    auto youngerCall = createPrediction(0x3004, 0x4000, true, false);
+    ras->specUpdateState(youngerCall);
+    ras->recoverState(createStream(0x3000, 0x2004, true, true, popPushMeta));
+    checkReturnTarget(0x2004, 0x3004);
+
+    ras->update(createStream(0x3000, 0x2004, true, true, popPushMeta));
+    checkReturnTarget(0x2004, 0x3004);
+}
+
+} // namespace test
+} // namespace btb_pred
+} // namespace branch_prediction
+} // namespace gem5
+
+int
+main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/cpu/pred/btb/test/uras_test.cc
+++ b/src/cpu/pred/btb/test/uras_test.cc
@@ -82,14 +82,14 @@ public:
         // do push & pops on prediction
         pred.returnTarget = stack[sp].retAddr;
         auto takenSlot = pred.getTakenEntry();
-        if (takenSlot.isCall) { // call inst, push retAddr to spec stack
-            Addr retAddr = takenSlot.pc + takenSlot.size;
-            push(retAddr, stack, sp);
-        }
         if (takenSlot.isReturn) { // return inst, pop retAddr from spec stack
             // do pop
             auto retAddr = stack[sp].retAddr;
             pop(stack, sp);
+        }
+        if (takenSlot.isCall) { // call inst, push retAddr to spec stack
+            Addr retAddr = takenSlot.pc + takenSlot.size;
+            push(retAddr, stack, sp);
         }
     }
 
@@ -376,6 +376,29 @@ TEST_F(URASTest, SpecUpdateStateCallReturn) {
     EXPECT_EQ(sp, 0);
     // 2. returnTarget应该匹配call的下一条指令
     EXPECT_EQ(pred2.returnTarget, 0x1004);
+}
+
+TEST_F(URASTest, SpecUpdateStatePopThenPush) {
+    auto& stack = uras->getSpecStack();
+    auto& sp = uras->getSpecSp();
+    uras->push(0x1004, stack, sp);
+    uras->push(0x2004, stack, sp);
+
+    FullBTBPrediction pred;
+    pred.bbStart = 0x3000;
+    BTBEntry entry;
+    entry.valid = true;
+    entry.pc = 0x3000;
+    entry.size = 4;
+    entry.isCall = true;
+    entry.isReturn = true;
+    pred.btbEntries.push_back(entry);
+
+    uras->specUpdateState(pred);
+
+    EXPECT_EQ(pred.returnTarget, 0x2004);
+    EXPECT_EQ(sp, 2);
+    EXPECT_EQ(stack[sp].retAddr, 0x3004);
 }
 
 // Test basic recovery functionality

--- a/src/cpu/pred/btb/uras.cc
+++ b/src/cpu/pred/btb/uras.cc
@@ -100,16 +100,7 @@ BTBuRAS::specUpdateState(FullBTBPrediction &pred)
     // do push & pops on prediction
     pred.returnTarget = stack[sp].retAddr;
     auto takenSlot = pred.getTakenEntry();
-    if (takenSlot.isCall) {
-        Addr retAddr = takenSlot.pc + takenSlot.size;
-        if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
-                retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
-            specRasTrace->write_record(rec);
-        }
-        DPRINTF(URAS, "spec stack push addr 0x%llx\n", retAddr);
-        push(retAddr, stack, sp);
-    }
+    // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
     if (takenSlot.isReturn) {
         if (enableDB) {
             SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.pc,
@@ -120,6 +111,16 @@ BTBuRAS::specUpdateState(FullBTBPrediction &pred)
         auto retAddr = stack[sp].retAddr;
         DPRINTF(URAS, "spec stack pop at pc 0x%llx target %llx\n", pred.bbStart, retAddr);
         pop(stack, sp);
+    }
+    if (takenSlot.isCall) {
+        Addr retAddr = takenSlot.pc + takenSlot.size;
+        if (enableDB) {
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
+                retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
+            specRasTrace->write_record(rec);
+        }
+        DPRINTF(URAS, "spec stack push addr 0x%llx\n", retAddr);
+        push(retAddr, stack, sp);
     }
     printStack("after specUpdateState", stack, sp);
 }
@@ -175,6 +176,15 @@ BTBuRAS::update(const FetchTarget &entry)
         auto pred_sp = meta_ptr->sp;
         auto pred_tos = meta_ptr->tos;
         auto miss = entry.squashType == SQUASH_CTRL && entry.squashPC == entry.exeBranchInfo.pc;
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
+        if (takenSlot.isReturn) {
+            if (enableDB) {
+                NonSpecRASTrace rec(RAS_OP::POP, entry.startPC, takenSlot.pc, takenSlot.target,
+                    pred_sp, pred_tos.retAddr, pred_tos.ctr, sp, stack[sp].retAddr, stack[sp].ctr, miss);
+                nonSpecRasTrace->write_record(rec);
+            }
+            pop(stack, sp);
+        }
         if (takenSlot.isCall) {
             Addr retAddr = takenSlot.pc + takenSlot.size;
             if (enableDB) {
@@ -183,14 +193,6 @@ BTBuRAS::update(const FetchTarget &entry)
                 nonSpecRasTrace->write_record(rec);
             }
             push(retAddr, stack, sp);
-        }
-        if (takenSlot.isReturn) {
-            if (enableDB) {
-                NonSpecRASTrace rec(RAS_OP::POP, entry.startPC, takenSlot.pc, takenSlot.target,
-                    pred_sp, pred_tos.retAddr, pred_tos.ctr, sp, stack[sp].retAddr, stack[sp].ctr, miss);
-                nonSpecRasTrace->write_record(rec);
-            }
-            pop(stack, sp);
         }
     }
     printStack("after update", stack, sp);

--- a/src/cpu/pred/ftb/ras.cc
+++ b/src/cpu/pred/ftb/ras.cc
@@ -86,13 +86,14 @@ FTBRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPrediction
     auto takenSlot = pred.getTakenSlot();
     DPRINTFR(RAS, "Do specUpdate for PC %x pred target %x ", pred.bbStart, pred.returnTarget);
 
-    if (takenSlot.isCall) {
-        Addr retAddr = takenSlot.pc + takenSlot.size;
-        push(retAddr);
-    }
+    // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
     if (takenSlot.isReturn) {
         // do pop
         pop();
+    }
+    if (takenSlot.isCall) {
+        Addr retAddr = takenSlot.pc + takenSlot.size;
+        push(retAddr);
     }
     if (takenSlot.isCall) {
         DPRINTFR(RAS, "IsCall spec PC %x\n", takenSlot.pc);
@@ -126,12 +127,13 @@ FTBRAS::recoverHist(const boost::dynamic_bitset<> &history, const FetchStream &e
 
     // do push & pops on control squash
     if (entry.exeTaken) {
-        if (takenSlot.isCall) {
-            push(retAddr);
-        }
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
         if (takenSlot.isReturn) {
             pop();
             //TOSW = (TOSR + 1) % numInflightEntries;
+        }
+        if (takenSlot.isCall) {
+            push(retAddr);
         }
     }
 
@@ -157,15 +159,16 @@ FTBRAS::update(const FetchStream &entry)
             nsp = meta_ptr->ssp;
         } else
             DPRINTF(RAS, "ssp and nsp match, ssp = %d, sctr = %d, nsp = %d, nctr = %d\n", meta_ptr->ssp, meta_ptr->sctr, nsp, stack[nsp].data.ctr);
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
+        if (takenSlot.isReturn) {
+            DPRINTF(RAS, "update ret entry PC %x\n", entry.startPC);
+            pop_stack();
+        }
         if (takenSlot.isCall) {
             DPRINTF(RAS, "real update call FTB hit %d meta TOSR %d TOSW %d\n entry PC %x", entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
             Addr retAddr = takenSlot.pc + takenSlot.size;
             push_stack(retAddr);
             BOS = inflightPtrPlus1(meta_ptr->TOSW);
-        }
-        if (takenSlot.isReturn) {
-            DPRINTF(RAS, "update ret entry PC %x\n", entry.startPC);
-            pop_stack();
         }
     }
     if (takenSlot.isCall || takenSlot.isReturn) {

--- a/src/cpu/pred/ftb/uras.cc
+++ b/src/cpu/pred/ftb/uras.cc
@@ -101,16 +101,7 @@ FTBuRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPredictio
     // do push & pops on prediction
     pred.returnTarget = stack[sp].retAddr;
     auto takenSlot = pred.getTakenSlot();
-    if (takenSlot.isCall) {
-        Addr retAddr = takenSlot.pc + takenSlot.size;
-        if (enableDB) {
-            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
-                retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
-            specRasTrace->write_record(rec);
-        }
-        DPRINTF(URAS, "spec stack push addr 0x%llx\n", retAddr);
-        push(retAddr, stack, sp);
-    }
+    // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
     if (takenSlot.isReturn) {
         if (enableDB) {
             SpecRASTrace rec(When::SPECULATIVE, RAS_OP::POP, pred.bbStart, takenSlot.pc,
@@ -121,6 +112,16 @@ FTBuRAS::specUpdateHist(const boost::dynamic_bitset<> &history, FullFTBPredictio
         auto retAddr = stack[sp].retAddr;
         DPRINTF(URAS, "spec stack pop at pc 0x%llx target %llx\n", pred.bbStart, retAddr);
         pop(stack, sp);
+    }
+    if (takenSlot.isCall) {
+        Addr retAddr = takenSlot.pc + takenSlot.size;
+        if (enableDB) {
+            SpecRASTrace rec(When::SPECULATIVE, RAS_OP::PUSH, pred.bbStart, takenSlot.pc,
+                retAddr, sp, stack[sp].retAddr, stack[sp].ctr);
+            specRasTrace->write_record(rec);
+        }
+        DPRINTF(URAS, "spec stack push addr 0x%llx\n", retAddr);
+        push(retAddr, stack, sp);
     }
     printStack("after specUpdateHist", stack, sp);
 }
@@ -176,6 +177,15 @@ FTBuRAS::update(const FetchStream &entry)
         auto pred_sp = meta_ptr->sp;
         auto pred_tos = meta_ptr->tos;
         auto miss = entry.squashType == SQUASH_CTRL && entry.squashPC == entry.exeBranchInfo.pc;
+        // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
+        if (takenSlot.isReturn) {
+            if (enableDB) {
+                NonSpecRASTrace rec(RAS_OP::POP, entry.startPC, takenSlot.pc, takenSlot.target,
+                    pred_sp, pred_tos.retAddr, pred_tos.ctr, sp, stack[sp].retAddr, stack[sp].ctr, miss);
+                nonSpecRasTrace->write_record(rec);
+            }
+            pop(stack, sp);
+        }
         if (takenSlot.isCall) {
             Addr retAddr = takenSlot.pc + takenSlot.size;
             if (enableDB) {
@@ -184,14 +194,6 @@ FTBuRAS::update(const FetchStream &entry)
                 nonSpecRasTrace->write_record(rec);
             }
             push(retAddr, stack, sp);
-        }
-        if (takenSlot.isReturn) {
-            if (enableDB) {
-                NonSpecRASTrace rec(RAS_OP::POP, entry.startPC, takenSlot.pc, takenSlot.target,
-                    pred_sp, pred_tos.retAddr, pred_tos.ctr, sp, stack[sp].retAddr, stack[sp].ctr, miss);
-                nonSpecRasTrace->write_record(rec);
-            }
-            pop(stack, sp);
         }
     }
     printStack("after update", stack, sp);


### PR DESCRIPTION
RISC-V JALR can be classified as both a call and a return when rd and
rs1 are different link registers, for example `jalr x5, 0(x1)` or
`jalr x1, 0(x5)`.

These PopAndPush instructions must update the return address stack by
popping the old return address before pushing the new `pc + size`
return address. The previous push-then-pop ordering removed the newly
pushed address and left the stale stack top in place.

Apply the correct pop-then-push ordering to speculative update,
recovery, and commit paths in both BTBRAS and FTBRAS. Add a BTBRAS
regression test covering the call-and-return entry across all three
paths.

Change-Id: I4d038bd71ee13e9f56b55b12671bf3e39834a981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected return-address stack handling for instructions that both return and call.
  * Preserved the correct new return address across prediction, recovery, and commit paths.
  * Improved support for RISC-V JALR pop-and-push behavior.

* **Tests**
  * Added and enabled coverage validating return-address stack pop-and-push behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->