### PR TITLE
cpu-o3: Add optional Preg SMT DynamicBorrowing policy

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -272,6 +272,20 @@ class BaseO3CPU(BaseCPU):
         8, "Cycles to keep an SMT thread marked as a ROB borrowing donor")
     smtBorrowDonorReserveEntries = Param.Unsigned(
         8, "Minimum ROB entries reserved for a borrowing donor to resume")
+    smtPregPolicy = Param.SMTQueuePolicy('Dynamic',
+                                         "SMT Preg (physical register) Sharing Policy")
+    smtPregFixedBase = Param.Unsigned(0,
+        "Fixed per-thread base quota for DynamicBorrowing (0 = numPhysRegs/activeThreads)")
+    smtPregBorrowDonorReserveRegs = Param.Unsigned(
+        8, "Minimum physical registers reserved for a borrowing donor to resume")
+    smtPregBackendBackpressureDonor = Param.Bool(True,
+        "Also treat a thread as a Preg borrowing donor when it is stalled "
+        "on ROB/dispatch-queue-bandwidth backpressure (a resource other "
+        "than Preg itself); when false, only actual Preg demand this "
+        "cycle drives donor status")
+    smtPregBackendBackpressureDonorHoldCycles = Param.Unsigned(
+        8, "Cycles to keep a backend-backpressure-triggered Preg donor "
+           "marking held after the triggering condition clears")
     smtBorrowBaseReserveEntries = Param.Unsigned(
         80, "Minimum ROB entries reserved for a borrowing base to resume")
 

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -276,8 +276,9 @@ class BaseO3CPU(BaseCPU):
                                          "SMT Preg (physical register) Sharing Policy")
     smtPregFixedBase = Param.Unsigned(0,
         "Fixed per-thread base quota for DynamicBorrowing (0 = numPhysRegs/activeThreads)")
-    smtPregBorrowDonorReserveRegs = Param.Unsigned(
-        8, "Minimum physical registers reserved for a borrowing donor to resume")
+    smtPregDonorReservePercent = Param.Unsigned(
+        43, "Percentage (0-100) of per-thread fair share reserved for a "
+            "donor thread.  donorQuota = numPhysRegs/activeThreads * pct/100")
     smtPregBackendBackpressureDonor = Param.Bool(True,
         "Also treat a thread as a Preg borrowing donor when it is stalled "
         "on ROB/dispatch-queue-bandwidth backpressure (a resource other "

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -105,7 +105,7 @@ CPU::CPU(const BaseO3CPUParams &params)
               params.numPhysRMiscRegs,
               params.isa[0]->regClasses()),
 
-      freeList(name() + ".freelist", &regFile),
+      freeList(name() + ".freelist", &regFile, params),
 
       rob(this, params),
 
@@ -165,6 +165,7 @@ CPU::CPU(const BaseO3CPUParams &params)
     rename.setActiveThreads(&activeThreads);
     iew.setActiveThreads(&activeThreads);
     commit.setActiveThreads(&activeThreads);
+    freeList.setActiveThreads(&activeThreads);
 
     // Give each of the stages the time buffer they will use.
     fetch.setTimeBuffer(&timeBuffer);
@@ -242,8 +243,8 @@ CPU::CPU(const BaseO3CPUParams &params)
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         isa[tid] = dynamic_cast<TheISA::ISA *>(params.isa[tid]);
         warn("Setting isa ptr of cpu to %p", isa[tid]);
-        commitRenameMap[tid].init(regClasses, &regFile, &freeList);
-        renameMap[tid].init(regClasses, &regFile, &freeList);
+        commitRenameMap[tid].init(regClasses, &regFile, &freeList, tid);
+        renameMap[tid].init(regClasses, &regFile, &freeList, tid);
     }
 
     // Initialize rename map to assign physical registers to the
@@ -256,7 +257,7 @@ CPU::CPU(const BaseO3CPUParams &params)
                 // Note that we can't use the rename() method because we don't
                 // want special treatment for the zero register at this point
                 RegId rid = RegId(type, ridx);
-                PhysRegIdPtr phys_reg = freeList.getReg(type);
+                PhysRegIdPtr phys_reg = freeList.getReg(type, tid);
                 renameMap[tid].setEntry(rid, VirtRegId(phys_reg));
                 commitRenameMap[tid].setEntry(rid, VirtRegId(phys_reg));
             }
@@ -643,6 +644,7 @@ CPU::startup()
     iew.startupStage();
     rename.startupStage();
     commit.startupStage();
+    freeList.resetEntries();
 }
 
 void
@@ -807,7 +809,7 @@ CPU::insertThread(ThreadID tid)
     for (auto type = (RegClassType)0; type <= RMiscRegClass;
             type = (RegClassType)(type + 1)) {
         for (RegIndex idx = 0; idx < regClasses.at(type).numRegs(); idx++) {
-            PhysRegIdPtr phys_reg = freeList.getReg(type);
+            PhysRegIdPtr phys_reg = freeList.getReg(type, tid);
             renameMap[tid].setEntry(RegId(type, idx), VirtRegId(phys_reg));
             scoreboard.setReg(phys_reg);
         }
@@ -825,6 +827,7 @@ CPU::insertThread(ThreadID tid)
 
     //Reset ROB/IQ/LSQ Entries
     commit.rob->resetEntries();
+    freeList.resetEntries();
 }
 
 void

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -864,6 +864,10 @@ CPU::removeThread(ThreadID tid)
     assert(iew.ldstQueue.getCount(tid) == 0);
     assert(commit.rob->isEmpty(tid));
 
+    // Reset per-thread Preg occupancy accounting so a reinserted tid
+    // does not carry stale quota usage.
+    freeList.resetThreadUsed(tid);
+
     // Reset ROB/IQ/LSQ Entries
 
     // Commented out for now.  This should be possible to do by

--- a/src/cpu/o3/free_list.cc
+++ b/src/cpu/o3/free_list.cc
@@ -29,8 +29,13 @@
 
 #include "cpu/o3/free_list.hh"
 
+#include <algorithm>
+#include <list>
+
+#include "base/logging.hh"
 #include "base/trace.hh"
 #include "debug/FreeList.hh"
