### PR TITLE
mem: align xs-stream depth

### DIFF
--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -345,7 +345,11 @@ class XsStreamPrefetcher(QueuedPrefetcher):
     on_write = False
     on_data  = True
     on_inst  = False
-    xs_stream_depth = Param.Int(32, "The depth of xs_stream_depth")
+    xs_stream_depth = Param.Int(64, "The depth of xs_stream_depth")
+    xs_stream_l2_depth = Param.Unsigned(
+        640,
+        "L2 stream lookahead in cache blocks; zero derives from depth << 2"
+    )
     enable_auto_depth = Param.Bool(False, "enable autp depth.")
     enable_l3_stream_pre = Param.Bool(False, "enable l3 stream pre.")
     xs_stream_entries = Param.MemorySize(

--- a/src/mem/cache/prefetch/xs_stream.cc
+++ b/src/mem/cache/prefetch/xs_stream.cc
@@ -16,6 +16,7 @@ XsStreamPrefetcher::XsStreamPrefetcher(const XsStreamPrefetcherParams &p)
       badPreNum(0),
       enableAutoDepth(p.enable_auto_depth),
       enableL3StreamPre(p.enable_l3_stream_pre),
+      l2Depth(p.xs_stream_l2_depth),
       stream_array(p.xs_stream_entries, p.xs_stream_entries, p.xs_stream_indexing_policy,
                    p.xs_stream_replacement_policy, STREAMEntry()),
       streamBlkFilter(pfFilterSize)
@@ -55,8 +56,9 @@ XsStreamPrefetcher::calculatePrefetch(const PrefetchInfo &pfi, std::vector<AddrP
     if (in_active_page) {
         Addr pf_stream_l1 = decr ? block_addr - depth * blkSize : block_addr + depth * blkSize;
         sendPFWithFilter(pfi, pf_stream_l1, addresses, 1, stream_type, L1BLKDEGREE, 1, entry);
-        Addr pf_stream_l2 =
-            decr ? block_addr - (depth << l2Ratio) * blkSize : block_addr + (depth << l2Ratio) * blkSize;
+        const auto l2_depth = l2Depth ? l2Depth : (depth << l2Ratio);
+        Addr pf_stream_l2 = decr ? block_addr - l2_depth * blkSize :
+                                   block_addr + l2_depth * blkSize;
         sendPFWithFilter(pfi, pf_stream_l2, addresses, 1, stream_type, L2BLKDEGREE, 2, entry);
         if (enableL3StreamPre) {
             Addr pf_stream_l3 =

--- a/src/mem/cache/prefetch/xs_stream.hh
+++ b/src/mem/cache/prefetch/xs_stream.hh
@@ -35,6 +35,7 @@ class XsStreamPrefetcher : public Queued
     int badPreNum;
     bool enableAutoDepth;
     bool enableL3StreamPre;
+    const unsigned l2Depth;
     const int l2Ratio = 2;
     const int l3Ratio = 3;
     const int DEPTHRIGHT = 1 << 9;


### PR DESCRIPTION
Change-Id: If7dca4b42dbfad3207e3193ca4423ca2e6a8c9cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable L2 cache prefetch depth, with a default of 640 cache blocks.
  * Increased the default stream prefetch depth from 32 to 64.

* **Improvements**
  * L2 prefetch distance now respects the configured value, while retaining automatic fallback behavior when no value is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->