### PR TITLE
misc: Add regression label trigger to gem5 full test

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,12 +93,16 @@
 
 **目标**: 确保 `xs-dev` 分支永远健康、可发布
 
-**触发**: PR 合入 `xs-dev` 分支后自动运行
+**触发**:
+- PR 合入 `xs-dev` 分支后自动运行
+- 在目标分支为 `xs-dev` 的同仓库 PR 上添加 `regression` 标签，合入前按 PR head commit 运行
 
 ### 包含的测试 Workflows
 
 #### 1. `gem5.yml` - 功能回归测试
 8个并行 jobs（遵循DRY原则，排除已在 Tier 1 运行的测试）
+
+维护者可以在 PR 上添加 `regression` 标签，提前运行与合入后相同的完整功能回归。为避免 `pull_request_target` 执行外部代码，该入口仅接受目标分支为 `xs-dev` 的同仓库 PR。
 
 **已移除**（避免重复）:
 - ~~`unit_tests`~~ → 在 `pr-quick-check.yml`
@@ -163,9 +167,10 @@ git push origin xs-dev
 
 1. 检查 Tier 1 快速检查结果
 2. 对于性能敏感的 PR，添加 `perf` 或 `perf-align` 标签
-3. 审查代码和性能影响
-4. 合入后监控 Tier 2 测试
-5. 如发现失败，立即回滚
+3. 对于可能影响 gem5 功能回归的 PR，添加 `regression` 标签
+4. 审查代码和性能影响
+5. 合入后监控 Tier 2 测试
+6. 如发现失败，立即回滚
 
 ---
 
@@ -197,7 +202,7 @@ python actions_gem5.py --token <github-token> --always-on
 
 - `.github/workflows/pr-quick-check.yml` - Tier 1
 - `.github/workflows/gem5-perf-template.yml` - 性能测试模板
-- `.github/workflows/gem5.yml` - Tier 2 功能测试
+- `.github/workflows/gem5.yml` - `xs-dev` 合入后或 `regression` 标签触发的完整功能回归
 - `.github/workflows/gem5-ideal-btb-perf.yml` - `xs-dev` / `*-perf` / `perf` 标签默认性能测试
 - `.github/workflows/gem5-align-btb-0.3c.yml` - `xs-dev` / `*-align` / `perf-align` 标签默认对齐性能测试
 - `.github/workflows/on-demand-spec-rvv.yml` - `rvv` 标签 RVV 性能测试
@@ -212,6 +217,9 @@ A: 性能测试耗时长，会拖慢 PR 审查。现在改为按需触发，既�
 
 **Q: 如何触发性能测试？**
 A: 在 PR 上添加 `perf` 或 `perf-align` 标签；需要自定义配置时使用 `manual-perf.yml`。
+
+**Q: 如何在合入前运行完整的 gem5 功能回归？**
+A: 在目标分支为 `xs-dev` 的同仓库 PR 上添加 `regression` 标签。workflow 会按标签创建时的 PR head commit 运行，外部 fork PR 不会触发。
 
 **Q: 为什么外部 fork PR 加标签不会触发性能测试？**
 A: 性能测试会 checkout 并执行 PR 代码。为了避免 `pull_request_target` 执行外部 fork 代码，label 触发仅允许同仓库 PR。

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -3,18 +3,30 @@ name: gem5 Full Test (Tier 2 - Post-Merge)
 on:
   push:
     branches: [ xs-dev ]
-  # Removed pull_request trigger - moved to pr-quick-check.yml (Tier 1)
-  # can be triggered manually
+  # Run the full functional suite before merge when the `regression` label is added.
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   paralel_cpt_test:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     # gem5.cfg 使用的切片 ck_path 位于小机房
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Running test checkpoints
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
 
       - name: Build GEM5 opt
@@ -74,12 +86,19 @@ jobs:
             head -2000 || true
 
   paralel_cpt_h_test:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     # 使用 open runner 可见的固定 H/V NEMU reference
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Running h test checkpoints
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
 
       - name: Build GEM5 opt
@@ -191,11 +210,18 @@ jobs:
             head -1000 || true
 
   valgrind_memory_check:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Check memory corruption
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 debug
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
@@ -207,11 +233,18 @@ jobs:
 
 
   new_sim_script_test_gcbv:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Test new simulation script on RV64GCBV
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
@@ -225,11 +258,18 @@ jobs:
           bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
 
   new_sim_script_test_gcb_multi_core:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Test Multi-core + RV64GCB
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - name: Build GEM5 opt
         run: |
           CC=clang CXX=clang++ scons build/RISCV_CHI/gem5.opt -j 48 --gold-linker
@@ -244,11 +284,18 @@ jobs:
 
 
   test_fix_l2tlb_bugs:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Test fix L2TLB bugs
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -261,11 +308,18 @@ jobs:
           bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
 
   new_sim_script_test_gcbh:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     name: XS-GEM5 - Test new simulation script on RV64GCBH
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
@@ -279,12 +333,19 @@ jobs:
           bash ../kmh_6wide_h.sh /nfs/home/share/gem5_ci/checkpoints/gcbh_test.zstd
 
   raw_linux_boot_test:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      (github.event.label.name == 'regression' &&
+       github.event.pull_request.base.ref == 'xs-dev' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
     timeout-minutes: 30
     name: XS-GEM5 - Boot raw Linux
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 opt
         run: |


### PR DESCRIPTION
## Motivation

The full gem5 functional workflow currently detects regressions only after changes reach xs-dev. Maintainers need a way to run the same suite before merge.

## Changes

- Add a pull_request_target labeled trigger to gem5.yml for the regression label.
- Restrict label-triggered runs to same-repository PRs targeting xs-dev.
- Check out the labeled PR head SHA so the suite tests the PR code.
- Preserve existing push and workflow_dispatch behavior.
- Document the new pre-merge trigger in the workflow README.

## Validation

- Parsed gem5.yml successfully.
- Verified all 8 jobs have the regression label guard and PR-head checkout.
- git diff --check passed.

The regression label must be created in the repository once; maintainers can then add it to an xs-dev PR to run the full regression suite before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in full regression test workflow for same-repository pull requests targeting `xs-dev`.
  * Maintainers can start pre-merge validation by adding the `regression` label.
  * Validation runs against the pull request’s latest commit and remains available through push and manual triggers.
  * External fork pull requests are excluded from this workflow.

* **Documentation**
  * Updated workflow guidance and FAQ with the new regression testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->