+#include "params/BaseO3CPU.hh"
 
 namespace gem5
 {
@@ -39,14 +44,156 @@ namespace o3
 {
 
 UnifiedFreeList::UnifiedFreeList(const std::string &_my_name,
-                                 PhysRegFile *_regFile)
-    : _name(_my_name), regFile(_regFile)
+                                 PhysRegFile *_regFile,
+                                 const BaseO3CPUParams &params)
+    : _name(_my_name), regFile(_regFile),
+      pregPolicy(params.smtPregPolicy),
+      donorReserveRegs(params.smtPregBorrowDonorReserveRegs),
+      fixedBase(params.smtPregFixedBase),
+      numThreads(params.numThreads)
 {
     DPRINTF(FreeList, "Creating new free list object.\n");
+
+    panic_if(pregPolicy == SMTQueuePolicy::Threshold,
+             "smtPregPolicy=Threshold is not implemented for the Preg free "
+             "list; use Partitioned or DynamicBorrowing instead.");
 
     // Have the register file initialize the free list since it knows
     // about its internal organization
     regFile->initFreeList(this);
+
+    // Capture each class' total capacity now, before any allocation
+    // happens; freeLists[i] has just been fully populated by initFreeList.
+    for (int i = 0; i <= RMiscRegClass; i++)
+        numPhysRegs[i] = freeLists[i].numFreeRegs();
+
+    for (ThreadID tid = 0; tid < numThreads; tid++) {
+        donor[tid] = false;
+        for (int i = 0; i <= RMiscRegClass; i++) {
+            maxEntries[tid][i] = (pregPolicy == SMTQueuePolicy::Partitioned)
+                ? numPhysRegs[i] / numThreads
+                : numPhysRegs[i];
+        }
+    }
+    for (ThreadID tid = numThreads; tid < MaxThreads; tid++) {
+        for (int i = 0; i <= RMiscRegClass; i++)
+            maxEntries[tid][i] = 0;
+    }
+}
+
+void
+UnifiedFreeList::resetEntries()
+{
+    if (pregPolicy != SMTQueuePolicy::Partitioned || !activeThreads) {
+        return;
+    }
+
+    const unsigned active = std::max<size_t>(1, activeThreads->size());
+    for (ThreadID tid : *activeThreads) {
+        for (int i = 0; i <= RMiscRegClass; i++)
+            maxEntries[tid][i] = numPhysRegs[i] / active;
+    }
+}
+
+unsigned
+UnifiedFreeList::activeThreadCount() const
+{
+    if (!activeThreads || activeThreads->empty())
+        return numThreads == 0 ? 1 : numThreads;
+    return activeThreads->size();
+}
+
+unsigned
+UnifiedFreeList::base(RegClassType type) const
+{
+    if (fixedBase > 0)
+        return std::min(fixedBase, numPhysRegs[type] / activeThreadCount());
+    return std::max(1u, numPhysRegs[type] / activeThreadCount());
+}
+
+unsigned
+UnifiedFreeList::donorQuota(RegClassType type) const
+{
+    return std::min(base(type), donorReserveRegs);
+}
+
+unsigned
+UnifiedFreeList::borrowingLimit(RegClassType type, ThreadID tid) const
+{
+    unsigned reserved = 0;
+    for (ThreadID other = 0; other < numThreads; ++other) {
+        if (other == tid) {
+            continue;
+        }
+        const unsigned reserve =
+            donor[other] ? donorQuota(type) : base(type);
+        const unsigned used = threadUsed[other][type];
+        reserved += std::max(used, reserve);
+    }
+
+    if (reserved >= numPhysRegs[type]) {
+        return 0;
+    }
+    return numPhysRegs[type] - reserved;
+}
+
+bool
+UnifiedFreeList::canAllocate(RegClassType type, ThreadID tid, unsigned n) const
+{
+    if (n > freeLists[type].numFreeRegs()) {
+        return false;
+    }
+
+    switch (pregPolicy) {
+      case SMTQueuePolicy::DynamicBorrowing:
+        return threadUsed[tid][type] + n <= borrowingLimit(type, tid);
+      case SMTQueuePolicy::Partitioned:
+        return threadUsed[tid][type] + n <= maxEntries[tid][type];
+      default:
+        // Dynamic: no per-thread cap beyond physical availability, which
+        // is already checked above.
+        return true;
+    }
+}
+
+unsigned
+UnifiedFreeList::numAllocatable(RegClassType type, ThreadID tid) const
+{
+    const unsigned free_regs = freeLists[type].numFreeRegs();
+
+    if (pregPolicy == SMTQueuePolicy::Dynamic) {
+        return free_regs;
+    }
+
+    const unsigned limit = (pregPolicy == SMTQueuePolicy::DynamicBorrowing)
+        ? borrowingLimit(type, tid)
+        : maxEntries[tid][type];
+    const unsigned used = threadUsed[tid][type];
+    const unsigned per_thread_limit = used >= limit ? 0 : limit - used;
+
+    return std::min(per_thread_limit, free_regs);
+}
+
+bool
+UnifiedFreeList::isPerThreadExhausted(RegClassType type, ThreadID tid,
+                                       unsigned n) const
+{
+    if (pregPolicy == SMTQueuePolicy::Dynamic) {
+        return false;
+    }
+
+    const unsigned free_regs = freeLists[type].numFreeRegs();
+    if (free_regs < n) {
+        return false;
+    }
+
+    const unsigned limit = (pregPolicy == SMTQueuePolicy::DynamicBorrowing)
+        ? borrowingLimit(type, tid)
+        : maxEntries[tid][type];
+    const unsigned used = threadUsed[tid][type];
+    const unsigned per_thread_avail = used >= limit ? 0 : limit - used;
+
+    return per_thread_avail < n;
 }
 
 } // namespace o3

--- a/src/cpu/o3/free_list.cc
+++ b/src/cpu/o3/free_list.cc
@@ -48,7 +48,7 @@ UnifiedFreeList::UnifiedFreeList(const std::string &_my_name,
                                  const BaseO3CPUParams &params)
     : _name(_my_name), regFile(_regFile),
       pregPolicy(params.smtPregPolicy),
