### PR TITLE
cpu-o3: Reformat O3 source files

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -105,40 +105,40 @@ Commit::processTrapEvent(ThreadID tid)
 
 Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUParams &params)
     : commitPolicy(params.smtCommitPolicy),
-      stuckCheckEvent([this]() {
-        static std::vector<DynInstPtr> debug_insts;
+      stuckCheckEvent(
+          [this]() {
+              static std::vector<DynInstPtr> debug_insts;
 
-        for (ThreadID tid = 0; tid < numThreads; tid++) {
-            if (cpu->curCycle() - this->lastCommitCycle[tid] > 40000) {
-                if (traceMaybeExitOnPipelineDrainFromStuckCheck()) {
-                    return;
-                }
+              for (ThreadID tid = 0; tid < numThreads; tid++) {
+                  if (cpu->curCycle() - this->lastCommitCycle[tid] > 40000) {
+                      if (traceMaybeExitOnPipelineDrainFromStuckCheck()) {
+                          return;
+                      }
 
-                if (auto inst = rob->readHeadInst(0)) {
-                    warn("can't commit inst %s\n", inst->genDisassembly());
-                    debug_insts.insert(
-                        debug_insts.begin(), rob->getInstList(tid).begin(),
-                        rob->getInstList(tid).end());
-                    warn("dump rob front 10 insts\n");
-                    int i = 0;
-                    for (auto inst = debug_insts.begin();
-                        inst != debug_insts.end() && i < 10; inst++, i++) {
-                        warn("%s\n", (*inst)->genDisassembly());
-                    }
-                } else {
-                    warn("rob was empty, may be fetch or rename stuck\n");
-                }
-                panic(
-                    "Commit stage is stucked for more than 40,000 cycles!\n"
-                    "Thread: %d Last commit cycle: %lu, current cycle: %lu, suggested "
-                    "--debug-start=%llu --debug-end=%llu\n", tid,
-                    lastCommitCycle[tid], cpu->curCycle(),
-                    cpu->cyclesToTicks(Cycles(lastCommitCycle[tid] - 200)),
-                    cpu->cyclesToTicks(Cycles(lastCommitCycle[tid] + 200)));
-            }
-        }
-        cpu->schedule(this->stuckCheckEvent, cpu->clockEdge(Cycles(40010)));
-      }, "CommitStuckCheckEvent"),
+                      if (auto inst = rob->readHeadInst(0)) {
+                          warn("can't commit inst %s\n", inst->genDisassembly());
+                          debug_insts.insert(debug_insts.begin(), rob->getInstList(tid).begin(),
+                                             rob->getInstList(tid).end());
+                          warn("dump rob front 10 insts\n");
+                          int i = 0;
+                          for (auto inst = debug_insts.begin(); inst != debug_insts.end() && i < 10; inst++, i++) {
+                              warn("%s\n", (*inst)->genDisassembly());
+                          }
+                      } else {
+                          warn("rob was empty, may be fetch or rename stuck\n");
+                      }
+                      panic(
+                          "Commit stage is stucked for more than 40,000 cycles!\n"
+                          "Thread: %d Last commit cycle: %lu, current cycle: %lu, suggested "
+                          "--debug-start=%llu --debug-end=%llu\n",
+                          tid, lastCommitCycle[tid], cpu->curCycle(),
+                          cpu->cyclesToTicks(Cycles(lastCommitCycle[tid] - 200)),
+                          cpu->cyclesToTicks(Cycles(lastCommitCycle[tid] + 200)));
+                  }
+              }
+              cpu->schedule(this->stuckCheckEvent, cpu->clockEdge(Cycles(40010)));
+          },
+          "CommitStuckCheckEvent"),
       cpu(_cpu),
       bp(_bp),
       valuePred(params.valuePred),
@@ -159,15 +159,16 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
       archDBer(params.arch_db)
 {
     if (commitWidth > MaxWidth)
-        fatal("commitWidth (%d) is larger than compiled limit (%d),\n"
-             "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
-             commitWidth, static_cast<int>(MaxWidth));
+        fatal(
+            "commitWidth (%d) is larger than compiled limit (%d),\n"
+            "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
+            commitWidth, static_cast<int>(MaxWidth));
 
     _status = Active;
     _nextStatus = Inactive;
 
     if (commitPolicy == CommitPolicy::RoundRobin) {
-        //Set-Up Priority List
+        // Set-Up Priority List
         for (ThreadID tid = 0; tid < numThreads; tid++) {
             priority_list.push_back(tid);
         }
@@ -205,10 +206,9 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
             tempVec.push_back(std::make_pair(it.first, it.second));
         }
         std::sort(tempVec.begin(), tempVec.end(),
-            [](const std::pair<Addr, unsigned> &a,
-               const std::pair<Addr, unsigned> &b) {
-                return a.second > b.second;
-            });
+                  [](const std::pair<Addr, unsigned> &a, const std::pair<Addr, unsigned> &b) {
+                      return a.second > b.second;
+                  });
         for (auto it : tempVec) {
             *out_handle->stream() << std::oct << it.second << " " << std::hex << it.first << std::endl;
         }
@@ -223,108 +223,73 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
     faultNum.insert(RiscvISA::ExceptionCode::LOAD_G_PAGE);
     faultNum.insert(RiscvISA::ExceptionCode::STORE_G_PAGE);
 
-    cpu->schedule(stuckCheckEvent,
-                   cpu->clockEdge(Cycles(40000)));
+    cpu->schedule(stuckCheckEvent, cpu->clockEdge(Cycles(40000)));
 }
 
-std::string Commit::name() const { return cpu->name() + ".commit"; }
+std::string
+Commit::name() const
+{
+    return cpu->name() + ".commit";
+}
 
 void
 Commit::regProbePoints()
 {
-    ppCommit = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "Commit");
-    ppCommitStall = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "CommitStall");
-    ppSquash = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "Squash");
+    ppCommit = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "Commit");
+    ppCommitStall = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "CommitStall");
+    ppSquash = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "Squash");
 }
 
 Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
     : statistics::Group(cpu, "commit"),
-      ADD_STAT(commitSquashedInsts, statistics::units::Count::get(),
-               "The number of squashed insts skipped by commit"),
+      ADD_STAT(commitSquashedInsts, statistics::units::Count::get(), "The number of squashed insts skipped by commit"),
       ADD_STAT(commitNonSpecStalls, statistics::units::Count::get(),
                "The number of times commit has been forced to stall to "
                "communicate backwards"),
       ADD_STAT(recovery_bubble, "Unutilized issue-pipeline slots due to recovery from earlier miss-speculation"),
-      ADD_STAT(branchMispredicts, statistics::units::Count::get(),
-               "The number of times a branch was mispredicted"),
-      ADD_STAT(numCommittedDist, statistics::units::Count::get(),
-               "Number of insts commited each cycle"),
-      ADD_STAT(instsCommitted, statistics::units::Count::get(),
-               "Number of instructions committed"),
-      ADD_STAT(pagefaulttimes, statistics::units::Count::get(),
-               "Number of pagefaulttimes"),
-      ADD_STAT(opsCommitted, statistics::units::Count::get(),
-               "Number of ops (including micro ops) committed"),
-      ADD_STAT(memRefs, statistics::units::Count::get(),
-               "Number of memory references committed"),
+      ADD_STAT(branchMispredicts, statistics::units::Count::get(), "The number of times a branch was mispredicted"),
+      ADD_STAT(numCommittedDist, statistics::units::Count::get(), "Number of insts commited each cycle"),
+      ADD_STAT(instsCommitted, statistics::units::Count::get(), "Number of instructions committed"),
+      ADD_STAT(pagefaulttimes, statistics::units::Count::get(), "Number of pagefaulttimes"),
+      ADD_STAT(opsCommitted, statistics::units::Count::get(), "Number of ops (including micro ops) committed"),
+      ADD_STAT(memRefs, statistics::units::Count::get(), "Number of memory references committed"),
       ADD_STAT(loads, statistics::units::Count::get(), "Number of loads committed"),
-      ADD_STAT(stores, statistics::units::Count::get(),
-               "Number of stores committed"),
-      ADD_STAT(amos, statistics::units::Count::get(),
-               "Number of atomic instructions committed"),
-      ADD_STAT(membars, statistics::units::Count::get(),
-               "Number of memory barriers committed"),
-      ADD_STAT(branches, statistics::units::Count::get(),
-               "Number of branches committed"),
-      ADD_STAT(vectorInstructions, statistics::units::Count::get(),
-               "Number of committed Vector instructions."),
-      ADD_STAT(floating, statistics::units::Count::get(),
-               "Number of committed floating point instructions."),
-      ADD_STAT(integer, statistics::units::Count::get(),
-               "Number of committed integer instructions."),
-      ADD_STAT(functionCalls, statistics::units::Count::get(),
-               "Number of function calls committed."),
-      ADD_STAT(committedInstType, statistics::units::Count::get(),
-               "Class of committed instruction"),
-      ADD_STAT(commitEligibleSamples, statistics::units::Cycle::get(),
-               "number cycles where commit BW limit reached"),
-      ADD_STAT(loadTriple, statistics::units::Cycle::get(),
-               "load trip number"),
+      ADD_STAT(stores, statistics::units::Count::get(), "Number of stores committed"),
+      ADD_STAT(amos, statistics::units::Count::get(), "Number of atomic instructions committed"),
+      ADD_STAT(membars, statistics::units::Count::get(), "Number of memory barriers committed"),
+      ADD_STAT(branches, statistics::units::Count::get(), "Number of branches committed"),
+      ADD_STAT(vectorInstructions, statistics::units::Count::get(), "Number of committed Vector instructions."),
+      ADD_STAT(floating, statistics::units::Count::get(), "Number of committed floating point instructions."),
+      ADD_STAT(integer, statistics::units::Count::get(), "Number of committed integer instructions."),
+      ADD_STAT(functionCalls, statistics::units::Count::get(), "Number of function calls committed."),
+      ADD_STAT(committedInstType, statistics::units::Count::get(), "Class of committed instruction"),
+      ADD_STAT(commitEligibleSamples, statistics::units::Cycle::get(), "number cycles where commit BW limit reached"),
+      ADD_STAT(loadTriple, statistics::units::Cycle::get(), "load trip number"),
       ADD_STAT(loadEAReused, statistics::units::Cycle::get(),
                "Committed loads whose EA equals last committed instance of same static load (PC)"),
-      ADD_STAT(loadsWithProducer, statistics::units::Cycle::get(),
-               "store-load related"),
+      ADD_STAT(loadsWithProducer, statistics::units::Cycle::get(), "store-load related"),
       ADD_STAT(producerStable, statistics::units::Cycle::get(),
                "Loads whose producer store PC equals last time for same static load (PC)"),
-      ADD_STAT(segUnitStrideNF, statistics::units::Count::get(),
-               "Distribution of segment unit stride NF"),
-      ADD_STAT(segStrideNF, statistics::units::Count::get(),
-               "Distribution of segment stride NF"),
-      ADD_STAT(segIndexedNF, statistics::units::Count::get(),
-               "Distribution of segment indexed NF"),
-      ADD_STAT(vectorVma, statistics::units::Count::get(),
-               "Number of vector vma enable"),
-      ADD_STAT(vectorVmu, statistics::units::Count::get(),
-               "Number of vector vmu enable"),
-      ADD_STAT(vectorVta, statistics::units::Count::get(),
-               "Number of vector vta enable"),
-      ADD_STAT(vectorVtu, statistics::units::Count::get(),
-               "Number of vector vtu enable"),
-      ADD_STAT(squashDueToBranch, statistics::units::Count::get(),
-               "Number of squash due to branch"),
-      ADD_STAT(squashDueToOrderViolation, statistics::units::Count::get(),
-               "Number of squash due to order violation"),
+      ADD_STAT(segUnitStrideNF, statistics::units::Count::get(), "Distribution of segment unit stride NF"),
+      ADD_STAT(segStrideNF, statistics::units::Count::get(), "Distribution of segment stride NF"),
+      ADD_STAT(segIndexedNF, statistics::units::Count::get(), "Distribution of segment indexed NF"),
+      ADD_STAT(vectorVma, statistics::units::Count::get(), "Number of vector vma enable"),
+      ADD_STAT(vectorVmu, statistics::units::Count::get(), "Number of vector vmu enable"),
+      ADD_STAT(vectorVta, statistics::units::Count::get(), "Number of vector vta enable"),
+      ADD_STAT(vectorVtu, statistics::units::Count::get(), "Number of vector vtu enable"),
+      ADD_STAT(squashDueToBranch, statistics::units::Count::get(), "Number of squash due to branch"),
+      ADD_STAT(squashDueToOrderViolation, statistics::units::Count::get(), "Number of squash due to order violation"),
       ADD_STAT(squashDueToValuePrediction, statistics::units::Count::get(),
                "Number of squash due to value prediction"),
-      ADD_STAT(squashDueToTrap, statistics::units::Count::get(),
-               "Number of squash due to trap"),
-      ADD_STAT(squashDueToTC, statistics::units::Count::get(),
-               "Number of squash due to TC"),
-      ADD_STAT(squashDueToSquashAfter, statistics::units::Count::get(),
-               "Number of squash due to squash after"),
-      ADD_STAT(totalSquash, statistics::units::Count::get(),
-               "Total number of squash"),
-      ADD_STAT(ROBFull, statistics::units::Count::get(),
-               "Total number of ROBFull"),
+      ADD_STAT(squashDueToTrap, statistics::units::Count::get(), "Number of squash due to trap"),
+      ADD_STAT(squashDueToTC, statistics::units::Count::get(), "Number of squash due to TC"),
+      ADD_STAT(squashDueToSquashAfter, statistics::units::Count::get(), "Number of squash due to squash after"),
+      ADD_STAT(totalSquash, statistics::units::Count::get(), "Total number of squash"),
+      ADD_STAT(ROBFull, statistics::units::Count::get(), "Total number of ROBFull"),
       ADD_STAT(smtRestEntryWhileROBFull, statistics::units::Count::get(),
                "Distribution of total rest entries while ROBFull in SMT mode"),
-      ADD_STAT(ROBBorrowingStateChange, statistics::units::Count::get(),
-               "changing times of borrowing state"),
-      ADD_STAT(smtStateHoldCycle, statistics::units::Count::get(),
-               "SMT base/donor state holding cycle distribution"),
+      ADD_STAT(ROBBorrowingStateChange, statistics::units::Count::get(), "changing times of borrowing state"),
+      ADD_STAT(smtStateHoldCycle, statistics::units::Count::get(), "SMT base/donor state holding cycle distribution"),
       ADD_STAT(smtROBEntriesWhileStateChange, statistics::units::Count::get(),
                "SMT ROB thread used/rest entries distribution while state change")
 {
@@ -333,138 +298,75 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
     commitSquashedInsts.prereq(commitSquashedInsts);
     commitNonSpecStalls.prereq(commitNonSpecStalls);
 
-    branchMispredicts
-        .init(cpu->numThreads)
-        .flags(total);
+    branchMispredicts.init(cpu->numThreads).flags(total);
 
-    numCommittedDist
-        .init(0,commit->commitWidth * 8,1)
-        .flags(statistics::pdf).flags(statistics::nozero);
+    numCommittedDist.init(0, commit->commitWidth * 8, 1).flags(statistics::pdf).flags(statistics::nozero);
 
-    segUnitStrideNF
-        .init(0, 8, 1)
-        .flags(statistics::pdf);
+    segUnitStrideNF.init(0, 8, 1).flags(statistics::pdf);
 
-    segStrideNF
-        .init(0, 8, 1)
-        .flags(statistics::pdf);
+    segStrideNF.init(0, 8, 1).flags(statistics::pdf);
 
-    segIndexedNF
-        .init(0, 8, 1)
-        .flags(statistics::pdf);
+    segIndexedNF.init(0, 8, 1).flags(statistics::pdf);
 
-    instsCommitted
-        .init(cpu->numThreads)
-        .flags(total);
+    instsCommitted.init(cpu->numThreads).flags(total);
 
-    pagefaulttimes
-        .init(cpu->numThreads)
-        .flags(total);
+    pagefaulttimes.init(cpu->numThreads).flags(total);
 
-    opsCommitted
-        .init(cpu->numThreads)
-        .flags(total);
+    opsCommitted.init(cpu->numThreads).flags(total);
 
-    memRefs
-        .init(cpu->numThreads)
-        .flags(total);
+    memRefs.init(cpu->numThreads).flags(total);
 
-    loads
-        .init(cpu->numThreads)
-        .flags(total);
+    loads.init(cpu->numThreads).flags(total);
 
-    stores
-        .init(cpu->numThreads)
-        .flags(total);
+    stores.init(cpu->numThreads).flags(total);
 
-    amos
-        .init(cpu->numThreads)
-        .flags(total);
+    amos.init(cpu->numThreads).flags(total);
 
-    membars
-        .init(cpu->numThreads)
-        .flags(total);
+    membars.init(cpu->numThreads).flags(total);
 
-    branches
-        .init(cpu->numThreads)
-        .flags(total);
+    branches.init(cpu->numThreads).flags(total);
 
-    vectorInstructions
-        .init(cpu->numThreads)
-        .flags(total);
+    vectorInstructions.init(cpu->numThreads).flags(total);
 
-    floating
-        .init(cpu->numThreads)
-        .flags(total);
+    floating.init(cpu->numThreads).flags(total);
 
-    integer
-        .init(cpu->numThreads)
-        .flags(total);
+    integer.init(cpu->numThreads).flags(total);
 
-    functionCalls
-        .init(commit->numThreads)
-        .flags(total);
+    functionCalls.init(commit->numThreads).flags(total);
 
-    committedInstType
-        .init(commit->numThreads,enums::Num_OpClass)
-        .flags(total | pdf | dist);
+    committedInstType.init(commit->numThreads, enums::Num_OpClass).flags(total | pdf | dist);
 
     committedInstType.ysubnames(enums::OpClassStrings);
 
-    recovery_bubble
-        .init(cpu->numThreads)
-        .flags(total);
+    recovery_bubble.init(cpu->numThreads).flags(total);
 
-    squashDueToBranch
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToBranch.init(cpu->numThreads).flags(total);
 
-    squashDueToOrderViolation
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToOrderViolation.init(cpu->numThreads).flags(total);
 
-    squashDueToValuePrediction
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToValuePrediction.init(cpu->numThreads).flags(total);
 
-    squashDueToTrap
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToTrap.init(cpu->numThreads).flags(total);
 
-    squashDueToTC
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToTC.init(cpu->numThreads).flags(total);
 
-    squashDueToSquashAfter
-        .init(cpu->numThreads)
-        .flags(total);
+    squashDueToSquashAfter.init(cpu->numThreads).flags(total);
 
-    totalSquash = squashDueToBranch + squashDueToOrderViolation + \
-        squashDueToValuePrediction + squashDueToTrap + squashDueToTC + \
-        squashDueToSquashAfter;
+    totalSquash = squashDueToBranch + squashDueToOrderViolation + squashDueToValuePrediction + squashDueToTrap +
+                  squashDueToTC + squashDueToSquashAfter;
 
-    ROBFull
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    ROBFull.init(cpu->numThreads).flags(statistics::total);
 
-    smtRestEntryWhileROBFull
-        .init(0, 160, 5)
-        .flags(statistics::pdf);
+    smtRestEntryWhileROBFull.init(0, 160, 5).flags(statistics::pdf);
 
-    ROBBorrowingStateChange
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    ROBBorrowingStateChange.init(cpu->numThreads).flags(statistics::total);
 
-    smtStateHoldCycle
-        .init(2, 0, 100, 10)
-        .flags(statistics::pdf);
-    
+    smtStateHoldCycle.init(2, 0, 100, 10).flags(statistics::pdf);
+
     smtStateHoldCycle.subname(0, "Base");
     smtStateHoldCycle.subname(1, "Donor");
 
-    smtROBEntriesWhileStateChange
-        .init(4, 0, 160, 8)
-        .flags(statistics::pdf);
+    smtROBEntriesWhileStateChange.init(4, 0, 160, 8).flags(statistics::pdf);
 
     smtROBEntriesWhileStateChange.subname(0, "BaseToDonor_used");
     smtROBEntriesWhileStateChange.subname(1, "BaseToDonor_rest");
@@ -542,7 +444,11 @@ Commit::setRenameMap(UnifiedRenameMap rm_ptr[MaxThreads])
         renameMap[tid] = &rm_ptr[tid];
 }
 
-void Commit::setROB(ROB *rob_ptr) { rob = rob_ptr; }
+void
+Commit::setROB(ROB *rob_ptr)
+{
+    rob = rob_ptr;
+}
 
 void
 Commit::startupStage()
@@ -576,9 +482,14 @@ Commit::clearStates(ThreadID tid)
     pc[tid].reset(cpu->tcBase(tid)->getIsaPtr()->newPCState());
     lastCommitedSeqNum[tid] = 0;
     squashAfterInst[tid] = NULL;
+
 }
 
-void Commit::drain() { drainPending = true; }
+void
+Commit::drain()
+{
+    drainPending = true;
+}
 
 void
 Commit::drainResume()
@@ -625,8 +536,7 @@ Commit::isDrained() const
      * makes debugging easier since CPU handover and restoring from a
      * checkpoint with a different CPU should have the same timing.
      */
-    return rob->isEmpty() &&
-        interrupt == NoFault;
+    return rob->isEmpty() && interrupt == NoFault;
 }
 
 void
