### PR TITLE
mem: set sqFullUpperLimit as VSQ - 4 instead of PSQ - 4

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -457,7 +457,7 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
       stats(nullptr)
 {
     // reserve space, we want if sq will be full, sbuffer will start evicting
-    sqFullUpperLimit = physicalSqEntries - 4;
+    sqFullUpperLimit = sqEntries - 4;
 
     loadPipeSx.resize(ldPipeStages);
     storePipeSx.resize(stPipeStages);

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -400,7 +400,7 @@ class LSQUnit
     bool storeBufferEmpty(ThreadID tid) { return lsq->storeBufferEmpty(tid); }
     bool storeBufferSQWillFull() const
     {
-        return addrOrDataReadyNums > sqFullUpperLimit;
+        return storeQueue.size() > sqFullUpperLimit;
     }
     void recordStoreBufferBlockedByCache() { ++stats.blockedByCache; }
 


### PR DESCRIPTION
Change-Id: I148b14f856b2b567b750a3d4df8f2110105753ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store-queue capacity tracking during speculative execution.
  * Corrected store-buffer fullness detection to use the configured queue capacity and current queue size.
  * Helps prevent premature or inaccurate full-queue conditions, supporting more reliable instruction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->