### PR TITLE
feat(smt): add per-IQ Watermark partitioning policy for SMT

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -990,6 +990,31 @@ def xiangshan_system_init():
               "RAT-checkpoint recovery-cost model.",
     )
 
+    parser.add_argument(
+        "--smt-iq-policy",
+        type=str,
+        default="Dynamic",
+        help="SMT IQ partitioning policy (Dynamic/Watermark)",
+    )
+    parser.add_argument(
+        "--smt-iq-watermark-int",
+        type=int,
+        default=0,
+        help="SMT IQ Watermark for intIQ (min entries reserved per thread)",
+    )
+    parser.add_argument(
+        "--smt-iq-watermark-mem",
+        type=int,
+        default=0,
+        help="SMT IQ Watermark for memIQ (min entries reserved per thread)",
+    )
+    parser.add_argument(
+        "--smt-iq-watermark-fp",
+        type=int,
+        default=0,
+        help="SMT IQ Watermark for fpIQ/vecIQ (min entries reserved per thread)",
+    )
+
     # Add the ruby specific and protocol specific args
     if '--ruby' in sys.argv:
         Ruby.define_options(parser)

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -26,6 +26,14 @@ def setSharedLSQParams(args, system):
         cpu.smtLSQMode = 'Shared'
         cpu.smtLSQPolicy = 'Dynamic'
         cpu.smtROBPolicy = 'DynamicBorrowing'
+        cpu.smtIQPolicy = args.smt_iq_policy
+        for iq in cpu.scheduler.IQs:
+            if iq.name.startswith("int"):
+                iq.smtIQWatermark = args.smt_iq_watermark_int
+            elif iq.name.startswith("fp") or iq.name.startswith("vec"):
+                iq.smtIQWatermark = args.smt_iq_watermark_fp
+            else:
+                iq.smtIQWatermark = args.smt_iq_watermark_mem
         cpu.branchPred.smtFTQMode = 'Shared'
         cpu.branchPred.smtFTQPolicy = 'Partitioned'
 

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -51,7 +51,7 @@ class SMTFetchPolicy(ScopedEnum):
     vals = [ 'RoundRobin', 'Branch', 'IQCount', 'LSQCount' ]
 
 class SMTQueuePolicy(ScopedEnum):
-    vals = [ 'Dynamic', 'Partitioned', 'Threshold', 'DynamicBorrowing' ]
+    vals = [ 'Dynamic', 'Partitioned', 'Threshold', 'DynamicBorrowing', 'Watermark' ]
 
 class SMTLSQMode(ScopedEnum):
     vals = [ 'Independent', 'Shared' ]
@@ -255,7 +255,7 @@ class BaseO3CPU(BaseCPU):
     smtLSQPolicy    = Param.SMTQueuePolicy('Partitioned',
                                            "SMT shared LSQ allocation policy")
     smtLSQThreshold = Param.Int(100, "SMT LSQ Threshold Sharing Parameter")
