### PR TITLE
cpu-o3: Separate vector load and store split

### DIFF
--- a/docs/Gem5_Docs/RVV/vector.md
+++ b/docs/Gem5_Docs/RVV/vector.md
@@ -14,44 +14,50 @@
 向量访存 ready 后，会经过下面这条路径：
 
 1. 进入 `vectorReadyQ`
-2. 被分配到某个 vector split unit
+2. 按访问方向被分配到 `VLSplit` 或 `VSSplit` split unit
 3. 在 split unit 中等待固定 `3` 拍
 4. 释放到 `vectorDelayedReadyQ`
 5. 再回到常规 `readyQ`，参与后续 schedule / issue
 
-本次实现后，`IssueQue` 默认有 `2` 个独立的 vector split unit，可通过 `vectorSplitUnits` 参数修改。
+本次实现后，每个 `IssueQue` 默认有两类拆分资源：
+
+- `VLSplit[0]`、`VLSplit[1]`：向量 load 拆分单元
+- `VSSplit[0]`、`VSSplit[1]`：向量 store 拆分单元
+
+`vectorSplitUnits` 参数控制每个方向的实例数，默认值为 `2`。
 
 ## Two-Unit Semantics
 
-两个 split unit 之间没有阻塞关系。
+同一方向的 split unit 之间没有阻塞关系；`VLSplit` 和 `VSSplit` 两个资源池之间也没有阻塞关系。
 
 每个 split unit 内部保留原有阻塞语义：
 
-- 如果该 unit 里已经有非 `unit-stride` 的向量访存正在 split，这个 unit 就不再接收新的待拆分指令
-- 另一个 unit 如果没有被这种指令占住，仍然可以继续接收新的待拆分指令
+- 如果该 unit 里已经有会阻塞拆分的向量访存正在 split，这个 unit 就不再接收新的同方向待拆分指令
+- 同方向的另一个 unit 如果没有被这种指令占住，仍然可以继续接收新的待拆分指令
 
-`unit-stride` 指令仍然视为非阻塞型：
+现有规则中，`VectorUnitStrideLoad` 仍然视为非阻塞型：
 
-- 它们会被送入某个具体 split unit
-- 但不会把该 unit 标记成 blocked
+- load 只会送入 `VLSplit`，store 只会送入 `VSSplit`
+- 每个方向的指令会被送入某个具体编号的 split unit
+- `VectorUnitStrideLoad` 不会把所在 unit 标记成 blocked；其他向量访存沿用原有 blocker 语义
 
 因此，效果上等价于：
 
 - 旧模型：1 套“split 通道 + 全局 blocker”
-- 新模型：2 套彼此独立的“split 通道 + 每通道各自的 blocker”
+- 新模型：4 个带方向的 split 通道（2 个 `VLSplit` + 2 个 `VSSplit`），每通道各自维护 blocker
 
 ## Unit Selection
 
-待拆分指令统一先进入全局 `vectorReadyQ`。
+待拆分指令先按方向进入 `vectorLoadReadyQ` 或 `vectorStoreReadyQ`。
 
 当 `IssueQue` 尝试启动 split 时：
 
-1. 按 `vectorReadyQ` 的 FIFO 顺序取最老指令
-2. 在所有未 blocked 的 split unit 中做轮转选择
+1. 按对应方向 FIFO 顺序取最老指令
+2. 在对应方向所有未 blocked 的 split unit 中做轮转选择
 3. 将该指令送入选中的 unit
 4. 若该指令是非 `unit-stride`，则只阻塞它所在的那个 unit
 
-如果 2 个 unit 都被非 `unit-stride` 指令占住，则 `vectorReadyQ` 停止继续向前推进，直到至少一个 unit 释放。
+如果某个方向的 2 个 unit 都被阻塞，则该方向的 ready queue 停止继续向前推进，直到至少一个同方向 unit 释放；另一方向仍可独立推进。
 
 ## What Stays Unchanged
 