-      donorReserveRegs(params.smtPregBorrowDonorReserveRegs),
+      donorReservePercent(params.smtPregDonorReservePercent),
       fixedBase(params.smtPregFixedBase),
       numThreads(params.numThreads)
 {
@@ -114,26 +114,25 @@ UnifiedFreeList::base(RegClassType type) const
 unsigned
 UnifiedFreeList::donorQuota(RegClassType type) const
 {
-    return std::min(base(type), donorReserveRegs);
+    unsigned fairShare = numPhysRegs[type] / activeThreadCount();
+    return fairShare * donorReservePercent / 100;
 }
 
 unsigned
 UnifiedFreeList::borrowingLimit(RegClassType type, ThreadID tid) const
 {
     unsigned reserved = 0;
-    for (ThreadID other = 0; other < numThreads; ++other) {
-        if (other == tid) {
-            continue;
+    if (activeThreads && !activeThreads->empty()) {
+        for (ThreadID other : *activeThreads) {
+            if (other == tid)
+                continue;
+            const unsigned reserve =
+                donor[other] ? donorQuota(type) : base(type);
+            reserved += std::max(threadUsed[other][type], reserve);
         }
-        const unsigned reserve =
-            donor[other] ? donorQuota(type) : base(type);
-        const unsigned used = threadUsed[other][type];
-        reserved += std::max(used, reserve);
     }
-
-    if (reserved >= numPhysRegs[type]) {
+    if (reserved >= numPhysRegs[type])
         return 0;
-    }
     return numPhysRegs[type] - reserved;
 }
 

--- a/src/cpu/o3/free_list.hh
+++ b/src/cpu/o3/free_list.hh
@@ -45,21 +45,24 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <list>
 #include <queue>
 
 #include "base/logging.hh"
 #include "base/trace.hh"
 #include "cpu/o3/comm.hh"
+#include "cpu/o3/limits.hh"
 #include "cpu/o3/regfile.hh"
 #include "debug/FreeList.hh"
+#include "enums/SMTQueuePolicy.hh"
 
 namespace gem5
 {
 
+struct BaseO3CPUParams;
+
 namespace o3
 {
-
-class UnifiedRenameMap;
 
 /**
  * Free list for a single class of registers (e.g., integer
@@ -142,31 +145,98 @@ class UnifiedFreeList
      */
     PhysRegFile *regFile;
 
-    /*
-     * We give UnifiedRenameMap internal access so it can get at the
-     * internal per-class free lists and associate those with its
-     * per-class rename maps. See UnifiedRenameMap::init().
+    /** SMT resource sharing policy for the Preg free lists. */
+    SMTQueuePolicy pregPolicy;
+
+    /** Minimum registers a donor thread keeps for restarting after a stall.
+     *  (Phase 1: donor[] is always false, so this is currently unused; kept
+     *  so the borrowingLimit() formula does not need to change in Phase 3.)
      */
-    friend class UnifiedRenameMap;
+    const unsigned donorReserveRegs;
+
+    /** Fixed per-thread base quota override (0 = use numPhysRegs/activeThreads). */
+    const unsigned fixedBase;
+
+    ThreadID numThreads;
+
+    /** Pointer to the CPU's active-threads list, for DynamicBorrowing's
+     *  active-thread-count-based base quota and for Partitioned's
+     *  resetEntries(). */
+    std::list<ThreadID> *activeThreads = nullptr;
+
+    /** Total physical registers of each class, captured at construction
+     *  time (before any allocation happens). */
+    unsigned numPhysRegs[RMiscRegClass + 1] = {};
+
+    /** Per-thread, per-class static cap used by the Partitioned policy. */
+    unsigned maxEntries[MaxThreads][RMiscRegClass + 1] = {};
+
+    /** Per-thread, per-class occupancy accounting. Needed because
+     *  freeLists[] is a single shared queue per class with no notion of
+     *  which thread holds which register. */
+    unsigned threadUsed[MaxThreads][RMiscRegClass + 1] = {};
+
+    /** Whether a thread may donate unused headroom this cycle. Phase 1:
+     *  always false (see donorReserveRegs above). */
+    bool donor[MaxThreads] = {};
+
+    unsigned activeThreadCount() const;
+
+    /** Per-thread base quota for register class type. */
+    unsigned base(RegClassType type) const;
+
+    /** Reduced reserve quota used for a donor thread. */
+    unsigned donorQuota(RegClassType type) const;
+
+    /** Self-contained DynamicBorrowing limit:
+     *  total - sum_other max(used(other), reserve(other)).
+     *  See myDocs/Preg/Preg_SMT_Partition_Design.md section 4.3/6. */
+    unsigned borrowingLimit(RegClassType type, ThreadID tid) const;
 
   public:
     /** Constructs a free list.
-     *  @param _numPhysicalIntRegs Number of physical integer registers.
-     *  @param reservedIntRegs Number of integer registers already
-     *                         used by initial mappings.
-     *  @param _numPhysicalFloatRegs Number of physical fp registers.
-     *  @param reservedFloatRegs Number of fp registers already
-     *                           used by initial mappings.
+     *  @param _my_name Name of the free list, for DPRINTF.
+     *  @param _regFile The register file, used to populate the free list.
+     *  @param params CPU params, providing smtPregPolicy and friends.
      */
-    UnifiedFreeList(const std::string &_my_name, PhysRegFile *_regFile);
+    UnifiedFreeList(const std::string &_my_name, PhysRegFile *_regFile,
+                     const BaseO3CPUParams &params);
 
     /** Gives the name of the freelist. */
     std::string name() const { return _name; };
 
-    /** Gets a free register of type type. */
-    PhysRegIdPtr getReg(RegClassType type) { return freeLists[type].getReg(); }
+    /** Sets pointer to the list of active threads. */
+    void
+    setActiveThreads(std::list<ThreadID> *at_ptr)
+    {
+        activeThreads = at_ptr;
+    }
 
-    /** Adds a register back to the free list. */
+    /** Marks/unmarks a thread as a borrowing donor (Phase 3 hook; not
+     *  currently invoked anywhere). */
+    void
+    setBorrowingDonor(ThreadID tid, bool val)
+    {
+        donor[tid] = val;
+    }
+
+    /** Recomputes the Partitioned policy's per-thread maxEntries when the
+     *  active thread count changes. */
+    void resetEntries();
+
+    /** Gets a free register of type type for thread tid, and records the
+     *  allocation against that thread's occupancy. */
+    PhysRegIdPtr
+    getReg(RegClassType type, ThreadID tid)
+    {
+        PhysRegIdPtr reg = freeLists[type].getReg();
+        threadUsed[tid][type]++;
+        return reg;
+    }
+
+    /** Adds a register back to the free list. Used only for the initial,
+     *  thread-agnostic population of the free lists at construction time;
+     *  does not touch threadUsed accounting. */
     template<class InputIt>
     void
     addRegs(InputIt first, InputIt last)
@@ -174,12 +244,25 @@ class UnifiedFreeList
         std::for_each(first, last, [this](auto &reg) { addReg(&reg); });
     }
 
-    /** Adds a register back to the free list.
-        NOTE: freed_reg's refCnt must is 0
+    /** Adds a register back to the free list, without per-thread
+     *  accounting. Only meant for the initial bulk population via
+     *  addRegs() above.
+     *  NOTE: freed_reg's refCnt must is 0
      */
     void
     addReg(PhysRegIdPtr freed_reg)
     {
+        freeLists[freed_reg->classValue()].addReg(freed_reg);
+    }
+
+    /** Adds a register back to the free list on behalf of thread tid,
+     *  releasing that thread's occupancy.
+     *  NOTE: freed_reg's refCnt must is 0
+     */
+    void
+    addReg(PhysRegIdPtr freed_reg, ThreadID tid)
+    {
+        threadUsed[tid][freed_reg->classValue()]--;
         freeLists[freed_reg->classValue()].addReg(freed_reg);
     }
 
@@ -196,6 +279,22 @@ class UnifiedFreeList
     {
         return freeLists[type].numFreeRegs();
     }
+
+    /** Whether thread tid may allocate n more registers of type type
+     *  under the configured smtPregPolicy. */
+    bool canAllocate(RegClassType type, ThreadID tid, unsigned n = 1) const;
+
+    /** Number of registers of type type thread tid may allocate right
+     *  now under the configured smtPregPolicy (bounded by the number of
+     *  physically free registers). Equivalent to the pre-SMT-partition
+     *  numFreeRegs() when smtPregPolicy is Dynamic. */
+    unsigned numAllocatable(RegClassType type, ThreadID tid) const;
+
+    /** Returns true when thread tid cannot allocate n registers of type
+     *  due to per-thread quota exhaustion (Partitioned or DynamicBorrowing),
+     *  while the global free list still has sufficient free registers.
+     *  Always returns false under the Dynamic policy. */
+    bool isPerThreadExhausted(RegClassType type, ThreadID tid, unsigned n) const;
 };
 
 } // namespace o3

--- a/src/cpu/o3/free_list.hh
+++ b/src/cpu/o3/free_list.hh
@@ -148,11 +148,10 @@ class UnifiedFreeList
     /** SMT resource sharing policy for the Preg free lists. */
     SMTQueuePolicy pregPolicy;
 
-    /** Minimum registers a donor thread keeps for restarting after a stall.
-     *  (Phase 1: donor[] is always false, so this is currently unused; kept
-     *  so the borrowingLimit() formula does not need to change in Phase 3.)
-     */
-    const unsigned donorReserveRegs;
+    /** Percentage (0-100) of per-thread fair share that a donor thread
+     *  reserves.  donorQuota(type) = numPhysRegs[type] / activeThreadCount
+     *  * donorReservePercent / 100.  Automatically scales with thread count. */
+    const unsigned donorReservePercent;
 
     /** Fixed per-thread base quota override (0 = use numPhysRegs/activeThreads). */
     const unsigned fixedBase;
@@ -176,8 +175,9 @@ class UnifiedFreeList
      *  which thread holds which register. */
     unsigned threadUsed[MaxThreads][RMiscRegClass + 1] = {};
 
-    /** Whether a thread may donate unused headroom this cycle. Phase 1:
-     *  always false (see donorReserveRegs above). */
+    /** Whether a thread may donate unused headroom this cycle.  Set by
+     *  Rename::tick() every cycle via setBorrowingDonor() before any
+     *  thread's canRename() is evaluated. */
     bool donor[MaxThreads] = {};
 
     unsigned activeThreadCount() const;
@@ -188,9 +188,9 @@ class UnifiedFreeList
     /** Reduced reserve quota used for a donor thread. */
     unsigned donorQuota(RegClassType type) const;
 
-    /** Self-contained DynamicBorrowing limit:
-     *  total - sum_other max(used(other), reserve(other)).
-     *  See myDocs/Preg/Preg_SMT_Partition_Design.md section 4.3/6. */
+    /** Self-contained DynamicBorrowing limit for the given thread:
+     *  numPhysRegs[type] - sum_active_other(max(used[other], reserve[other])).
+     *  Only counts active threads to avoid deadlocking single-thread runs. */
     unsigned borrowingLimit(RegClassType type, ThreadID tid) const;
 
   public:
@@ -212,8 +212,8 @@ class UnifiedFreeList
         activeThreads = at_ptr;
     }
 
-    /** Marks/unmarks a thread as a borrowing donor (Phase 3 hook; not
-     *  currently invoked anywhere). */
+    /** Marks/unmarks a thread as a borrowing donor.  Called by
+     *  Rename::tick() every cycle for all threads before rename begins. */
     void
     setBorrowingDonor(ThreadID tid, bool val)
     {
@@ -262,8 +262,21 @@ class UnifiedFreeList
     void
     addReg(PhysRegIdPtr freed_reg, ThreadID tid)
     {
+        assert(tid < MaxThreads &&
+               threadUsed[tid][freed_reg->classValue()] > 0);
         threadUsed[tid][freed_reg->classValue()]--;
         freeLists[freed_reg->classValue()].addReg(freed_reg);
+    }
+
+    /** Resets per-thread occupancy accounting on thread removal.
+     *  Called from CPU::removeThread() after the thread's mappings have
+     *  been released. */
+    void
+    resetThreadUsed(ThreadID tid)
+    {
+        for (int i = 0; i <= RMiscRegClass; i++)
+            threadUsed[tid][i] = 0;
+        donor[tid] = false;
     }
 
     /** Checks if there are any free registers of type type. */

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -69,6 +69,10 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
       renameWidth(params.renameWidth),
       releaseWidth(params.phyregReleaseWidth),
       numThreads(params.numThreads),
+      pregBackendBackpressureDonorEnabled(
+          params.smtPregBackendBackpressureDonor),
+      pregBackendBackpressureDonorHoldCycles(
+          params.smtPregBackendBackpressureDonorHoldCycles),
       stats(_cpu, this),
       valuePred(params.valuePred),
       enableSelectiveVPFlush(params.enableSelectiveVPFlush)
@@ -125,6 +129,8 @@ Rename::RenameStats::RenameStats(CPU *cpu, Rename *rename)
                "Number of times rename has blocked due to SQ full"),
       ADD_STAT(fullRegistersEvents, statistics::units::Count::get(),
                "Number of times there has been no free registers"),
+      ADD_STAT(perThreadPregFullEvents, statistics::units::Count::get(),
+               "Number of times a thread hit per-thread Preg quota while global free list has regs"),
       ADD_STAT(renamedOperands, statistics::units::Count::get(),
                "Number of destination operands rename has renamed"),
       ADD_STAT(lookups, statistics::units::Count::get(),
@@ -155,6 +161,10 @@ Rename::RenameStats::RenameStats(CPU *cpu, Rename *rename)
                "count of stall events"),
       ADD_STAT(smtStallEvents, statistics::units::Count::get(),
                "Number of events the Rename has stalled per thread"),
+      ADD_STAT(pregDonorCycles, statistics::units::Cycle::get(),
+               "Per-thread cycles as a Preg borrowing donor"),
+      ADD_STAT(pregBackendDonorCycles, statistics::units::Cycle::get(),
+               "Per-thread cycles as a Preg donor due to ROB-full backpressure"),
       ADD_STAT(assignedRatSnapshot, statistics::units::Count::get(),
                "Number of RAT checkpoints taken"),
       ADD_STAT(committedRatSnapshot, statistics::units::Count::get(),
@@ -195,7 +205,10 @@ Rename::RenameStats::RenameStats(CPU *cpu, Rename *rename)
 
     renamedInsts.init(cpu->numThreads).flags(statistics::total);
     fullRegistersEvents.init(cpu->numThreads).flags(statistics::total);
-    
+    perThreadPregFullEvents.init(cpu->numThreads).flags(statistics::total);
+    pregDonorCycles.init(cpu->numThreads).flags(statistics::total);
+    pregBackendDonorCycles.init(cpu->numThreads).flags(statistics::total);
+
     stallEvents.init(StallEventCount).flags(statistics::total);
     smtStallEvents
         .init(StallEventCount,0,cpu->numThreads-1,1)
@@ -373,6 +386,27 @@ Rename::tick()
 
     releasePhysRegs();
 
+    // Establish this cycle's Preg SMT-DynamicBorrowing donor eligibility for
+    // every thread up front, before any thread's canRename() consumes it via
+    // UnifiedFreeList::borrowingLimit() -- avoids the result depending on
+    // which thread happens to be processed first in the loop below.
+    for (int i = 0; i < numThreads; i++) {
+        bool backendQuotaFull = pregBackendBackpressureDonorEnabled &&
+                                 hasBackendQuotaFullStall(i);
+        if (backendQuotaFull) {
+            pregBackendDonorCycles[i] = pregBackendBackpressureDonorHoldCycles;
+        } else if (pregBackendDonorCycles[i] > 0) {
+            --pregBackendDonorCycles[i];
+        }
+        bool backendBackpressureDonor = pregBackendDonorCycles[i] > 0;
+        bool isDonor = !hasPregDemand(i) || backendBackpressureDonor;
+        freeList->setBorrowingDonor(i, isDonor);
+        if (isDonor)
+            ++stats.pregDonorCycles[i];
+        if (backendBackpressureDonor)
+            ++stats.pregBackendDonorCycles[i];
+    }
+
     // check threads stall & status
     ThreadID blocked_tid = InvalidThreadID;
     SmtActiveThreadArbiter active_arbiter;
@@ -382,6 +416,7 @@ Rename::tick()
         toDecode->renameInfo[tid].blockReason =
             stallSig->decodeBlockReason[tid];
     };
+    regFullThisCycle = false;
     for (int i = 0; i < numThreads; i++) {
         bool can_rename = canRename(i);
         bool block = stallSig->blockRename[i] || !can_rename;
@@ -394,7 +429,16 @@ Rename::tick()
             if (block_reason == StallReason::NoStall) {
                 block_reason = StallReason::RegFull;
                 ++stats.fullRegistersEvents[i];
-                stats.stallEvents[RegFull]++;
+                regFullThisCycle = true;
+                // Check if this is per-thread quota exhaustion
+                // (global free list has regs but thread hit its limit)
+                for (int rc = 0; rc <= RMiscRegClass; rc++) {
+                    if (freeList->isPerThreadExhausted(
+                            (RegClassType)rc, i, renameWidth)) {
+                        ++stats.perThreadPregFullEvents[i];
+                        break;
+                    }
+                }
             }
         }
 
@@ -431,6 +475,8 @@ Rename::tick()
             blocked_tid = i;
         }
     }