-    smtIQPolicy    = Param.SMTQueuePolicy('Partitioned',
+    smtIQPolicy    = Param.SMTQueuePolicy('Dynamic',
                                           "SMT IQ Sharing Policy")
     smtIQThreshold = Param.Int(100, "SMT IQ Threshold Sharing Parameter")
     smtROBPolicy   = Param.SMTQueuePolicy('Partitioned',

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -87,6 +87,7 @@ class IssueQue(SimObject):
     vectorSplitUnits = Param.Unsigned(2, "Number of independent vector split units")
     oports = VectorParam.IssuePort("")
     sel = Param.BaseSelector(BaseSelector(), "Selector for this IQ")
+    smtIQWatermark = Param.Int(0, "SMT IQ Watermark per thread")
 
 class Scheduler(SimObject):
     type = 'Scheduler'

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -24,6 +24,7 @@
 #include "debug/Dispatch.hh"
 #include "debug/Schedule.hh"
 #include "enums/OpClass.hh"
+#include "cpu/o3/cpu.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_object.hh"
@@ -34,6 +35,8 @@
         assert((*instNumClassify[x->opClass()]) != 0); \
         (*instNumClassify[x->opClass()])--;            \
         instNum--;                        \
+        assert(threadEntries[x->threadNumber] != 0);   \
+        threadEntries[x->threadNumber]--;              \
         selector->deallocate(x);          \
     } while (0)
 
@@ -207,6 +210,7 @@ IssueQue::IssueQue(const IssueQueParams& params)
 {
     panic_if(vectorSplitUnits == 0,
              "%s: vectorSplitUnits must be greater than 0\n", iqname);
+    smtIQWatermark = params.smtIQWatermark;
 
     // TODO: keep this in sync with the current load IQ naming convention.
     // This should become an explicit IssueQue parameter when the config grows
@@ -337,6 +341,26 @@ IssueQue::setCPU(CPU* cpu)
     _name = cpu->name() + ".scheduler." + getName();
     iqstats = new IssueQueStats(cpu, this, "scheduler." + this->getName());
     iqstats->instsNum.init(cpu->numThreads);
+
+    // Initialize SMT IQ partitioning
+    smtIQPolicy = scheduler->smtIQPolicy;
+    // A negative watermark would wrap to a huge value when cast to uint32_t
+    // in ready(), making wmLimit permanently 0 and deadlocking dispatch.
+    if (smtIQWatermark < 0) {
+        warn_once("%s: negative SMT IQ watermark %d clamped to 0",
+                  iqname, smtIQWatermark);
+        smtIQWatermark = 0;
+    }
+    if (smtIQPolicy != SMTQueuePolicy::Dynamic &&
+        smtIQPolicy != SMTQueuePolicy::Watermark) {
+        warn_once("%s: SMT IQ policy %d not implemented for IQ, "
+                  "falling back to Dynamic", iqname, (int)smtIQPolicy);
+    }
+    numThreads = cpu->numThreads;
+    for (int t = 0; t < MaxThreads; t++)
+        threadEntries[t] = 0;
+    DPRINTF(Schedule, "%s: SMT IQ policy=%d, iqsize=%d, numThreads=%d, wm=%d\n",
+            iqname, (int)smtIQPolicy, iqsize, numThreads, smtIQWatermark);
 }
 
 void
@@ -1001,17 +1025,34 @@ IssueQue::tick()
 }
 
 bool
-IssueQue::ready()
+IssueQue::ready(ThreadID tid)
 {
     bool bwFull = instNumInsert >= inports;
-    bool full = (instNum >= iqsize) || (replayQ.size() > replayQsize);
+    bool globalFull = (instNum >= iqsize) || (replayQ.size() > replayQsize);
     if (bwFull) {
         DPRINTF(Schedule, "can't insert more due to inports exhausted\n");
     }
-    if (full) {
+    if (globalFull) {
         DPRINTF(Schedule, "has full!\n");
     }
-    return !full && !bwFull;
+    if (bwFull || globalFull)
+        return false;
+
+    switch (smtIQPolicy) {
+    case SMTQueuePolicy::Dynamic:
+        return true;
+    case SMTQueuePolicy::Watermark: {
+        uint32_t reserved = 0;
+        for (int t = 0; t < numThreads; t++) {
+            if (t != (int)tid)
+                reserved += std::max((uint32_t)smtIQWatermark, threadEntries[t]);
+        }
+        uint32_t wmLimit = (uint32_t)(iqsize > (int)reserved ? iqsize - reserved : 0);
+        return threadEntries[tid] < wmLimit;
+    }
+    default:
+        return true;
+    }
 }
 
 void
@@ -1021,6 +1062,7 @@ IssueQue::insert(const DynInstPtr& inst)
     (*instNumClassify[inst->opClass()])++;
     instNum++;
     instNumInsert++;
+    threadEntries[inst->threadNumber]++;
 
     cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueQue);
 