@@ -68,7 +74,8 @@
 `src/cpu/o3/FuncScheduler.py` 中给 `IssueQue` 新增了：
 
 ```python
-vectorSplitUnits = Param.Unsigned(2, "Number of independent vector split units")
+vectorSplitUnits = Param.Unsigned(
+    2, "Number of independent vector load/store split units per direction")
 ```
 
 默认值是 `2`。如果需要回退到旧行为，可以显式把它设成 `1`。

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -84,7 +84,8 @@ class IssueQue(SimObject):
     size = Param.Int(16, "")
     inports = Param.Int(2, "")
     scheduleToExecDelay = Param.Cycles(2, "")
-    vectorSplitUnits = Param.Unsigned(2, "Number of independent vector split units")
+    vectorSplitUnits = Param.Unsigned(
+        2, "Number of independent vector load/store split units per direction")
     oports = VectorParam.IssuePort("")
     sel = Param.BaseSelector(BaseSelector(), "Selector for this IQ")
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -198,9 +198,11 @@ IssueQue::IssueQue(const IssueQueParams& params)
       scheduleToExecDelay(params.scheduleToExecDelay),
       iqname(params.name),
       vectorSplitUnits(params.vectorSplitUnits),
-      nextVectorSplitUnit(0),
+      nextVectorLoadSplitUnit(0),
+      nextVectorStoreSplitUnit(0),
       inflightIssues(scheduleToExecDelay, 0),
-      vectorSplitStates(params.vectorSplitUnits),
+      vectorLoadSplitStates(params.vectorSplitUnits),
+      vectorStoreSplitStates(params.vectorSplitUnits),
       vectorReadyQEvent([this]() { processVectorReadyQ(); },
                         csprintf("%s.vectorReadyQEvent", params.name)),
       selector(params.sel)
@@ -392,6 +394,43 @@ IssueQue::isVectorMemInst(const DynInstPtr& inst) const
     return inst && inst->isVector() && inst->isMemRef() && !inst->isSquashed();
 }
 
+IssueQue::VectorSplitKind
+IssueQue::vectorSplitKind(const DynInstPtr& inst) const
+{
+    panic_if(!inst || !inst->isVector() || !inst->isMemRef() ||
+                 (!inst->isLoad() && !inst->isStore()),
+             "Unsupported vector split instruction [sn:%llu]\n",
+             inst ? inst->seqNum : 0);
+    return inst->isLoad() ? VectorSplitKind::Load : VectorSplitKind::Store;
+}
+
+const char*
+IssueQue::vectorSplitKindName(VectorSplitKind kind) const
+{
+    return kind == VectorSplitKind::Load ? "VLSplit" : "VSSplit";
+}
+
+std::vector<IssueQue::VectorSplitUnitState>&
+IssueQue::vectorSplitStatesFor(VectorSplitKind kind)
+{
+    return kind == VectorSplitKind::Load ? vectorLoadSplitStates :
+                                           vectorStoreSplitStates;
+}
+
+const std::vector<IssueQue::VectorSplitUnitState>&
+IssueQue::vectorSplitStatesFor(VectorSplitKind kind) const
+{
+    return kind == VectorSplitKind::Load ? vectorLoadSplitStates :
+                                           vectorStoreSplitStates;
+}
+
+unsigned&
+IssueQue::nextVectorSplitUnitFor(VectorSplitKind kind)
+{
+    return kind == VectorSplitKind::Load ? nextVectorLoadSplitUnit :
+                                           nextVectorStoreSplitUnit;
+}
+
 bool
 IssueQue::isBlockingVectorSplitInst(const DynInstPtr& inst) const
 {
@@ -399,9 +438,9 @@ IssueQue::isBlockingVectorSplitInst(const DynInstPtr& inst) const
 }
 
 bool