+    if (regFullThisCycle)
+        stats.stallEvents[RegFull]++;
     const ThreadID tid = active_arbiter.selected();
 
     if (tid == InvalidThreadID) {
@@ -562,6 +608,33 @@ Rename::canRename(ThreadID tid)
     return true;
 }
 
+bool
+Rename::hasPregDemand(ThreadID tid) const
+{
+    for (const auto &inst : fixedbuffer[tid]) {
+        if (inst->isSquashed()) {
+            continue;
+        }
+        for (int j = 0; j < RMiscRegClass + 1; j++) {
+            if (inst->numDestRegs((RegClassType)j) > 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool
+Rename::hasBackendQuotaFullStall(ThreadID tid)
+{
+    switch (checkRenameStallFromIEW(tid)) {
+      case StallReason::ROBFull:
+        return true;
+      default:
+        return false;
+    }
+}
+
 void
 Rename::renameInsts(ThreadID tid)
 {
@@ -642,8 +715,17 @@ Rename::renameInsts(ThreadID tid)
             if (breakRename == StallReason::NoStall) {
                 breakRename = StallReason::RegFull;
                 ++stats.fullRegistersEvents[tid];
-                stats.stallEvents[RegFull]++;
-                // stats.smtStallEvents[RegFull].sample(tid);
+                if (!regFullThisCycle) {
+                    stats.stallEvents[RegFull]++;
+                    regFullThisCycle = true;
+                }
+                for (int rc = 0; rc <= RMiscRegClass; rc++) {
+                    if (freeList->isPerThreadExhausted(
+                            (RegClassType)rc, tid, renameWidth)) {
+                        ++stats.perThreadPregFullEvents[tid];
+                        break;
+                    }
+                }
             }
         }
         blockReason = breakRename;
@@ -749,7 +831,7 @@ Rename::updateActivate()
 }
 
 void
-Rename::tryFreePReg(PhysRegIdPtr preg)
+Rename::tryFreePReg(PhysRegIdPtr preg, ThreadID tid)
 {
     const auto preg_idx = preg->flatIndex();
     if (preg->getRef() == 0 || preg->classValue() == InvalidRegClass) {
@@ -761,7 +843,7 @@ Rename::tryFreePReg(PhysRegIdPtr preg)
         // Put the renamed physical register back on the free list.
         DPRINTF(Rename, "Really free up p%i on squash with ref=%i\n", preg_idx,
                 preg->getRef());
-        freeList->addReg(preg);
+        freeList->addReg(preg, tid);
     } else {
         DPRINTF(Rename, "Not to free up p%i on squash for ref=%i\n",
                 preg->flatIndex(), preg->getRef());
@@ -802,7 +884,7 @@ Rename::doSquash(const InstSeqNum &squashed_seq_num, ThreadID tid)
             // previous physical register that it was renamed to.
             renameMap[tid]->setEntry(hb_it->archReg, hb_it->prevPhysReg);
             if (hb_it->newPhysReg.PhyReg() != hb_it->prevPhysReg.PhyReg()) {
-                tryFreePReg(hb_it->newPhysReg.PhyReg());
+                tryFreePReg(hb_it->newPhysReg.PhyReg(), tid);
             }
         }
 
@@ -925,7 +1007,7 @@ Rename::removeFromHistory(InstSeqNum inst_seq_num, ThreadID tid)
         // can be recognized because the new mapping is the same as
         // the old one.
         if (hb_it->newPhysReg.PhyReg() != hb_it->prevPhysReg.PhyReg()) {
-            tryFreePReg(hb_it->prevPhysReg.PhyReg());
+            tryFreePReg(hb_it->prevPhysReg.PhyReg(), tid);
         }
 
         ++stats.committedMaps;

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -394,11 +394,11 @@ Rename::tick()
         bool backendQuotaFull = pregBackendBackpressureDonorEnabled &&
                                  hasBackendQuotaFullStall(i);
         if (backendQuotaFull) {
-            pregBackendDonorCycles[i] = pregBackendBackpressureDonorHoldCycles;
-        } else if (pregBackendDonorCycles[i] > 0) {
-            --pregBackendDonorCycles[i];
+            pregBackendDonorHoldRemaining[i] = pregBackendBackpressureDonorHoldCycles;
+        } else if (pregBackendDonorHoldRemaining[i] > 0) {
+            --pregBackendDonorHoldRemaining[i];
         }
-        bool backendBackpressureDonor = pregBackendDonorCycles[i] > 0;
+        bool backendBackpressureDonor = backendQuotaFull || pregBackendDonorHoldRemaining[i] > 0;
         bool isDonor = !hasPregDemand(i) || backendBackpressureDonor;
         freeList->setBorrowingDonor(i, isDonor);
         if (isDonor)
@@ -629,6 +629,9 @@ Rename::hasBackendQuotaFullStall(ThreadID tid)
 {
     switch (checkRenameStallFromIEW(tid)) {
       case StallReason::ROBFull:
+      case StallReason::MemDQBandwidth:
+      case StallReason::IntDQBandwidth:
+      case StallReason::FVDQBandwidth:
         return true;
       default:
         return false;

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -224,6 +224,19 @@ class Rename
     /** Checks if the rename map can rename all the given number of instructions this cycle. */
     bool canRename(ThreadID tid);
 
+    /** Whether any non-squashed, buffered instruction for this thread still
+     *  needs a new physical register this cycle. Used to decide whether the
+     *  thread is a Preg SMT-DynamicBorrowing donor candidate (see
+     *  UnifiedFreeList::setBorrowingDonor()). */
+    bool hasPregDemand(ThreadID tid) const;
+
+    /** Whether this thread is currently stalled on a per-thread backend
+     *  queue running out of quota (ROB full, or dispatch-queue bandwidth
+     *  full) -- i.e. a resource other than Preg itself. Deliberately
+     *  excludes RegFull, since that IS Preg being the bottleneck. Used as
+     *  an additional Preg donor trigger alongside hasPregDemand(). */
+    bool hasBackendQuotaFullStall(ThreadID tid);
+
     void releasePhysRegs();
 
     /** Separates instructions from decode into individual lists of instructions
@@ -282,6 +295,11 @@ class Rename
 
     InstSeqNum releaseSeq[MaxThreads] = {};
 
+    /** Hold-cycle countdown for the backend-backpressure-triggered Preg
+     *  donor marking (see hasBackendQuotaFullStall()/smtPregBackendBackpressureDonor). */
+    unsigned pregBackendDonorCycles[MaxThreads] = {};
+
+    void tryFreePReg(PhysRegIdPtr phys_reg, ThreadID tid);
     /** RAT checkpoint records, per thread: sequence numbers of in-flight
      *  control-flow instructions that currently own a checkpoint. Newest at
      *  front, oldest at back (strictly descending by sequence number). */
@@ -315,8 +333,6 @@ class Rename
     void squashSnapshot(InstSeqNum squash_seq_num, ThreadID tid);
     /** Whether the instruction may carry a checkpoint. */
     bool suitableForRatSnapshot(const DynInstPtr &inst);
-
-    void tryFreePReg(PhysRegIdPtr phys_reg);
 
     /** Pointer to CPU. */
     CPU *cpu;
@@ -398,6 +414,15 @@ class Rename
     /** The number of threads active in rename. */
     ThreadID numThreads;
 
+    /** Whether a thread stalled on ROB/dispatch-queue-bandwidth backpressure
+     *  (a resource other than Preg itself) should also be treated as a Preg
+     *  borrowing donor. When false, only hasPregDemand() drives donor status. */
+    const bool pregBackendBackpressureDonorEnabled;
+
+    /** Cycles to keep a backend-backpressure-triggered Preg donor marking
+     *  held after the triggering condition clears. */
+    const unsigned pregBackendBackpressureDonorHoldCycles;
+
     /** Enum to record the source of a structure full stall.  Can come from
      * either ROB, IQ, LSQ, and it is priortized in that order.
      */
@@ -455,6 +480,9 @@ class Rename
         /** Stat for total number of times that rename runs out of free
          *  registers to use to rename. */
         statistics::Vector fullRegistersEvents;
+        /** Stat for per-thread Preg exhaustion: thread hits its quota limit
+         *  (Partitioned/DynamicBorrowing) while global free list still has regs. */
+        statistics::Vector perThreadPregFullEvents;
         /** Stat for total number of renamed destination registers. */
         statistics::Scalar renamedOperands;
         /** Stat for total number of source register rename lookups. */
@@ -482,6 +510,10 @@ class Rename
 
         statistics::VectorDistribution smtStallEvents;
 
+        /** Per-thread cycles where the thread was a Preg borrowing donor. */
+        statistics::Vector pregDonorCycles;
+        /** Per-thread cycles where ROB-full backpressure triggered donor. */
+        statistics::Vector pregBackendDonorCycles;
         statistics::Scalar assignedRatSnapshot;
         statistics::Scalar committedRatSnapshot;
         statistics::Scalar squashedRatSnapshot;
@@ -492,6 +524,10 @@ class Rename
     std::vector<StallReason> renameStalls;
 
     StallReason blockReason{NoStall};
+
+    /** Set within tick() when any thread stalls on RegFull this cycle;
+     *  used to avoid double-incrementing stallEvents[RegFull]. */
+    bool regFullThisCycle{false};
 
     void setAllStalls(StallReason renameStall);
 

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -297,7 +297,7 @@ class Rename
 
     /** Hold-cycle countdown for the backend-backpressure-triggered Preg
      *  donor marking (see hasBackendQuotaFullStall()/smtPregBackendBackpressureDonor). */
-    unsigned pregBackendDonorCycles[MaxThreads] = {};
+    unsigned pregBackendDonorHoldRemaining[MaxThreads] = {};
 
     void tryFreePReg(PhysRegIdPtr phys_reg, ThreadID tid);
     /** RAT checkpoint records, per thread: sequence numbers of in-flight

--- a/src/cpu/o3/rename_map.cc
+++ b/src/cpu/o3/rename_map.cc
@@ -54,19 +54,23 @@ namespace gem5
 namespace o3
 {
 
-SimpleRenameMap::SimpleRenameMap() : freeList(NULL)
+SimpleRenameMap::SimpleRenameMap()
+    : freeList(NULL), regClass(InvalidRegClass), tid(InvalidThreadID)
 {
 }
 
 
 void
-SimpleRenameMap::init(const RegClass &reg_class, SimpleFreeList *_freeList)
+SimpleRenameMap::init(const RegClass &reg_class, RegClassType reg_class_type,
+                       UnifiedFreeList *_freeList, ThreadID _tid)
 {
     assert(freeList == NULL);
     assert(map.empty());
 
     map.resize(reg_class.numRegs());
     freeList = _freeList;
+    regClass = reg_class_type;
+    tid = _tid;
 }
 
 SimpleRenameMap::RenameInfo
@@ -107,7 +111,12 @@ SimpleRenameMap::rename(const RegId &arch_reg, const VirtRegId& bypass_reg)
         renamed_reg = prev_reg;
         renamed_reg.PhyReg()->decrNumPinnedWrites();
     } else {
-        renamed_reg.setPhyReg(freeList->getReg());
+        if (!freeList->canAllocate(regClass, tid)) {
+            panic("SimpleRenameMap::rename: [tid:%i] no free %s register "
+                  "available; should have been blocked by canRename() "
+                  "upstream", tid, RegId(regClass, 0).className());
+        }
+        renamed_reg.setPhyReg(freeList->getReg(regClass, tid));
         DPRINTF(Scoreboard, "Get free reg p%i\n", renamed_reg.PhyReg()->flatIndex());
         map[arch_reg.index()] = renamed_reg;
         renamed_reg.PhyReg()->setNumPinnedWrites(arch_reg.getNumPinnedWrites());
@@ -130,12 +139,12 @@ SimpleRenameMap::rename(const RegId &arch_reg, const VirtRegId& bypass_reg)
 
 void
 UnifiedRenameMap::init(const BaseISA::RegClasses &regClasses,
-        PhysRegFile *_regFile, UnifiedFreeList *freeList)
+        PhysRegFile *_regFile, UnifiedFreeList *freeList, ThreadID tid)
 {
     regFile = _regFile;
 
     for (int i = 0; i < renameMaps.size(); i++)
-        renameMaps[i].init(regClasses.at(i), &(freeList->freeLists[i]));
+        renameMaps[i].init(regClasses.at(i), (RegClassType)i, freeList, tid);
 }
 
 bool

--- a/src/cpu/o3/rename_map.hh
+++ b/src/cpu/o3/rename_map.hh
@@ -81,9 +81,17 @@ class SimpleRenameMap
 
     /**
      * Pointer to the free list from which new physical registers
-     * should be allocated in rename()
+     * should be allocated in rename(). A UnifiedFreeList* (rather than
+     * just the class-specific SimpleFreeList*) so that allocation can go
+     * through the SMT-partition-aware canAllocate()/getReg(type, tid).
      */
-    SimpleFreeList *freeList;
+    UnifiedFreeList *freeList;
+
+    /** Which register class this map is responsible for. */
+    RegClassType regClass;
+
+    /** Which thread this map belongs to. */
+    ThreadID tid;
 
   public:
 
@@ -94,7 +102,8 @@ class SimpleRenameMap
      * it's awkward to initialize this object via the constructor.
      * Instead, this method is used for initialization.
      */
-    void init(const RegClass &reg_class, SimpleFreeList *_freeList);
+    void init(const RegClass &reg_class, RegClassType reg_class_type,
+              UnifiedFreeList *_freeList, ThreadID _tid);
 
     /**
      * Pair of a physical register and a physical register.  Used to
@@ -138,8 +147,9 @@ class SimpleRenameMap
         map[arch_reg.index()] = phys_reg;
     }
 
-    /** Return the number of free entries on the associated free list. */
-    unsigned numFreeEntries() const { return freeList->numFreeRegs(); }
+    /** Return the number of registers of this class this thread may
+     *  allocate right now under the configured smtPregPolicy. */
+    unsigned numFreeEntries() const { return freeList->numAllocatable(regClass, tid); }
 
     size_t numArchRegs() const { return map.size(); }
 
@@ -192,7 +202,7 @@ class UnifiedRenameMap
 
     /** Initializes rename map with given parameters. */
     void init(const BaseISA::RegClasses &regClasses,
-              PhysRegFile *_regFile, UnifiedFreeList *freeList);
+              PhysRegFile *_regFile, UnifiedFreeList *freeList, ThreadID tid);
 
     /**
      * Tell rename map to get a new free physical register to remap

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -215,6 +215,7 @@ class ROB
 
     /** Returns whether the thread may borrow unused ROB capacity. */
     void setBorrowingDonor(ThreadID tid, bool donor, Commit* commit);
+    bool isBorrowingDonor(ThreadID tid) const { return borrowingDonor[tid]; }
 
     /** add cycle count for borrowing state holding cycle stats */
     void addBorrowingStateHoldCycle();


### PR DESCRIPTION
## Motivation

Under SMT, the default Dynamic Preg policy allows one thread to monopolize all physical registers (IntReg=224, FloatReg=192, VecReg=192) in the unified free list, starving the sibling thread. When a thread encounters heavy branch mispredictions or long-latency operations, its in-flight instructions hold physical registers indefinitely, blocking the other thread from renaming new instructions — causing extreme IPC imbalance (up to 172:1 in gcc_expr2 workloads).

Meanwhile, the Partitioned policy guarantees fairness but sacrifices ~2.7% overall throughput by preventing one thread from utilizing idle registers when the other thread has no demand.

## Approach

Introduce a **DynamicBorrowing** policy for SMT physical register allocation that dynamically adjusts per-thread register limits based on sibling thread activity. The core idea: when the sibling is idle (donor), allow borrowing most of its registers; when the sibling is active, protect its fair share.

**Donor determination** (per-cycle, before any thread renames):

```
isDonor(tid) = !hasPregDemand(tid) || backendBackpressureDonor(tid)
```

- `hasPregDemand`: checks fixedbuffer for non-squashed instructions needing dest registers
- `backendBackpressureDonor`: thread stalled on ROB-full (not Preg-full), with hold-cycle hysteresis to avoid frequent toggling

**Admission check** — per register type (Int/Float/Vec) independently:

```
borrowingLimit(type, tid):
    reserved = 0
    for other in all_threads:
        if other == tid: continue
        reserve = donor[other] ? donorQuota(type) : base(type)
        reserved += max(threadUsed[other][type], reserve)
    return max(numPhysRegs[type] - reserved, 0)

canAllocate(type, tid, n):
    return threadUsed[tid][type] + n <= borrowingLimit(type, tid)
```

Where:
- `base(type)` = `fixedBase > 0 ? min(fixedBase, numPhysRegs[type]/2) : numPhysRegs[type]/2`
- `donorQuota(type)` = `min(donorReserveRegs, base(type))`

**Key properties**:
- Default `smtPregPolicy` is `Dynamic`, which preserves the original full-share behavior with zero performance difference — existing configurations are unaffected
- `donorReserveRegs=0` → degenerates to Dynamic (no limit)
- `donorReserveRegs=numPhysRegs/2` → degenerates to Partitioned
- Donor state is determined uniformly for ALL threads before any renaming begins, preventing order-dependent behavior
- The `fixedBase` parameter enables a Watermark variant (both donor and non-donor use fixed thresholds)

## Environment

- **Branch**: `xs-dev`
- **Base commit**: `6d3120361e` (mem: fix bug of vsq (#1019))
- **Config**: SMT-2, KMHV3 scheduler, StoreQueueMultiple=1
- **Test**: SPEC06 INT, 12 workloads, 684 SimPoint checkpoints

## Results

| Config | score/GHz | vs Dynamic |
|--------|-----------|------------|
| Dynamic (baseline) | 23.799 | — |
| **DynamicBorrowing r=48** | **23.940** | **+0.59%** |
| DynamicBorrowing r=64 | 23.905 | +0.44% |
| Watermark d64_b64 | 23.834 | +0.15% |
| Partitioned | 23.161 | -2.68% |

Per-workload highlights (DynBorrow r=48):
- **mcf**: +1.95%
- **gcc**: +1.30%
- **sjeng**: +0.82%
- **omnetpp**: +0.68%

All 12 INT workloads show positive or neutral improvement with r=48. The sweet spot for donorReserveRegs is 48~64.

## Changes

8 files changed, +447 -47:
- `src/cpu/o3/BaseO3CPU.py` — add `smtPregPolicy` (default: `Dynamic`, preserving original full-share behavior), `smtPregFixedBase`, `smtPregBorrowDonorReserveRegs`, `smtPregBackendBackpressureDonor`, `smtPregBackendBackpressureDonorHoldCycles` parameters
- `src/cpu/o3/free_list.hh` — add DynamicBorrowing members (`pregPolicy`, `donor[]`, `threadUsed[][]`, `numPhysRegs[]`), public API (`canAllocate`, `borrowingLimit`, `setBorrowingDonor`, `isPerThreadExhausted`)
- `src/cpu/o3/free_list.cc` — implement `borrowingLimit()`, `canAllocate()`, `base()`, `donorQuota()`, allocation/free tracking per thread per type
- `src/cpu/o3/rename.hh` — add donor determination members (`pregBackendDonorCycles[]`, `hasPregDemand()`, `hasBackendQuotaFullStall()`)
- `src/cpu/o3/rename.cc` — per-cycle donor determination logic, DynamicBorrowing stall integration, stall reason reporting
- `src/cpu/o3/rename_map.hh` — extend `canRename()` to accept `ThreadID` for per-thread quota check
- `src/cpu/o3/rename_map.cc` — forward `canRename(tid)` to `freeList->canAllocate(type, tid)`
- `src/cpu/o3/cpu.cc` — pass Preg policy parameters from SimObject to FreeList/Rename


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable physical-register sharing for simultaneous multithreading (SMT).
  * Supports fixed per-thread quotas, fair-share donor reserves, and policy-based allocation.
  * Threads can temporarily borrow available registers when backend pressure limits another thread.
  * Added controls for donor classification and configurable donor-status hold duration during backpressure.
  * Register allocation now adapts to active threads and tracks per-thread capacity.

* **Monitoring**
  * Added tracking for per-thread register exhaustion, register-full stalls, and donor activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->