@@ -1394,6 +1436,11 @@ Scheduler::setCPU(CPU* cpu, LSQ* lsq)
 {
     this->cpu = cpu;
     this->lsq = lsq;
+
+    // Read SMT IQ params from CPU
+    const auto &cpuParams = dynamic_cast<const BaseO3CPUParams &>(cpu->params());
+    smtIQPolicy = cpuParams.smtIQPolicy;
+
     for (auto it : issueQues) {
         it->setCPU(cpu);
         it->selector->setparent(this, it);
@@ -1500,7 +1547,9 @@ Scheduler::lookahead(std::deque<DynInstPtr>& insts)
 bool
 Scheduler::ready(const DynInstPtr& inst, int disp_seq)
 {
-    if (inst->staticInst->isSplitStoreAddr() && !ready(StoreDataOp, disp_seq)) {
+    ThreadID tid = inst->threadNumber;
+
+    if (inst->staticInst->isSplitStoreAddr() && !ready(StoreDataOp, tid, disp_seq)) {
         return false;
     }
 
@@ -1509,12 +1558,12 @@ Scheduler::ready(const DynInstPtr& inst, int disp_seq)
 
     if (old_disp) [[unlikely]] {
         for (auto iq : iqs) {
-            if (iq->ready()) {
+            if (iq->ready(tid)) {
                 return true;
             }
         }
     } else {
-        if (iqs[dispSeqVec.at(disp_seq)]->ready()) {
+        if (iqs[dispSeqVec.at(disp_seq)]->ready(tid)) {
             return true;
         }
     }
@@ -1524,19 +1573,19 @@ Scheduler::ready(const DynInstPtr& inst, int disp_seq)
 }
 
 bool
-Scheduler::ready(OpClass op, int disp_seq)
+Scheduler::ready(OpClass op, ThreadID tid, int disp_seq)
 {
     auto& iqs = dispTable[op];
     assert(!iqs.empty());
 
     if (old_disp) {
         for (auto iq : iqs) {
-            if (iq->ready()) {
+            if (iq->ready(tid)) {
                 return true;
             }
         }
     } else {
-        if (iqs[dispSeqVec.at(disp_seq)]->ready()) {
+        if (iqs[dispSeqVec.at(disp_seq)]->ready(tid)) {
             return true;
         }
     }
@@ -1601,11 +1650,12 @@ Scheduler::insert(const DynInstPtr& inst, int disp_seq)
 
     auto& iqs = dispTable[inst->opClass()];
 
+    ThreadID insert_tid = inst->threadNumber;
     if (old_disp) {
         bool insert = false;
         std::sort(iqs.begin(), iqs.end(), disp_policy(inst->opClass()));
         for (auto iq : iqs) {
-            if (iq->ready()) {
+            if (iq->ready(insert_tid)) {
                 insert = true;
                 iq->insert(inst);
                 break;
@@ -1613,7 +1663,7 @@ Scheduler::insert(const DynInstPtr& inst, int disp_seq)
         }
         panic_if(!insert, "can't find ready IQ to insert");
     } else {
-        assert(iqs[dispSeqVec.at(disp_seq)]->ready());
+        assert(iqs[dispSeqVec.at(disp_seq)]->ready(insert_tid));
         iqs[dispSeqVec.at(disp_seq)]->insert(inst);
     }
 
@@ -1624,9 +1674,10 @@ void
 Scheduler::insertNonSpec(const DynInstPtr& inst)
 {
     auto& iqs = dispTable[inst->opClass()];
+    ThreadID tid = inst->threadNumber;
 
     for (auto iq : iqs) {
-        if (iq->ready()) {
+        if (iq->ready(tid)) {
             iq->insertNonSpec(inst);
             break;
         }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -27,6 +27,7 @@
 #include "params/PAgeSelector.hh"
 #include "params/Scheduler.hh"
 #include "params/SpecWakeupChannel.hh"
+#include "enums/SMTQueuePolicy.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_object.hh"
 
@@ -198,6 +199,12 @@ class IssueQue : public SimObject
     // iq per-thread occupancy counter, used for fetch-side feedback stats
     InstsCounter* instsCounter = nullptr;
 
+    // SMT IQ partitioning
+    SMTQueuePolicy smtIQPolicy = SMTQueuePolicy::Dynamic;
+    int smtIQWatermark = 0;
+    int numThreads = 1;
+    uint32_t threadEntries[MaxThreads] = {};
+
     struct IssueQueStats : public statistics::Group
     {
         IssueQueStats(statistics::Group* parent, IssueQue* que, std::string name);
@@ -253,7 +260,7 @@ class IssueQue : public SimObject
     bool hasInstsCounter() const { return instsCounter != nullptr; }
 
     void tick();
-    bool ready();
+    bool ready(int tid);
     int emptyEntries() const { return iqsize - instNum; }
     void insert(const DynInstPtr& inst);
     void insertNonSpec(const DynInstPtr& inst);
@@ -367,9 +374,12 @@ class Scheduler : public SimObject
 
     std::vector<int> dispSeqVec;
 
+    // SMT IQ partitioning params (forwarded to each IssueQue in setCPU)
+    SMTQueuePolicy smtIQPolicy = SMTQueuePolicy::Dynamic;
+
     // should call at issue first/last cycle,
     void specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_queue);
-    bool ready(OpClass op, int disp_seq);
+    bool ready(OpClass op, int tid, int disp_seq);
 
   public:
     PendingWakeEventsType specWakeEvents;


### PR DESCRIPTION
## Motivation

Under SMT, the default Dynamic IQ dispatch policy allows one thread to monopolize all IQ entries, starving the other thread. This is especially problematic for memory-intensive workloads where cache-missed instructions accumulate in the IQ waiting for data return, blocking the other thread from dispatching.

## Approach

Introduce a **Watermark** policy for SMT IQ dispatch that reserves a minimum number of entries per hardware thread. Each IQ instance carries a per-thread watermark value configured through CLI arguments (`--smt-iq-policy`, `--smt-iq-watermark-int/mem/fp`). The Python config layer classifies IQs by name prefix (int/fp/vec/mem) and binds the appropriate watermark, so the C++ side needs no string-matching logic.

The `ready(tid)` admission check computes a per-thread limit based on the other threads' actual occupancy and the watermark floor:

```
wmLimit = iqsize - sum(max(watermark, entries[t]) for t != tid)
```

- `watermark=0` (default) preserves the existing Dynamic behavior
- Negative watermark values are clamped to 0 with a warning to prevent uint32 overflow deadlock
- Unsupported policies (Partitioned/Threshold/DynamicBorrowing) fall back to Dynamic with a warning

## Environment

- **Branch**: `xs-dev`
- **Base commit**: `6d3120361e` (mem: fix bug of vsq (#1019))
- **Config**: SMT-2, KMHV3 scheduler
- **Test**: SPEC06 INT, 12 workloads, 682 checkpoints

## Results

| Config | score/GHz | Improvement |
|--------|-----------|-------------|
| Dynamic (baseline) | 23.799 | - |
| Watermark int=2 mem=4 | **23.933** | **+0.56%** |

Per-workload highlights:
- **mcf**: +2.44%
- **omnetpp**: +1.87%
- **gcc**: +1.84%

Memory-sensitive workloads benefit most, consistent with the design goal of memIQ watermark suppressing load accumulation and preventing sibling thread starvation.

## Changes

6 files changed, +112 -17:
- `src/cpu/o3/FuncScheduler.py` — add `smtIQWatermark` SimObject parameter
- `src/cpu/o3/BaseO3CPU.py` — add `Watermark` enum value, change `smtIQPolicy` default to `Dynamic`
- `src/cpu/o3/issue_queue.hh` — add SMT IQ partitioning members, update `ready()` signature
- `src/cpu/o3/issue_queue.cc` — Watermark admission logic, `threadEntries` tracking, `setCPU` init
- `configs/common/xiangshan.py` — add 4 CLI arguments
- `configs/example/smt_idealkmhv3.py` — bind per-IQ watermark by name prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SMT instruction-queue policies, including dynamic sharing and watermark-based partitioning.
  * Added separate queue watermarks for integer, memory, and floating-point/vector workloads.
  * Added command-line options for selecting policies and configuring per-queue limits.

* **Improvements**
  * Issue-queue capacity management now tracks workloads per thread and applies configured limits.
  * Added validation and fallback behavior for unsupported policies or invalid watermark values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->