@@ -648,8 +558,7 @@ Commit::takeOverFrom()
 void
 Commit::deactivateThread(ThreadID tid)
 {
-    std::list<ThreadID>::iterator thread_it = std::find(priority_list.begin(),
-            priority_list.end(), tid);
+    std::list<ThreadID>::iterator thread_it = std::find(priority_list.begin(), priority_list.end(), tid);
 
     if (thread_it != priority_list.end()) {
         priority_list.erase(thread_it);
@@ -668,8 +577,7 @@ Commit::executingHtmTransaction(ThreadID tid) const
 void
 Commit::resetHtmStartsStops(ThreadID tid)
 {
-    if (tid != InvalidThreadID)
-    {
+    if (tid != InvalidThreadID) {
         htmStarts[tid] = 0;
         htmStops[tid] = 0;
     }
@@ -689,8 +597,7 @@ Commit::updateStatus()
         changedROBNumEntries[tid] = false;
 
         // Also check if any of the threads has a trap pending
-        if (commitStatus[tid] == TrapPending ||
-            commitStatus[tid] == FetchTrapPending) {
+        if (commitStatus[tid] == TrapPending || commitStatus[tid] == FetchTrapPending) {
             _nextStatus = Active;
         }
     }
@@ -734,16 +641,13 @@ Commit::generateTrapEvent(ThreadID tid, Fault inst_fault)
 {
     DPRINTF(Commit, "Generating trap event for [tid:%i]\n", tid);
 
-    EventFunctionWrapper *trap = new EventFunctionWrapper(
-        [this, tid]{ processTrapEvent(tid); },
-        "Trap", true, Event::CPU_Tick_Pri);
+    EventFunctionWrapper *trap =
+        new EventFunctionWrapper([this, tid] { processTrapEvent(tid); }, "Trap", true, Event::CPU_Tick_Pri);
 
-    Cycles latency = std::dynamic_pointer_cast<SyscallRetryFault>(inst_fault) ?
-                     cpu->syscallRetryLatency : trapLatency;
+    Cycles latency = std::dynamic_pointer_cast<SyscallRetryFault>(inst_fault) ? cpu->syscallRetryLatency : trapLatency;
 
     // hardware transactional memory
-    if (inst_fault != nullptr &&
-        std::dynamic_pointer_cast<GenericHtmFailureFault>(inst_fault)) {
+    if (inst_fault != nullptr && std::dynamic_pointer_cast<GenericHtmFailureFault>(inst_fault)) {
         // TODO
         // latency = default abort/restore latency
         // could also do some kind of exponential back off if desired
@@ -770,8 +674,7 @@ Commit::squashAll(ThreadID tid)
     // then use one older sequence number.
     // Hopefully this doesn't mess things up.  Basically I want to squash
     // all instructions of this thread.
-    InstSeqNum squashed_inst = rob->isEmpty(tid) ?
-        lastCommitedSeqNum[tid] : rob->readHeadInst(tid)->seqNum - 1;
+    InstSeqNum squashed_inst = rob->isEmpty(tid) ? lastCommitedSeqNum[tid] : rob->readHeadInst(tid)->seqNum - 1;
 
     // All younger instructions will be squashed. Set the sequence
     // number as the youngest instruction in the ROB (0 in this case.
@@ -813,12 +716,8 @@ Commit::squashAll(ThreadID tid)
 void
 Commit::squashFromTrap(ThreadID tid)
 {
-    DPRINTF(Commit,
-            "[tid:%i] [squash-source=trap] tick=%llu committedPC=%#lx newPC=%s\n",
-            tid,
-            (unsigned long long)curTick(),
-            (unsigned long)committedPC[tid],
-            *pc[tid]);
+    DPRINTF(Commit, "[tid:%i] [squash-source=trap] tick=%llu committedPC=%#lx newPC=%s\n", tid,
+            (unsigned long long)curTick(), (unsigned long)committedPC[tid], *pc[tid]);
     squashAll(tid);
 
     toIEW->commitInfo[tid].isTrapSquash = true;
@@ -840,11 +739,7 @@ Commit::squashFromTrap(ThreadID tid)
 void
 Commit::squashFromTC(ThreadID tid)
 {
-    DPRINTF(Commit,
-            "[tid:%i] [squash-source=tc] tick=%llu newPC=%s\n",
-            tid,
-            (unsigned long long)curTick(),
-            *pc[tid]);
+    DPRINTF(Commit, "[tid:%i] [squash-source=tc] tick=%llu newPC=%s\n", tid, (unsigned long long)curTick(), *pc[tid]);
     squashAll(tid);
 
     DPRINTF(Commit, "Squashing from TC, restarting at PC %s\n", *pc[tid]);
@@ -863,18 +758,11 @@ void
 Commit::squashFromSquashAfter(ThreadID tid)
 {
     if (squashAfterInst[tid]) {
-        DPRINTF(Commit,
-                "[tid:%i] [squash-source=squashAfter] tick=%llu newPC=%s inst=[sn:%llu]\n",
-                tid,
-                (unsigned long long)curTick(),
-                *pc[tid],
-                (unsigned long long)squashAfterInst[tid]->seqNum);
+        DPRINTF(Commit, "[tid:%i] [squash-source=squashAfter] tick=%llu newPC=%s inst=[sn:%llu]\n", tid,
+                (unsigned long long)curTick(), *pc[tid], (unsigned long long)squashAfterInst[tid]->seqNum);
     } else {
-        DPRINTF(Commit,
-                "[tid:%i] [squash-source=squashAfter] tick=%llu newPC=%s inst=[null]\n",
-                tid,
-                (unsigned long long)curTick(),
-                *pc[tid]);
+        DPRINTF(Commit, "[tid:%i] [squash-source=squashAfter] tick=%llu newPC=%s inst=[null]\n", tid,
+                (unsigned long long)curTick(), *pc[tid]);
     }
 
     squashAll(tid);
@@ -892,8 +780,7 @@ Commit::squashFromSquashAfter(ThreadID tid)
 void
 Commit::squashAfter(ThreadID tid, const DynInstPtr &head_inst)
 {
-    DPRINTF(Commit, "Executing squash after for [tid:%i] inst [sn:%llu]\n",
-            tid, head_inst->seqNum);
+    DPRINTF(Commit, "Executing squash after for [tid:%i] inst [sn:%llu]\n", tid, head_inst->seqNum);
 
     assert(!squashAfterInst[tid] || squashAfterInst[tid] == head_inst);
     commitStatus[tid] = SquashAfterPending;
@@ -939,10 +826,12 @@ Commit::tick()
 
             if (rob->isDoneSquashing(tid)) {
                 commitStatus[tid] = Running;
-                DPRINTF(Commit,"[tid:%i] Switch from ROB squashing to Running.\n", tid);
+                DPRINTF(Commit, "[tid:%i] Switch from ROB squashing to Running.\n", tid);
             } else {
-                DPRINTF(Commit,"[tid:%i] Still Squashing, cannot commit any"
-                        " insts this cycle.\n", tid);
+                DPRINTF(Commit,
+                        "[tid:%i] Still Squashing, cannot commit any"
+                        " insts this cycle.\n",
+                        tid);
                 rob->doSquash(tid);
                 changedROBNumEntries[tid] = true;
                 toIEW->commitInfo[tid].robSquashing = true;
@@ -950,7 +839,7 @@ Commit::tick()
             }
         }
     }
-    
+
     rob->addBorrowingStateHoldCycle();
 
     commit();
@@ -969,7 +858,8 @@ Commit::tick()
 
             [[maybe_unused]] const DynInstPtr &inst = rob->readHeadInst(tid);
 
-            DPRINTF(Commit,"[tid:%i] Instruction [sn:%llu] PC %s is head of"
+            DPRINTF(Commit,
+                    "[tid:%i] Instruction [sn:%llu] PC %s is head of"
                     " ROB and ready to commit\n",
                     tid, inst->seqNum, inst->pcState());
 
@@ -978,15 +868,16 @@ Commit::tick()
 
             ppCommitStall->notify(inst);
 
-            DPRINTF(Commit,"[tid:%i] Can't commit, Instruction [sn:%llu] PC "
+            DPRINTF(Commit,
+                    "[tid:%i] Can't commit, Instruction [sn:%llu] PC "
                     "%s is head of ROB and not ready\n",
                     tid, inst->seqNum, inst->pcState());
             DPRINTF(Counters, "instruction ready tick:%lu\n", inst->readyTick);
             DPRINTF(Commit, "%s\n", inst->staticInst->disassemble(inst->pcState().instAddr()).c_str());
         }
 
-        DPRINTF(Commit, "[tid:%i] ROB has %d insts & %d free entries.\n",
-                tid, rob->countInsts(tid), rob->numFreeEntries(tid));
+        DPRINTF(Commit, "[tid:%i] ROB has %d insts & %d free entries.\n", tid, rob->countInsts(tid),
+                rob->numFreeEntries(tid));
     }
 
 
@@ -1006,7 +897,8 @@ Commit::handleInterrupt()
 {
     // Verify that we still have an interrupt to handle
     if (!cpu->checkInterrupts(0)) {
-        DPRINTF(Commit, "Pending interrupt is cleared by requestor before "
+        DPRINTF(Commit,
+                "Pending interrupt is cleared by requestor before "
                 "it got handled. Restart fetching from the orig path.\n");
         toIEW->commitInfo[0].clearInterrupt = true;
         interrupt = NoFault;
@@ -1052,10 +944,10 @@ Commit::handleInterrupt()
 
         avoidQuiesceLiveLock = false;
     } else {
-        DPRINTF(Commit, "Interrupt pending: instruction is %sin "
+        DPRINTF(Commit,
+                "Interrupt pending: instruction is %sin "
                 "flight, ROB is %sempty\n",
-                canHandleInterrupts ? "not " : "",
-                cpu->instList.empty() ? "" : "not " );
+                canHandleInterrupts ? "not " : "", cpu->instList.empty() ? "" : "not ");
     }
 }
 
@@ -1064,8 +956,7 @@ Commit::propagateInterrupt()
 {
     // Don't propagate intterupts if we are currently handling a trap or
     // in draining and the last observable instruction has been committed.
-    if (commitStatus[0] == TrapPending || interrupt || trapSquash[0] ||
-            tcSquash[0] || drainImminent)
+    if (commitStatus[0] == TrapPending || interrupt || trapSquash[0] || tcSquash[0] || drainImminent)
         return;
 
     // Process interrupts if interrupts are enabled, not in PAL
@@ -1129,33 +1020,27 @@ Commit::commit()
         // instruction in the ROB. This prevents squashes from younger
         // instructions overriding squashes from older instructions.
         DPRINTF(Commit, "fromIEW->squash %d, commitStatus %d, fromIEW->squashedSeqNum %d, youngestSeqNum %d\n",
-            fromIEW->squash[tid], commitStatus[tid], fromIEW->squashedSeqNum[tid], youngestSeqNum[tid]);
-        if (fromIEW->squash[tid] &&
-            commitStatus[tid] != TrapPending &&
+                fromIEW->squash[tid], commitStatus[tid], fromIEW->squashedSeqNum[tid], youngestSeqNum[tid]);
+        if (fromIEW->squash[tid] && commitStatus[tid] != TrapPending &&
             fromIEW->squashedSeqNum[tid] <= youngestSeqNum[tid]) {
 
             if (fromIEW->mispredictInst[tid]) {
                 DPRINTF(Commit,
-                    "[tid:%i] Squashing due to branch mispred "
-                    "PC:%#x [sn:%llu]\n",
-                    tid,
-                    fromIEW->mispredictInst[tid]->pcState().instAddr(),
-                    fromIEW->squashedSeqNum[tid]);
+                        "[tid:%i] Squashing due to branch mispred "
+                        "PC:%#x [sn:%llu]\n",
+                        tid, fromIEW->mispredictInst[tid]->pcState().instAddr(), fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToBranch[tid]++;
             } else if (fromIEW->valuePredictionError[tid]) {
-                DPRINTF(Commit,
-                    "[tid:%i] Squashing due to value prediction error [sn:%llu]\n",
-                    tid, fromIEW->squashedSeqNum[tid]);
+                DPRINTF(Commit, "[tid:%i] Squashing due to value prediction error [sn:%llu]\n", tid,
+                        fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToValuePrediction[tid]++;
             } else {
-                DPRINTF(Commit,
-                    "[tid:%i] Squashing due to order violation [sn:%llu]\n",
-                    tid, fromIEW->squashedSeqNum[tid]);
+                DPRINTF(Commit, "[tid:%i] Squashing due to order violation [sn:%llu]\n", tid,
+                        fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToOrderViolation[tid]++;
             }
 
-            DPRINTF(Commit, "[tid:%i] Redirecting to PC %#x\n",
-                    tid, *fromIEW->pc[tid]);
+            DPRINTF(Commit, "[tid:%i] Redirecting to PC %#x\n", tid, *fromIEW->pc[tid]);
 
             commitStatus[tid] = ROBSquashing;
 
@@ -1186,23 +1071,20 @@ Commit::commit()
             // the ROB is in the process of squashing.
             toIEW->commitInfo[tid].robSquashing = true;
 
-            toIEW->commitInfo[tid].mispredictInst =
-                fromIEW->mispredictInst[tid];
-            toIEW->commitInfo[tid].branchTaken =
-                fromIEW->branchTaken[tid];
+            toIEW->commitInfo[tid].mispredictInst = fromIEW->mispredictInst[tid];
+            toIEW->commitInfo[tid].branchTaken = fromIEW->branchTaken[tid];
 
             auto squashed_inst_ptr = rob->findInst(tid, squashed_inst);
             toIEW->commitInfo[tid].squashInst = squashed_inst_ptr;
             if (!squashed_inst_ptr) {
-                DPRINTF(Commit,
-                        "Unable to find squashed instruction in ROB\n");
+                DPRINTF(Commit, "Unable to find squashed instruction in ROB\n");
             }
             toIEW->commitInfo[tid].squashedTargetId = fromIEW->squashedTargetId[tid];
             toIEW->commitInfo[tid].squashedLoopIter = fromIEW->squashedLoopIter[tid];
 
             if (toIEW->commitInfo[tid].mispredictInst) {
                 if (toIEW->commitInfo[tid].mispredictInst->isUncondCtrl()) {
-                     toIEW->commitInfo[tid].branchTaken = true;
+                    toIEW->commitInfo[tid].branchTaken = true;
                 }
                 ++stats.branchMispredicts[tid];
             }
@@ -1230,7 +1112,7 @@ Commit::commit()
         commitInsts();
     }
 
-    //Check for any activity
+    // Check for any activity
     threads = activeThreads->begin();
 
     while (threads != end) {
@@ -1254,18 +1136,18 @@ Commit::commit()
         // d) no squashAfter is pending
         // @todo: Make this handle multi-cycle communication between
         // commit and IEW.
-        if (checkEmptyROB[tid] && rob->isEmpty(tid) &&
-            !iewStage->hasStoresToWB(tid) && !committedStores[tid] && commitStatus[tid] != SquashAfterPending) {
+        if (checkEmptyROB[tid] && rob->isEmpty(tid) && !iewStage->hasStoresToWB(tid) && !committedStores[tid] &&
+            commitStatus[tid] != SquashAfterPending) {
             checkEmptyROB[tid] = false;
             toIEW->commitInfo[tid].usedROB = true;
             toIEW->commitInfo[tid].emptyROB = true;
             wroteToTimeBuffer = true;
         }
-
     }
 }
 void
-Commit::updateMstatusSd(ThreadID tid){
+Commit::updateMstatusSd(ThreadID tid)
+{
     RiscvISA::STATUS mstatus = cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_STATUS, tid);
     mstatus.sd = (mstatus.fs == 3) || (mstatus.vs == 3);
     cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_STATUS, (RegVal)mstatus, tid);
@@ -1293,8 +1175,7 @@ Commit::commitInsts()
 
     int commit_width = 0;
     for (ThreadID tid : *activeThreads) {
-        commit_width_per_thread[tid] =
-            rob->countInstsOfGroups(tid, commitWidth);
+        commit_width_per_thread[tid] = rob->countInstsOfGroups(tid, commitWidth);
         commit_width += commit_width_per_thread[tid];
     }
 
@@ -1304,17 +1185,14 @@ Commit::commitInsts()
 
     // Commit each thread independently for up to its local commit window.
     for (ThreadID commit_thread : *activeThreads) {
-        if (commitStatus[commit_thread] != Running &&
-            commitStatus[commit_thread] != Idle &&
+        if (commitStatus[commit_thread] != Running && commitStatus[commit_thread] != Idle &&
             commitStatus[commit_thread] != FetchTrapPending) {
             continue;
         }
 
         while (num_committed < commit_width &&
-               num_committed_per_thread[commit_thread] <
-                   commit_width_per_thread[commit_thread] &&
-               (commitStatus[commit_thread] == Running ||
-                commitStatus[commit_thread] == Idle ||
+               num_committed_per_thread[commit_thread] < commit_width_per_thread[commit_thread] &&
+               (commitStatus[commit_thread] == Running || commitStatus[commit_thread] == Idle ||
                 commitStatus[commit_thread] == FetchTrapPending)) {
             // hardware transactionally memory
             // If executing within a transaction,
@@ -1338,13 +1216,11 @@ Commit::commitInsts()
 
             if (!rob->isHeadGroupReady(commit_thread)) {
                 if (debug::Commit && head_inst->readyToCommit()) {
-                    InstSeqNum seqnum =
-                        rob->getHeadGroupLastDoneSeq(commit_thread);
-                    DPRINTF(
-                        Commit,
-                        "[sn:%llu] Head is ready to commit, but the group "
-                        "is not all ready, last done inst [sn:%llu]\n",
-                        head_inst->seqNum, seqnum);
+                    InstSeqNum seqnum = rob->getHeadGroupLastDoneSeq(commit_thread);
+                    DPRINTF(Commit,
+                            "[sn:%llu] Head is ready to commit, but the group "
+                            "is not all ready, last done inst [sn:%llu]\n",
+                            head_inst->seqNum, seqnum);
                 }
                 break;
             }
@@ -1353,18 +1229,19 @@ Commit::commitInsts()
 
             assert(tid == commit_thread);
 
-            DPRINTF(Commit,
-                    "Trying to commit head instruction, [tid:%i] [sn:%llu]\n",
-                    tid, head_inst->seqNum);
+            DPRINTF(Commit, "Trying to commit head instruction, [tid:%i] [sn:%llu]\n", tid, head_inst->seqNum);
 
             // If the head instruction is squashed, it is ready to retire
             // (be removed from the ROB) at any time.
             if (head_inst->isSquashed()) {
 
-                DPRINTF(Commit, "Retiring squashed instruction from "
+                DPRINTF(Commit,
+                        "Retiring squashed instruction from "
                         "ROB.\n");
 
                 rob->drainSquashedHead(commit_thread);
+
+
 
                 ++stats.commitSquashedInsts;
                 // Notify potential listeners that this instruction is squashed
@@ -1377,61 +1254,48 @@ Commit::commitInsts()
                 traceMaybeInjectCtrlFlowChangeFault(tid, head_inst);
 
                 // Try to commit the head instruction.
-                bool commit_success = commitHead(head_inst,
-                                                num_committed_per_thread[tid]);
+                bool commit_success = commitHead(head_inst, num_committed_per_thread[tid]);
 
                 if (commit_success) {
-                    cpu->perfCCT->updateInstPos(head_inst->seqNum,
-                                                PerfRecord::AtCommit);
+                    cpu->perfCCT->updateInstPos(head_inst->seqNum, PerfRecord::AtCommit);
                     auto res = head_inst->getResult();
                     if (res.is<RegVal>()) {
-                        cpu->perfCCT->updateInstMeta(
-                            head_inst->seqNum, InstDetail::Result,
-                            res.as<RegVal>());
+                        cpu->perfCCT->updateInstMeta(head_inst->seqNum, InstDetail::Result, res.as<RegVal>());
                     }
                     cpu->perfCCT->commitMeta(head_inst->seqNum);
 
-                    DPRINTF(CommitTrace, "CT [tid:%d]: %s\n",
-                            head_inst->threadNumber,
-                            head_inst->genDisassembly());
+                    DPRINTF(CommitTrace, "CT [tid:%d]: %s\n", head_inst->threadNumber, head_inst->genDisassembly());
 
                     if (ismispred[tid]) {
                         ismispred[tid] = false;
-                        stats.recovery_bubble[tid] +=
-                            (cpu->curCycle() - lastCommitCycle[tid]) *
-                            renameWidth;
+                        stats.recovery_bubble[tid] += (cpu->curCycle() - lastCommitCycle[tid]) * renameWidth;
                     }
                     if (head_inst->mispredicted()) {
                         ismispred[tid] = true;
                     }
 
                     lastCommitCycle[tid] = cpu->curCycle();
-                    const auto &head_rv_pc =
-                        head_inst->pcState().as<RiscvISA::PCState>();
+                    const auto &head_rv_pc = head_inst->pcState().as<RiscvISA::PCState>();
                     if (bp->isBTB()) {
-                        auto dbbtb = dynamic_cast<
-                            branch_prediction::btb_pred::
-                                DecoupledBPUWithBTB *>(bp);
+                        auto dbbtb = dynamic_cast<branch_prediction::btb_pred::DecoupledBPUWithBTB *>(bp);
                         bool miss = head_inst->mispredicted();
                         if (head_inst->isReturn()) {
                             DPRINTF(RAS, "commit inst PC %x miss %d real target %x pred target %x\n",
-                                    head_inst->pcState().instAddr(), miss,
-                                    head_rv_pc.npc(), *(head_inst->predPC));
+                                    head_inst->pcState().instAddr(), miss, head_rv_pc.npc(), *(head_inst->predPC));
                         }
 
                         // FIXME: ignore mret/sret/uret in correspond with RTL
                         if (!head_inst->isNonSpeculative() && head_inst->isControl()) {
                             dbbtb->commitBranch(head_inst, miss);
-                            if (!head_inst->isReturn() &&
-                                head_inst->isIndirectCtrl() && miss) {
+                            if (!head_inst->isReturn() && head_inst->isIndirectCtrl() && miss) {
                                 misPredIndirect[head_inst->pcState().instAddr()]++;
                             }
                         }
                         dbbtb->notifyInstCommit(head_inst);
                     }
-                        if (traceMaybeExitOnLastTraceInst(head_inst)) {
-                            return;
-                        }
+                    if (traceMaybeExitOnLastTraceInst(head_inst)) {
+                        return;
+                    }
 
                       // Vector loads write architectural vector registers.
                       // Mark mstatus.VS dirty when the instruction commits.
@@ -1448,30 +1312,25 @@ Commit::commitInsts()
                       }
 
                     if (head_inst->isUpdateVsstatusSd()) {
-                        auto v = cpu->readMiscRegNoEffect(
-                            RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);
+                        auto v = cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);
                         RiscvISA::HSTATUS hstatus =
-                            cpu->readMiscRegNoEffect(
-                                RiscvISA::MiscRegIndex::MISCREG_HSTATUS, tid);
+                            cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_HSTATUS, tid);
                         RiscvISA::VSSTATUS vsstatus =
                             cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, tid);
                         RiscvISA::VSSTATUS32 vsstatus32 =
                             cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, tid);
 
                         if (v) {
-                            if (hstatus.vsxl ==1) {
+                            if (hstatus.vsxl == 1) {
                                 vsstatus32.sd = (vsstatus32.fs == 3) || (vsstatus32.vs == 3);
-                                cpu->setMiscRegNoEffect(
-                                    RiscvISA::MiscRegIndex::MISCREG_VSSTATUS,
-                                    (RegVal)vsstatus32, tid);
+                                cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, (RegVal)vsstatus32,
+                                                        tid);
                             } else {
                                 vsstatus.sd = (vsstatus.fs == 3) || (vsstatus.vs == 3);
-                                cpu->setMiscRegNoEffect(
-                                    RiscvISA::MiscRegIndex::MISCREG_VSSTATUS,
-                                    (RegVal)vsstatus, tid);
+                                cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, (RegVal)vsstatus,
+                                                        tid);
                             }
                         }
-
                     }
                     if (head_inst->isUpdateMstatusSd()) {
                         updateMstatusSd(tid);
@@ -1515,20 +1374,16 @@ Commit::commitInsts()
 
                     // at this point store conditionals should either have
                     // been completed or predicated false
-                    assert(!head_inst->isStoreConditional() ||
-                        head_inst->isCompleted() ||
-                        !head_inst->readPredicate());
+                    assert(!head_inst->isStoreConditional() || head_inst->isCompleted() ||
+                           !head_inst->readPredicate());
 
                     // Updates misc. registers.
                     head_inst->updateMiscRegs();
                     if (head_inst->staticInst->isVectorConfig()) {
-                        auto vset = static_cast<RiscvISA::VConfOp *>(
-                            head_inst->staticInst.get());
+                        auto vset = static_cast<RiscvISA::VConfOp *>(head_inst->staticInst.get());
                         if (!(vset->vtypeIsImm)) {
                             auto tc = head_inst->tcBase();
-                            RiscvISA::VTYPE new_vtype =
-                                head_inst->readMiscReg(
-                                    RiscvISA::MISCREG_VTYPE);
+                            RiscvISA::VTYPE new_vtype = head_inst->readMiscReg(RiscvISA::MISCREG_VTYPE);
                             tc->getDecoderPtr()->as<RiscvISA::Decoder>().setVtype(new_vtype);
                         }
                         if (hasExecutedYoungerInst(tid, head_inst->seqNum)) {
@@ -1542,43 +1397,35 @@ Commit::commitInsts()
                         }
                     }
                     if (head_inst->isFloating() && head_inst->isLoad()) {
-                        RiscvISA::STATUS status = cpu->readMiscRegNoEffect(
-                            RiscvISA::MiscRegIndex::MISCREG_STATUS, tid);
+                        RiscvISA::STATUS status =
+                            cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_STATUS, tid);
                         status.sd = 1;
                         status.fs = 3;
-                        cpu->setMiscRegNoEffect(
-                            RiscvISA::MiscRegIndex::MISCREG_STATUS,
-                            (RegVal)status, tid);
+                        cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_STATUS, (RegVal)status, tid);
                     }
                     if (head_inst->isUpdateVsstatusSd()) {
-                        auto v = cpu->readMiscRegNoEffect(
-                            RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);
+                        auto v = cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VIRMODE, tid);
                         RiscvISA::HSTATUS hstatus =
-                            cpu->readMiscRegNoEffect(
-                                RiscvISA::MiscRegIndex::MISCREG_HSTATUS, tid);
+                            cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_HSTATUS, tid);
                         RiscvISA::VSSTATUS vsstatus =
                             cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, tid);
                         RiscvISA::VSSTATUS32 vsstatus32 =
                             cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, tid);
 
                         if (v) {
-                            if (hstatus.vsxl ==1) {
+                            if (hstatus.vsxl == 1) {
                                 vsstatus32.sd = (vsstatus32.fs == 3) || (vsstatus.vs == 3);
-                                cpu->setMiscRegNoEffect(
-                                    RiscvISA::MiscRegIndex::MISCREG_VSSTATUS,
-                                    (RegVal)vsstatus32, tid);
+                                cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, (RegVal)vsstatus32,
+                                                        tid);
                             } else {
                                 vsstatus.sd = (vsstatus.fs == 3) || (vsstatus.vs == 3);
-                                cpu->setMiscRegNoEffect(
-                                    RiscvISA::MiscRegIndex::MISCREG_VSSTATUS,
-                                    (RegVal)vsstatus, tid);
+                                cpu->setMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_VSSTATUS, (RegVal)vsstatus,
+                                                        tid);
                             }
                         }
-
                     }
 
-                    if (head_inst->isReadBarrier() ||
-                        head_inst->isWriteBarrier()) {
+                    if (head_inst->isReadBarrier() || head_inst->isWriteBarrier()) {
                         cpu->armSyncVisibleStoreReplay(tid);
                     }
 
@@ -1592,8 +1439,7 @@ Commit::commitInsts()
                         char buffer[8] = {0};
                         if (head_inst->memData) {
                             std::memcpy(buffer, head_inst->memData,
-                                        std::min<size_t>(head_inst->effSize,
-                                                        sizeof(buffer)));
+                                        std::min<size_t>(head_inst->effSize, sizeof(buffer)));
                         }
                         Addr load_value = *((uint64_t *)buffer);
                         bool hit = loadTripleCounter.update(load_pc, load_addr, load_value);
@@ -1617,8 +1463,8 @@ Commit::commitInsts()
                             }
                             lastLoadProducerStorePC[load_pc] = prodPC;
 
-                        // optional: clear after use to avoid confusing later stages
-                        head_inst->clearProducerStorePC();
+                            // optional: clear after use to avoid confusing later stages
+                            head_inst->clearProducerStorePC();
                         }
                     }
 
@@ -1643,8 +1489,7 @@ Commit::commitInsts()
                         squashAfter(tid, head_inst);
 
                     if (drainPending) {
-                        if (pc[tid]->microPC() == 0 && interrupt == NoFault &&
-                            !thread[tid]->trapPending) {
+                        if (pc[tid]->microPC() == 0 && interrupt == NoFault && !thread[tid]->trapPending) {
                             // Last architectually committed instruction.
                             // Squash the pipeline, stall fetch, and use
                             // drainImminent to disable interrupts
@@ -1655,30 +1500,26 @@ Commit::commitInsts()
                         }
                     }
 
-                    bool onInstBoundary = !head_inst->isMicroop() ||
-                                        head_inst->isLastMicroop() ||
-                                        !head_inst->isDelayedCommit();
+                    bool onInstBoundary =
+                        !head_inst->isMicroop() || head_inst->isLastMicroop() || !head_inst->isDelayedCommit();
 
                     if (onInstBoundary) {
                         int count = 0;
                         Addr oldpc;
                         // Make sure we're not currently updating state while
                         // handling PC events.
-                        assert(!thread[tid]->noSquashFromTC &&
-                            !thread[tid]->trapPending);
+                        assert(!thread[tid]->noSquashFromTC && !thread[tid]->trapPending);
                         do {
                             oldpc = pc[tid]->instAddr();
-                            thread[tid]->pcEventQueue.service(
-                                    oldpc, thread[tid]->getTC());
+                            thread[tid]->pcEventQueue.service(oldpc, thread[tid]->getTC());
                             count++;
                         } while (oldpc != pc[tid]->instAddr());
                         if (count > 1) {
-                            DPRINTF(Commit,
-                                    "PC skip function event, stopping commit\n");
+                            DPRINTF(Commit, "PC skip function event, stopping commit\n");
                             break;
                         }
-                            traceOnMacroCommit(tid);
-                        }
+                        traceOnMacroCommit(tid);
+                    }
 
                     // Check if an instruction just enabled interrupts and we've
                     // previously had an interrupt pending that was not handled
@@ -1688,13 +1529,13 @@ Commit::commitInsts()
                     //
                     // If we don't do this, we might end up in a live lock
                     // situation.
-                    if (!interrupt && avoidQuiesceLiveLock &&
-                        onInstBoundary && cpu->checkInterrupts(0))
+                    if (!interrupt && avoidQuiesceLiveLock && onInstBoundary && cpu->checkInterrupts(0))
                         squashAfter(tid, head_inst);
                 } else {
-                    DPRINTF(Commit, "Unable to commit head instruction PC:%s "
+                    DPRINTF(Commit,
+                            "Unable to commit head instruction PC:%s "
                             "[tid:%i] [sn:%llu].\n",
-                            head_inst->pcState(), tid ,head_inst->seqNum);
+                            head_inst->pcState(), tid, head_inst->seqNum);
                     break;
                 }
             }
@@ -1708,7 +1549,7 @@ Commit::commitInsts()
             std::max(toIEW->commitInfo[tid].doneSeqNum, rob->getHeadGroupLastDoneSeq(tid));
 
         InstSeqNum robheadSeqNum = 0;
-        if (auto& it = rob->readHeadInst(tid)) {
+        if (auto &it = rob->readHeadInst(tid)) {
             robheadSeqNum = it->seqNum;
         }
         toIEW->commitInfo[tid].robheadSeqNum = robheadSeqNum;
@@ -1725,7 +1566,8 @@ Commit::commitInsts()
 
 
 void
-Commit::diffInst(ThreadID tid, const DynInstPtr &inst) {
+Commit::diffInst(ThreadID tid, const DynInstPtr &inst)
+{
     cpu->diffInfo.lastCommittedMsg.push(inst);
     if (cpu->diffInfo.lastCommittedMsg.size() > 20) {
         cpu->diffInfo.lastCommittedMsg.pop();
@@ -1741,8 +1583,7 @@ Commit::diffInst(ThreadID tid, const DynInstPtr &inst) {
             cpu->getArchReg(dest, &(cpu->diffInfo.vecResult), tid);
         }
     }
-    cpu->diffInfo.curInstStrictOrdered =
-        inst->strictlyOrdered();
+    cpu->diffInfo.curInstStrictOrdered = inst->strictlyOrdered();
     cpu->diffInfo.physEffAddr = inst->physEffAddr;
     cpu->diffInfo.effSize = inst->effSize;
     cpu->diffInfo.goldenValue = inst->getGolden();
@@ -1764,10 +1605,9 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     if (!head_inst->isExecuted()) {
         // Make sure we are only trying to commit un-executed instructions we
         // think are possible.
-        assert(head_inst->isNonSpeculative() || head_inst->isStoreConditional()
-               || head_inst->isReadBarrier() || head_inst->isWriteBarrier()
-               || head_inst->isAtomic()
-               || (head_inst->isLoad() && head_inst->strictlyOrdered()));
+        assert(head_inst->isNonSpeculative() || head_inst->isStoreConditional() || head_inst->isReadBarrier() ||
+               head_inst->isWriteBarrier() || head_inst->isAtomic() ||
+               (head_inst->isLoad() && head_inst->strictlyOrdered()));
 
         DPRINTF(Commit,
                 "Encountered a barrier or non-speculative "
@@ -1779,16 +1619,12 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         // fence must not execute until older stores are visible. RISC-V AMO
         // fence micro-ops are already ordered by the normal barrier path and
         // should not force a full store-buffer drain.
-        const bool is_ordering_barrier =
-            head_inst->isReadBarrier() || head_inst->isWriteBarrier();
+        const bool is_ordering_barrier = head_inst->isReadBarrier() || head_inst->isWriteBarrier();
         const bool is_amo_fence_microop =
-            is_ordering_barrier && head_inst->isMicroop() &&
-            !head_inst->isNonSpeculative();
+            is_ordering_barrier && head_inst->isMicroop() && !head_inst->isNonSpeculative();
         const bool needs_store_drain =
-            head_inst->isMemRef() || head_inst->isReturn() ||
-            (is_ordering_barrier && !is_amo_fence_microop);
-        const bool stores_drained =
-            !needs_store_drain || iewStage->flushStores(tid, head_inst->seqNum);
+            head_inst->isMemRef() || head_inst->isReturn() || (is_ordering_barrier && !is_amo_fence_microop);
+        const bool stores_drained = !needs_store_drain || iewStage->flushStores(tid, head_inst->seqNum);
         if (needs_store_drain && (inst_num > 0 || !stores_drained)) {
             DPRINTF(Commit,
                     "[tid:%i] [sn:%llu] "
@@ -1804,7 +1640,8 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         head_inst->clearCanCommit();
 
         if (head_inst->isLoad() && head_inst->strictlyOrdered()) {
-            DPRINTF(Commit, "[tid:%i] [sn:%llu] "
+            DPRINTF(Commit,
+                    "[tid:%i] [sn:%llu] "
                     "Strictly ordered load, PC %s.\n",
                     tid, head_inst->seqNum, head_inst->pcState());
             toIEW->commitInfo[tid].strictlyOrdered = true;
@@ -1825,12 +1662,12 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     if (inst_fault != NoFault && head_inst->inHtmTransactionalState()) {
         // There exists a generic HTM fault common to all ISAs
         if (!std::dynamic_pointer_cast<GenericHtmFailureFault>(inst_fault)) {
-            DPRINTF(HtmCpu, "%s - fault (%s) encountered within transaction"
-                            " - converting to GenericHtmFailureFault\n",
-            head_inst->staticInst->getName(), inst_fault->name());
-            inst_fault = std::make_shared<GenericHtmFailureFault>(
-                head_inst->getHtmTransactionUid(),
-                HtmFailureFaultCause::EXCEPTION);
+            DPRINTF(HtmCpu,
+                    "%s - fault (%s) encountered within transaction"
+                    " - converting to GenericHtmFailureFault\n",
+                    head_inst->staticInst->getName(), inst_fault->name());
+            inst_fault = std::make_shared<GenericHtmFailureFault>(head_inst->getHtmTransactionUid(),
+                                                                  HtmFailureFaultCause::EXCEPTION);
         }
         // If this point is reached and the fault inherits from the HTM fault,
         // then there is no need to raise a new fault
@@ -1856,8 +1693,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
             // do not fuse again
             inst_fault = std::make_shared<ReExec>();
             decodeStage->setIgnoreNextFusion(head_inst->getPC());
-            DPRINTF(Commit, "Fault on fusion instruction, re-execute without fusion, PC %s\n",
-                    head_inst->pcState());
+            DPRINTF(Commit, "Fault on fusion instruction, re-execute without fusion, PC %s\n", head_inst->pcState());
         }
 
         if (faultNum.find(inst_fault->exception()) != faultNum.end()) {
@@ -1886,28 +1722,20 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         // prevents external agents from changing any specific state
         // that the trap need.
         cpu->mmu->setOldPriv(cpu->getContext(tid));
-        cpu->trap(inst_fault, tid,
-                  head_inst->notAnInst() ? nullStaticInstPtr :
-                      head_inst->staticInst);
+        cpu->trap(inst_fault, tid, head_inst->notAnInst() ? nullStaticInstPtr : head_inst->staticInst);
 
         // Exit state update mode to avoid accidental updating.
         thread[tid]->noSquashFromTC = false;
 
         commitStatus[tid] = TrapPending;
 
-        DPRINTF(
-            Commit,
-            "[tid:%i] [sn:%llu] %s Committing instruction with fault %s\n",
-            tid, head_inst->seqNum,
-            head_inst->staticInst->disassemble(
-                head_inst->pcState().instAddr()).c_str(), inst_fault->name());
-
+        DPRINTF(Commit, "[tid:%i] [sn:%llu] %s Committing instruction with fault %s\n", tid, head_inst->seqNum,
+                head_inst->staticInst->disassemble(head_inst->pcState().instAddr()).c_str(), inst_fault->name());
 
         if (head_inst->traceData) {
             // We ignore ReExecution "faults" here as they are not real
             // (architectural) faults but signal flush/replays.
-            if (debug::ExecFaulting
-                && dynamic_cast<ReExec*>(inst_fault.get()) == nullptr) {
+            if (debug::ExecFaulting && dynamic_cast<ReExec *>(inst_fault.get()) == nullptr) {
 
                 head_inst->traceData->setFaulting(true);
                 head_inst->traceData->setFetchSeq(head_inst->seqNum);
@@ -1919,23 +1747,18 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         }
 
         if (cpu->difftestEnabled() && inst_fault->isFromISA()) {
-            auto priv = cpu->readMiscRegNoEffect(
-                RiscvISA::MiscRegIndex::MISCREG_PRV, tid);
+            auto priv = cpu->readMiscRegNoEffect(RiscvISA::MiscRegIndex::MISCREG_PRV, tid);
             RegVal cause = 0;
             if (priv == RiscvISA::PRV_M) {
                 DPRINTF(Commit, "Force to raise exception at machine mode\n");
-                cause = cpu->readMiscReg(
-                    RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
+                cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
             } else if (priv == RiscvISA::PRV_S) {
                 DPRINTF(Commit, "Force to raise exception at supvs mode\n");
-                cause = cpu->readMiscReg(
-                    RiscvISA::MiscRegIndex::MISCREG_SCAUSE, tid);
+                cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_SCAUSE, tid);
             } else {
-                DPRINTF(Commit,
-                        "Trap ended in unexpected PRV_U, fallback to MCAUSE\n");
+                DPRINTF(Commit, "Trap ended in unexpected PRV_U, fallback to MCAUSE\n");
                 assert(priv == RiscvISA::PRV_U);
-                cause = cpu->readMiscReg(
-                    RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
+                cause = cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MCAUSE, tid);
             }
             auto exception_no = inst_fault->exception();
             if (faultNum.find(exception_no) != faultNum.end()) {
@@ -1944,14 +1767,12 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
                     exception_no, cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_MTVAL, tid),
                     cpu->readMiscReg(RiscvISA::MiscRegIndex::MISCREG_STVAL, tid), false, 0, tid);
             }
-            if (cause == RiscvISA::ExceptionCode::ECALL_USER ||
-                cause == RiscvISA::ExceptionCode::ECALL_SUPER ||
+            if (cause == RiscvISA::ExceptionCode::ECALL_USER || cause == RiscvISA::ExceptionCode::ECALL_SUPER ||
                 cause == RiscvISA::ExceptionCode::ECALL_MACHINE) {
                 diffInst(tid, head_inst);
             }
 
             // Maybe set interrupt here?
-
         }
 
         // Generate trap squash event.
@@ -1960,8 +1781,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     }
 
     // if (IsSerializeAfter, IsNonSpeculative, IsReturn)
-    if (head_inst->isSerializeAfter() && head_inst->isNonSpeculative() &&
-        head_inst->isReturn()) {
+    if (head_inst->isSerializeAfter() && head_inst->isNonSpeculative() && head_inst->isReturn()) {
         traceLogPrivReturn(head_inst, tid);
     }
 
@@ -1979,13 +1799,11 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         dumpTicks(head_inst);
     lastCommitTick = curTick();
 
-    DPRINTF(Commit,
-            "[tid:%i] [sn:%llu] Committing instruction with PC %s\n",
-            tid, head_inst->seqNum, head_inst->pcState());
+    DPRINTF(Commit, "[tid:%i] [sn:%llu] Committing instruction with PC %s\n", tid, head_inst->seqNum,
+            head_inst->pcState());
 
-    DPRINTF(
-        InstCommited, "[instCommited: %d, %s]\n", head_inst->opClass(),
-        head_inst->staticInst->disassemble(head_inst->pcState().instAddr()));
+    DPRINTF(InstCommited, "[instCommited: %d, %s]\n", head_inst->opClass(),
+            head_inst->staticInst->disassemble(head_inst->pcState().instAddr()));
 
     if (head_inst->traceData) {
         head_inst->traceData->setFetchSeq(head_inst->seqNum);
@@ -1995,24 +1813,20 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         head_inst->traceData = NULL;
     }
     if (head_inst->isReturn()) {
-        DPRINTF(Commit,
-                "[tid:%i] [sn:%llu] Return Instruction Committed PC %s \n",
-                tid, head_inst->seqNum, head_inst->pcState());
+        DPRINTF(Commit, "[tid:%i] [sn:%llu] Return Instruction Committed PC %s \n", tid, head_inst->seqNum,
+                head_inst->pcState());
     }
 
     if (head_inst->isStoreConditional()) {
         DPRINTF(Commit, "[tid:%i] [sn:%llu] Store Conditional success: %i\n", tid, head_inst->seqNum,
                 head_inst->lockedWriteSuccess());
-        cpu->setSCSuccess(head_inst->lockedWriteSuccess(),
-                          head_inst->physEffAddr, tid);
+        cpu->setSCSuccess(head_inst->lockedWriteSuccess(), head_inst->physEffAddr, tid);
     }
 
     // Update the commit rename map
     for (int i = 0; i < head_inst->numDestRegs(); i++) {
-        renameMap[tid]->setEntry(head_inst->flattenedDestIdx(i),
-                                 head_inst->extRenamedDestIdx(i));
-        DPRINTF(Commit, "Committing rename map entry %s -> %s\n",
-                head_inst->destRegIdx(i),
+        renameMap[tid]->setEntry(head_inst->flattenedDestIdx(i), head_inst->extRenamedDestIdx(i));
+        DPRINTF(Commit, "Committing rename map entry %s -> %s\n", head_inst->destRegIdx(i),
                 head_inst->extRenamedDestIdx(i).toString());
     }
 
@@ -2031,30 +1845,23 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         updateInfo.isMisprediction = head_inst->vpMisprediction;
         // extra trainning info for specific value predictors
         updateInfo.emplaceExt<valuepred::ESUpdateInfoExt>(
-                head_inst->isLoad(),
-                curTick() - head_inst->fetchTick,
-                head_inst->staticInst->disassemble(head_inst->pcState().instAddr()));
+            head_inst->isLoad(), curTick() - head_inst->fetchTick,
+            head_inst->staticInst->disassemble(head_inst->pcState().instAddr()));
         if (head_inst->hasProducerStorePC()) {
-            updateInfo.emplaceExt<valuepred::ProducerInfoExt>(
-                    head_inst->producerStorePC());
+            updateInfo.emplaceExt<valuepred::ProducerInfoExt>(head_inst->producerStorePC());
         }
         // ExampleValuePredictor shows how a predictor can request extra
         // commit-time inputs through VPUpdateInfo extensions.
-        updateInfo.emplaceExt<valuepred::ExampleUpdateInfoExt>(
-                head_inst->effAddrValid(),
-                head_inst->effAddr,
-                head_inst->physEffAddr);
+        updateInfo.emplaceExt<valuepred::ExampleUpdateInfoExt>(head_inst->effAddrValid(), head_inst->effAddr,
+                                                               head_inst->physEffAddr);
 
         // additional auxiliary info for the value predictor
         valuepred::VPFeedback feedback;
         feedback.selected = head_inst->vpApplied;
         feedback.applied = head_inst->vpApplied;
-        feedback.offeredPrediction = head_inst->vpRecord &&
-            head_inst->vpRecord->offeredPrediction;
-        feedback.predictedValue = head_inst->vpRecord ?
-            head_inst->vpRecord->predictedValue : 0;
-        feedback.wouldHaveBeenCorrect = feedback.applied &&
-            !head_inst->vpMisprediction;
+        feedback.offeredPrediction = head_inst->vpRecord && head_inst->vpRecord->offeredPrediction;
+        feedback.predictedValue = head_inst->vpRecord ? head_inst->vpRecord->predictedValue : 0;
+        feedback.wouldHaveBeenCorrect = feedback.applied && !head_inst->vpMisprediction;
 
         valuePred->update(updateInfo, head_inst->vpRecord.get(), feedback);
         valuePred->stats.VPsupported++;
@@ -2156,8 +1963,7 @@ Commit::moveInstsToBuffer()
         stallSig->blockIEW[i] = block;
         stallSig->iewBlockReason[i] = block ? block_reason : StallReason::NoStall;
         if (active) {
-            const auto freeze = active_arbiter.observe(
-                i, smtBorrowPriority(robInfoFromIEW->iewInfo[i]));
+            const auto freeze = active_arbiter.observe(i, smtBorrowPriority(robInfoFromIEW->iewInfo[i]));
             if (freeze.previousActive != InvalidThreadID) {
                 freezeActiveThread(freeze.previousActive);
             }
@@ -2176,13 +1982,10 @@ Commit::moveInstsToBuffer()
     int insts_to_process = fixedbuffer[tid].size();
     for (int inst_num = 0; inst_num < insts_to_process; ++inst_num) {
         const DynInstPtr &inst = fixedbuffer[tid].front();
-        if (!inst->isSquashed() &&
-            commitStatus[tid] != ROBSquashing &&
-            commitStatus[tid] != TrapPending) {
+        if (!inst->isSquashed() && commitStatus[tid] != ROBSquashing && commitStatus[tid] != TrapPending) {
             changedROBNumEntries[tid] = true;
 
-            DPRINTF(Commit, "[tid:%i] [sn:%llu] Inserting PC %s into ROB.\n",
-                    tid, inst->seqNum, inst->pcState());
+            DPRINTF(Commit, "[tid:%i] [sn:%llu] Inserting PC %s into ROB.\n", tid, inst->seqNum, inst->pcState());
 
             rob->insertInst(inst);
 
@@ -2190,7 +1993,8 @@ Commit::moveInstsToBuffer()
 
             youngestSeqNum[tid] = inst->seqNum;
         } else {
-            DPRINTF(Commit, "[tid:%i] [sn:%llu] "
+            DPRINTF(Commit,
+                    "[tid:%i] [sn:%llu] "
                     "Instruction PC %s was squashed, skipping.\n",
                     tid, inst->seqNum, inst->pcState());
         }
@@ -2218,7 +2022,8 @@ Commit::squashInflightAndUpdateVersion(ThreadID tid)
                     inst->threadNumber, inst->seqNum, tid);
             continue;
         }
-        DPRINTF(Commit, "[tid:%i] [sn:%llu] Squashing in-flight "
+        DPRINTF(Commit,
+                "[tid:%i] [sn:%llu] Squashing in-flight "
                 "instruction PC %s\n",
                 inst->threadNumber, inst->seqNum, inst->pcState());
         inst->setSquashed();
@@ -2228,8 +2033,7 @@ Commit::squashInflightAndUpdateVersion(ThreadID tid)
 
     localSquashVer[tid].update(localSquashVer[tid].nextVersion());
     toIEW->commitInfo[tid].squashVersion = localSquashVer[tid];
-    DPRINTF(Commit, "Updating squash version to %u\n",
-            localSquashVer[tid].getVersion());
+    DPRINTF(Commit, "Updating squash version to %u\n", localSquashVer[tid].getVersion());
 }
 
 void
@@ -2251,9 +2055,7 @@ Commit::markCompletedInsts()
             auto &inst = fromIEW->insts[inst_num];
 
             panic_if(!rob->findInst(inst->threadNumber, inst->seqNum),
-                     "[tid:%i] [sn:%llu] Committed instruction not found in ROB",
-                     inst->threadNumber,
-                     inst->seqNum);
+                     "[tid:%i] [sn:%llu] Committed instruction not found in ROB", inst->threadNumber, inst->seqNum);
         }
     }
 }
@@ -2269,8 +2071,7 @@ Commit::updateComInstStats(const DynInstPtr &inst)
 
     // To match the old model, don't count nops and instruction
     // prefetches towards the total commit count.
-    if (!inst->isNop() &&
-        !inst->isInstPrefetch()) {
+    if (!inst->isNop() && !inst->isInstPrefetch()) {
         cpu->instDone(tid, inst);
     }
 
@@ -2281,23 +2082,20 @@ Commit::updateComInstStats(const DynInstPtr &inst)
         inst->staticInst->advancePC(*tmp_next_pc);
         // add if taken
         if (tmp_next_pc->instAddr() != inst->fallThruPC) {
-            BranchInfo temp = {inst->pcState().instAddr(),
-                               tmp_next_pc->instAddr()};
+            BranchInfo temp = {inst->pcState().instAddr(), tmp_next_pc->instAddr()};
             if (branchLog.size() >= 20) {
                 branchLog.pop_front();
             }
             branchLog.push_back(temp);
         }
+
         // tracing recent taken branches
-        DPRINTF(DecoupleBP, "Control inst %lu, PC: %#lx -> target: %#lx\n",
-                inst->seqNum, inst->pcState().instAddr(),
+        DPRINTF(DecoupleBP, "Control inst %lu, PC: %#lx -> target: %#lx\n", inst->seqNum, inst->pcState().instAddr(),
                 tmp_next_pc->instAddr());
-        DPRINTF(DecoupleBP, "mispredicted: %i, pred taken: %i\n", mispred,
-                inst->readPredTaken());
+        DPRINTF(DecoupleBP, "mispredicted: %i, pred taken: %i\n", mispred, inst->readPredTaken());
         DPRINTF(DecoupleBP, "Start print branch logs\n");
         for (auto it : branchLog) {
-            DPRINTF(DecoupleBP, "control pc: %#lx -> target pc: %#lx\n,",
-                    it.pc, it.target);
+            DPRINTF(DecoupleBP, "control pc: %#lx -> target pc: %#lx\n,", it.pc, it.target);
         }
         DPRINTF(DecoupleBP, "End\n");
 
@@ -2352,7 +2150,6 @@ Commit::updateComInstStats(const DynInstPtr &inst)
     // Function Calls
     if (inst->isCall())
         stats.functionCalls[tid]++;
-
 }
 
 ////////////////////////////////////////
@@ -2365,22 +2162,20 @@ Commit::getCommittingThread()
 {
     if (numThreads > 1) {
         switch (commitPolicy) {
-          case CommitPolicy::RoundRobin:
-            return roundRobin();
+            case CommitPolicy::RoundRobin:
+                return roundRobin();
 
-          case CommitPolicy::OldestReady:
-            return oldestReady();
+            case CommitPolicy::OldestReady:
+                return oldestReady();
 
-          default:
-            return InvalidThreadID;
+            default:
+                return InvalidThreadID;
         }
     } else {
         assert(!activeThreads->empty());
         ThreadID tid = activeThreads->front();
 
-        if (commitStatus[tid] == Running ||
-            commitStatus[tid] == Idle ||
-            commitStatus[tid] == FetchTrapPending) {
+        if (commitStatus[tid] == Running || commitStatus[tid] == Idle || commitStatus[tid] == FetchTrapPending) {
             return tid;
         } else {
             return InvalidThreadID;
@@ -2392,14 +2187,12 @@ ThreadID
 Commit::roundRobin()
 {
     std::list<ThreadID>::iterator pri_iter = priority_list.begin();
-    std::list<ThreadID>::iterator end      = priority_list.end();
+    std::list<ThreadID>::iterator end = priority_list.end();
 
     while (pri_iter != end) {
         ThreadID tid = *pri_iter;
 
-        if (commitStatus[tid] == Running ||
-            commitStatus[tid] == Idle ||
-            commitStatus[tid] == FetchTrapPending) {
+        if (commitStatus[tid] == Running || commitStatus[tid] == Idle || commitStatus[tid] == FetchTrapPending) {
 
             if (rob->isHeadGroupReady(tid)) {
                 priority_list.erase(pri_iter);
@@ -2429,9 +2222,7 @@ Commit::oldestReady()
         ThreadID tid = *threads++;
 
         if (!rob->isEmpty(tid) &&
-            (commitStatus[tid] == Running ||
-             commitStatus[tid] == Idle ||
-             commitStatus[tid] == FetchTrapPending)) {
+            (commitStatus[tid] == Running || commitStatus[tid] == Idle || commitStatus[tid] == FetchTrapPending)) {
 
             if (rob->isHeadGroupReady(tid)) {
 
@@ -2461,24 +2252,20 @@ Commit::dumpTicks(const DynInstPtr &inst)
 {
     assert(archDBer);
     archDBer->memTraceWrite(curTick(), inst->isLoad(), inst->pcState().instAddr(), inst->effAddr, inst->physEffAddr,
-                            inst->firstIssue, inst->translatedTick, inst->completionTick, curTick(), 0, inst->pf_source);
+                            inst->firstIssue, inst->translatedTick, inst->completionTick, curTick(), 0,
+                            inst->pf_source);
 }
 
 
 void
-Commit::recordROBBorrowingStateChangeStats(
-    ThreadID tid, bool old_donor,
-    unsigned state_hold_cycle,
-    unsigned rob_entries_used,
-    unsigned rob_entries_free)
+Commit::recordROBBorrowingStateChangeStats(ThreadID tid, bool old_donor, unsigned state_hold_cycle,
+                                           unsigned rob_entries_used, unsigned rob_entries_free)
 {
     stats.smtStateHoldCycle[old_donor].sample(state_hold_cycle);
-    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2]
-        .sample(rob_entries_used);
-    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2 + 1]
-        .sample(rob_entries_free);
+    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2].sample(rob_entries_used);
+    stats.smtROBEntriesWhileStateChange[(int)(old_donor) * 2 + 1].sample(rob_entries_free);
     stats.ROBBorrowingStateChange[tid]++;
 }
 
-} // namespace o3
-} // namespace gem5
+}  // namespace o3
+}  // namespace gem5

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -88,11 +88,12 @@ namespace o3
 class IssueQue;
 class InstructionQueue;
 
-class DynInst : public ExecContext, public RefCounted
+class DynInst
+    : public ExecContext
+    , public RefCounted
 {
   private:
-    DynInst(const StaticInstPtr &staticInst, const StaticInstPtr &macroop,
-            InstSeqNum seq_num, CPU *cpu);
+    DynInst(const StaticInstPtr &staticInst, const StaticInstPtr &macroop, InstSeqNum seq_num, CPU *cpu);
 
   public:
     // The list of instructions iterator type.
@@ -111,19 +112,17 @@ class DynInst : public ExecContext, public RefCounted
     };
 
     static void *operator new(size_t count, Arrays &arrays);
-    static void  operator delete(void* ptr);
+    static void operator delete(void *ptr);
 
     /** BaseDynInst constructor given a binary instruction. */
-    DynInst(const Arrays &arrays, const StaticInstPtr &staticInst,
-            const StaticInstPtr &macroop, InstSeqNum seq_num, CPU *cpu);
+    DynInst(const Arrays &arrays, const StaticInstPtr &staticInst, const StaticInstPtr &macroop, InstSeqNum seq_num,
+            CPU *cpu);
 
-    DynInst(const Arrays &arrays, const StaticInstPtr &staticInst,
-            const StaticInstPtr &macroop, const PCStateBase &pc,
+    DynInst(const Arrays &arrays, const StaticInstPtr &staticInst, const StaticInstPtr &macroop, const PCStateBase &pc,
             const PCStateBase &pred_pc, InstSeqNum seq_num, CPU *cpu);
 
     /** BaseDynInst constructor given a static inst pointer. */
-    DynInst(const Arrays &arrays, const StaticInstPtr &_staticInst,
-            const StaticInstPtr &_macroop);
+    DynInst(const Arrays &arrays, const StaticInstPtr &_staticInst, const StaticInstPtr &_macroop);
 
     ~DynInst();
 
@@ -176,19 +175,19 @@ class DynInst : public ExecContext, public RefCounted
   protected:
     enum Status
     {
-        RobEntry,                /// Instruction is in the ROB
-        LsqEntry,                /// Instruction is in the LSQ
-        Completed,               /// Instruction has completed
-        ResultReady,             /// Instruction has its result
+        RobEntry,     /// Instruction is in the ROB
+        LsqEntry,     /// Instruction is in the LSQ
+        Completed,    /// Instruction has completed
+        ResultReady,  /// Instruction has its result
 
         // scheduler state begin
-        CanIssue,                /// Instruction can issue and execute
-        MemDepSolved,            /// Memory dependencies are solved
-        InReadyQue,              /// Instruction is in the ready queue
-        Canceled,                /// Instruction is canceled
-        Scheduled,               /// Instruction is scheduled
+        CanIssue,      /// Instruction can issue and execute
+        MemDepSolved,  /// Memory dependencies are solved
+        InReadyQue,    /// Instruction is in the ready queue
+        Canceled,      /// Instruction is canceled
+        Scheduled,     /// Instruction is scheduled
         ArbFailed,
-        Issued,                  /// Instruction has issued
+        Issued,  /// Instruction has issued
         // scheduler state end
 
         // load/store pipe state begin
@@ -203,25 +202,25 @@ class DynInst : public ExecContext, public RefCounted
 
         // load/store pipe state end
 
-        Executed,                /// Instruction has executed
-        CanCommit,               /// Instruction can commit
-        AtCommit,                /// Instruction has reached commit
-        Committed,               /// Instruction has committed
-        Squashed,                /// Instruction is squashed
-        SquashedInIQ,            /// Instruction is squashed in the IQ
-        SquashedInLSQ,           /// Instruction is squashed in the LSQ
-        SquashedInROB,           /// Instruction is squashed in the ROB
-        PinnedRegsRenamed,       /// Pinned registers are renamed
-        PinnedRegsWritten,       /// Pinned registers are written back
-        PinnedRegsSquashDone,    /// Regs pinning status updated after squash
-        RecoverInst,             /// Is a recover instruction
-        BlockingInst,            /// Is a blocking instruction
-        ThreadsyncWait,          /// Is a thread synchronization instruction
-        SerializeBefore,         /// Needs to serialize on
-                                 /// instructions ahead of it
-        SerializeAfter,          /// Needs to serialize instructions behind it
-        SerializeHandled,        /// Serialization has been handled
-        RatSnapshotted,          /// Instruction owns a RAT checkpoint
+        Executed,              /// Instruction has executed
+        CanCommit,             /// Instruction can commit
+        AtCommit,              /// Instruction has reached commit
+        Committed,             /// Instruction has committed
+        Squashed,              /// Instruction is squashed
+        SquashedInIQ,          /// Instruction is squashed in the IQ
+        SquashedInLSQ,         /// Instruction is squashed in the LSQ
+        SquashedInROB,         /// Instruction is squashed in the ROB
+        PinnedRegsRenamed,     /// Pinned registers are renamed
+        PinnedRegsWritten,     /// Pinned registers are written back
+        PinnedRegsSquashDone,  /// Regs pinning status updated after squash
+        RecoverInst,           /// Is a recover instruction
+        BlockingInst,          /// Is a blocking instruction
+        ThreadsyncWait,        /// Is a thread synchronization instruction
+        SerializeBefore,       /// Needs to serialize on
+                               /// instructions ahead of it
+        SerializeAfter,        /// Needs to serialize instructions behind it
+        SerializeHandled,      /// Serialization has been handled
+        RatSnapshotted,        /// Instruction owns a RAT checkpoint
         NumStatus
     };
 
@@ -253,12 +252,7 @@ class DynInst : public ExecContext, public RefCounted
     };
 
   public:
-    enum class LoadPipeSource
-    {
-        IssueQueue,
-        ReplayQueue,
-        FastReplay
-    };
+    enum class LoadPipeSource { IssueQueue, ReplayQueue, FastReplay };
 
   private:
     /* An amalgamation of a lot of boolean values into one */
@@ -323,92 +317,49 @@ class DynInst : public ExecContext, public RefCounted
 
     // Returns the flattened register index of the idx'th destination
     // register.
-    const RegId &
-    flattenedDestIdx(int idx) const
-    {
-        return _flatDestIdx[idx];
-    }
+    const RegId &flattenedDestIdx(int idx) const { return _flatDestIdx[idx]; }
 
     // Flattens a destination architectural register index into a logical
     // index.
-    void
-    flattenedDestIdx(int idx, const RegId &reg_id)
-    {
-        _flatDestIdx[idx] = reg_id;
-    }
+    void flattenedDestIdx(int idx, const RegId &reg_id) { _flatDestIdx[idx] = reg_id; }
 
     // Returns the physical register index of the idx'th destination
     // register.
-    PhysRegIdPtr
-    renamedDestIdx(int idx) const
-    {
-        return _destIdx[idx].PhyReg();
-    }
+    PhysRegIdPtr renamedDestIdx(int idx) const { return _destIdx[idx].PhyReg(); }
 
-    VirtRegId
-    extRenamedDestIdx(int idx) const
-    {
-        return _destIdx[idx];
-    }
+    VirtRegId extRenamedDestIdx(int idx) const { return _destIdx[idx]; }
 
     // Set the renamed dest register id.
-    void
-    renamedDestIdx(int idx, VirtRegId phys_reg_id)
-    {
-        _destIdx[idx] = phys_reg_id;
-    }
+    void renamedDestIdx(int idx, VirtRegId phys_reg_id) { _destIdx[idx] = phys_reg_id; }
 
     // Returns the physical register index of the previous physical
     // register that remapped to the same logical register index.
-    VirtRegId
-    prevDestIdx(int idx) const
-    {
-        return _prevDestIdx[idx];
-    }
+    VirtRegId prevDestIdx(int idx) const { return _prevDestIdx[idx]; }
 
     // Set the previous renamed dest register id.
-    void
-    prevDestIdx(int idx, VirtRegId phys_reg_id)
-    {
-        _prevDestIdx[idx] = phys_reg_id;
-    }
+    void prevDestIdx(int idx, VirtRegId phys_reg_id) { _prevDestIdx[idx] = phys_reg_id; }
 
     // Returns the physical register index of the i'th source register.
-    PhysRegIdPtr
-    renamedSrcIdx(int idx) const
-    {
-        return _srcIdx[idx].PhyReg();
-    }
+    PhysRegIdPtr renamedSrcIdx(int idx) const { return _srcIdx[idx].PhyReg(); }
 
-    VirtRegId
-    extRenamedSrcIdx(int idx) const
-    {
-        return _srcIdx[idx];
-    }
+    VirtRegId extRenamedSrcIdx(int idx) const { return _srcIdx[idx]; }
 
-    void
-    renamedSrcIdx(int idx, VirtRegId phys_reg_id)
-    {
-        _srcIdx[idx] = phys_reg_id;
-    }
+    void renamedSrcIdx(int idx, VirtRegId phys_reg_id) { _srcIdx[idx] = phys_reg_id; }
 
     // after dispatch, it's status was speculative
-    bool
-    readySrcIdx(int idx) const
+    bool readySrcIdx(int idx) const
     {
         uint8_t &byte = _readySrcIdx[idx / 8];
         return bits(byte, idx % 8);
     }
 
-    void
-    readySrcIdx(int idx, bool ready)
+    void readySrcIdx(int idx, bool ready)
     {
         uint8_t &byte = _readySrcIdx[idx / 8];
         replaceBits(byte, idx % 8, ready ? 1 : 0);
     }
 
-    void
-    setProducerStorePC(Addr pc)
+    void setProducerStorePC(Addr pc)
     {
         _hasProducerStorePC = true;
         _producerStorePC = pc;
@@ -481,7 +432,7 @@ class DynInst : public ExecContext, public RefCounted
     /** If load data is from cache then it must be golden */
     uint8_t goldenData[8] = {0};
 
-    int pf_source  = -1; // if load cache line is prefetched
+    int pf_source = -1;  // if load cache line is prefetched
     /////////////////////// TLB Miss //////////////////////
     /**
      * Saved memory request (needed when the DTB address translation is
@@ -542,62 +493,41 @@ class DynInst : public ExecContext, public RefCounted
     //
     ////////////////////////////////////////////
 
-    void
-    demapPage(Addr vaddr, uint64_t asn) override
-    {
-        cpu->demapPage(vaddr, asn);
-    }
+    void demapPage(Addr vaddr, uint64_t asn) override { cpu->demapPage(vaddr, asn); }
 
     void updateVectorMemCrossCacheBlock(
             Addr addr, unsigned size, const std::vector<bool> &byte_enable);
 
     Fault initiateMemRead(Addr addr, unsigned size, Request::Flags flags,
-            const std::vector<bool> &byte_enable) override;
+                          const std::vector<bool> &byte_enable) override;
 
     Fault initiateMemMgmtCmd(Request::Flags flags) override;
 
-    Fault writeMem(uint8_t *data, unsigned size, Addr addr,
-                   Request::Flags flags, uint64_t *res,
+    Fault writeMem(uint8_t *data, unsigned size, Addr addr, Request::Flags flags, uint64_t *res,
                    const std::vector<bool> &byte_enable) override;
 
-    Fault initiateMemAMO(Addr addr, unsigned size, Request::Flags flags,
-                         AtomicOpFunctorPtr amo_op) override;
+    Fault initiateMemAMO(Addr addr, unsigned size, Request::Flags flags, AtomicOpFunctorPtr amo_op) override;
 
     /** True if the DTB address translation has started. */
     bool translationStarted() const { return instFlags[TranslationStarted]; }
     void translationStarted(bool f) { instFlags[TranslationStarted] = f; }
 
     /** True if the DTB address translation has completed. */
-    bool
-    translationCompleted() const
-    {
-        return instFlags[TranslationCompleted];
-    }
+    bool translationCompleted() const { return instFlags[TranslationCompleted]; }
     void translationCompleted(bool f) { instFlags[TranslationCompleted] = f; }
 
 
     void setNormalLd(bool t) { instFlags[NormalLd] = t; }
 
-    bool isNormalLd() const
-    {
-        return instFlags[NormalLd];
-    }
+    bool isNormalLd() const { return instFlags[NormalLd]; }
 
     /** True if this address was found to match a previous load and they issued
      * out of order. If that happend, then it's only a problem if an incoming
      * snoop invalidate modifies the line, in which case we need to squash.
      * If nothing modified the line the order doesn't matter.
      */
-    bool
-    possibleLoadViolation() const
-    {
-        return instFlags[PossibleLoadViolation];
-    }
-    void
-    possibleLoadViolation(bool f)
-    {
-        instFlags[PossibleLoadViolation] = f;
-    }
+    bool possibleLoadViolation() const { return instFlags[PossibleLoadViolation]; }
+    void possibleLoadViolation(bool f) { instFlags[PossibleLoadViolation] = f; }
 
     /** True if the address hit a external snoop while sitting in the LSQ.
      * If this is true and a older instruction sees it, this instruction must
@@ -610,11 +540,7 @@ class DynInst : public ExecContext, public RefCounted
      * Returns true if the DTB address translation is being delayed due to a hw
      * page table walk.
      */
-    bool
-    isTranslationDelayed() const
-    {
-        return (translationStarted() && !translationCompleted());
-    }
+    bool isTranslationDelayed() const { return (translationStarted() && !translationCompleted()); }
 
   public:
 #ifdef DEBUG
@@ -627,9 +553,7 @@ class DynInst : public ExecContext, public RefCounted
     /** Renames a destination register to a physical register.  Also records
      *  the previous physical register that the logical register mapped to.
      */
-    void
-    renameDestReg(int idx, VirtRegId renamed_dest,
-                  VirtRegId previous_rename)
+    void renameDestReg(int idx, VirtRegId renamed_dest, VirtRegId previous_rename)
     {
         renamedDestIdx(idx, renamed_dest);
         prevDestIdx(idx, previous_rename);
@@ -641,11 +565,7 @@ class DynInst : public ExecContext, public RefCounted
      *  has/will produce that logical register's result.
      *  @todo: add in whether or not the source register is ready.
      */
-    void
-    renameSrcReg(int idx, VirtRegId renamed_src)
-    {
-        renamedSrcIdx(idx, renamed_src);
-    }
+    void renameSrcReg(int idx, VirtRegId renamed_src) { renamedSrcIdx(idx, renamed_src); }
 
     bool isDependentOn(const DynInstPtr &other) const;
 
@@ -671,7 +591,7 @@ class DynInst : public ExecContext, public RefCounted
     Fault getFault() const { return fault; }
     /** TODO: This I added for the LSQRequest side to be able to modify the
      * fault. There should be a better mechanism in place. */
-    Fault& getFault() { return fault; }
+    Fault &getFault() { return fault; }
 
     bool faulted() const { return fault != NoFault; }
 
@@ -690,11 +610,7 @@ class DynInst : public ExecContext, public RefCounted
     /** Returns whether the instruction was predicted taken or not. */
     bool readPredTaken() { return instFlags[PredTaken]; }
 
-    void
-    setPredTaken(bool predicted_taken)
-    {
-        instFlags[PredTaken] = predicted_taken;
-    }
+    void setPredTaken(bool predicted_taken) { instFlags[PredTaken] = predicted_taken; }
 
     // ---- Trace branch/control-flow ground-truth (used by Decode/EXE in trace mode)
     bool traceBranchInfoValid = false;
@@ -721,22 +637,16 @@ class DynInst : public ExecContext, public RefCounted
         traceIsIndirectValue = false;
     }
 
-    void setTraceBranchInfo(bool taken, bool hasTarget, Addr branchTarget,
-                            Addr fallthrough)
+    void setTraceBranchInfo(bool taken, bool hasTarget, Addr branchTarget, Addr fallthrough)
     {
         traceBranchInfoValid = true;
         traceBranchTakenValue = taken;
         traceBranchHasTargetValue = hasTarget;
         traceBranchTargetValue = hasTarget ? branchTarget : 0;
-        traceBranchNextPCValue = taken ?
-            (hasTarget ? branchTarget : fallthrough) :
-            fallthrough;
+        traceBranchNextPCValue = taken ? (hasTarget ? branchTarget : fallthrough) : fallthrough;
     }
 
-    void setTraceCtrlFlowChange(bool hasCtrlFlowChange)
-    {
-        traceCtrlFlowChangeValue = hasCtrlFlowChange;
-    }
+    void setTraceCtrlFlowChange(bool hasCtrlFlowChange) { traceCtrlFlowChangeValue = hasCtrlFlowChange; }
     void setTraceIsCall(bool v) { traceIsCallValue = v; }
     void setTraceIsReturn(bool v) { traceIsReturnValue = v; }
     void setTraceIsIndirect(bool v) { traceIsIndirectValue = v; }
@@ -757,67 +667,53 @@ class DynInst : public ExecContext, public RefCounted
     bool isLastTraceInst() const { return lastTraceInstFlag; }
 
     /** Returns whether the instruction mispredicted. */
-    bool
-    mispredicted()
+    bool mispredicted()
     {
         std::unique_ptr<PCStateBase> next_pc(pc->clone());
         staticInst->advancePC(*next_pc);
-        DPRINTF(DecoupleBP, "check misprediction next pc=%s and pred pc=%s\n",
-                *next_pc, *predPC);
+        DPRINTF(DecoupleBP, "check misprediction next pc=%s and pred pc=%s\n", *next_pc, *predPC);
         return *next_pc != *predPC;
     }
 
     //
     //  Instruction types.  Forward checks to StaticInst object.
     //
-    bool isSplitStoreAddr()   const { return staticInst->isSplitStoreAddr(); }
+    bool isSplitStoreAddr() const { return staticInst->isSplitStoreAddr(); }
     bool isSplitStoreData() const { return opClass() == StoreDataOp; }
-    bool isFusion()       const { return staticInst->isFusion(); }
-    bool isNop()          const { return staticInst->isNop(); }
-    bool isMemRef()       const { return staticInst->isMemRef(); }
-    bool isLoad()         const { return staticInst->isLoad(); }
-    bool isHInst()        const { return staticInst->isHInst(); }
-    bool isStore()        const { return staticInst->isStore(); }
-    bool isAtomic()       const { return staticInst->isAtomic(); }
+    bool isFusion() const { return staticInst->isFusion(); }
+    bool isNop() const { return staticInst->isNop(); }
+    bool isMemRef() const { return staticInst->isMemRef(); }
+    bool isLoad() const { return staticInst->isLoad(); }
+    bool isHInst() const { return staticInst->isHInst(); }
+    bool isStore() const { return staticInst->isStore(); }
+    bool isAtomic() const { return staticInst->isAtomic(); }
     bool isLoadReserved() const { return staticInst->isLoadReserved(); }
-    bool isStoreConditional() const
-    { return staticInst->isStoreConditional(); }
+    bool isStoreConditional() const { return staticInst->isStoreConditional(); }
     bool isInstPrefetch() const { return staticInst->isInstPrefetch(); }
     bool isDataPrefetch() const { return staticInst->isDataPrefetch(); }
-    bool isInteger()      const { return staticInst->isInteger(); }
-    bool isFloating()     const { return staticInst->isFloating(); }
-    bool isVector()       const { return staticInst->isVector(); }
-    bool isControl()      const { return staticInst->isControl(); }
-    bool isCall()         const { return staticInst->isCall(); }
-    bool isReturn()       const { return staticInst->isReturn(); }
-    bool isDirectCtrl()   const { return staticInst->isDirectCtrl(); }
+    bool isInteger() const { return staticInst->isInteger(); }
+    bool isFloating() const { return staticInst->isFloating(); }
+    bool isVector() const { return staticInst->isVector(); }
+    bool isControl() const { return staticInst->isControl(); }
+    bool isCall() const { return staticInst->isCall(); }
+    bool isReturn() const { return staticInst->isReturn(); }
+    bool isDirectCtrl() const { return staticInst->isDirectCtrl(); }
     bool isIndirectCtrl() const { return staticInst->isIndirectCtrl(); }
-    bool isCondCtrl()     const { return staticInst->isCondCtrl(); }
-    bool isUncondCtrl()   const { return staticInst->isUncondCtrl(); }
-    bool isSerializing()  const { return staticInst->isSerializing(); }
-    bool isMov()          const { return staticInst->isMov(); }
-    bool isAddImm()       const { return staticInst->isAddImm(); }
-    bool isEliminated() const
-    {
-        return instFlags[IsEmptyMov] || instFlags[IsConstantFolded];
-    }
-    bool
-    isSerializeBefore() const
-    {
-        return staticInst->isSerializeBefore() || status[SerializeBefore];
-    }
-    bool
-    isSerializeAfter() const
-    {
-        return staticInst->isSerializeAfter() || status[SerializeAfter];
-    }
+    bool isCondCtrl() const { return staticInst->isCondCtrl(); }
+    bool isUncondCtrl() const { return staticInst->isUncondCtrl(); }
+    bool isSerializing() const { return staticInst->isSerializing(); }
+    bool isMov() const { return staticInst->isMov(); }
+    bool isAddImm() const { return staticInst->isAddImm(); }
+    bool isEliminated() const { return instFlags[IsEmptyMov] || instFlags[IsConstantFolded]; }
+    bool isSerializeBefore() const { return staticInst->isSerializeBefore() || status[SerializeBefore]; }
+    bool isSerializeAfter() const { return staticInst->isSerializeAfter() || status[SerializeAfter]; }
     bool isSquashAfter() const { return staticInst->isSquashAfter(); }
-    bool isFullMemBarrier()   const { return staticInst->isFullMemBarrier(); }
+    bool isFullMemBarrier() const { return staticInst->isFullMemBarrier(); }
     bool isReadBarrier() const { return staticInst->isReadBarrier(); }
     bool isWriteBarrier() const { return staticInst->isWriteBarrier(); }
     bool isNonSpeculative() const { return staticInst->isNonSpeculative(); }
-    bool isUpdateVsstatusSd() const {return staticInst->isUpdateVsstatusSd(); }
-    bool isUpdateMstatusSd() const {return staticInst->isUpdateMstatusSd(); }
+    bool isUpdateVsstatusSd() const { return staticInst->isUpdateVsstatusSd(); }
+    bool isUpdateMstatusSd() const { return staticInst->isUpdateMstatusSd(); }
     bool isQuiesce() const { return staticInst->isQuiesce(); }
     bool isUnverifiable() const { return staticInst->isUnverifiable(); }
     bool isSyscall() const { return staticInst->isSyscall(); }
@@ -832,28 +728,21 @@ class DynInst : public ExecContext, public RefCounted
     bool isHtmCancel() const { return staticInst->isHtmCancel(); }
     bool isHtmCmd() const { return staticInst->isHtmCmd(); }
 
-    uint64_t
-    getHtmTransactionUid() const override
+    uint64_t getHtmTransactionUid() const override
     {
         assert(instFlags[HtmFromTransaction]);
         return htmUid;
     }
 
-    uint64_t
-    newHtmTransactionUid() const override
+    uint64_t newHtmTransactionUid() const override
     {
         panic("Not yet implemented\n");
         return 0;
     }
 
-    bool
-    inHtmTransactionalState() const override
-    {
-        return instFlags[HtmFromTransaction];
-    }
+    bool inHtmTransactionalState() const override { return instFlags[HtmFromTransaction]; }
 
-    uint64_t
-    getHtmTransactionalDepth() const override
+    uint64_t getHtmTransactionalDepth() const override
     {
         if (inHtmTransactionalState())
             return htmDepth;
@@ -861,21 +750,17 @@ class DynInst : public ExecContext, public RefCounted
             return 0;
     }
 
-    void
-    setHtmTransactionalState(uint64_t htm_uid, uint64_t htm_depth)
+    void setHtmTransactionalState(uint64_t htm_uid, uint64_t htm_depth)
     {
         instFlags.set(HtmFromTransaction);
         htmUid = htm_uid;
         htmDepth = htm_depth;
     }
 
-    void
-    clearHtmTransactionalState()
+    void clearHtmTransactionalState()
     {
         if (inHtmTransactionalState()) {
-            DPRINTF(HtmCpu,
-                "clearing instuction's transactional state htmUid=%u\n",
-                getHtmTransactionUid());
+            DPRINTF(HtmCpu, "clearing instuction's transactional state htmUid=%u\n", getHtmTransactionUid());
 
             instFlags.reset(HtmFromTransaction);
             htmUid = -1;
@@ -921,8 +806,7 @@ class DynInst : public ExecContext, public RefCounted
     OpClass opClass() const { return staticInst->opClass(); }
 
     /** Returns the branch target address. */
-    std::unique_ptr<PCStateBase>
-    branchTarget() const
+    std::unique_ptr<PCStateBase> branchTarget() const
     {
         if (traceBranchHasTarget()) {
             // Construct a concrete PCState for the current ISA to hold the
@@ -939,21 +823,17 @@ class DynInst : public ExecContext, public RefCounted
     /** Returns the number of destination registers. */
     size_t numDestRegs() const { return numDests(); }
 
-    size_t
-    numDestRegs(RegClassType type) const
-    {
-        return staticInst->numDestRegs(type);
-    }
+    size_t numDestRegs(RegClassType type) const { return staticInst->numDestRegs(type); }
 
     /** Returns the logical register index of the i'th destination register. */
-    const RegId& destRegIdx(int i) const { return staticInst->destRegIdx(i); }
+    const RegId &destRegIdx(int i) const { return staticInst->destRegIdx(i); }
 
     /** Returns the logical register index of the i'th source register. */
-    const RegId& srcRegIdx(int i) const { return staticInst->srcRegIdx(i); }
+    const RegId &srcRegIdx(int i) const { return staticInst->srcRegIdx(i); }
 
     uint64_t getAmoOldGoldenValue() const { return amoOldGoldenValue; }
 
-    void *getAmoOldGoldenValuePtr() { return (void *) &amoOldGoldenValue; }
+    void *getAmoOldGoldenValuePtr() { return (void *)&amoOldGoldenValue; }
 
     /** Return the size of the instResult queue. */
     uint8_t resultSize() { return instResult.size(); }
@@ -961,8 +841,7 @@ class DynInst : public ExecContext, public RefCounted
     /** Pops a result off the instResult queue.
      * If the result stack is empty, return the default value.
      * */
-    InstResult
-    popResult(InstResult dflt=InstResult())
+    InstResult popResult(InstResult dflt = InstResult())
     {
         if (!instResult.empty()) {
             InstResult t = instResult.front();
@@ -984,8 +863,7 @@ class DynInst : public ExecContext, public RefCounted
     /** Pushes a result onto the instResult queue. */
     /** @{ */
     template<typename T>
-    void
-    setResult(T &&t)
+    void setResult(T &&t)
     {
         if (instFlags[RecordResult]) {
             instResult.emplace(std::forward<T>(t));
@@ -1031,7 +909,11 @@ class DynInst : public ExecContext, public RefCounted
 
     bool memDepSolved() const { return status[MemDepSolved]; }
 
-    void setWriteback() { issueQue = nullptr; issueportid = -1; }
+    void setWriteback()
+    {
+        issueQue = nullptr;
+        issueportid = -1;
+    }
 
     /** Scheduler state begin */
 
@@ -1072,70 +954,60 @@ class DynInst : public ExecContext, public RefCounted
 
     /** load/store pipe state begin */
 
-    void beginPipelining() {
-                status &= ~(
-                    (1 << CacheHit) |
-                    (1 << WakeUpEarly) |
-                    (1 << FullForward) |
-                    (1 << LocalAccess) |
-                    (1 << NeedReplay) |
-                    (1 << SkipFollowingPipe));
+    void beginPipelining()
+    {
+        status &= ~((1 << CacheHit) | (1 << WakeUpEarly) | (1 << FullForward) | (1 << LocalAccess) |
+                    (1 << NeedReplay) | (1 << SkipFollowingPipe));
         status.set(InPipe);
         clearReplayType();
         clearReplayFlags();
     }
 
-    void endPipelining() {
-        status.reset(InPipe);
-    }
+    void endPipelining() { status.reset(InPipe); }
 
     bool inPipe() const { return status[InPipe]; }
 
     void setCacheHit() { status.set(CacheHit); }
     bool cacheHit() const { return status[CacheHit]; }
 
-    void setReplay(LdStReplayType type) {
+    void setReplay(LdStReplayType type)
+    {
         markReplayFlag(type);
         setNeedReplay();
         replayType = type;
     }
-    std::optional<LdStReplayType> getReplayType() const {
-        return replayType;
-    }
+    std::optional<LdStReplayType> getReplayType() const { return replayType; }
     void clearReplayType() { replayType.reset(); }
     void clearReplayFlags() { replayFlags.reset(); }
-    void markReplayFlag(LdStReplayType type) {
-        replayFlags.set(static_cast<size_t>(type));
-    }
-    bool hasReplayFlag(LdStReplayType type) const {
-        return replayFlags.test(static_cast<size_t>(type));
-    }
-    std::optional<LdStReplayType> selectReplayTypeFromFlags() const {
+    void markReplayFlag(LdStReplayType type) { replayFlags.set(static_cast<size_t>(type)); }
+    bool hasReplayFlag(LdStReplayType type) const { return replayFlags.test(static_cast<size_t>(type)); }
+    std::optional<LdStReplayType> selectReplayTypeFromFlags() const
+    {
         auto rtlReplayPriority = [](LdStReplayType type) -> int {
             switch (type) {
-              case LdStReplayType::MdpAddrReplay:
-                return 2;  // C_MA
-              case LdStReplayType::TLBMissReplay:
-                return 3;  // C_TM
-              case LdStReplayType::STLFReplay:
-                return 4;  // C_FF
-              case LdStReplayType::CacheBlockedReplay:
-              case LdStReplayType::MshrAliasFailReplay:
-              case LdStReplayType::HitInWriteBufferReplay:
-              case LdStReplayType::MshrArbFailReplay:
-                return 5;  // C_DR
-              case LdStReplayType::CacheMissReplay:
-                return 6;  // C_DM
-              case LdStReplayType::BankConflictReplay:
-                return 8;  // C_BC
-              case LdStReplayType::RARReplay:
-                return 9;  // C_RAR
-              case LdStReplayType::RAWReplay:
-                return 10; // C_RAW
-              case LdStReplayType::NukeReplay:
-                return 11; // C_NK
-              default:
-                return 100 + static_cast<int>(type);
+                case LdStReplayType::MdpAddrReplay:
+                    return 2;  // C_MA
+                case LdStReplayType::TLBMissReplay:
+                    return 3;  // C_TM
+                case LdStReplayType::STLFReplay:
+                    return 4;  // C_FF
+                case LdStReplayType::CacheBlockedReplay:
+                case LdStReplayType::MshrAliasFailReplay:
+                case LdStReplayType::HitInWriteBufferReplay:
+                case LdStReplayType::MshrArbFailReplay:
+                    return 5;  // C_DR
+                case LdStReplayType::CacheMissReplay:
+                    return 6;  // C_DM
+                case LdStReplayType::BankConflictReplay:
+                    return 8;  // C_BC
+                case LdStReplayType::RARReplay:
+                    return 9;  // C_RAR
+                case LdStReplayType::RAWReplay:
+                    return 10;  // C_RAW
+                case LdStReplayType::NukeReplay:
+                    return 11;  // C_NK
+                default:
+                    return 100 + static_cast<int>(type);
             }
         };
 
@@ -1161,7 +1033,8 @@ class DynInst : public ExecContext, public RefCounted
         return {};
     }
 
-    bool finalizeReplayTypeFromFlags() {
+    bool finalizeReplayTypeFromFlags()
+    {
         auto selected = selectReplayTypeFromFlags();
         if (!selected) {
             return false;
@@ -1176,7 +1049,8 @@ class DynInst : public ExecContext, public RefCounted
     LoadPipeSource getLoadPipeSource() const { return loadPipeSource; }
 
     // only can be set once!!!
-    void setNeedReplay() {
+    void setNeedReplay()
+    {
         assert(!status[NeedReplay]);
         status.set(NeedReplay);
     }
@@ -1286,13 +1160,17 @@ class DynInst : public ExecContext, public RefCounted
     bool isSquashed() const { return status[Squashed]; }
 
     /** Sets this instruction as squashed in the IQ. */
-    void setSquashedInIQ() { status.set(SquashedInIQ); status.set(Squashed);}
+    void setSquashedInIQ()
+    {
+        status.set(SquashedInIQ);
+        status.set(Squashed);
+    }
 
     /** Returns whether or not this instruction is squashed in the IQ. */
     bool isSquashedInIQ() const { return status[SquashedInIQ]; }
 
 
-    //Load / Store Queue Functions
+    // Load / Store Queue Functions
     //-----------------------
     /** Sets this instruction as a entry the LSQ. */
     void setInLSQ() { status.set(LsqEntry); }
@@ -1304,13 +1182,17 @@ class DynInst : public ExecContext, public RefCounted
     bool isInLSQ() const { return status[LsqEntry]; }
 
     /** Sets this instruction as squashed in the LSQ. */
-    void setSquashedInLSQ() { status.set(SquashedInLSQ); status.set(Squashed);}
+    void setSquashedInLSQ()
+    {
+        status.set(SquashedInLSQ);
+        status.set(Squashed);
+    }
 
     /** Returns whether or not this instruction is squashed in the LSQ. */
     bool isSquashedInLSQ() const { return status[SquashedInLSQ]; }
 
 
-    //Reorder Buffer Functions
+    // Reorder Buffer Functions
     //-----------------------
     /** Sets this instruction as a entry the ROB. */
     void setInROB() { status.set(RobEntry); }
@@ -1331,8 +1213,7 @@ class DynInst : public ExecContext, public RefCounted
     bool isPinnedRegsRenamed() const { return status[PinnedRegsRenamed]; }
 
     /** Sets the destination registers as renamed */
-    void
-    setPinnedRegsRenamed()
+    void setPinnedRegsRenamed()
     {
         assert(!status[PinnedRegsSquashDone]);
         assert(!status[PinnedRegsWritten]);
@@ -1343,8 +1224,7 @@ class DynInst : public ExecContext, public RefCounted
     bool isPinnedRegsWritten() const { return status[PinnedRegsWritten]; }
 
     /** Sets destination registers as written */
-    void
-    setPinnedRegsWritten()
+    void setPinnedRegsWritten()
     {
         assert(!status[PinnedRegsSquashDone]);
         assert(status[PinnedRegsRenamed]);
@@ -1352,34 +1232,24 @@ class DynInst : public ExecContext, public RefCounted
     }
 
     /** Return whether dest registers' pinning status updated after squash */
-    bool
-    isPinnedRegsSquashDone() const
-    {
-        return status[PinnedRegsSquashDone];
-    }
+    bool isPinnedRegsSquashDone() const { return status[PinnedRegsSquashDone]; }
 
     /** Sets dest registers' status updated after squash */
-    void
-    setPinnedRegsSquashDone()
+    void setPinnedRegsSquashDone()
     {
         assert(!status[PinnedRegsSquashDone]);
         status.set(PinnedRegsSquashDone);
     }
 
     /** Read the PC state of this instruction. */
-    const PCStateBase &
-    pcState() const override
-    {
-        return *pc;
-    }
+    const PCStateBase &pcState() const override { return *pc; }
 
     /** Set the PC state of this instruction. */
     void pcState(const PCStateBase &val) override { set(pc, val); }
 
     bool readPredicate() const override { return instFlags[Predicate]; }
 
-    void
-    setPredicate(bool val) override
+    void setPredicate(bool val) override
     {
         instFlags[Predicate] = val;
 
@@ -1388,17 +1258,9 @@ class DynInst : public ExecContext, public RefCounted
         }
     }
 
-    bool
-    readMemAccPredicate() const override
-    {
-        return instFlags[MemAccPredicate];
-    }
+    bool readMemAccPredicate() const override { return instFlags[MemAccPredicate]; }
 
-    void
-    setMemAccPredicate(bool val) override
-    {
-        instFlags[MemAccPredicate] = val;
-    }
+    void setMemAccPredicate(bool val) override { instFlags[MemAccPredicate] = val; }
 
     /** Sets the thread id. */
     void setTid(ThreadID tid) { threadNumber = tid; }
@@ -1426,44 +1288,18 @@ class DynInst : public ExecContext, public RefCounted
     void setInstListIt(ListIt _instListIt) { instListIt = _instListIt; }
 
   public:
-
-
     /** Returns the number of consecutive store conditional failures. */
-    unsigned int
-    readStCondFailures() const override
-    {
-        return thread->storeCondFailures;
-    }
+    unsigned int readStCondFailures() const override { return thread->storeCondFailures; }
 
     /** Sets the number of consecutive store conditional failures. */
-    void
-    setStCondFailures(unsigned int sc_failures) override
-    {
-        thread->storeCondFailures = sc_failures;
-    }
+    void setStCondFailures(unsigned int sc_failures) override { thread->storeCondFailures = sc_failures; }
 
   public:
     // monitor/mwait funtions
-    void
-    armMonitor(Addr address) override
-    {
-        cpu->armMonitor(threadNumber, address);
-    }
-    bool
-    mwait(PacketPtr pkt) override
-    {
-        return cpu->mwait(threadNumber, pkt);
-    }
-    void
-    mwaitAtomic(gem5::ThreadContext *tc) override
-    {
-        return cpu->mwaitAtomic(threadNumber, tc, cpu->mmu);
-    }
-    AddressMonitor *
-    getAddrMonitor() override
-    {
-        return cpu->getCpuAddrMonitor(threadNumber);
-    }
+    void armMonitor(Addr address) override { cpu->armMonitor(threadNumber, address); }
+    bool mwait(PacketPtr pkt) override { return cpu->mwait(threadNumber, pkt); }
+    void mwaitAtomic(gem5::ThreadContext *tc) override { return cpu->mwaitAtomic(threadNumber, tc, cpu->mmu); }
+    AddressMonitor *getAddrMonitor() override { return cpu->getCpuAddrMonitor(threadNumber); }
 
   private:
     // hardware transactional memory
@@ -1471,7 +1307,7 @@ class DynInst : public ExecContext, public RefCounted
     uint64_t htmDepth = 0;
 
   public:
-    Tick fetchTick = -1;      // instruction fetch is completed.
+    Tick fetchTick = -1;  // instruction fetch is completed.
 #if TRACING_ON
     // Value -1 indicates that particular phase
     // hasn't happened (yet).
@@ -1505,17 +1341,12 @@ class DynInst : public ExecContext, public RefCounted
     /** Reads a misc. register, including any side-effects the read
      * might have as defined by the architecture.
      */
-    RegVal
-    readMiscReg(int misc_reg) override
-    {
-        return cpu->readMiscReg(misc_reg, threadNumber);
-    }
+    RegVal readMiscReg(int misc_reg) override { return cpu->readMiscReg(misc_reg, threadNumber); }
 
     /** Sets a misc. register, including any side-effects the write
      * might have as defined by the architecture.
      */
-    void
-    setMiscReg(int misc_reg, RegVal val) override
+    void setMiscReg(int misc_reg, RegVal val) override
     {
         /** Writes to misc. registers are recorded and deferred until the
          * commit stage, when updateMiscRegs() is called. First, check if
@@ -1523,7 +1354,7 @@ class DynInst : public ExecContext, public RefCounted
          * committed instead of making a new entry. If not, make a new
          * entry and record the write.
          */
-        for (auto &idx: _destMiscRegIdx) {
+        for (auto &idx : _destMiscRegIdx) {
             if (idx == misc_reg)
                 return;
         }
@@ -1536,10 +1367,9 @@ class DynInst : public ExecContext, public RefCounted
     /** Reads a misc. register, including any side-effects the read
      * might have as defined by the architecture.
      */
-    RegVal
-    readMiscRegOperand(const StaticInst *si, int idx) override
+    RegVal readMiscRegOperand(const StaticInst *si, int idx) override
     {
-        const RegId& reg = si->srcRegIdx(idx);
+        const RegId &reg = si->srcRegIdx(idx);
         assert(reg.is(MiscRegClass));
         return cpu->readMiscReg(reg.index(), threadNumber);
     }
@@ -1547,17 +1377,15 @@ class DynInst : public ExecContext, public RefCounted
     /** Sets a misc. register, including any side-effects the write
      * might have as defined by the architecture.
      */
-    void
-    setMiscRegOperand(const StaticInst *si, int idx, RegVal val) override
+    void setMiscRegOperand(const StaticInst *si, int idx, RegVal val) override
     {
-        const RegId& reg = si->destRegIdx(idx);
+        const RegId &reg = si->destRegIdx(idx);
         assert(reg.is(MiscRegClass));
         setMiscReg(reg.index(), val);
     }
 
     /** Called at the commit stage to update the misc. registers. */
-    void
-    updateMiscRegs()
+    void updateMiscRegs()
     {
         // @todo: Pretty convoluted way to avoid squashing from happening when
         // using the TC during an instruction's execution (specifically for
@@ -1567,52 +1395,43 @@ class DynInst : public ExecContext, public RefCounted
         thread->noSquashFromTC = true;
 
         for (int i = 0; i < _destMiscRegIdx.size(); i++)
-            cpu->setMiscReg(
-                _destMiscRegIdx[i], _destMiscRegVal[i], threadNumber);
+            cpu->setMiscReg(_destMiscRegIdx[i], _destMiscRegVal[i], threadNumber);
 
         thread->noSquashFromTC = no_squash_from_TC;
     }
 
-    void
-    forwardOldRegs()
+    void forwardOldRegs()
     {
 
         for (int idx = 0; idx < numDestRegs(); idx++) {
             VirtRegId prev_phys_reg = prevDestIdx(idx);
-            const RegId& original_dest_reg = staticInst->destRegIdx(idx);
+            const RegId &original_dest_reg = staticInst->destRegIdx(idx);
             switch (original_dest_reg.classValue()) {
-              case IntRegClass:
-              case FloatRegClass:
-              case CCRegClass:
-              case RMiscRegClass:
-                setRegOperand(staticInst.get(), idx,
-                        cpu->getReg(prev_phys_reg));
-                break;
-              case VecRegClass:
-                {
+                case IntRegClass:
+                case FloatRegClass:
+                case CCRegClass:
+                case RMiscRegClass:
+                    setRegOperand(staticInst.get(), idx, cpu->getReg(prev_phys_reg));
+                    break;
+                case VecRegClass: {
                     TheISA::VecRegContainer val;
                     cpu->getReg(prev_phys_reg.PhyReg(), &val);
                     setRegOperand(staticInst.get(), idx, &val);
-                }
-                break;
-              case VecElemClass:
-                setRegOperand(staticInst.get(), idx,
-                        cpu->getReg(prev_phys_reg));
-                break;
-              case VecPredRegClass:
-                {
+                } break;
+                case VecElemClass:
+                    setRegOperand(staticInst.get(), idx, cpu->getReg(prev_phys_reg));
+                    break;
+                case VecPredRegClass: {
                     TheISA::VecPredRegContainer val;
                     cpu->getReg(prev_phys_reg.PhyReg(), &val);
                     setRegOperand(staticInst.get(), idx, &val);
-                }
-                break;
-              case InvalidRegClass:
-              case MiscRegClass:
-                // no need to forward misc reg values
-                break;
-              default:
-                panic("Unknown register class: %d",
-                        (int)original_dest_reg.classValue());
+                } break;
+                case InvalidRegClass:
+                case MiscRegClass:
+                    // no need to forward misc reg values
+                    break;
+                default:
+                    panic("Unknown register class: %d", (int)original_dest_reg.classValue());
             }
         }
     }
@@ -1620,7 +1439,6 @@ class DynInst : public ExecContext, public RefCounted
     void trap(const Fault &fault);
 
   public:
-
     // The register accessor methods provide the index of the
     // instruction's operand (e.g., 0 or 1), not the architectural
     // register index, to simplify the implementation of register
@@ -1632,15 +1450,13 @@ class DynInst : public ExecContext, public RefCounted
     // storage (which is pretty hard to imagine they would have reason
     // to do).
 
-    RegVal
-    getRegOperand(const StaticInst *si, int idx) override
+    RegVal getRegOperand(const StaticInst *si, int idx) override
     {
         const VirtRegId reg = extRenamedSrcIdx(idx);
         return cpu->getReg(reg);
     }
 
-    void
-    getRegOperand(const StaticInst *si, int idx, void *val) override
+    void getRegOperand(const StaticInst *si, int idx, void *val) override
     {
         const VirtRegId reg = extRenamedSrcIdx(idx);
         if (reg.PhyReg()->is(InvalidRegClass))
@@ -1648,8 +1464,7 @@ class DynInst : public ExecContext, public RefCounted
         cpu->getReg(reg.PhyReg(), val);
     }
 
-    void *
-    getWritableRegOperand(const StaticInst *si, int idx) override
+    void *getWritableRegOperand(const StaticInst *si, int idx) override
     {
         return cpu->getWritableReg(extRenamedDestIdx(idx).PhyReg());
     }
@@ -1657,8 +1472,7 @@ class DynInst : public ExecContext, public RefCounted
     /** @todo: Make results into arrays so they can handle multiple dest
      *  registers.
      */
-    void
-    setRegOperand(const StaticInst *si, int idx, RegVal val) override
+    void setRegOperand(const StaticInst *si, int idx, RegVal val) override
     {
         const PhysRegIdPtr reg = extRenamedDestIdx(idx).PhyReg();
         if (reg->is(InvalidRegClass))
@@ -1667,14 +1481,13 @@ class DynInst : public ExecContext, public RefCounted
         setResult(val);
     }
 
-    void
-    setRegOperand(const StaticInst *si, int idx, const void *val) override
+    void setRegOperand(const StaticInst *si, int idx, const void *val) override
     {
         const PhysRegIdPtr reg = extRenamedDestIdx(idx).PhyReg();
         if (reg->is(InvalidRegClass))
             return;
         cpu->setReg(reg, val);
-        //TODO setResult
+        // TODO setResult
     }
 
     void printDisassemblyAndResult(const std::string &site) const;
@@ -1682,20 +1495,18 @@ class DynInst : public ExecContext, public RefCounted
     std::string genDisassembly() const
     {
         std::string str = "";
-        str += csprintf("[sn:%lu pc:%#lx] %s",
-                seqNum, pcState().instAddr(),
-                staticInst->disassemble(pcState().instAddr()));
+        str += csprintf("[sn:%lu pc:%#lx] %s", seqNum, pcState().instAddr(),
+                        staticInst->disassemble(pcState().instAddr()));
         if (instResult.size() > 0) {
             str += csprintf(", res: %#lx", instResult.front().as<uint64_t>());
-        }
-        else if (numDestRegs() > 0 && isVector()) {
+        } else if (numDestRegs() > 0 && isVector()) {
             uint64_t val[RiscvISA::NumVecElemPerVecReg];
             cpu->getArchReg(destRegIdx(0), val, threadNumber);
             std::string s_val;
-            for (int j=RiscvISA::NumVecElemPerVecReg-1; j>=0; j--) {
+            for (int j = RiscvISA::NumVecElemPerVecReg - 1; j >= 0; j--) {
                 s_val += csprintf("%016lx", val[j]);
                 if (j != 0) {
-                    s_val+="_";
+                    s_val += "_";
                 }
             }
             str += csprintf(", res: %s", s_val);
@@ -1707,29 +1518,13 @@ class DynInst : public ExecContext, public RefCounted
     }
 
 
-    void
-    setFtqId(unsigned id)
-    {
-        ftqId = id;
-    }
+    void setFtqId(unsigned id) { ftqId = id; }
 
-    unsigned
-    getFtqId()
-    {
-        return ftqId;
-    }
+    unsigned getFtqId() { return ftqId; }
 
-    void
-    setLoopIteration(unsigned iter)
-    {
-        loopIteration = iter;
-    }
+    void setLoopIteration(unsigned iter) { loopIteration = iter; }
 
-    unsigned
-    getLoopIteration()
-    {
-        return loopIteration;
-    }
+    unsigned getLoopIteration() { return loopIteration; }
 
     unsigned getInstBytes()
     {
@@ -1741,34 +1536,16 @@ class DynInst : public ExecContext, public RefCounted
     SquashVersion squashVer;
 
   public:
-    void setVersion(const SquashVersion &ver)
-    {
-        squashVer.update(ver.getVersion());
-    }
-    uint8_t getVersion()
-    {
-        return squashVer.getVersion();
-    }
+    void setVersion(const SquashVersion &ver) { squashVer.update(ver.getVersion()); }
+    uint8_t getVersion() { return squashVer.getVersion(); }
 
-    ssize_t getLqIdx()
-    {
-        return lqIdx;
-    }
+    ssize_t getLqIdx() { return lqIdx; }
 
-    Addr getPC()
-    {
-        return pc->instAddr();
-    }
+    Addr getPC() { return pc->instAddr(); }
 
-    Addr getNPC()
-    {
-        return pc->as<RiscvISA::PCState>().npc();
-    }
+    Addr getNPC() { return pc->as<RiscvISA::PCState>().npc(); }
 
-    bool branching()
-    {
-        return pc->as<RiscvISA::PCState>().branching();
-    }
+    bool branching() { return pc->as<RiscvISA::PCState>().branching(); }
 
     /** set golden */
     void setGolden(uint8_t *golden) { memcpy(goldenData, golden, effSize); }
@@ -1785,12 +1562,10 @@ class DynInst : public ExecContext, public RefCounted
     bool vpMisprediction = false;
     bool vpSupported = false;
 
-    bool canLVP(){
-        return isLoad() && !isVector() && !isLoadReserved();
-    }
+    bool canLVP() { return isLoad() && !isVector() && !isLoadReserved(); }
 };
 
-} // namespace o3
-} // namespace gem5
+}  // namespace o3
+}  // namespace gem5
 
-#endif // __CPU_O3_DYN_INST_HH__
+#endif  // __CPU_O3_DYN_INST_HH__

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -100,9 +100,10 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       iewStats(cpu)
 {
     if (wbWidth > MaxWidth)
-        fatal("wbWidth (%d) is larger than compiled limit (%d),\n"
-             "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
-             wbWidth, static_cast<int>(MaxWidth));
+        fatal(
+            "wbWidth (%d) is larger than compiled limit (%d),\n"
+            "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
+            wbWidth, static_cast<int>(MaxWidth));
 
     _status = Active;
     exeStatus = Running;
@@ -126,7 +127,6 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
     skidBufferMax = (renameToIEWDelay + 1) * params.renameWidth * 2;
 
     dispatchStalls.resize(renameWidth, StallReason::NoStall);
-
 }
 
 std::string
@@ -138,169 +138,108 @@ IEW::name() const
 void
 IEW::regProbePoints()
 {
-    ppDispatch = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "Dispatch");
-    ppMispredict = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "Mispredict");
+    ppDispatch = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "Dispatch");
+    ppMispredict = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "Mispredict");
     /**
      * Probe point with dynamic instruction as the argument used to probe when
      * an instruction starts to execute.
      */
-    ppExecute = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "Execute");
+    ppExecute = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "Execute");
     /**
      * Probe point with dynamic instruction as the argument used to probe when
      * an instruction execution completes and it is marked ready to commit.
      */
-    ppToCommit = new ProbePointArg<DynInstPtr>(
-            cpu->getProbeManager(), "ToCommit");
+    ppToCommit = new ProbePointArg<DynInstPtr>(cpu->getProbeManager(), "ToCommit");
 }
 
 IEW::IEWStats::IEWStats(CPU *cpu)
     : statistics::Group(cpu, "iew"),
-    ADD_STAT(idleCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is idle per thread"),
-    ADD_STAT(squashCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is squashing per thread"),
-    ADD_STAT(blockCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is blocking per thread"),
-    ADD_STAT(unblockCycles, statistics::units::Cycle::get(),
-             "Number of cycles IEW is unblocking"),
-    ADD_STAT(dispatchedInsts, statistics::units::Count::get(),
-             "Number of instructions dispatched to IQ"),
-    ADD_STAT(dispSquashedInsts, statistics::units::Count::get(),
-             "Number of squashed instructions skipped by dispatch"),
-    ADD_STAT(dispLoadInsts, statistics::units::Count::get(),
-             "Number of dispatched load instructions"),
-    ADD_STAT(dispStoreInsts, statistics::units::Count::get(),
-             "Number of dispatched store instructions"),
-    ADD_STAT(dispNonSpecInsts, statistics::units::Count::get(),
-             "Number of dispatched non-speculative instructions"),
-    ADD_STAT(iqFullEvents, statistics::units::Count::get(),
-             "Number of times the IQ has become full, causing a stall"),
-    ADD_STAT(lsqFullEvents, statistics::units::Count::get(),
-             "Number of times the LSQ has become full, causing a stall"),
-    ADD_STAT(memOrderViolationEvents, statistics::units::Count::get(),
-             "Number of memory order violations"),
-    ADD_STAT(predictedTakenIncorrect, statistics::units::Count::get(),
-             "Number of branches that were predicted taken incorrectly"),
-    ADD_STAT(predictedNotTakenIncorrect, statistics::units::Count::get(),
-             "Number of branches that were predicted not taken incorrectly"),
-    ADD_STAT(branchMispredicts, statistics::units::Count::get(),
-             "Number of branch mispredicts detected at execute",
-             predictedTakenIncorrect + predictedNotTakenIncorrect),
-    ADD_STAT(dispDist, statistics::units::Count::get(),
-             "Number of branch mispredicts detected at execute"),
-    executedInstStats(cpu),
-    ADD_STAT(instsToCommit, statistics::units::Count::get(),
-             "Cumulative count of insts sent to commit"),
-    ADD_STAT(writebackCount, statistics::units::Count::get(),
-             "Cumulative count of insts written-back"),
-    ADD_STAT(producerInst, statistics::units::Count::get(),
-             "Number of instructions producing a value"),
-    ADD_STAT(consumerInst, statistics::units::Count::get(),
-             "Number of instructions consuming a value"),
-    ADD_STAT(wbRate, statistics::units::Rate<
-                statistics::units::Count, statistics::units::Cycle>::get(),
-             "Insts written-back per cycle"),
-    ADD_STAT(wbFanout, statistics::units::Rate<
-                statistics::units::Count, statistics::units::Count>::get(),
-             "Average fanout of values written-back"),
-    ADD_STAT(stallEvents, statistics::units::Count::get(),
-             "Number of events the IEW has stalled"),
-    ADD_STAT(smtStallEvents, statistics::units::Count::get(),
-             "Number of events the IEW has stalled per thread"),
-    ADD_STAT(fetchStallReason, statistics::units::Count::get(),
-             "Number of fetch stall reasons each tick (Total)"),
-    ADD_STAT(decodeStallReason, statistics::units::Count::get(),
-             "Number of decode stall reasons each tick (Total)"),
-    ADD_STAT(renameStallReason, statistics::units::Count::get(),
-             "Number of rename stall reasons each tick (Total)"),
-    ADD_STAT(dispatchStallReason, statistics::units::Count::get(),
-             "Number of dispatch stall reasons each tick (Total)")
+      ADD_STAT(idleCycles, statistics::units::Cycle::get(), "Number of cycles IEW is idle per thread"),
+      ADD_STAT(squashCycles, statistics::units::Cycle::get(), "Number of cycles IEW is squashing per thread"),
+      ADD_STAT(blockCycles, statistics::units::Cycle::get(), "Number of cycles IEW is blocking per thread"),
+      ADD_STAT(unblockCycles, statistics::units::Cycle::get(), "Number of cycles IEW is unblocking"),
+      ADD_STAT(dispatchedInsts, statistics::units::Count::get(), "Number of instructions dispatched to IQ"),
+      ADD_STAT(dispSquashedInsts, statistics::units::Count::get(),
+               "Number of squashed instructions skipped by dispatch"),
+      ADD_STAT(dispLoadInsts, statistics::units::Count::get(), "Number of dispatched load instructions"),
+      ADD_STAT(dispStoreInsts, statistics::units::Count::get(), "Number of dispatched store instructions"),
+      ADD_STAT(dispNonSpecInsts, statistics::units::Count::get(), "Number of dispatched non-speculative instructions"),
+      ADD_STAT(iqFullEvents, statistics::units::Count::get(),
+               "Number of times the IQ has become full, causing a stall"),
+      ADD_STAT(lsqFullEvents, statistics::units::Count::get(),
+               "Number of times the LSQ has become full, causing a stall"),
+      ADD_STAT(memOrderViolationEvents, statistics::units::Count::get(), "Number of memory order violations"),
+      ADD_STAT(predictedTakenIncorrect, statistics::units::Count::get(),
+               "Number of branches that were predicted taken incorrectly"),
+      ADD_STAT(predictedNotTakenIncorrect, statistics::units::Count::get(),
+               "Number of branches that were predicted not taken incorrectly"),
+      ADD_STAT(branchMispredicts, statistics::units::Count::get(), "Number of branch mispredicts detected at execute",
+               predictedTakenIncorrect + predictedNotTakenIncorrect),
+      ADD_STAT(dispDist, statistics::units::Count::get(), "Number of branch mispredicts detected at execute"),
+      executedInstStats(cpu),
+      ADD_STAT(instsToCommit, statistics::units::Count::get(), "Cumulative count of insts sent to commit"),
+      ADD_STAT(writebackCount, statistics::units::Count::get(), "Cumulative count of insts written-back"),
+      ADD_STAT(producerInst, statistics::units::Count::get(), "Number of instructions producing a value"),
+      ADD_STAT(consumerInst, statistics::units::Count::get(), "Number of instructions consuming a value"),
+      ADD_STAT(wbRate, statistics::units::Rate<statistics::units::Count, statistics::units::Cycle>::get(),
+               "Insts written-back per cycle"),
+      ADD_STAT(wbFanout, statistics::units::Rate<statistics::units::Count, statistics::units::Count>::get(),
+               "Average fanout of values written-back"),
+      ADD_STAT(stallEvents, statistics::units::Count::get(), "Number of events the IEW has stalled"),
+      ADD_STAT(smtStallEvents, statistics::units::Count::get(), "Number of events the IEW has stalled per thread"),
+      ADD_STAT(fetchStallReason, statistics::units::Count::get(), "Number of fetch stall reasons each tick (Total)"),
+      ADD_STAT(decodeStallReason, statistics::units::Count::get(), "Number of decode stall reasons each tick (Total)"),
+      ADD_STAT(renameStallReason, statistics::units::Count::get(), "Number of rename stall reasons each tick (Total)"),
+      ADD_STAT(dispatchStallReason, statistics::units::Count::get(),
+               "Number of dispatch stall reasons each tick (Total)")
 {
-    idleCycles
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    idleCycles.init(cpu->numThreads).flags(statistics::total);
 
-    squashCycles
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    squashCycles.init(cpu->numThreads).flags(statistics::total);
 
-    blockCycles
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    blockCycles.init(cpu->numThreads).flags(statistics::total);
 
-    instsToCommit
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    instsToCommit.init(cpu->numThreads).flags(statistics::total);
 
-    writebackCount
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    writebackCount.init(cpu->numThreads).flags(statistics::total);
 
-    producerInst
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    producerInst.init(cpu->numThreads).flags(statistics::total);
 
-    consumerInst
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    consumerInst.init(cpu->numThreads).flags(statistics::total);
 
-    dispatchedInsts
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    dispatchedInsts.init(cpu->numThreads).flags(statistics::total);
 
-    wbRate
-        .flags(statistics::total);
+    wbRate.flags(statistics::total);
     wbRate = writebackCount / cpu->baseStats.numCycles;
 
-    wbFanout
-        .flags(statistics::total);
+    wbFanout.flags(statistics::total);
     wbFanout = producerInst / consumerInst;
 
-    stallEvents
-        .init(StallEventCount)
-        .flags(statistics::total);
-        
-    smtStallEvents
-        .init(StallEventCount,0,cpu->numThreads-1,1)
-        .flags(statistics::total);
+    stallEvents.init(StallEventCount).flags(statistics::total);
+
+    smtStallEvents.init(StallEventCount, 0, cpu->numThreads - 1, 1).flags(statistics::total);
 
 
-    dispDist.init(0,10,1).flags(statistics::nozero);
+    dispDist.init(0, 10, 1).flags(statistics::nozero);
 
-    std::map < StallEvent, const char* > stall_event_str = {
-        { CacheMiss, "CacheMiss" },
-        { Translation, "Translation" },
-        { ROBWalk, "ROBWalk" },
-        { IQFull, "IQFull" },
-        { LSQFull, "LSQFull" },
-        { DispBWFull, "DispBWFull" }
-    };
+    std::map<StallEvent, const char *> stall_event_str = {{CacheMiss, "CacheMiss"}, {Translation, "Translation"},
+                                                          {ROBWalk, "ROBWalk"},     {IQFull, "IQFull"},
+                                                          {LSQFull, "LSQFull"},     {DispBWFull, "DispBWFull"}};
 
     for (int i = 0; i < StallEventCount; i++) {
         stallEvents.subname(i, stall_event_str[static_cast<StallEvent>(i)]);
         smtStallEvents.subname(i, stall_event_str[static_cast<StallEvent>(i)]);
     }
 
-    fetchStallReason
-            .init(NumStallReasons)
-            .flags(statistics::total | statistics::pdf);
+    fetchStallReason.init(NumStallReasons).flags(statistics::total | statistics::pdf);
 
-    decodeStallReason
-            .init(NumStallReasons)
-            .flags(statistics::total | statistics::pdf);
+    decodeStallReason.init(NumStallReasons).flags(statistics::total | statistics::pdf);
 
-    renameStallReason
-            .init(NumStallReasons)
-            .flags(statistics::total | statistics::pdf);
+    renameStallReason.init(NumStallReasons).flags(statistics::total | statistics::pdf);
 
-    dispatchStallReason
-            .init(NumStallReasons)
-            .flags(statistics::total | statistics::pdf);
+    dispatchStallReason.init(NumStallReasons).flags(statistics::total | statistics::pdf);
 
-    std::map <StallReason, const char*> stallReasonStr = {
+    std::map<StallReason, const char *> stallReasonStr = {
         {StallReason::NoStall, "NoStall"},
         {StallReason::IcacheStall, "IcacheStall"},
         {StallReason::ITlbStall, "ITlbStall"},
@@ -327,7 +266,7 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::StoreL3Bound, "StoreL3Bound"},
         {StallReason::StoreMemBound, "StoreMemBound"},
         {StallReason::MemSquashed, "MemSquashed"},
-        {StallReason::Atomic,"Atomic"},
+        {StallReason::Atomic, "Atomic"},
         {StallReason::ResumeUnblock, "ResumeUnblock"},
         {StallReason::CommitSquash, "CommitSquash"},
         {StallReason::ROBFull, "ROBFull"},
@@ -342,10 +281,9 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::MemCommitRateLimit, "MemCommitRateLimit"},
         {StallReason::OtherMemStall, "OtherMemStall"},
         {StallReason::VectorReadyButNotIssued, "VectorReadyButNotIssued"},
-        {StallReason::ScalarReadyButNotIssued, "ScalarReadyButNotIssued"}
-    };
+        {StallReason::ScalarReadyButNotIssued, "ScalarReadyButNotIssued"}};
 
-    for (int i = 0;i < NumStallReasons;i++) {
+    for (int i = 0; i < NumStallReasons; i++) {
         fetchStallReason.subname(i, stallReasonStr[static_cast<StallReason>(i)]);
         decodeStallReason.subname(i, stallReasonStr[static_cast<StallReason>(i)]);
         renameStallReason.subname(i, stallReasonStr[static_cast<StallReason>(i)]);
@@ -355,52 +293,32 @@ IEW::IEWStats::IEWStats(CPU *cpu)
 
 IEW::IEWStats::ExecutedInstStats::ExecutedInstStats(CPU *cpu)
     : statistics::Group(cpu, "executed_inst"),
-    ADD_STAT(numInsts, statistics::units::Count::get(),
-             "Number of executed instructions"),
-    ADD_STAT(numLoadInsts, statistics::units::Count::get(),
-             "Number of load instructions executed"),
-    ADD_STAT(numSquashedInsts, statistics::units::Count::get(),
-             "Number of squashed instructions skipped in execute"),
-    ADD_STAT(numSwp, statistics::units::Count::get(),
-             "Number of swp insts executed"),
-    ADD_STAT(numNop, statistics::units::Count::get(),
-             "Number of nop insts executed"),
-    ADD_STAT(numRefs, statistics::units::Count::get(),
-             "Number of memory reference insts executed"),
-    ADD_STAT(numBranches, statistics::units::Count::get(),
-             "Number of branches executed"),
-    ADD_STAT(numStoreInsts, statistics::units::Count::get(),
-             "Number of stores executed"),
-    ADD_STAT(numRate, statistics::units::Rate<
-                statistics::units::Count, statistics::units::Cycle>::get(),
-             "Inst execution rate", numInsts / cpu->baseStats.numCycles)
+      ADD_STAT(numInsts, statistics::units::Count::get(), "Number of executed instructions"),
+      ADD_STAT(numLoadInsts, statistics::units::Count::get(), "Number of load instructions executed"),
+      ADD_STAT(numSquashedInsts, statistics::units::Count::get(),
+               "Number of squashed instructions skipped in execute"),
+      ADD_STAT(numSwp, statistics::units::Count::get(), "Number of swp insts executed"),
+      ADD_STAT(numNop, statistics::units::Count::get(), "Number of nop insts executed"),
+      ADD_STAT(numRefs, statistics::units::Count::get(), "Number of memory reference insts executed"),
+      ADD_STAT(numBranches, statistics::units::Count::get(), "Number of branches executed"),
+      ADD_STAT(numStoreInsts, statistics::units::Count::get(), "Number of stores executed"),
+      ADD_STAT(numRate, statistics::units::Rate<statistics::units::Count, statistics::units::Cycle>::get(),
+               "Inst execution rate", numInsts / cpu->baseStats.numCycles)
 {
-    numLoadInsts
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    numLoadInsts.init(cpu->numThreads).flags(statistics::total);
 
-    numSwp
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    numSwp.init(cpu->numThreads).flags(statistics::total);
 
-    numNop
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    numNop.init(cpu->numThreads).flags(statistics::total);
 
-    numRefs
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    numRefs.init(cpu->numThreads).flags(statistics::total);
 
-    numBranches
-        .init(cpu->numThreads)
-        .flags(statistics::total);
+    numBranches.init(cpu->numThreads).flags(statistics::total);
 
-    numStoreInsts
-        .flags(statistics::total);
+    numStoreInsts.flags(statistics::total);
     numStoreInsts = numRefs - numLoadInsts;
 
-    numRate
-        .flags(statistics::total);
+    numRate.flags(statistics::total);
 }
 
 void
@@ -475,11 +393,12 @@ IEW::setScoreboard(Scoreboard *sb_ptr)
 }
 
 void
-IEW::lvpWakeDependents(const DynInstPtr &inst) {
+IEW::lvpWakeDependents(const DynInstPtr &inst)
+{
     assert(inst->numDestRegs() == 1);
     if (enableSelectiveVPFlush) {
         scheduler->specWakeUpFromVP(inst);
-        DPRINTF(IEW,"[sn:%llu] vp specWakeUp dependents\n", inst->seqNum);
+        DPRINTF(IEW, "[sn:%llu] vp specWakeUp dependents\n", inst->seqNum);
     } else {
         for (int i = 0; i < inst->numDestRegs(); i++) {
             auto dest = inst->renamedDestIdx(i);
@@ -487,7 +406,7 @@ IEW::lvpWakeDependents(const DynInstPtr &inst) {
                 continue;
             }
             scheduler->setAllScoreBoard(dest);
-            DPRINTF(IEW,"[sn:%llu] vp set scoreboard to true\n", inst->seqNum);
+            DPRINTF(IEW, "[sn:%llu] vp set scoreboard to true\n", inst->seqNum);
         }
     }
 }
@@ -501,7 +420,7 @@ IEW::isDrained() const
         return false;
     }
 
-    for (int i=0;i<numThreads;i++) {
+    for (int i = 0; i < numThreads; i++) {
         if (!fixedbuffer[i].empty()) {
             DPRINTF(Drain, "%i: Insts not empty.\n", i);
             drained = false;
@@ -553,8 +472,8 @@ IEW::squash(ThreadID tid)
 
     DPRINTF(IEW, "[tid:%i] Squashing all instructions.\n", tid);
 
-    for (auto& dp : dispQue) {
-        for (auto& it : dp) {
+    for (auto &dp : dispQue) {
+        for (auto &it : dp) {
             if (it->seqNum > fromCommit->commitInfo[tid].doneSeqNum && (it->threadNumber == tid)) {
                 it->setSquashed();
             }
@@ -580,13 +499,14 @@ IEW::squash(ThreadID tid)
 }
 
 void
-IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
+IEW::squashDueToBranch(const DynInstPtr &inst, ThreadID tid)
 {
     recordThreadSquash(tid);
 
     DPRINTF(IEW, "[tid:%i] [sn:%llu] Squashing from a specific instruction,"
             " PC: %s "
-            "\n", tid, inst->seqNum, inst->pcState() );
+            "\n",
+            tid, inst->seqNum, inst->pcState());
 
     if (!toCommit->squash[tid] || inst->seqNum < toCommit->squashedSeqNum[tid]) {
         toFetch->iewInfo[tid].redirectPending = true;
@@ -607,16 +527,16 @@ IEW::squashDueToBranch(const DynInstPtr& inst, ThreadID tid)
         DPRINTF(DecoupleBP,
                 "Branch misprediction (pc=%#lx) set target "
                 "id to %lu, loop iter to %u\n",
-                toCommit->pc[tid]->instAddr(),
-                toCommit->squashedTargetId[tid],
-                toCommit->squashedLoopIter[tid]);
+                toCommit->pc[tid]->instAddr(), toCommit->squashedTargetId[tid], toCommit->squashedLoopIter[tid]);
     }
+
+
 
     stallSig->blockRename[tid] = true;
 }
 
 void
-IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
+IEW::squashDueToMemOrder(const DynInstPtr &inst, ThreadID tid)
 {
     recordThreadSquash(tid);
 
@@ -646,10 +566,10 @@ IEW::squashDueToMemOrder(const DynInstPtr& inst, ThreadID tid)
         DPRINTF(DecoupleBP,
                 "Memory violation (pc=%#lx) set target id "
                 "to %lu, loop iter to %u\n",
-                toCommit->pc[tid]->instAddr(),
-                toCommit->squashedTargetId[tid],
-                toCommit->squashedLoopIter[tid]);
+                toCommit->pc[tid]->instAddr(), toCommit->squashedTargetId[tid], toCommit->squashedLoopIter[tid]);
     }
+
+
 
     stallSig->blockRename[tid] = true;
 }
@@ -686,40 +606,40 @@ IEW::squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid)
         DPRINTF(DecoupleBP,
                 "value prediction error (pc=%#lx) set target id "
                 "to %lu, loop iter to %u\n",
-                toCommit->pc[tid]->instAddr(),
-                toCommit->squashedTargetId[tid],
-                toCommit->squashedLoopIter[tid]);
+                toCommit->pc[tid]->instAddr(), toCommit->squashedTargetId[tid], toCommit->squashedLoopIter[tid]);
     }
+
+
 
     stallSig->blockRename[tid] = true;
 }
 
 void
-IEW::wakeDependents(const DynInstPtr& inst)
+IEW::wakeDependents(const DynInstPtr &inst)
 {
     instQueue.wakeDependents(inst);
 }
 
 void
-IEW::rescheduleMemInst(const DynInstPtr& inst)
+IEW::rescheduleMemInst(const DynInstPtr &inst)
 {
     instQueue.rescheduleMemInst(inst);
 }
 
 void
-IEW::replayMemInst(const DynInstPtr& inst)
+IEW::replayMemInst(const DynInstPtr &inst)
 {
     instQueue.replayMemInst(inst);
 }
 
 void
-IEW::blockMemInst(const DynInstPtr& inst)
+IEW::blockMemInst(const DynInstPtr &inst)
 {
     instQueue.blockMemInst(inst);
 }
 
 void
-IEW::cacheMissLdReplay(const DynInstPtr& inst)
+IEW::cacheMissLdReplay(const DynInstPtr &inst)
 {
     instQueue.cacheMissLdReplay(inst);
 }
@@ -731,7 +651,7 @@ IEW::cacheUnblocked()
 }
 
 void
-IEW::readyToFinish(const DynInstPtr& inst)
+IEW::readyToFinish(const DynInstPtr &inst)
 {
     // This function should not be called after writebackInsts in a
     // single cycle.  That will cause problems with an instruction
@@ -763,22 +683,21 @@ IEW::readyToFinish(const DynInstPtr& inst)
     ThreadID tid = inst->threadNumber;
     if (inst->vpMisprediction) {
         if (!enableSelectiveVPFlush) {
-            if (!fetchRedirect[tid] || !toCommit->squash[tid] ||
-                toCommit->squashedSeqNum[tid] > inst->seqNum) {
+            if (!fetchRedirect[tid] || !toCommit->squash[tid] || toCommit->squashedSeqNum[tid] > inst->seqNum) {
                 fetchRedirect[tid] = true;
                 squashDueToValuePrediction(inst, tid);
             }
         } else {
             // VP selective flush: cancel data-dependent consumers when possible.
             // If any dependent consumer is already issued, fallback to squash.
-            DPRINTF(IEW, "[sn:%llu] VP misprediction detected, "
-                    "selective cancel via loadCancel\n", inst->seqNum);
+            DPRINTF(IEW,
+                    "[sn:%llu] VP misprediction detected, "
+                    "selective cancel via loadCancel\n",
+                    inst->seqNum);
             bool needSquashFallback = scheduler->loadCancel(inst);
             if (needSquashFallback) {
-                DPRINTF(IEW, "[sn:%llu] VP fallback to squash due to issued dependent\n",
-                        inst->seqNum);
-                if (!fetchRedirect[tid] || !toCommit->squash[tid] ||
-                    toCommit->squashedSeqNum[tid] > inst->seqNum) {
+                DPRINTF(IEW, "[sn:%llu] VP fallback to squash due to issued dependent\n", inst->seqNum);
+                if (!fetchRedirect[tid] || !toCommit->squash[tid] || toCommit->squashedSeqNum[tid] > inst->seqNum) {
                     fetchRedirect[tid] = true;
                     squashDueToValuePrediction(inst, tid);
                 }
@@ -789,8 +708,8 @@ IEW::readyToFinish(const DynInstPtr& inst)
         }
     }
 
-    DPRINTF(IEW, "Current wb cycle: %i, width: %i, numInst: %i\nwbActual:%i\n",
-            wbCycle, wbWidth, wbNumInst, wbCycle * wbWidth + wbNumInst);
+    DPRINTF(IEW, "Current wb cycle: %i, width: %i, numInst: %i\nwbActual:%i\n", wbCycle, wbWidth, wbNumInst,
+            wbCycle * wbWidth + wbNumInst);
     // Add finished instruction to queue to commit.
     (*iewQueue)[wbCycle].insts[wbNumInst] = inst;
     (*iewQueue)[wbCycle].size++;
@@ -805,16 +724,13 @@ IEW::updateActivate()
     // and there's no stores waiting to write back, and dispatch is not
     // unblocking, then there is no internal activity for the IEW stage.
     instQueue.iqIOStats.intInstQueueReads++;
-    if (_status == Active && !instQueue.hasReadyInsts() &&
-        !ldstQueue.willWB() && !any_unblocking) {
+    if (_status == Active && !instQueue.hasReadyInsts() && !ldstQueue.willWB() && !any_unblocking) {
         DPRINTF(IEW, "IEW switching to idle\n");
 
         deactivateStage();
 
         _status = Inactive;
-    } else if (_status == Inactive && (instQueue.hasReadyInsts() ||
-                                       ldstQueue.willWB() ||
-                                       any_unblocking)) {
+    } else if (_status == Inactive && (instQueue.hasReadyInsts() || ldstQueue.willWB() || any_unblocking)) {
         // Otherwise there is internal activity.  Set to active.
         DPRINTF(IEW, "IEW switching to active\n");
 
@@ -825,7 +741,7 @@ IEW::updateActivate()
 }
 
 bool
-IEW::checkSerialize(const DynInstPtr& inst)
+IEW::checkSerialize(const DynInstPtr &inst)
 {
     ThreadID tid = inst->threadNumber;
     bool skipserialize = fromCommit->commitInfo[tid].robheadSeqNum >= inst->seqNum;
@@ -858,10 +774,8 @@ IEW::checkSquash()
     for (int i = 0; i < numThreads; i++) {
         if (fromCommit->commitInfo[i].squash) {
             squash(i);
-            localSquashVer[i].update(
-                fromCommit->commitInfo[i].squashVersion.getVersion());
-            DPRINTF(IEW, "Updating squash version to %u\n",
-                    localSquashVer[i].getVersion());
+            localSquashVer[i].update(fromCommit->commitInfo[i].squashVersion.getVersion());
+            DPRINTF(IEW, "Updating squash version to %u\n", localSquashVer[i].getVersion());
 
             fetchRedirect[i] = false;
             iewStats.stallEvents[ROBWalk]++;
@@ -937,24 +851,21 @@ IEW::canInsertLDSTQue(ThreadID tid)
 
     int lastClockLQPopEntries = ldstQueue.getAndResetLastLQPopEntries(tid);
     int lastClockSQPopEntries = ldstQueue.getAndResetLastSQPopEntries(tid);
-    if (freeLQEntries >= renameWidth + lastClockLQPopEntries &&
-        freeSQEntries >= renameWidth + lastClockSQPopEntries) {
+    if (freeLQEntries >= renameWidth + lastClockLQPopEntries && freeSQEntries >= renameWidth + lastClockSQPopEntries) {
         return true;
     }
     return false;
 }
 
 void
-IEW::setDispatchAgeCtr(const DynInstPtr& inst, int dispatch_pos)
+IEW::setDispatchAgeCtr(const DynInstPtr &inst, int dispatch_pos)
 {
     constexpr uint64_t dispatchAgeScale = 8;
 
     assert(dispatch_pos >= 0);
     assert(dispatch_pos < static_cast<int>(dispatchAgeScale));
-    inst->ageCtr = static_cast<uint64_t>(cpu->curCycle()) * dispatchAgeScale +
-                   static_cast<uint64_t>(dispatch_pos);
-    DPRINTF(IEW, "[tid:%i] [sn:%llu] ageCtr=%llu at dispatch pos %d.\n",
-            inst->threadNumber, inst->seqNum,
+    inst->ageCtr = static_cast<uint64_t>(cpu->curCycle()) * dispatchAgeScale + static_cast<uint64_t>(dispatch_pos);
+    DPRINTF(IEW, "[tid:%i] [sn:%llu] ageCtr=%llu at dispatch pos %d.\n", inst->threadNumber, inst->seqNum,
             static_cast<unsigned long long>(inst->ageCtr), dispatch_pos);
 }
 
@@ -1018,14 +929,9 @@ IEW::dispatchInsts()
     };
     for (int i = 0; i < numThreads; i++) {
         auto &iew_info = toRename->iewInfo[i];
-        iew_info.robHeadStallReason =
-            checkDispatchStall(i, NumDQ, nullptr, -1);
-        iew_info.lqHeadStallReason =
-            ldstQueue.lqEmpty(i) ? StallReason::NoStall :
-                                   checkLSQStall(i, true);
-        iew_info.sqHeadStallReason =
-            ldstQueue.sqEmpty(i) ? StallReason::NoStall :
-                                   checkLSQStall(i, false);
+        iew_info.robHeadStallReason = checkDispatchStall(i, NumDQ, nullptr, -1);
+        iew_info.lqHeadStallReason = ldstQueue.lqEmpty(i) ? StallReason::NoStall : checkLSQStall(i, true);
+        iew_info.sqHeadStallReason = ldstQueue.sqEmpty(i) ? StallReason::NoStall : checkLSQStall(i, false);
         iew_info.ldstqCount = ldstQueue.getCount(i);
         iew_info.robCount = rob->getThreadEntries(i);
         iew_info.iqCount = scheduler->getIQInsts(i);
@@ -1047,11 +953,9 @@ IEW::dispatchInsts()
         iew_info.blockReason = rename_block ? block_reason : StallReason::NoStall;
 
         stallSig->blockRename[i] = rename_block;
-        stallSig->renameBlockReason[i] =
-            rename_block ? block_reason : StallReason::NoStall;
+        stallSig->renameBlockReason[i] = rename_block ? block_reason : StallReason::NoStall;
         if (active) {
-            const auto freeze =
-                active_arbiter.observe(i, smtBorrowPriority(iew_info));
+            const auto freeze = active_arbiter.observe(i, smtBorrowPriority(iew_info));
             if (freeze.previousActive != InvalidThreadID) {
                 freezeActiveThread(freeze.previousActive);
             }
@@ -1063,7 +967,7 @@ IEW::dispatchInsts()
     const ThreadID tid = active_arbiter.selected();
 
     if (tid != InvalidThreadID) {
-        DPRINTF(IEW,"Processing [tid:%i]\n",tid);
+        DPRINTF(IEW, "Processing [tid:%i]\n", tid);
 
         // dispatch to IQ
         if (enableDispatchStage) {
@@ -1075,8 +979,7 @@ IEW::dispatchInsts()
         if (!fixedbuffer[tid].empty()) {
             stallSig->blockRename[tid] = true;
             stallSig->renameBlockReason[tid] =
-                blockReason == StallReason::NoStall ?
-                    StallReason::OtherFragStall : blockReason;
+                blockReason == StallReason::NoStall ? StallReason::OtherFragStall : blockReason;
             DPRINTF(IEW, "Dispatch bandwidth full, blocking thread %i\n", tid);
         }
 
@@ -1268,12 +1171,12 @@ IEW::dispatchInstFromRename(ThreadID tid)
         // no totally stall, pass rename stall
         // assert(dispatched != 0);
         for (int i = 0; i < dispatchStalls.size(); i++) {
-            if (i < dispatched) {   // dispatch success, no stall
+            if (i < dispatched) {  // dispatch success, no stall
                 dispatchStalls.at(i) = StallReason::NoStall;
-            } else {    // dispatch no insts, pass rename stall
-                if (fromRename->renameStallReason.size() == 0) {    // initialize, no stall
+            } else {                                              // dispatch no insts, pass rename stall
+                if (fromRename->renameStallReason.size() == 0) {  // initialize, no stall
                     dispatchStalls.at(i) = StallReason::NoStall;
-                } else {    // not dispatch initialize, pass rename stall
+                } else {  // not dispatch initialize, pass rename stall
                     dispatchStalls.at(i) = fromRename->renameStallReason.at(i);
                 }
             }
@@ -1281,18 +1184,16 @@ IEW::dispatchInstFromRename(ThreadID tid)
     }
 
 
-    for (int i = 0;i < dispatchStalls.size();i++) {
-        DPRINTF(IEW,"[tid:%i] dispatchStalls[%d]=%d\n", tid, i, dispatchStalls.at(i));
+    for (int i = 0; i < dispatchStalls.size(); i++) {
+        DPRINTF(IEW, "[tid:%i] dispatchStalls[%d]=%d\n", tid, i, dispatchStalls.at(i));
     }
 
     if (!insts_to_dispatch.empty()) {
-        DPRINTF(IEW,"[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
+        DPRINTF(IEW, "[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
 
         iewStats.stallEvents[DispBWFull]++;
         iewStats.smtStallEvents[DispBWFull].sample(tid);
-        
     }
-
 }
 
 void
@@ -1307,7 +1208,7 @@ IEW::classifyInstToDispQue(ThreadID tid)
     StallReason breakDispatch = StallReason::NoStall;
     unsigned dispatched = 0;
     while (!insts_to_dispatch.empty()) {
-        auto& inst = insts_to_dispatch.front();
+        auto &inst = insts_to_dispatch.front();
         int ins = cpu->cpuStats.committedInsts.total();
         if (cpu->hasHintDownStream() && ins % 10000 == 1) {
             cpu->hintDownStream->notifyIns(ins);
@@ -1333,8 +1234,7 @@ IEW::classifyInstToDispQue(ThreadID tid)
             const int numHtmStops = ldstQueue.numHtmStops(tid);
             const int htmDepth = numHtmStarts - numHtmStops;
             if (htmDepth > 0) {
-                inst->setHtmTransactionalState(ldstQueue.getLatestHtmUid(tid),
-                                                htmDepth);
+                inst->setHtmTransactionalState(ldstQueue.getLatestHtmUid(tid), htmDepth);
             } else {
                 inst->clearHtmTransactionalState();
             }
@@ -1385,12 +1285,12 @@ IEW::classifyInstToDispQue(ThreadID tid)
         // no totally stall, pass rename stall
         // assert(dispatched != 0);
         for (int i = 0; i < dispatchStalls.size(); i++) {
-            if (i < dispatched) {   // dispatch success, no stall
+            if (i < dispatched) {  // dispatch success, no stall
                 dispatchStalls.at(i) = StallReason::NoStall;
-            } else {    // dispatch no insts, pass rename stall
-                if (fromRename->renameStallReason.size() == 0) {    // initialize, no stall
+            } else {                                              // dispatch no insts, pass rename stall
+                if (fromRename->renameStallReason.size() == 0) {  // initialize, no stall
                     dispatchStalls.at(i) = StallReason::NoStall;
-                } else {    // not dispatch initialize, pass rename stall
+                } else {  // not dispatch initialize, pass rename stall
                     dispatchStalls.at(i) = fromRename->renameStallReason.at(i);
                 }
             }
@@ -1398,12 +1298,12 @@ IEW::classifyInstToDispQue(ThreadID tid)
     }
 
 
-    for (int i = 0;i < dispatchStalls.size();i++) {
-        DPRINTF(IEW,"[tid:%i] dispatchStalls[%d]=%d\n", tid, i, dispatchStalls.at(i));
+    for (int i = 0; i < dispatchStalls.size(); i++) {
+        DPRINTF(IEW, "[tid:%i] dispatchStalls[%d]=%d\n", tid, i, dispatchStalls.at(i));
     }
 
     if (!insts_to_dispatch.empty()) {
-        DPRINTF(IEW,"[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
+        DPRINTF(IEW, "[tid:%i] Dispatch: Bandwidth Full. Blocking.\n", tid);
         iewStats.stallEvents[DispBWFull]++;
         iewStats.smtStallEvents[DispBWFull].sample(tid);
     }
@@ -1426,8 +1326,10 @@ IEW::dispatchInstFromDispQue()
 
             // Check for squashed instructions.
             if (inst->isSquashed()) {
-                DPRINTF(IEW, "[tid:%i] [sn:%llu] Dispatch: Squashed instruction encountered, "
-                        "not adding to IQ.\n", tid, inst->seqNum);
+                DPRINTF(IEW,
+                        "[tid:%i] [sn:%llu] Dispatch: Squashed instruction encountered, "
+                        "not adding to IQ.\n",
+                        tid, inst->seqNum);
 
                 dispQue[i].pop_front();
                 continue;
@@ -1444,11 +1346,9 @@ IEW::dispatchInstFromDispQue()
             }
 
             // Check LSQ if inst is LD/ST
-            if ((inst->isAtomic() && ldstQueue.sqFull(tid)) ||
-                (inst->isLoad() && ldstQueue.lqFull(tid)) ||
+            if ((inst->isAtomic() && ldstQueue.sqFull(tid)) || (inst->isLoad() && ldstQueue.lqFull(tid)) ||
                 (inst->isStore() && ldstQueue.sqFull(tid))) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: %s has become full.\n",tid,
-                        inst->isLoad() ? "LQ" : "SQ");
+                DPRINTF(IEW, "[tid:%i] Dispatch: %s has become full.\n", tid, inst->isLoad() ? "LQ" : "SQ");
 
                 iewStats.stallEvents[LSQFull]++;
                 iewStats.smtStallEvents[LSQFull].sample(tid);
@@ -1459,8 +1359,10 @@ IEW::dispatchInstFromDispQue()
             bool add_to_iq = false;
             // Otherwise issue the instruction just fine.
             if (inst->isAtomic()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n", tid);
+                DPRINTF(IEW,
+                        "[tid:%i] Dispatch: Memory instruction "
+                        "encountered, adding to LSQ.\n",
+                        tid);
 
                 // allocate entry in store queue
                 ldstQueue.insertStore(inst);
@@ -1472,8 +1374,10 @@ IEW::dispatchInstFromDispQue()
                 instQueue.insertNonSpec(inst);
                 add_to_iq = false;
             } else if (inst->isLoad()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n", tid);
+                DPRINTF(IEW,
+                        "[tid:%i] Dispatch: Memory instruction "
+                        "encountered, adding to LSQ.\n",
+                        tid);
 
                 // allocate entry in load queue
                 ldstQueue.insertLoad(inst);
@@ -1481,8 +1385,10 @@ IEW::dispatchInstFromDispQue()
                 add_to_iq = true;
 
             } else if (inst->isStore()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Memory instruction "
-                        "encountered, adding to LSQ.\n", tid);
+                DPRINTF(IEW,
+                        "[tid:%i] Dispatch: Memory instruction "
+                        "encountered, adding to LSQ.\n",
+                        tid);
 
                 // allocate entry in store queue
                 ldstQueue.insertStore(inst);
@@ -1505,8 +1411,10 @@ IEW::dispatchInstFromDispQue()
                 instQueue.insertBarrier(inst);
                 add_to_iq = false;
             } else if (inst->isNop() || inst->isEliminated()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Nop instruction [sn:%llu] encountered, "
-                        "skipping.\n", tid, inst->seqNum);
+                DPRINTF(IEW,
+                        "[tid:%i] Dispatch: Nop instruction [sn:%llu] encountered, "
+                        "skipping.\n",
+                        tid, inst->seqNum);
 
                 inst->setIssued();
                 inst->setExecuted();
@@ -1521,8 +1429,10 @@ IEW::dispatchInstFromDispQue()
             }
 
             if (add_to_iq && inst->isNonSpeculative()) {
-                DPRINTF(IEW, "[tid:%i] Dispatch: Nonspeculative instruction "
-                        "encountered, skipping.\n", tid);
+                DPRINTF(IEW,
+                        "[tid:%i] Dispatch: Nonspeculative instruction "
+                        "encountered, skipping.\n",
+                        tid);
 
                 // Same as non-speculative stores.
                 inst->setCanCommit();
@@ -1543,9 +1453,9 @@ IEW::dispatchInstFromDispQue()
 
             inst->exitDQTick = curTick();
 
-    #if TRACING_ON
+#if TRACING_ON
             inst->dispatchTick = curTick() - inst->fetchTick;
-    #endif
+#endif
             ppDispatch->notify(inst);
 
             dispQue[i].pop_front();
@@ -1564,14 +1474,13 @@ IEW::printAvailableInsts()
 
     while (fromIssue->insts[inst]) {
 
-        if (inst%3==0) std::cout << "\n\t";
+        if (inst % 3 == 0)
+            std::cout << "\n\t";
 
-        std::cout << "PC: " << fromIssue->insts[inst]->pcState()
-             << " TN: " << fromIssue->insts[inst]->threadNumber
-             << " SN: " << fromIssue->insts[inst]->seqNum << " | ";
+        std::cout << "PC: " << fromIssue->insts[inst]->pcState() << " TN: " << fromIssue->insts[inst]->threadNumber
+                  << " SN: " << fromIssue->insts[inst]->seqNum << " | ";
 
         inst++;
-
     }
 
     std::cout << "\n";
@@ -1590,9 +1499,7 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
         resolved_cfis.push_back(entry);
     }
 
-    if (!fetchRedirect[tid] ||
-        !toCommit->squash[tid] ||
-        toCommit->squashedSeqNum[tid] > inst->seqNum) {
+    if (!fetchRedirect[tid] || !toCommit->squash[tid] || toCommit->squashedSeqNum[tid] > inst->seqNum) {
 
         // Prevent testing for misprediction on load instructions,
         // that have not been executed.
@@ -1604,17 +1511,19 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             inst->pcState(*new_pc);
         }
 
-        if (inst->mispredicted() && !loadNotExecuted &&
-            !inst->isNonSpeculative()) {
+        if (inst->mispredicted() && !loadNotExecuted && !inst->isNonSpeculative()) {
             fetchRedirect[tid] = true;
 
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "
+            DPRINTF(IEW,
+                    "[tid:%i] [sn:%llu] Execute: "
                     "Branch mispredict detected.\n",
                     tid, inst->seqNum);
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] "
+            DPRINTF(IEW,
+                    "[tid:%i] [sn:%llu] "
                     "Predicted target was PC: %s\n",
                     tid, inst->seqNum, inst->readPredTarg());
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "
+            DPRINTF(IEW,
+                    "[tid:%i] [sn:%llu] Execute: "
                     "Redirecting fetch to PC: %s\n",
                     tid, inst->seqNum, inst->pcState());
             // If incorrect, then signal the ROB that it must be squashed.
@@ -1635,16 +1544,18 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
             DynInstPtr violator;
             violator = ldstQueue.getMemDepViolator(tid);
 
-            DPRINTF(IEW, "LDSTQ detected a violation. Violator PC: %s "
+            DPRINTF(IEW,
+                    "LDSTQ detected a violation. Violator PC: %s "
                     "[sn:%lli], inst PC: %s [sn:%lli]. Addr is: %#x.\n",
-                    violator->pcState(), violator->seqNum,
-                    inst->pcState(), inst->seqNum, inst->physEffAddr);
+                    violator->pcState(), violator->seqNum, inst->pcState(), inst->seqNum, inst->physEffAddr);
 
             fetchRedirect[tid] = true;
 
             // Tell the instruction queue that a violation has occured.
             if (enableStoreSetTrain) {
-                instQueue.violation(inst, violator);
+
+                instQueue.violation(inst,
+                                    violator);
             }
             violator->setProducerStorePC(inst->pcState().instAddr());
 
@@ -1661,11 +1572,12 @@ IEW::SquashCheckAfterExe(DynInstPtr inst)
 
             DynInstPtr violator = ldstQueue.getMemDepViolator(tid);
 
-            DPRINTF(IEW, "LDSTQ detected a violation.  Violator PC: "
+            DPRINTF(IEW,
+                    "LDSTQ detected a violation.  Violator PC: "
                     "%s, inst PC: %s.  Addr is: %#x.\n",
-                    violator->pcState(), inst->pcState(),
-                    inst->physEffAddr);
-            DPRINTF(IEW, "Violation will not be handled because "
+                    violator->pcState(), inst->pcState(), inst->physEffAddr);
+            DPRINTF(IEW,
+                    "Violation will not be handled because "
                     "already squashing\n");
 
             ++iewStats.memOrderViolationEvents;
@@ -1693,14 +1605,13 @@ IEW::executeInsts()
 
     // Uncomment this if you want to see all available instructions.
     // @todo This doesn't actually work anymore, we should fix it.
-//    printAvailableInsts();
+    //    printAvailableInsts();
 
     // Execute/writeback any instructions that are available.
     int insts_to_execute = fromIssue->size;
     fromIssue->size = 0;
     int inst_num = 0;
-    for (; inst_num < insts_to_execute;
-          ++inst_num) {
+    for (; inst_num < insts_to_execute; ++inst_num) {
 
         DPRINTF(IEW, "Execute: Executing instructions from IQ.\n");
 
@@ -1710,16 +1621,16 @@ IEW::executeInsts()
         // executing
         ppExecute->notify(inst);
 
-        if (inst->isSplitStoreData() &&
-            ldstQueue.splitStoreAddrSquashed(inst)) {
+        if (inst->isSplitStoreData() && ldstQueue.splitStoreAddrSquashed(inst)) {
             inst->setSquashed();
         }
 
         // Check if the instruction is squashed; if so then skip it
         if (inst->isSquashed()) {
-            DPRINTF(IEW, "Execute: Instruction was squashed. PC: %s, [tid:%i]"
-                         " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
-                         inst->seqNum);
+            DPRINTF(IEW,
+                    "Execute: Instruction was squashed. PC: %s, [tid:%i]"
+                    " [sn:%llu]\n",
+                    inst->pcState(), inst->threadNumber, inst->seqNum);
 
             // Consider this instruction executed so that commit can go
             // ahead and retire the instruction.
@@ -1743,7 +1654,8 @@ IEW::executeInsts()
         // Note that if the instruction faults, it will be handled
         // at the commit stage.
         if (inst->isMemRef()) {
-            DPRINTF(IEW, "Execute: Calculating address for memory "
+            DPRINTF(IEW,
+                    "Execute: Calculating address for memory "
                     "reference.\n");
 
             // Tell the LDSTQ to execute this instruction (if it is a load).
@@ -1751,11 +1663,11 @@ IEW::executeInsts()
                 // AMOs are treated like store requests
                 fault = ldstQueue.executeAmo(inst);
 
-                if (inst->isTranslationDelayed() &&
-                    fault == NoFault) {
+                if (inst->isTranslationDelayed() && fault == NoFault) {
                     // A hw page table walk is currently going on; the
                     // instruction must be deferred.
-                    DPRINTF(IEW, "Execute: Delayed translation, deferring "
+                    DPRINTF(IEW,
+                            "Execute: Delayed translation, deferring "
                             "store.\n");
                     deferMemInst(inst);
                     continue;
@@ -1832,7 +1744,6 @@ IEW::executeInsts()
     // iew queue.  That way the writeback event will write into the correct
     // spot in the queue.
     wbNumInst = 0;
-
 }
 
 void
@@ -1844,8 +1755,7 @@ IEW::writebackInsts()
     // Either have IEW have direct access to scoreboard, or have this
     // as part of backwards communication.
 
-    for (int inst_num = 0; inst_num < wbWidth &&
-             toCommit->insts[inst_num]; inst_num++) {
+    for (int inst_num = 0; inst_num < wbWidth && toCommit->insts[inst_num]; inst_num++) {
         DynInstPtr inst = toCommit->insts[inst_num];
         ThreadID tid = inst->threadNumber;
 
@@ -1853,8 +1763,7 @@ IEW::writebackInsts()
             inst->pf_source = ldstQueue.getLoadPFSource(inst);
         }
 
-        DPRINTF(IEW, "Sending instructions to commit, [sn:%lli] PC %s.\n",
-                inst->seqNum, inst->pcState());
+        DPRINTF(IEW, "Sending instructions to commit, [sn:%lli] PC %s.\n", inst->seqNum, inst->pcState());
 
         iewStats.instsToCommit[tid]++;
         // Notify potential listeners that execution is complete for this
@@ -1866,18 +1775,15 @@ IEW::writebackInsts()
         // E.g. Strictly ordered loads have not actually executed when they
         // are first sent to commit.  Instead commit must tell the LSQ
         // when it's ready to execute the strictly ordered load.
-        if (!inst->isSquashed() && inst->isExecuted() &&
-                inst->getFault() == NoFault) {
+        if (!inst->isSquashed() && inst->isExecuted() && inst->getFault() == NoFault) {
 
             scheduler->writebackWakeup(inst);
             int dependents = instQueue.wakeDependents(inst);
 
             for (int i = 0; i < inst->numDestRegs(); i++) {
                 // Mark register as ready if not pinned
-                if (inst->renamedDestIdx(i)->
-                        getNumPinnedWritesToComplete() == 0) {
-                    DPRINTF(IEW,"Setting Destination Register %i (%s)\n",
-                            inst->renamedDestIdx(i)->index(),
+                if (inst->renamedDestIdx(i)->getNumPinnedWritesToComplete() == 0) {
+                    DPRINTF(IEW, "Setting Destination Register %i (%s)\n", inst->renamedDestIdx(i)->index(),
                             inst->renamedDestIdx(i)->className());
                     scoreboard->setReg(inst->renamedDestIdx(i));
                 }
@@ -1885,7 +1791,7 @@ IEW::writebackInsts()
 
             if (dependents) {
                 iewStats.producerInst[tid]++;
-                iewStats.consumerInst[tid]+= dependents;
+                iewStats.consumerInst[tid] += dependents;
             }
             iewStats.writebackCount[tid]++;
         }
@@ -1896,13 +1802,13 @@ void
 IEW::tick()
 {
     blockReason = StallReason::NoStall;
-    for (int i = 0;i < fromRename->fetchStallReason.size();i++) {
+    for (int i = 0; i < fromRename->fetchStallReason.size(); i++) {
         iewStats.fetchStallReason[fromRename->fetchStallReason[i]]++;
     }
-    for (int i = 0;i < fromRename->decodeStallReason.size();i++) {
+    for (int i = 0; i < fromRename->decodeStallReason.size(); i++) {
         iewStats.decodeStallReason[fromRename->decodeStallReason[i]]++;
     }
-    for (int i = 0;i < fromRename->renameStallReason.size();i++) {
+    for (int i = 0; i < fromRename->renameStallReason.size(); i++) {
         iewStats.renameStallReason[fromRename->renameStallReason[i]]++;
     }
 
@@ -1931,7 +1837,7 @@ IEW::tick()
     checkSquash();
     dispatchInsts();
 
-    for (int i = 0;i < dispatchStalls.size();i++) {
+    for (int i = 0; i < dispatchStalls.size(); i++) {
         iewStats.dispatchStallReason[dispatchStalls[i]]++;
     }
 
@@ -1966,42 +1872,38 @@ IEW::tick()
     while (threads != activeThreads->end()) {
         ThreadID tid = (*threads++);
 
-        DPRINTF(IEW,"Commit processing [tid:%i]\n",tid);
+        DPRINTF(IEW, "Commit processing [tid:%i]\n", tid);
 
-        if (fromCommit->commitInfo[tid].doneMemSeqNum != 0 &&
-            !fromCommit->commitInfo[tid].squash &&
+        if (fromCommit->commitInfo[tid].doneMemSeqNum != 0 && !fromCommit->commitInfo[tid].squash &&
             !fromCommit->commitInfo[tid].robSquashing) {
             recordThreadWork(tid);
 
             // Marks some of the entries in the store queue as canWB and
             // they will be moved to the store buffer when appropriate.
-            ldstQueue.commitStores(fromCommit->commitInfo[tid].doneMemSeqNum,tid);
+            ldstQueue.commitStores(fromCommit->commitInfo[tid].doneMemSeqNum, tid);
             updateLSQNextCycle = true;
         }
 
         // Update structures based on instructions committed.
-        if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&
-            !fromCommit->commitInfo[tid].squash &&
+        if (fromCommit->commitInfo[tid].doneSeqNum != 0 && !fromCommit->commitInfo[tid].squash &&
             !fromCommit->commitInfo[tid].robSquashing) {
             recordThreadWork(tid);
 
-            ldstQueue.commitLoads(fromCommit->commitInfo[tid].doneSeqNum,tid);
+            ldstQueue.commitLoads(fromCommit->commitInfo[tid].doneSeqNum, tid);
             updateLSQNextCycle = true;
 
-            instQueue.commit(fromCommit->commitInfo[tid].doneSeqNum,tid);
+            instQueue.commit(fromCommit->commitInfo[tid].doneSeqNum, tid);
         }
 
         if (fromCommit->commitInfo[tid].nonSpecSeqNum != 0) {
             recordThreadWork(tid);
 
-            //DPRINTF(IEW,"NonspecInst from thread %i",tid);
+            // DPRINTF(IEW,"NonspecInst from thread %i",tid);
             if (fromCommit->commitInfo[tid].strictlyOrdered) {
-                instQueue.replayMemInst(
-                    fromCommit->commitInfo[tid].strictlyOrderedLoad);
+                instQueue.replayMemInst(fromCommit->commitInfo[tid].strictlyOrderedLoad);
                 fromCommit->commitInfo[tid].strictlyOrderedLoad->setAtCommit();
             } else {
-                instQueue.scheduleNonSpec(
-                    fromCommit->commitInfo[tid].nonSpecSeqNum);
+                instQueue.scheduleNonSpec(fromCommit->commitInfo[tid].nonSpecSeqNum);
             }
         }
 
@@ -2036,7 +1938,7 @@ IEW::tick()
 }
 
 void
-IEW::updateExeInstStats(const DynInstPtr& inst)
+IEW::updateExeInstStats(const DynInstPtr &inst)
 {
     ThreadID tid = inst->threadNumber;
 
@@ -2061,13 +1963,11 @@ IEW::updateExeInstStats(const DynInstPtr& inst)
 }
 
 void
-IEW::checkMisprediction(const DynInstPtr& inst)
+IEW::checkMisprediction(const DynInstPtr &inst)
 {
     ThreadID tid = inst->threadNumber;
 
-    if (!fetchRedirect[tid] ||
-        !toCommit->squash[tid] ||
-        toCommit->squashedSeqNum[tid] > inst->seqNum) {
+    if (!fetchRedirect[tid] || !toCommit->squash[tid] || toCommit->squashedSeqNum[tid] > inst->seqNum) {
         // In trace mode, override npc with trace nextPC so that
         // mispredicted() and squash use standard advancePC logic.
         if (cpu->isTraceMode() && inst->hasTraceBranchInfo()) {
@@ -2079,12 +1979,13 @@ IEW::checkMisprediction(const DynInstPtr& inst)
         if (inst->mispredicted() && !inst->isNonSpeculative()) {
             fetchRedirect[tid] = true;
 
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "
+            DPRINTF(IEW,
+                    "[tid:%i] [sn:%llu] Execute: "
                     "Branch mispredict detected.\n",
                     tid, inst->seqNum);
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] Predicted target was PC: %s\n",
-                    tid, inst->seqNum, inst->readPredTarg());
-            DPRINTF(IEW, "[tid:%i] [sn:%llu] Execute: "
+            DPRINTF(IEW, "[tid:%i] [sn:%llu] Predicted target was PC: %s\n", tid, inst->seqNum, inst->readPredTarg());
+            DPRINTF(IEW,
+                    "[tid:%i] [sn:%llu] Execute: "
                     "Redirecting fetch to PC: %s\n",
                     tid, inst->seqNum, inst->pcState());
             // If incorrect, then signal the ROB that it must be squashed.
@@ -2112,15 +2013,13 @@ IEW::stlfFailLdReplay(const DynInstPtr &inst, const InstSeqNum &store_seq_num)
 }
 
 void
-IEW::mdpAddrReplayRegister(const DynInstPtr &inst,
-                           const std::vector<InstSeqNum> &store_seq_nums)
+IEW::mdpAddrReplayRegister(const DynInstPtr &inst, const std::vector<InstSeqNum> &store_seq_nums)
 {
     instQueue.mdpAddrReplayRegister(inst, store_seq_nums);
 }
 
 void
-IEW::mdpAddrReplayRegisterStrict(const DynInstPtr &inst,
-                                 size_t required_store_completed_idx)
+IEW::mdpAddrReplayRegisterStrict(const DynInstPtr &inst, size_t required_store_completed_idx)
 {
     instQueue.mdpAddrReplayRegisterStrict(inst, required_store_completed_idx);
 }
@@ -2132,8 +2031,7 @@ IEW::mdpAddrReplayPipeDone(const DynInstPtr &inst)
 }
 
 void
-IEW::mdpAddrReplayUpdateStoreCompletedIdx(ThreadID tid,
-                                          size_t store_completed_idx)
+IEW::mdpAddrReplayUpdateStoreCompletedIdx(ThreadID tid, size_t store_completed_idx)
 {
     instQueue.mdpAddrReplayUpdateStoreCompletedIdx(tid, store_completed_idx);
 }
@@ -2147,7 +2045,7 @@ IEW::getIQInsts()
 void
 IEW::setAllStalls(StallReason dispatchStall)
 {
-    for (int i = 0;i < dispatchStalls.size();i++) {
+    for (int i = 0; i < dispatchStalls.size(); i++) {
         dispatchStalls.at(i) = dispatchStall;
     }
 }
@@ -2164,7 +2062,7 @@ IEW::checkLoadStoreInst(DynInstPtr inst)
     if (inst->isAtomic() || inst->isStoreConditional()) {
         return StallReason::Atomic;
     }
-    if (!inst->readyToIssue()){
+    if (!inst->readyToIssue()) {
         return StallReason::MemNotReady;
     }
     assert(inst->isLoad() || inst->isStore());
@@ -2175,9 +2073,9 @@ IEW::checkLoadStoreInst(DynInstPtr inst)
 
     bool inFlight = inst->isIssued() && inst->hasPendingCacheReq();
     bool lsuStall = inst->isIssued() && !inst->hasPendingCacheReq();
-    //Level of the cache hierachy where this request was responded to
-    //e.g. 0:in l1, 1:in l2
-    int depth=-1;
+    // Level of the cache hierachy where this request was responded to
+    // e.g. 0:in l1, 1:in l2
+    int depth = -1;
     if (inFlight) {
         assert(inst->pendingCacheReq);
         depth = inst->pendingCacheReq->mainReq()->depth;
@@ -2189,7 +2087,7 @@ IEW::checkLoadStoreInst(DynInstPtr inst)
     bool other_stall = depth == -1;
     // maybe soc does not have l3cache
     // so we can not use in_mem = depth==3
-    bool in_mem = !(in_l1 ||  in_l2 || in_l3 || other_stall);
+    bool in_mem = !(in_l1 || in_l2 || in_l3 || other_stall);
     if (inFlight && in_l1) {
         return inst->isLoad() ? StallReason::LoadL1Bound : StallReason::StoreL1Bound;
     } else if (inFlight && in_l2) {
@@ -2241,7 +2139,8 @@ IEW::getInstDQType(const DynInstPtr &inst)
 }
 
 StallReason
-IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_inst, int disp_seq) {
+IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_inst, int disp_seq)
+{
     DynInstPtr head_inst = rob->readHeadInst(tid);
     if (head_inst == rob->dummyInst) {
         if (dq_stall != NumDQ) {
@@ -2272,8 +2171,7 @@ IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_i
             return StallReason::MemDQBandwidth;
         }
 
-        if ((dispatch_inst->isFloating() || dispatch_inst->isVector()) &&
-            !(rob->isFull() || !ready)) {
+        if ((dispatch_inst->isFloating() || dispatch_inst->isVector()) && !(rob->isFull() || !ready)) {
             return StallReason::FVDQBandwidth;
         }
 
@@ -2285,7 +2183,8 @@ IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_i
     assert(head_inst);
 
     if (head_inst->readyTick == -1) {
-        DPRINTF(Counters, "IEW: [tid:%i] [sn:%llu] "
+        DPRINTF(Counters,
+                "IEW: [tid:%i] [sn:%llu] "
                 "Dispatch: Instruction not ready. nonSpeculative:%d\n",
                 tid, head_inst->seqNum, head_inst->isNonSpeculative());
         if (head_inst->isNonSpeculative()) {
@@ -2295,8 +2194,7 @@ IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_i
                 return StallReason::InstNotReady;
             }
             return checkLSQStall(tid, true);
-        } else if ((head_inst->isStore() || head_inst->isAtomic()) &&
-                   ldstQueue.sqFull(tid)) {
+        } else if ((head_inst->isStore() || head_inst->isAtomic()) && ldstQueue.sqFull(tid)) {
             if (ldstQueue.sqEmpty(tid)) {
                 return StallReason::InstNotReady;
             }
@@ -2330,8 +2228,7 @@ IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_i
 StallReason
 IEW::checkLSQStall(ThreadID tid, bool isLoad)
 {
-    if ((isLoad && ldstQueue.lqEmpty(tid)) ||
-        (!isLoad && ldstQueue.sqEmpty(tid))) {
+    if ((isLoad && ldstQueue.lqEmpty(tid)) || (!isLoad && ldstQueue.sqEmpty(tid))) {
         return StallReason::InstNotReady;
     }
 
@@ -2345,5 +2242,5 @@ IEW::setRob(ROB *rob)
     this->rob = rob;
 }
 
-} // namespace o3
-} // namespace gem5
+}  // namespace o3
+}  // namespace gem5

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -28,6 +28,7 @@
 
 #include "cpu/o3/mem_dep_unit.hh"
 
+
 #include <map>
 #include <memory>
 #include <vector>
@@ -57,8 +58,9 @@ MemDepUnit::MemDepUnit() : iqPtr(NULL), stats(nullptr) {}
 
 MemDepUnit::MemDepUnit(const BaseO3CPUParams &params)
     : _name(params.name + ".memdepunit"),
-      depPred(params.store_set_clear_period, params.SSITSize,
-              params.LFSTSize,params.store_set_clear_thres,params.LFSTEntrySize),
+      depPred(params.store_set_clear_period, params.SSITSize, params.LFSTSize, params.store_set_clear_thres,
+              params.LFSTEntrySize),
+
       iqPtr(NULL),
       stats(nullptr)
 {
@@ -92,13 +94,14 @@ MemDepUnit::~MemDepUnit()
 void
 MemDepUnit::init(const BaseO3CPUParams &params, ThreadID tid, CPU *cpu)
 {
-    DPRINTF(MemDepUnit, "Creating MemDepUnit %i object.\n",tid);
+    DPRINTF(MemDepUnit, "Creating MemDepUnit %i object.\n", tid);
 
     _name = csprintf("%s.memDep%d", params.name, tid);
     id = tid;
 
-    depPred.init(params.store_set_clear_period, params.store_set_clear_thres, params.SSITSize,
-            params.LFSTSize, params.LFSTEntrySize);
+    depPred.init(params.store_set_clear_period, params.store_set_clear_thres, params.SSITSize, params.LFSTSize,
+                 params.LFSTEntrySize);
+
 
     enableReplayBasedMDP = params.EnableReplayBasedMDP;
     enableMDPStrictWait = params.EnableMDPStrictWait;
@@ -110,25 +113,19 @@ MemDepUnit::init(const BaseO3CPUParams &params, ThreadID tid, CPU *cpu)
 
 MemDepUnit::MemDepUnitStats::MemDepUnitStats(statistics::Group *parent)
     : statistics::Group(parent),
-      ADD_STAT(insertedLoads, statistics::units::Count::get(),
-               "Number of loads inserted to the mem dependence unit."),
+      ADD_STAT(insertedLoads, statistics::units::Count::get(), "Number of loads inserted to the mem dependence unit."),
       ADD_STAT(insertedStores, statistics::units::Count::get(),
                "Number of stores inserted to the mem dependence unit."),
-      ADD_STAT(conflictingLoads, statistics::units::Count::get(),
-               "Number of conflicting loads."),
-      ADD_STAT(conflictingStores, statistics::units::Count::get(),
-               "Number of conflicting stores."),
-      ADD_STAT(dependentLoads, statistics::units::Count::get(),
-               "Number of  predicted conflicting loads.")
+      ADD_STAT(conflictingLoads, statistics::units::Count::get(), "Number of conflicting loads."),
+      ADD_STAT(conflictingStores, statistics::units::Count::get(), "Number of conflicting stores."),
+      ADD_STAT(dependentLoads, statistics::units::Count::get(), "Number of  predicted conflicting loads.")
 {
 }
 
 bool
 MemDepUnit::isDrained() const
 {
-    bool drained = instsToReplay.empty()
-                 && memDepHash.empty()
-                 && instsToReplay.empty();
+    bool drained = instsToReplay.empty() && memDepHash.empty() && instsToReplay.empty();
     for (int i = 0; i < MaxThreads; ++i)
         drained = drained && instList[i].empty();
 
@@ -181,13 +178,13 @@ MemDepUnit::insertBarrierSN(const DynInstPtr &barr_inst)
             barrier_type = "write";
 
         if (barrier_type) {
-            DPRINTF(MemDepUnit, "Inserted a %s barrier %s SN:%lli\n",
-                    barrier_type, barr_inst->pcState(), barr_sn);
+            DPRINTF(MemDepUnit, "Inserted a %s barrier %s SN:%lli\n", barrier_type, barr_inst->pcState(), barr_sn);
         }
 
         if (loadBarrierSNs.size() || storeBarrierSNs.size()) {
-            DPRINTF(MemDepUnit, "Outstanding load barriers = %d; "
-                                "store barriers = %d\n",
+            DPRINTF(MemDepUnit,
+                    "Outstanding load barriers = %d; "
+                    "store barriers = %d\n",
                     loadBarrierSNs.size(), storeBarrierSNs.size());
         }
     }
@@ -201,36 +198,29 @@ MemDepUnit::insert(const DynInstPtr &inst)
     MemDepEntryPtr inst_entry = std::make_shared<MemDepEntry>(inst);
 
     // Add the MemDepEntry to the hash.
-    memDepHash.insert(
-        std::pair<InstSeqNum, MemDepEntryPtr>(inst->seqNum, inst_entry));
+    memDepHash.insert(std::pair<InstSeqNum, MemDepEntryPtr>(inst->seqNum, inst_entry));
 #ifdef DEBUG
     MemDepEntry::memdep_insert++;
 #endif
 
     instList[tid].push_back(inst);
-
     inst_entry->listIt = --(instList[tid].end());
 
     // Check any barriers and the dependence predictor for any
     // producing memrefs/stores.
-    std::vector<InstSeqNum>  producing_stores;
+
+    std::vector<InstSeqNum> producing_stores;
     bool store_set_pred = false;
     bool strict_wait = false;
+
     if ((inst->isLoad() || inst->isAtomic()) && hasLoadBarrier()) {
-        DPRINTF(MemDepUnit, "%d load barriers in flight\n",
-                loadBarrierSNs.size());
-        producing_stores.insert(std::end(producing_stores),
-                                std::begin(loadBarrierSNs),
-                                std::end(loadBarrierSNs));
+        DPRINTF(MemDepUnit, "%d load barriers in flight\n", loadBarrierSNs.size());
+        producing_stores.insert(std::end(producing_stores), std::begin(loadBarrierSNs), std::end(loadBarrierSNs));
     } else if ((inst->isStore() || inst->isAtomic()) && hasStoreBarrier()) {
-        DPRINTF(MemDepUnit, "%d store barriers in flight\n",
-                storeBarrierSNs.size());
-        producing_stores.insert(std::end(producing_stores),
-                                std::begin(storeBarrierSNs),
-                                std::end(storeBarrierSNs));
-    } else {
-        if (inst->isLoad()) {
-            store_set_pred = true;
+        DPRINTF(MemDepUnit, "%d store barriers in flight\n", storeBarrierSNs.size());
+        producing_stores.insert(std::end(producing_stores), std::begin(storeBarrierSNs), std::end(storeBarrierSNs));
+    } else { if (inst->isLoad()) {
+        store_set_pred = true;
             producing_stores = depPred.checkInst(inst->pcState().instAddr());
             if (enableMDPStrictWait) {
                 strict_wait = depPred.checkInstStrict(inst->pcState().instAddr());
@@ -249,11 +239,9 @@ MemDepUnit::insert(const DynInstPtr &inst)
     }
 
     std::vector<MemDepEntryPtr> store_entries;
-
     // If there is a producing store, try to find the entry.
     for (auto producing_store : producing_stores) {
-        DPRINTF(MemDepUnit, "Searching for producer [sn:%lli]\n",
-                            producing_store);
+        DPRINTF(MemDepUnit, "Searching for producer [sn:%lli]\n", producing_store);
         MemDepHashIt hash_it = memDepHash.find(producing_store);
 
         if (hash_it != memDepHash.end()) {
@@ -264,9 +252,12 @@ MemDepUnit::insert(const DynInstPtr &inst)
 
     // If no store entry, then instruction can issue as soon as the registers
     // are ready.
+
     if (store_entries.empty()) {
-        DPRINTF(MemDepUnit, "No dependency for inst PC "
-                "%s [sn:%lli].\n", inst->pcState(), inst->seqNum);
+        DPRINTF(MemDepUnit,
+                "No dependency for inst PC "
+                "%s [sn:%lli].\n",
+                inst->pcState(), inst->seqNum);
 
         assert(inst_entry->memDeps == 0);
 
@@ -274,10 +265,10 @@ MemDepUnit::insert(const DynInstPtr &inst)
     } else if (enableReplayBasedMDP && inst->isLoad() && store_set_pred) {
         // Replay-based MDP: do not stall loads in IQ. Carry the prediction
         // to load pipe and potentially replay there.
-        DPRINTF(MemDepUnit, "Replay-based MDP: bypass IQ stall for load PC "
+        DPRINTF(MemDepUnit,
+                "Replay-based MDP: bypass IQ stall for load PC "
                 "%s [sn:%lli], predicted producers: %lu, strict: %d\n",
-                inst->pcState(), inst->seqNum, producing_stores.size(),
-                strict_wait);
+                inst->pcState(), inst->seqNum, producing_stores.size(), strict_wait);
 
         inst->issueQue->markMemDepDone(inst);
 
@@ -286,10 +277,10 @@ MemDepUnit::insert(const DynInstPtr &inst)
         // Otherwise make the instruction dependent on the store/barrier.
         DPRINTF(MemDepUnit, "Adding to dependency list\n");
         for ([[maybe_unused]] auto producing_store : producing_stores)
-            DPRINTF(MemDepUnit, "\tinst PC %s is dependent on [sn:%lli].\n",
-                inst->pcState(), producing_store);
+            DPRINTF(MemDepUnit, "\tinst PC %s is dependent on [sn:%lli].\n", inst->pcState(), producing_store);
 
         // Add this instruction to the list of dependents.
+
         for (auto store_entry : store_entries)
             store_entry->dependInsts.push_back(inst_entry);
 
@@ -306,11 +297,11 @@ MemDepUnit::insert(const DynInstPtr &inst)
     insertBarrierSN(inst);
 
     if (inst->isStore() || inst->isAtomic()) {
-        DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n",
-                inst->pcState(), inst->seqNum);
+        DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n", inst->pcState(), inst->seqNum);
 
-        depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
-                inst->threadNumber, cpu->curCycle());
+
+            depPred.insertStore(inst->pcState().instAddr(), inst->seqNum, inst->threadNumber, cpu->curCycle());
+
 
         ++stats.insertedStores;
     } else if (inst->isLoad()) {
@@ -328,11 +319,11 @@ MemDepUnit::insertNonSpec(const DynInstPtr &inst)
     // Might want to turn this part into an inline function or something.
     // It's shared between both insert functions.
     if (inst->isStore() || inst->isAtomic()) {
-        DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n",
-                inst->pcState(), inst->seqNum);
+        DPRINTF(MemDepUnit, "Inserting store/atomic PC %s [sn:%lli].\n", inst->pcState(), inst->seqNum);
 
-        depPred.insertStore(inst->pcState().instAddr(), inst->seqNum,
-                inst->threadNumber, cpu->curCycle());
+
+            depPred.insertStore(inst->pcState().instAddr(), inst->seqNum, inst->threadNumber, cpu->curCycle());
+
 
         ++stats.insertedStores;
     } else if (inst->isLoad()) {
@@ -350,8 +341,7 @@ MemDepUnit::insertBarrier(const DynInstPtr &barr_inst)
     MemDepEntryPtr inst_entry = std::make_shared<MemDepEntry>(barr_inst);
 
     // Add the MemDepEntry to the hash.
-    memDepHash.insert(
-        std::pair<InstSeqNum, MemDepEntryPtr>(barr_inst->seqNum, inst_entry));
+    memDepHash.insert(std::pair<InstSeqNum, MemDepEntryPtr>(barr_inst->seqNum, inst_entry));
 #ifdef DEBUG
     MemDepEntry::memdep_insert++;
 #endif
@@ -367,13 +357,11 @@ MemDepUnit::insertBarrier(const DynInstPtr &barr_inst)
 void
 MemDepUnit::regsReady(const DynInstPtr &inst)
 {
-
 }
 
 void
 MemDepUnit::nonSpecInstReady(const DynInstPtr &inst)
 {
-
 }
 
 void
@@ -393,8 +381,7 @@ MemDepUnit::replay()
 
         MemDepEntryPtr inst_entry = findInHash(temp_inst);
 
-        DPRINTF(MemDepUnit, "Replaying mem instruction PC %s [sn:%lli].\n",
-                temp_inst->pcState(), temp_inst->seqNum);
+        DPRINTF(MemDepUnit, "Replaying mem instruction PC %s [sn:%lli].\n", temp_inst->pcState(), temp_inst->seqNum);
 
         inst_entry->inst->issueQue->retryMem(inst_entry->inst);
 
@@ -405,8 +392,7 @@ MemDepUnit::replay()
 void
 MemDepUnit::completed(const DynInstPtr &inst)
 {
-    DPRINTF(MemDepUnit, "Completed mem instruction PC %s [sn:%lli].\n",
-            inst->pcState(), inst->seqNum);
+    DPRINTF(MemDepUnit, "Completed mem instruction PC %s [sn:%lli].\n", inst->pcState(), inst->seqNum);
 
     ThreadID tid = inst->threadNumber;
 
@@ -450,8 +436,7 @@ MemDepUnit::completeInst(const DynInstPtr &inst)
             barrier_type = "Read";
 
         if (barrier_type) {
-            DPRINTF(MemDepUnit, "%s barrier completed: %s SN:%lli\n",
-                                barrier_type, inst->pcState(), inst->seqNum);
+            DPRINTF(MemDepUnit, "%s barrier completed: %s SN:%lli\n", barrier_type, inst->pcState(), inst->seqNum);
         }
     }
 }
@@ -460,15 +445,15 @@ void
 MemDepUnit::wakeDependents(const DynInstPtr &inst)
 {
     // Only stores, atomics and barriers have dependents.
-    if (!inst->isStore() && !inst->isAtomic() && !inst->isReadBarrier() &&
-        !inst->isWriteBarrier() && !inst->isHtmCmd()) {
+    if (!inst->isStore() && !inst->isAtomic() && !inst->isReadBarrier() && !inst->isWriteBarrier() &&
+        !inst->isHtmCmd()) {
         return;
     }
 
     MemDepEntryPtr inst_entry = findInHash(inst);
     stats.dependentLoads += inst_entry->dependInsts.size();
 
-    for (int i = 0; i < inst_entry->dependInsts.size(); ++i ) {
+    for (int i = 0; i < inst_entry->dependInsts.size(); ++i) {
         MemDepEntryPtr woken_inst = inst_entry->dependInsts[i];
 
         if (!woken_inst->inst) {
@@ -476,15 +461,17 @@ MemDepUnit::wakeDependents(const DynInstPtr &inst)
             continue;
         }
 
-        DPRINTF(MemDepUnit, "Waking up a dependent inst, "
+        DPRINTF(MemDepUnit,
+                "Waking up a dependent inst, "
                 "[sn:%lli].\n",
                 woken_inst->inst->seqNum);
+
+
 
         assert(woken_inst->memDeps > 0);
         woken_inst->memDeps -= 1;
 
-        if ((woken_inst->memDeps == 0) &&
-            !woken_inst->squashed) {
+        if ((woken_inst->memDeps == 0) && !woken_inst->squashed) {
             woken_inst->inst->issueQue->markMemDepDone(woken_inst->inst);
         }
     }
@@ -492,15 +479,12 @@ MemDepUnit::wakeDependents(const DynInstPtr &inst)
     inst_entry->dependInsts.clear();
 }
 
-MemDepUnit::MemDepEntry::MemDepEntry(const DynInstPtr &new_inst) :
-    inst(new_inst)
+MemDepUnit::MemDepEntry::MemDepEntry(const DynInstPtr &new_inst) : inst(new_inst)
 {
 #ifdef DEBUG
     ++memdep_count;
 
-    DPRINTF(MemDepUnit,
-            "Memory dependency entry created. memdep_count=%i %s\n",
-            memdep_count, inst->pcState());
+    DPRINTF(MemDepUnit, "Memory dependency entry created. memdep_count=%i %s\n", memdep_count, inst->pcState());
 #endif
 }
 
@@ -512,9 +496,7 @@ MemDepUnit::MemDepEntry::~MemDepEntry()
 #ifdef DEBUG
     --memdep_count;
 
-    DPRINTF(MemDepUnit,
-            "Memory dependency entry deleted. memdep_count=%i %s\n",
-            memdep_count, inst->pcState());
+    DPRINTF(MemDepUnit, "Memory dependency entry deleted. memdep_count=%i %s\n", memdep_count, inst->pcState());
 #endif
 }
 
@@ -524,8 +506,7 @@ MemDepUnit::squash(const InstSeqNum &squashed_num, ThreadID tid)
     if (!instsToReplay.empty()) {
         ListIt replay_it = instsToReplay.begin();
         while (replay_it != instsToReplay.end()) {
-            if ((*replay_it)->threadNumber == tid &&
-                (*replay_it)->seqNum > squashed_num) {
+            if ((*replay_it)->threadNumber == tid && (*replay_it)->seqNum > squashed_num) {
                 instsToReplay.erase(replay_it++);
             } else {
                 ++replay_it;
@@ -538,11 +519,9 @@ MemDepUnit::squash(const InstSeqNum &squashed_num, ThreadID tid)
 
     MemDepHashIt hash_it;
 
-    while (!instList[tid].empty() &&
-           (*squash_it)->seqNum > squashed_num) {
+    while (!instList[tid].empty() && (*squash_it)->seqNum > squashed_num) {
 
-        DPRINTF(MemDepUnit, "Squashing inst [sn:%lli]\n",
-                (*squash_it)->seqNum);
+        DPRINTF(MemDepUnit, "Squashing inst [sn:%lli]\n", (*squash_it)->seqNum);
 
         loadBarrierSNs.erase((*squash_it)->seqNum);
 
@@ -565,28 +544,31 @@ MemDepUnit::squash(const InstSeqNum &squashed_num, ThreadID tid)
     }
 
     // Tell the dependency predictor to squash as well.
-    depPred.squash(squashed_num, tid);
-}
+
+        depPred.squash(squashed_num, tid);
+    }
+
 
 void
-MemDepUnit::violation(const DynInstPtr &store_inst,
-        const DynInstPtr &violating_load)
+MemDepUnit::violation(const DynInstPtr &store_inst, const DynInstPtr &violating_load)
 {
-    DPRINTF(MemDepUnit, "Passing violating PCs to store sets,"
-            " load: %#x, store: %#x\n", violating_load->pcState().instAddr(),
-            store_inst->pcState().instAddr());
+    DPRINTF(MemDepUnit,
+            "Passing violating PCs to store sets,"
+            " load: %#x, store: %#x\n",
+            violating_load->pcState().instAddr(), store_inst->pcState().instAddr());
+
     // Tell the memory dependence unit of the violation.
-    depPred.violation(store_inst->pcState().instAddr(),
-            violating_load->pcState().instAddr());
+    depPred.violation(store_inst->pcState().instAddr(), violating_load->pcState().instAddr());
+
 }
 
 void
 MemDepUnit::issue(const DynInstPtr &inst)
 {
-    DPRINTF(MemDepUnit, "Issuing instruction PC %#x [sn:%lli].\n",
-            inst->pcState().instAddr(), inst->seqNum);
+    DPRINTF(MemDepUnit, "Issuing instruction PC %#x [sn:%lli].\n", inst->pcState().instAddr(), inst->seqNum);
 
-    depPred.issued(inst->pcState().instAddr(), inst->seqNum, inst->isStore());
+
+        depPred.issued(inst->pcState().instAddr(), inst->seqNum, inst->isStore());
 }
 
 MemDepUnit::MemDepEntryPtr &
@@ -603,20 +585,17 @@ void
 MemDepUnit::dumpLists()
 {
     for (ThreadID tid = 0; tid < MaxThreads; tid++) {
-        cprintf("Instruction list %i size: %i\n",
-                tid, instList[tid].size());
+        cprintf("Instruction list %i size: %i\n", tid, instList[tid].size());
 
         ListIt inst_list_it = instList[tid].begin();
         int num = 0;
 
         while (inst_list_it != instList[tid].end()) {
-            cprintf("Instruction:%i\nPC: %s\n[sn:%llu]\n[tid:%i]\nIssued:%i\n"
-                    "Squashed:%i\n\n",
-                    num, (*inst_list_it)->pcState(),
-                    (*inst_list_it)->seqNum,
-                    (*inst_list_it)->threadNumber,
-                    (*inst_list_it)->isIssued(),
-                    (*inst_list_it)->isSquashed());
+            cprintf(
+                "Instruction:%i\nPC: %s\n[sn:%llu]\n[tid:%i]\nIssued:%i\n"
+                "Squashed:%i\n\n",
+                num, (*inst_list_it)->pcState(), (*inst_list_it)->seqNum, (*inst_list_it)->threadNumber,
+                (*inst_list_it)->isIssued(), (*inst_list_it)->isSquashed());
             inst_list_it++;
             ++num;
         }
@@ -629,5 +608,5 @@ MemDepUnit::dumpLists()
 #endif
 }
 
-} // namespace o3
-} // namespace gem5
+}  // namespace o3
+}  // namespace gem5


### PR DESCRIPTION
## Motivation

Separate formatting-only O3 changes that were mixed into #1008, so PHAST behavior can be reviewed independently.

## Scope

- Reformat `commit.cc`, `dyn_inst.hh`, `iew.cc`, and `mem_dep_unit.cc`.
- No PHAST or MDP behavior, configuration, statistics, or other functional changes are included.

## Validation

- `git diff --check` passes.
- Each changed file has the same lexical token sequence as `xs-dev`; only whitespace, line wrapping, indentation, and comment spacing differ.