-IssueQue::hasAvailableVectorSplitUnit() const
+IssueQue::hasAvailableVectorSplitUnit(VectorSplitKind kind) const
 {
-    for (const auto& unit : vectorSplitStates) {
+    for (const auto& unit : vectorSplitStatesFor(kind)) {
         if (!unit.blocked()) {
             return true;
         }
@@ -411,17 +450,18 @@ IssueQue::hasAvailableVectorSplitUnit() const
 }
 
 int
-IssueQue::selectVectorSplitUnit()
+IssueQue::selectVectorSplitUnit(VectorSplitKind kind)
 {
-    if (vectorSplitStates.empty()) {
+    auto& states = vectorSplitStatesFor(kind);
+    if (states.empty()) {
         return -1;
     }
 
-    for (unsigned offset = 0; offset < vectorSplitStates.size(); ++offset) {
-        const unsigned idx = (nextVectorSplitUnit + offset) %
-                             vectorSplitStates.size();
-        if (!vectorSplitStates[idx].blocked()) {
-            nextVectorSplitUnit = (idx + 1) % vectorSplitStates.size();
+    auto& next_unit = nextVectorSplitUnitFor(kind);
+    for (unsigned offset = 0; offset < states.size(); ++offset) {
+        const unsigned idx = (next_unit + offset) % states.size();
+        if (!states[idx].blocked()) {
+            next_unit = (idx + 1) % states.size();
             return idx;
         }
     }
@@ -430,11 +470,11 @@ IssueQue::selectVectorSplitUnit()
 }
 
 Tick
-IssueQue::nextVectorSplitReleaseTick() const
+IssueQue::nextVectorSplitReleaseTick(VectorSplitKind kind) const
 {
     Tick next_tick = MaxTick;
 
-    for (const auto& unit : vectorSplitStates) {
+    for (const auto& unit : vectorSplitStatesFor(kind)) {
         if (!unit.splitQ.empty() && !unit.splitQReleaseTicks.empty()) {
             next_tick = std::min(next_tick, unit.splitQReleaseTicks.front());
         }
@@ -443,10 +483,20 @@ IssueQue::nextVectorSplitReleaseTick() const
     return next_tick;
 }
 
+Tick
+IssueQue::nextVectorSplitReleaseTick() const
+{
+    return std::min(nextVectorSplitReleaseTick(VectorSplitKind::Load),
+                    nextVectorSplitReleaseTick(VectorSplitKind::Store));
+}
+
 void
 IssueQue::eraseVectorSplitBlocker(InstSeqNum seq_num)
 {
-    for (auto& unit : vectorSplitStates) {
+    for (auto& unit : vectorLoadSplitStates) {
+        unit.blockingSeqs.erase(seq_num);
+    }
+    for (auto& unit : vectorStoreSplitStates) {
         unit.blockingSeqs.erase(seq_num);
     }
 }
@@ -459,7 +509,11 @@ IssueQue::scheduleVectorReadyQEvent()
     }
 
     Tick next_tick = MaxTick;
-    if (!vectorReadyQ.empty() && hasAvailableVectorSplitUnit()) {
+    const bool load_can_start = !vectorLoadReadyQ.empty() &&
+        hasAvailableVectorSplitUnit(VectorSplitKind::Load);
+    const bool store_can_start = !vectorStoreReadyQ.empty() &&
+        hasAvailableVectorSplitUnit(VectorSplitKind::Store);
+    if (load_can_start || store_can_start) {
         next_tick = curTick();
     } else {
         next_tick = nextVectorSplitReleaseTick();
@@ -487,8 +541,13 @@ IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
         return;
     }
 
-    vectorReadyQ.push(inst);
-    vectorReadyQReplay.push(replay);
+    if (vectorSplitKind(inst) == VectorSplitKind::Load) {
+        vectorLoadReadyQ.push(inst);
+        vectorLoadReadyQReplay.push(replay);
+    } else {
+        vectorStoreReadyQ.push(inst);
+        vectorStoreReadyQReplay.push(replay);
+    }
     DPRINTF(Schedule,
             "[sn:%llu] add to vectorReadyQ, replay:%d\n",
             inst->seqNum, replay);
@@ -497,17 +556,21 @@ IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
 }
 
 void
-IssueQue::tryStartVectorMemSplit()
+IssueQue::tryStartVectorMemSplit(VectorSplitKind kind)
 {
-    assert(vectorReadyQ.size() == vectorReadyQReplay.size());
+    auto& ready_q = kind == VectorSplitKind::Load ? vectorLoadReadyQ :
+                                                    vectorStoreReadyQ;
+    auto& replay_q = kind == VectorSplitKind::Load ? vectorLoadReadyQReplay :
+                                                     vectorStoreReadyQReplay;
+    assert(ready_q.size() == replay_q.size());
 
-    while (!vectorReadyQ.empty() && !vectorReadyQReplay.empty()) {
-        auto inst = vectorReadyQ.front();
-        const bool replay = vectorReadyQReplay.front();
+    while (!ready_q.empty() && !replay_q.empty()) {
+        auto inst = ready_q.front();
+        const bool replay = replay_q.front();
 
         if (!inst || inst->isSquashed() || (!replay && inst->canceled())) {
-            vectorReadyQ.pop();
-            vectorReadyQReplay.pop();
+            ready_q.pop();
+            replay_q.pop();
             if (inst) {
                 vectorReadyQSeqs.erase(inst->seqNum);
                 eraseVectorSplitBlocker(inst->seqNum);
@@ -515,17 +578,17 @@ IssueQue::tryStartVectorMemSplit()
             continue;
         }
 
-        const int split_unit = selectVectorSplitUnit();
+        const int split_unit = selectVectorSplitUnit(kind);
         if (split_unit < 0) {
             return;
         }
 
-        vectorReadyQ.pop();
-        vectorReadyQReplay.pop();
+        ready_q.pop();
+        replay_q.pop();
 
         assert(cpu);
         const Tick releaseTick = cpu->clockEdge(Cycles(3));
-        auto& unit = vectorSplitStates[split_unit];
+        auto& unit = vectorSplitStatesFor(kind)[split_unit];
         unit.splitQ.push(inst);
         unit.splitQReleaseTicks.push(releaseTick);
         unit.splitQReplay.push(replay);
@@ -534,11 +597,19 @@ IssueQue::tryStartVectorMemSplit()
         }
 
         DPRINTF(Schedule,
-                "[sn:%llu] enter vector split unit %d, replay:%d, release at "
-                "%llu, blocking:%d\n",
-                inst->seqNum, split_unit, replay, releaseTick,
+                "[%s:%d] [sn:%llu] enter vector split, replay:%d, release "
+                "at %llu, blocking:%d\n",
+                vectorSplitKindName(kind), split_unit, inst->seqNum,
+                replay, releaseTick,
                 isBlockingVectorSplitInst(inst));
     }
+}
+
+void
+IssueQue::tryStartVectorMemSplit()
+{
+    tryStartVectorMemSplit(VectorSplitKind::Load);
+    tryStartVectorMemSplit(VectorSplitKind::Store);
 }
 
 void
@@ -578,11 +649,10 @@ IssueQue::releaseVectorDelayedReadyQ()
 }
 
 void
-IssueQue::processVectorReadyQ()
+IssueQue::releaseVectorSplitUnits(VectorSplitKind kind)
 {
-    tryStartVectorMemSplit();
-
-    for (auto& unit : vectorSplitStates) {
+    auto& states = vectorSplitStatesFor(kind);
+    for (auto& unit : states) {
         assert(unit.splitQ.size() == unit.splitQReleaseTicks.size());
         assert(unit.splitQ.size() == unit.splitQReplay.size());
         while (!unit.splitQ.empty() && !unit.splitQReleaseTicks.empty() &&
@@ -605,10 +675,22 @@ IssueQue::processVectorReadyQ()
             vectorDelayedReadyQ.push(inst);
             vectorDelayedReadyQReplay.push(replay);
             DPRINTF(Schedule,
-                    "[sn:%llu] moved to vectorDelayedReadyQ, replay:%d\n",
-                    inst->seqNum, replay);
+                    "[%s:%d] [sn:%llu] moved to vectorDelayedReadyQ, "
+                    "replay:%d\n",
+                    vectorSplitKindName(kind),
+                    static_cast<int>(&unit - states.data()), inst->seqNum,
+                    replay);
         }
     }
+}
+
+void
+IssueQue::processVectorReadyQ()
+{
+    tryStartVectorMemSplit();
+
+    releaseVectorSplitUnits(VectorSplitKind::Load);
+    releaseVectorSplitUnits(VectorSplitKind::Store);
 
     releaseVectorDelayedReadyQ();
     tryStartVectorMemSplit();
@@ -768,8 +850,12 @@ IssueQue::idle()
         }
     }
     idle |= replayQ.size() > 0;
-    idle |= vectorReadyQ.size() > 0;
-    for (const auto& unit : vectorSplitStates) {
+    idle |= vectorLoadReadyQ.size() > 0;
+    idle |= vectorStoreReadyQ.size() > 0;
+    for (const auto& unit : vectorLoadSplitStates) {
+        idle |= unit.splitQ.size() > 0;
+    }
+    for (const auto& unit : vectorStoreSplitStates) {
         idle |= unit.splitQ.size() > 0;
     }
     idle |= vectorDelayedReadyQ.size() > 0;

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -124,8 +124,16 @@ class IssueQue : public SimObject
     int numLoadPipe = 0;
     int numStorePipe = 0;
     int loadPipeId = -1;
+
+    enum class VectorSplitKind
+    {
+        Load,
+        Store
+    };
+
     const unsigned vectorSplitUnits;
-    unsigned nextVectorSplitUnit = 0;
+    unsigned nextVectorLoadSplitUnit = 0;
+    unsigned nextVectorStoreSplitUnit = 0;
 
     struct select_policy
     {
@@ -183,9 +191,12 @@ class IssueQue : public SimObject
     };
 
     std::queue<DynInstPtr> replayQ;  // only for mem
-    std::queue<DynInstPtr> vectorReadyQ;
-    std::queue<bool> vectorReadyQReplay;
-    std::vector<VectorSplitUnitState> vectorSplitStates;
+    std::queue<DynInstPtr> vectorLoadReadyQ;
+    std::queue<bool> vectorLoadReadyQReplay;
+    std::queue<DynInstPtr> vectorStoreReadyQ;
+    std::queue<bool> vectorStoreReadyQReplay;
+    std::vector<VectorSplitUnitState> vectorLoadSplitStates;
+    std::vector<VectorSplitUnitState> vectorStoreSplitStates;
     std::queue<DynInstPtr> vectorDelayedReadyQ;
     std::queue<bool> vectorDelayedReadyQReplay;
     std::unordered_set<InstSeqNum> vectorReadyQSeqs;
@@ -219,13 +230,21 @@ class IssueQue : public SimObject
     void addToFu(const DynInstPtr& inst);
     bool checkScoreboard(const DynInstPtr& inst);
     bool isVectorMemInst(const DynInstPtr& inst) const;
+    VectorSplitKind vectorSplitKind(const DynInstPtr& inst) const;
+    const char* vectorSplitKindName(VectorSplitKind kind) const;
     bool isBlockingVectorSplitInst(const DynInstPtr& inst) const;
-    bool hasAvailableVectorSplitUnit() const;
-    int selectVectorSplitUnit();
+    std::vector<VectorSplitUnitState>& vectorSplitStatesFor(VectorSplitKind kind);
+    const std::vector<VectorSplitUnitState>& vectorSplitStatesFor(VectorSplitKind kind) const;
+    unsigned& nextVectorSplitUnitFor(VectorSplitKind kind);
+    bool hasAvailableVectorSplitUnit(VectorSplitKind kind) const;
+    int selectVectorSplitUnit(VectorSplitKind kind);
+    Tick nextVectorSplitReleaseTick(VectorSplitKind kind) const;
     Tick nextVectorSplitReleaseTick() const;
     void eraseVectorSplitBlocker(InstSeqNum seq_num);
     void enqueueVectorMemDelay(const DynInstPtr& inst, bool replay);
+    void tryStartVectorMemSplit(VectorSplitKind kind);
     void tryStartVectorMemSplit();
+    void releaseVectorSplitUnits(VectorSplitKind kind);
     void scheduleVectorReadyQEvent();
     void releaseVectorDelayedReadyQ();
     void issueToFu();


### PR DESCRIPTION
Model vector memory splitting with independent per-direction resources.

  - Add independent VLSplit and VSSplit queues and unit states.
  - Use per-direction round-robin unit allocation and release scheduling.
  - Preserve blocker, replay, cancel, and squash handling.
  - Keep the configurable three-cycle split delay.
  - Document the RVV load/store split model and its accuracy boundaries.

  This prevents vector loads and stores from contending on a shared split queue.

Change-Id: If0d1820cb78342fee7bca7617dae200658e61d63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector memory operations now use independent load and store split-unit pools.
  * Load and store operations can progress independently, even when one direction is blocked.
  * Operations are assigned fairly across available units using FIFO and round-robin scheduling.
  * The number of split units per direction is configurable, defaulting to two.

* **Documentation**
  * Updated configuration guidance, including the option to set one unit per direction for legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->