### PR TITLE
mem: set L2 pfq num as 128

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -527,7 +527,7 @@ def _configure_l2_wrapper_prefetcher(prefetcher, prefetcher_name, options,
         _configure_l2_composite(prefetcher, prefetcher_name, options)
         _set_pf_buffer_training_policy(prefetcher, pf_buffer_enabled)
         if options.l1_to_l2_pf_hint:
-            prefetcher.queue_size = 32
+            prefetcher.queue_size = 128
             prefetcher.max_prefetch_requests_with_pending_translation = 128
 
 def _configure_l3_prefetcher(prefetcher, options):


### PR DESCRIPTION
In RTL, each slice of L2 cache has a independent prefetch queue(pfq) which has 32 entries. So the total size is 4 slice * 32 = 128.

To align with that, set L2 pfq as 128 entries

Change-Id: I8597635bc7032d979ed2b89f7c218419d300e033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the prefetch queue capacity for aligned L2 configurations when L1-to-L2 prefetch hints are enabled, improving handling of queued prefetch requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->