### PR TITLE
Smt counters accuracy fix

### DIFF
--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -549,6 +549,8 @@ IEW::takeOverFrom()
 void
 IEW::squash(ThreadID tid)
 {
+    recordThreadSquash(tid);
+
     DPRINTF(IEW, "[tid:%i] Squashing all instructions.\n", tid);
 
     for (auto& dp : dispQue) {
@@ -580,6 +582,8 @@ IEW::squash(ThreadID tid)
 void
 IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
 {
+    recordThreadSquash(tid);
+
     DPRINTF(IEW, "[tid:%i] [sn:%llu] Squashing from a specific instruction,"
             " PC: %s "
             "\n", tid, inst->seqNum, inst->pcState() );
@@ -614,6 +618,8 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
 void
 IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
 {
+    recordThreadSquash(tid);
+
     DPRINTF(IEW, "[tid:%i] Memory violation, squashing violator and younger "
             "insts, PC: %s [sn:%llu].\n", tid, inst->pcState(), inst->seqNum);
     // Need to include inst->seqNum in the following comparison to cover the
@@ -651,6 +657,8 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
 void
 IEW::squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid)
 {
+    recordThreadSquash(tid);
+
     DPRINTF(IEW, "[tid:%i] value prediction error, squashing violator and younger "
             "insts, PC: %s [sn:%llu].\n",
             tid, inst->pcState(), inst->seqNum);
@@ -862,6 +870,7 @@ IEW::checkSquash()
         }
 
         if (fromCommit->commitInfo[i].robSquashing) {
+            recordThreadSquash(i);
             DPRINTF(IEW, "[tid:%i] ROB is still squashing.\n", i);
 
             wroteToTimeBuffer = true;
@@ -947,6 +956,50 @@ IEW::setDispatchAgeCtr(const DynInstPtr& inst, int dispatch_pos)
     DPRINTF(IEW, "[tid:%i] [sn:%llu] ageCtr=%llu at dispatch pos %d.\n",
             inst->threadNumber, inst->seqNum,
             static_cast<unsigned long long>(inst->ageCtr), dispatch_pos);
+}
+
+bool
+IEW::threadHasStageWork(ThreadID tid)
+{
+    if (!fixedbuffer[tid].empty() || scheduler->getIQInsts(tid) != 0 ||
+        ldstQueue.getCount(tid) != 0) {
+        return true;
+    }
+
+    for (const auto &queue : dispQue) {
+        for (const auto &inst : queue) {
+            if (inst->threadNumber == tid) {
+                return true;
+            }
+        }
+    }
+
+    for (int i = 0; i < fromIssue->size; ++i) {
+        if (fromIssue->insts[i] && fromIssue->insts[i]->threadNumber == tid) {
+            return true;
+        }
+    }
+
+    for (int i = 0; i < MaxWidth; ++i) {
+        if (toCommit->insts[i] && toCommit->insts[i]->threadNumber == tid) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void
+IEW::recordThreadWork(ThreadID tid)
+{
+    cycleThreadWork[tid] = true;
+}
+
+void
+IEW::recordThreadSquash(ThreadID tid)
+{
+    cycleThreadSquash[tid] = true;
+    recordThreadWork(tid);
 }
 
 void
@@ -1858,6 +1911,8 @@ IEW::tick()
 
     wroteToTimeBuffer = false;
     updatedQueues = false;
+    cycleThreadWork.fill(false);
+    cycleThreadSquash.fill(false);
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         toFetch->iewInfo[tid].redirectPending = false;
         toFetch->iewInfo[tid].resolvedCFIs.clear();
@@ -1869,32 +1924,12 @@ IEW::tick()
     // dispatch
     moveInstsToBuffer();
 
-    std::vector<bool> had_thread_work(numThreads, false);
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        had_thread_work[tid] = !fixedbuffer[tid].empty() ||
-            scheduler->getIQInsts(tid) != 0 || ldstQueue.getCount(tid) != 0;
-    }
-    for (const auto &queue : dispQue) {
-        for (const auto &inst : queue) {
-            had_thread_work[inst->threadNumber] = true;
-        }
+        cycleThreadWork[tid] = threadHasStageWork(tid);
     }
 
     checkSquash();
     dispatchInsts();
-
-    // Classify every thread once per cycle, with squash taking precedence.
-    for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        const bool squashing = fromCommit->commitInfo[tid].squash ||
-            fromCommit->commitInfo[tid].robSquashing;
-        if (squashing) {
-            ++iewStats.squashCycles[tid];
-        } else if (stallSig->blockRename[tid]) {
-            ++iewStats.blockCycles[tid];
-        } else if (!had_thread_work[tid]) {
-            ++iewStats.idleCycles[tid];
-        }
-    }
 
     for (int i = 0;i < dispatchStalls.size();i++) {
         iewStats.dispatchStallReason[dispatchStalls[i]]++;
@@ -1936,6 +1971,7 @@ IEW::tick()
         if (fromCommit->commitInfo[tid].doneMemSeqNum != 0 &&
             !fromCommit->commitInfo[tid].squash &&
             !fromCommit->commitInfo[tid].robSquashing) {
+            recordThreadWork(tid);
 
             // Marks some of the entries in the store queue as canWB and
             // they will be moved to the store buffer when appropriate.
@@ -1947,6 +1983,7 @@ IEW::tick()
         if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&
             !fromCommit->commitInfo[tid].squash &&
             !fromCommit->commitInfo[tid].robSquashing) {
+            recordThreadWork(tid);
 
             ldstQueue.commitLoads(fromCommit->commitInfo[tid].doneSeqNum,tid);
             updateLSQNextCycle = true;
@@ -1955,6 +1992,7 @@ IEW::tick()
         }
 
         if (fromCommit->commitInfo[tid].nonSpecSeqNum != 0) {
+            recordThreadWork(tid);
 
             //DPRINTF(IEW,"NonspecInst from thread %i",tid);
             if (fromCommit->commitInfo[tid].strictlyOrdered) {
@@ -1969,6 +2007,20 @@ IEW::tick()
 
         if (broadcast_free_entries) {
             wroteToTimeBuffer = true;
+        }
+    }
+
+    // Classify every thread once per cycle, using work and squash observed
+    // across the entire tick rather than only the pre-execute snapshot.
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        cycleThreadWork[tid] = cycleThreadWork[tid] || threadHasStageWork(tid);
+
+        if (cycleThreadSquash[tid]) {
+            ++iewStats.squashCycles[tid];
+        } else if (stallSig->blockRename[tid]) {
+            ++iewStats.blockCycles[tid];
+        } else if (!cycleThreadWork[tid]) {
+            ++iewStats.idleCycles[tid];
         }
     }
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -159,11 +159,11 @@ IEW::regProbePoints()
 IEW::IEWStats::IEWStats(CPU *cpu)
     : statistics::Group(cpu, "iew"),
     ADD_STAT(idleCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is idle"),
+             "Number of cycles IEW is idle per thread"),
     ADD_STAT(squashCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is squashing"),
+             "Number of cycles IEW is squashing per thread"),
     ADD_STAT(blockCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is blocking"),
+             "Number of cycles IEW is blocking per thread"),
     ADD_STAT(unblockCycles, statistics::units::Cycle::get(),
              "Number of cycles IEW is unblocking"),
     ADD_STAT(dispatchedInsts, statistics::units::Count::get(),
@@ -219,6 +219,18 @@ IEW::IEWStats::IEWStats(CPU *cpu)
     ADD_STAT(dispatchStallReason, statistics::units::Count::get(),
              "Number of dispatch stall reasons each tick (Total)")
 {
+    idleCycles
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
+    squashCycles
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
+    blockCycles
+        .init(cpu->numThreads)
+        .flags(statistics::total);
+
     instsToCommit
         .init(cpu->numThreads)
         .flags(statistics::total);
@@ -1856,8 +1868,33 @@ IEW::tick()
 
     // dispatch
     moveInstsToBuffer();
+
+    std::vector<bool> had_thread_work(numThreads, false);
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        had_thread_work[tid] = !fixedbuffer[tid].empty() ||
+            scheduler->getIQInsts(tid) != 0 || ldstQueue.getCount(tid) != 0;
+    }
+    for (const auto &queue : dispQue) {
+        for (const auto &inst : queue) {
+            had_thread_work[inst->threadNumber] = true;
+        }
+    }
+
     checkSquash();
     dispatchInsts();
+
+    // Classify every thread once per cycle, with squash taking precedence.
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        const bool squashing = fromCommit->commitInfo[tid].squash ||
+            fromCommit->commitInfo[tid].robSquashing;
+        if (squashing) {
+            ++iewStats.squashCycles[tid];
+        } else if (stallSig->blockRename[tid]) {
+            ++iewStats.blockCycles[tid];
+        } else if (!had_thread_work[tid]) {
+            ++iewStats.idleCycles[tid];
+        }
+    }
 
     for (int i = 0;i < dispatchStalls.size();i++) {
         iewStats.dispatchStallReason[dispatchStalls[i]]++;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -498,12 +498,12 @@ class IEW
     {
         IEWStats(CPU *cpu);
 
-        /** Stat for total number of idle cycles. */
-        statistics::Scalar idleCycles;
-        /** Stat for total number of squashing cycles. */
-        statistics::Scalar squashCycles;
-        /** Stat for total number of blocking cycles. */
-        statistics::Scalar blockCycles;
+        /** Stat for number of idle cycles per thread. */
+        statistics::Vector idleCycles;
+        /** Stat for number of squashing cycles per thread. */
+        statistics::Vector squashCycles;
+        /** Stat for number of blocking cycles per thread. */
+        statistics::Vector blockCycles;
         /** Stat for total number of unblocking cycles. */
         statistics::Scalar unblockCycles;
         /** Stat for total number of instructions dispatched. */

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -41,6 +41,7 @@
 #ifndef __CPU_O3_IEW_HH__
 #define __CPU_O3_IEW_HH__
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -359,6 +360,15 @@ class IEW
     /** Sorts instructions coming from rename into lists separated by thread. */
     void moveInstsToBuffer();
 
+    /** Returns whether a thread has pending or in-flight IEW work. */
+    bool threadHasStageWork(ThreadID tid);
+
+    /** Marks that IEW observed real work for the thread this cycle. */
+    void recordThreadWork(ThreadID tid);
+
+    /** Marks that IEW observed squashing for the thread this cycle. */
+    void recordThreadSquash(ThreadID tid);
+
   public:
     /** Ticks IEW stage, causing Dispatch, the IQ, the LSQ, Execute, and
      * Writeback to run for one cycle.
@@ -451,6 +461,12 @@ class IEW
   private:
     /** Records if there is a fetch redirect on this cycle for each thread. */
     bool fetchRedirect[MaxThreads];
+
+    /** Per-thread work observed during the current IEW tick. */
+    std::array<bool, MaxThreads> cycleThreadWork{};
+
+    /** Per-thread squash observed during the current IEW tick. */
+    std::array<bool, MaxThreads> cycleThreadSquash{};
 
     /** Records if the queues have been changed (inserted or issued insts),
      * so that IEW knows to broadcast the updated amount of free entries.

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -382,7 +382,7 @@ LSQ::StoreBuffer::release(StoreBufferEntry *entry)
     }
 }
 
-LSQ::LSQStats::LSQStats(statistics::Group *parent)
+LSQ::LSQStats::LSQStats(statistics::Group *parent, unsigned num_threads)
     : statistics::Group(parent),
       ADD_STAT(lqAvgEntryNum, statistics::units::Count::get(),
                "Average number of entries in load queue"),
@@ -391,11 +391,14 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
       ADD_STAT(sbufferAvgEntryNum, statistics::units::Count::get(),
                "Average number of valid entries in store buffer"),
       ADD_STAT(lqFullCycles, statistics::units::Cycle::get(),
-               "Cycles that LQ cannot accept a full enqueue bundle"),
+               "Per-thread cycles that LQ cannot accept a full enqueue "
+               "bundle"),
       ADD_STAT(sqFullCycles, statistics::units::Cycle::get(),
-               "Cycles that SQ cannot accept a full enqueue bundle"),
+               "Per-thread cycles that SQ cannot accept a full enqueue "
+               "bundle"),
       ADD_STAT(lsqFullCycles, statistics::units::Cycle::get(),
-               "Cycles that LSQ cannot accept a full enqueue bundle"),
+               "Per-thread cycles that LSQ cannot accept a full enqueue "
+               "bundle"),
       ADD_STAT(sbufferFullCycles, statistics::units::Cycle::get(),
                "Number of cycles that store buffer is physically full"),
       ADD_STAT(sbufferEvictDuetoFlush, statistics::units::Count::get(), ""),
@@ -447,6 +450,15 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent)
                statistics::units::Count::get(),
                "Number of store buffer requests that miss and exit fake dcache mainpipe at S2")
 {
+    lqFullCycles.init(num_threads);
+    sqFullCycles.init(num_threads);
+    lsqFullCycles.init(num_threads);
+    for (ThreadID tid = 0; tid < num_threads; ++tid) {
+        const std::string thread_name = csprintf("thread%d", tid);
+        lqFullCycles.subname(tid, thread_name);
+        sqFullCycles.subname(tid, thread_name);
+        lsqFullCycles.subname(tid, thread_name);
+    }
 }
 
 LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
@@ -483,7 +495,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       lsqMode(params.smtLSQMode),
       lsqPolicy(params.smtLSQPolicy),
       smtLSQThreshold(params.smtLSQThreshold),
-      stats(nullptr),
+      stats(nullptr, params.numThreads),
       LQEntries(params.LQEntries),
       physicalSQEntries(params.SQEntries),
       storeQueueMultiple(params.StoreQueueMultiple),
@@ -687,18 +699,23 @@ LSQ::tick()
     std::list<ThreadID>::iterator end = activeThreads->end();
     unsigned lq_entry_num = 0;
     unsigned sq_entry_num = 0;
-    bool lq_full = false;
-    bool sq_full = false;
-
     while (threads != end) {
         ThreadID tid = *threads++;
         lq_entry_num += thread[tid].numLoads();
         sq_entry_num += thread[tid].numStores();
-        // TODO: this per-thread OR is an approximation for SMT/shared-LSQ
-        // configurations. With multiple active threads it may not match the
-        // aggregate free-entry condition seen by rename/dispatch.
-        lq_full = lq_full || thread[tid].numFreeLoadEntries() < enqueueWidth;
-        sq_full = sq_full || thread[tid].numFreeStoreEntries() < enqueueWidth;
+        const bool thread_lq_full =
+            logicalFreeLoadEntries(tid) < enqueueWidth;
+        const bool thread_sq_full =
+            logicalFreeStoreEntries(tid) < enqueueWidth;
+        if (thread_lq_full) {
+            ++stats.lqFullCycles[tid];
+        }
+        if (thread_sq_full) {
+            ++stats.sqFullCycles[tid];
+        }
+        if (thread_lq_full || thread_sq_full) {
+            ++stats.lsqFullCycles[tid];
+        }
         thread[tid].tick();
     }
 
@@ -712,16 +729,6 @@ LSQ::tick()
     stats.sbufferAvgEntryNum = storeBuffer.size();
     if (storeBuffer.full()) {
         ++stats.sbufferFullCycles;
-    }
-
-    if (lq_full) {
-        ++stats.lqFullCycles;
-    }
-    if (sq_full) {
-        ++stats.sqFullCycles;
-    }
-    if (lq_full || sq_full) {
-        ++stats.lsqFullCycles;
     }
 
 }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -400,7 +400,7 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent, unsigned num_threads)
                "Per-thread cycles that LSQ cannot accept a full enqueue "
                "bundle"),
       ADD_STAT(sbufferFullCycles, statistics::units::Cycle::get(),
-               "Number of cycles that store buffer is physically full"),
+               "Per-thread cycles that store buffer cannot accept an entry"),
       ADD_STAT(sbufferEvictDuetoFlush, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferEvictDuetoFull, statistics::units::Count::get(), ""),
       ADD_STAT(sbufferEvictDuetoSQFull, statistics::units::Count::get(), ""),
@@ -453,11 +453,13 @@ LSQ::LSQStats::LSQStats(statistics::Group *parent, unsigned num_threads)
     lqFullCycles.init(num_threads);
     sqFullCycles.init(num_threads);
     lsqFullCycles.init(num_threads);
+    sbufferFullCycles.init(num_threads);
     for (ThreadID tid = 0; tid < num_threads; ++tid) {
         const std::string thread_name = csprintf("thread%d", tid);
         lqFullCycles.subname(tid, thread_name);
         sqFullCycles.subname(tid, thread_name);
         lsqFullCycles.subname(tid, thread_name);
+        sbufferFullCycles.subname(tid, thread_name);
     }
 }
 
@@ -727,8 +729,10 @@ LSQ::tick()
 
     // Sample current store buffer occupancy once per cycle.
     stats.sbufferAvgEntryNum = storeBuffer.size();
-    if (storeBuffer.full()) {
-        ++stats.sbufferFullCycles;
+    for (ThreadID tid : *activeThreads) {
+        if (storeBuffer.full(tid) || storeBuffer.full()) {
+            ++stats.sbufferFullCycles[tid];
+        }
     }
 
 }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1495,16 +1495,16 @@ class LSQ
 
     struct LSQStats : public statistics::Group
     {
-        LSQStats(statistics::Group *parent);
+        LSQStats(statistics::Group *parent, unsigned num_threads);
 
         /** Per-cycle occupancy samples for the aggregated LSQ structures. */
         statistics::Average lqAvgEntryNum;
         statistics::Average sqAvgEntryNum;
         statistics::Average sbufferAvgEntryNum;
-        /** Per-cycle full signals based on whether a full enqueue bundle fits. */
-        statistics::Scalar lqFullCycles;
-        statistics::Scalar sqFullCycles;
-        statistics::Scalar lsqFullCycles;
+        /** Per-thread full signals based on whether an enqueue bundle fits. */
+        statistics::Vector lqFullCycles;
+        statistics::Vector sqFullCycles;
+        statistics::Vector lsqFullCycles;
         statistics::Scalar sbufferFullCycles;
         statistics::Scalar sbufferEvictDuetoFlush;
         statistics::Scalar sbufferEvictDuetoFull;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1505,7 +1505,7 @@ class LSQ
         statistics::Vector lqFullCycles;
         statistics::Vector sqFullCycles;
         statistics::Vector lsqFullCycles;
-        statistics::Scalar sbufferFullCycles;
+        statistics::Vector sbufferFullCycles;
         statistics::Scalar sbufferEvictDuetoFlush;
         statistics::Scalar sbufferEvictDuetoFull;
         statistics::Scalar sbufferEvictDuetoSQFull;


### PR DESCRIPTION
Fix the accuracy of the following counters and their display when divided by two threads:
lsq.lqFullCycles, lsq.sqFullCycles, lsq.lsqFullCycles, lsq.sbufferFullCycles, lsq.lqAvgEntryNum, lsq.sqAvgEntryNum, and
lsq.sbufferAvgEntryNum. Also fix issues with iew.idleCycles, iew.squashCycles, iew.blockCycles, and iew.unblockCycles, whose counters do not increment normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-thread CPU pipeline activity tracking, including idle, blocked, and squashed cycles.
  - Added per-thread load/store queue and store-buffer capacity statistics.
  - Improved detection and reporting of thread work, queue fullness, and pipeline squashes.

- **Bug Fixes**
  - Corrected cycle classification and capacity reporting for systems running multiple threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->