### PR TITLE
util: enable dynamic-pf as default and updated CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,19 +60,19 @@
 - `rvv` 标签仍由独立的 RVV on-demand workflow 触发
 - Label 触发只允许同仓库 PR；外部 fork PR 需要先由维护者同步到受信任分支，再通过 label 或 `manual-perf.yml` 触发
 - 需要手动选择配置、benchmark 或 branch/SHA 时，请使用 `manual-perf.yml`
-- 需要动态预取 A/B 时，请使用 `manual-perf.yml` 的 `pf_control_profile` 输入；不要在 `extra_args` 中手写 `--pf-control-profile`
+- `idealkmhv3.py` 和 `smt_idealkmhv3.py` 在未显式传参时会默认启用 `--enable-dynamic-pf=True`
+- 需要手动切换动态预取时，请在 `manual-perf.yml` 的 `extra_args` 中直接写 `--enable-dynamic-pf=True|False`
 
-### Dynamic Prefetch Profile
+### Dynamic Prefetch Toggle
 
-`manual-perf.yml` 和性能测试模板支持 `pf_control_profile`：
+`manual-perf.yml` 不再提供独立的动态预取输入。相关行为由 `extra_args` 显式控制：
 
-| Profile | 语义 |
+| 开关值 | 语义 |
 | --- | --- |
-| `off` | 默认 base 行为，关闭内置动态预取控制 |
-| `adaptive` | 启用 CI 内置 adaptive profile，窗口为 8000 cycles，并打开 L1D/L2/L2Wrapper PFBad 表 |
-| `default` | 不套内置 profile，仅使用代码中的 `PF_CONTROL_CONFIG` 和可选的 `GEM5_PF_CONTROL_CONFIG` 覆盖 |
+| `False` | 显式关闭动态预取控制 |
+| `True` | 显式启用动态预取控制，窗口为 8000 cycles，并打开 L1D/L2/L2Wrapper PFBad 表 |
 
-动态预取 profile 会被模板统一追加到 gem5 config 参数。这样可以避免 manual 输入、weekly 配置和分布式 runner 之间出现参数口径不一致。
+如果 `extra_args` 没有显式传 `--enable-dynamic-pf`，`idealkmhv3.py` 和 `smt_idealkmhv3.py` 会默认补成 `True`。因此要做 base 对比时，请显式传 `--enable-dynamic-pf=False`。
 
 ### 性能结果
 
@@ -112,7 +112,7 @@
 
 #### 4. 其他测试
 - `gem5-vector.yml` - RVV 扩展测试
-- `gem5-ideal-btb-perf-weekly.yml` - 定时任务（每周四），包含 gcc15/spec17 常规回归、gcc12 `idealkmhv3.py` base/adaptive A/B，以及 SMT SPEC06 int-only dynamic prefetch 回归
+- `gem5-ideal-btb-perf-weekly.yml` - 定时任务（每周四），包含 gcc15/spec17 常规回归、gcc12 `idealkmhv3.py` 动态预取回归，以及 SMT SPEC06 int-only dynamic prefetch 回归
 
 ---
 
@@ -220,7 +220,7 @@ A: 性能测试会 checkout 并执行 PR 代码。为了避免 `pull_request_tar
 A: 只需修改 `gem5-perf-template.yml`
 
 **Q: 如何跑动态预取性能测试？**
-A: 使用 `manual-perf.yml`，把 `pf_control_profile` 设为 `adaptive`。base 对比使用默认的 `off`。模板会拒绝通过 `extra_args` 重复传 `--pf-control-profile`，防止一个 run 里出现两个互相冲突的 profile。
+A: 使用 `manual-perf.yml`，在 `extra_args` 里直接传 `--enable-dynamic-pf=True`。base 对比请显式传 `--enable-dynamic-pf=False`。`idealkmhv3.py` 和 `smt_idealkmhv3.py` 的默认值现在是 True。
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,7 +60,7 @@
 - `rvv` 标签仍由独立的 RVV on-demand workflow 触发
 - Label 触发只允许同仓库 PR；外部 fork PR 需要先由维护者同步到受信任分支，再通过 label 或 `manual-perf.yml` 触发
 - 需要手动选择配置、benchmark 或 branch/SHA 时，请使用 `manual-perf.yml`
-- `idealkmhv3.py` 和 `smt_idealkmhv3.py` 在未显式传参时会默认启用 `--enable-dynamic-pf=True`
+- `idealkmhv3.py` 默认关闭动态预取；`smt_idealkmhv3.py` 保持当前默认行为
 - 需要手动切换动态预取时，请在 `manual-perf.yml` 的 `extra_args` 中直接写 `--enable-dynamic-pf=True|False`
 
 ### Dynamic Prefetch Toggle
@@ -72,7 +72,7 @@
 | `False` | 显式关闭动态预取控制 |
 | `True` | 显式启用动态预取控制，窗口为 8000 cycles，并打开 L1D/L2/L2Wrapper PFBad 表 |
 
-如果 `extra_args` 没有显式传 `--enable-dynamic-pf`，`idealkmhv3.py` 和 `smt_idealkmhv3.py` 会默认补成 `True`。因此要做 base 对比时，请显式传 `--enable-dynamic-pf=False`。
+如果 `extra_args` 没有显式传 `--enable-dynamic-pf`，`idealkmhv3.py` 会默认保持关闭。SMT 配置保持现有默认行为不变。
 
 ### 性能结果
 
@@ -228,7 +228,7 @@ A: 性能测试会 checkout 并执行 PR 代码。为了避免 `pull_request_tar
 A: 只需修改 `gem5-perf-template.yml`
 
 **Q: 如何跑动态预取性能测试？**
-A: 使用 `manual-perf.yml`，在 `extra_args` 里直接传 `--enable-dynamic-pf=True`。base 对比请显式传 `--enable-dynamic-pf=False`。`idealkmhv3.py` 和 `smt_idealkmhv3.py` 的默认值现在是 True。
+A: 使用 `manual-perf.yml`，在 `extra_args` 里直接传 `--enable-dynamic-pf=True`。base 对比请显式传 `--enable-dynamic-pf=False`。`idealkmhv3.py` 默认关闭动态预取，SMT 配置保持当前默认行为不变。
 
 ---
 

--- a/.github/workflows/gem5-ideal-btb-perf-weekly.yml
+++ b/.github/workflows/gem5-ideal-btb-perf-weekly.yml
@@ -13,14 +13,12 @@ jobs:
     with:
       config_path: configs/example/kmhv3.py
       benchmark_type: "gcc15-spec06-1.0c"
-      pf_control_profile: "off"
 
   align_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/kmhv3.py
       benchmark_type: "spec17-1.0c"
-      pf_control_profile: "off"
 
   align_test_spec26:
     uses: ./.github/workflows/gem5-perf-template.yml
@@ -36,14 +34,12 @@ jobs:
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "gcc15-spec06-1.0c"
-      pf_control_profile: "off"
 
   perf_test_spec17:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "spec17-1.0c"
-      pf_control_profile: "off"
 
   perf_test_spec26:
     uses: ./.github/workflows/gem5-perf-template.yml
@@ -59,35 +55,14 @@ jobs:
     with:
       config_path: configs/example/smt_idealkmhv3.py
       benchmark_type: "gcc12-spec06-smt-1.0c"
-      pf_control_profile: "off"
       distributed_servers: "default"
       distributed_jobs_per_server: 32
       check_result: false
       timeout_minutes: 720
-
-  smt_dynpf_int_test_spec06:
-    uses: ./.github/workflows/gem5-perf-template.yml
-    with:
-      config_path: configs/example/smt_idealkmhv3.py
-      benchmark_type: "gcc12-spec06-smt-int-1.0c"
-      pf_control_profile: "adaptive"
-      distributed_servers: "default"
-      distributed_jobs_per_server: 32
-      check_result: false
-      timeout_minutes: 720
-
-  perf_test_spec06_gcc12_base:
-    uses: ./.github/workflows/gem5-perf-template.yml
-    with:
-      config_path: configs/example/idealkmhv3.py
-      benchmark_type: "gcc12-spec06-1.0c"
-      pf_control_profile: "off"
-      extra_args: "--dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"
 
   perf_test_spec06_gcc12_dynpf:
     uses: ./.github/workflows/gem5-perf-template.yml
     with:
       config_path: configs/example/idealkmhv3.py
       benchmark_type: "gcc12-spec06-1.0c"
-      pf_control_profile: "adaptive"
-      extra_args: "--dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini"
+      extra_args: "--dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini --enable-dynamic-pf=True"

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -12,11 +12,6 @@ on:
         type: string
         default: ""
         description: "Extra arguments for gem5 (e.g., --disable-mgsc). Only works with .py config files."
-      pf_control_profile:
-        required: false
-        type: string
-        default: "off"
-        description: "Prefetch control profile: off, adaptive, or default."
       benchmark_type:
         required: true
         type: string
@@ -80,8 +75,6 @@ jobs:
       
       - name: Set benchmark configuration
         id: config
-        env:
-          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
         run: |
           case "${{ inputs.benchmark_type }}" in
               "gcc12-spec06-0.3c")
@@ -194,21 +187,6 @@ jobs:
               ;;
           esac
 
-          case "$PF_CONTROL_PROFILE_INPUT" in
-            ""|"off")
-              echo "pf_artifact_suffix=" >> $GITHUB_OUTPUT
-              ;;
-            "adaptive")
-              echo "pf_artifact_suffix=-pf-adaptive" >> $GITHUB_OUTPUT
-              ;;
-            "default")
-              echo "pf_artifact_suffix=-pf-default" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "Error: Invalid pf_control_profile '$PF_CONTROL_PROFILE_INPUT'. Must be one of: off, adaptive, default"
-              exit 1
-              ;;
-          esac
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 fast
         run: |
@@ -244,7 +222,6 @@ jobs:
           BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_ARGS_INPUT: ${{ inputs.extra_args }}
-          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
           DISTRIBUTED_SERVERS_RAW: ${{ inputs.distributed_servers }}
           DISTRIBUTED_JOBS_PER_SERVER_RAW: ${{ inputs.distributed_jobs_per_server }}
         run: |
@@ -256,11 +233,6 @@ jobs:
           CONFIG_NAME=$(basename "$CONFIG_PATH_INPUT" .py)
           CONFIG_NAME=$(printf '%s' "$CONFIG_NAME" | tr -c 'A-Za-z0-9._-' '_')
           CONFIG_NAME=${CONFIG_NAME:-config}
-          PF_CONTROL_PROFILE="${PF_CONTROL_PROFILE_INPUT:-off}"
-          if [ "$PF_CONTROL_PROFILE" != "off" ]; then
-            PROFILE_NAME=$(printf '%s' "$PF_CONTROL_PROFILE" | tr -c 'A-Za-z0-9._-' '_')
-            CONFIG_NAME="${CONFIG_NAME}_pf_${PROFILE_NAME}"
-          fi
           TARGET_DIR="${BENCHMARK_DIR}/${TIMESTAMP}_${COMMIT_SHORT}_${CONFIG_NAME}_run${RUN_NUMBER}"
           DEFAULT_DISTRIBUTED_SERVERS="node020-node034,node036-node039"
           DISTRIBUTED_DISPATCH_HOST="ci-runner@172.28.9.101"
@@ -296,7 +268,6 @@ jobs:
           echo "run_number: $RUN_NUMBER" >> "$TARGET_DIR/metadata.txt"
           echo "benchmark_type: $BENCHMARK_TYPE_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "specific_benchmarks: $SPECIFIC_BENCHMARKS_INPUT" >> "$TARGET_DIR/metadata.txt"
-          echo "pf_control_profile: $PF_CONTROL_PROFILE" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers_input: $DISTRIBUTED_SERVERS_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers: $DISTRIBUTED_SERVERS" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_server_domain: " >> "$TARGET_DIR/metadata.txt"
@@ -368,7 +339,6 @@ jobs:
           BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_GEM5_ARGS_RAW: ${{ inputs.extra_args }}
-          PF_CONTROL_PROFILE_INPUT: ${{ inputs.pf_control_profile }}
           CHECKPOINT_LIST: ${{ steps.checkpoints.outputs.checkpoint_list }}
           CHECKPOINT_ROOT_NODE: ${{ steps.config.outputs.checkpoint_root_node }}
           DISTRIBUTED_SERVERS: ${{ steps.archive.outputs.distributed_servers }}
@@ -400,21 +370,6 @@ jobs:
           extra_args="$(echo "$extra_args" | xargs)"
           extra_args="${extra_args//\$\{GEM5_HOME\}/$GEM5_HOME}"
           extra_args="${extra_args//\$GEM5_HOME/$GEM5_HOME}"
-          pf_control_profile="${PF_CONTROL_PROFILE_INPUT:-off}"
-
-          case "$pf_control_profile" in
-            "off"|"adaptive"|"default")
-              ;;
-            *)
-              echo "Error: Invalid pf_control_profile '$pf_control_profile'. Must be one of: off, adaptive, default"
-              exit 1
-              ;;
-          esac
-          if [[ "$extra_args" == *"--pf-control-profile"* ]]; then
-            echo "Error: Do not pass --pf-control-profile through extra_args; use pf_control_profile workflow input instead."
-            exit 1
-          fi
-          extra_args="$(printf '%s --pf-control-profile=%s' "$extra_args" "$pf_control_profile" | xargs)"
           echo "Resolved extra gem5 args: $extra_args"
           printf 'resolved_extra_args: %s\n' "$extra_args" >> "$PERF_ARCHIVE_DIR/metadata.txt"
 
@@ -534,7 +489,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.config.outputs.artifact_name }}${{ steps.config.outputs.pf_artifact_suffix }}
+          name: ${{ steps.config.outputs.artifact_name }}
           path: score.txt
           retention-days: 30
       

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - pf:{4} - {5} - {6}{7}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.pf_control_profile || 'off', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.extra_args && format(' - {0}', github.event.inputs.extra_args) || '') }}
+run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5} - {6}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.vector_type, github.event.inputs.extra_args || 'no-extra-args') }}
 
 on:
   workflow_dispatch:
@@ -51,17 +51,8 @@ on:
         options:
           - base
           - simple
-      pf_control_profile:
-        description: 'Prefetch control profile'
-        required: false
-        type: choice
-        default: 'off'
-        options:
-          - 'off'
-          - adaptive
-          - default
       extra_args:
-        description: 'Extra gem5 args appended to config runs, e.g. --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini'
+        description: 'Extra gem5 args appended to config runs, e.g. --dramsim3-ini=$GEM5_HOME/ext/dramsim3/xiangshan_configs/xiangshan_DDR4_8Gb_x8_3200_8ch.ini --enable-dynamic-pf=True'
         required: false
         type: string
         default: ''
@@ -110,7 +101,6 @@ jobs:
       benchmark_type: ${{ github.event.inputs.benchmark_type }}
       specific_benchmarks: ${{ github.event.inputs.specific_benchmarks }}
       vector_type: ${{ github.event.inputs.vector_type }}
-      pf_control_profile: ${{ github.event.inputs.pf_control_profile }}
       extra_args: ${{ github.event.inputs.extra_args }}
       distributed_servers: ${{ github.event.inputs.distributed_servers }}
       distributed_jobs_per_server: ${{ fromJSON(github.event.inputs.distributed_jobs_per_server || '32') }}

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -98,6 +98,7 @@ class ListPlatform(argparse.Action):
         ObjectList.platform_list.print()
         sys.exit(0)
 
+
 # Add the very basic options that work also in the case of the no ISA
 # being used, and consequently no CPUs, but rather various types of
 # testers and traffic generators.
@@ -315,14 +316,6 @@ def addCommonOptions(parser, configure_xiangshan=False):
                         help="""
                         Force all hardware prefetchers to disable their
                         optional prefetch buffer (QueuedPrefetcher.use_pf_buffer).""")
-    parser.add_argument("--pf-control-profile", action="store",
-                        default="off",
-                        choices=("off", "adaptive", "default"),
-                        help="""
-                        Prefetch admission-control profile. 'off' disables
-                        built-in control/adaptive defaults, 'adaptive' enables
-                        the CI adaptive profile, and 'default' uses only
-                        PF_CONTROL_CONFIG plus GEM5_PF_CONTROL_CONFIG.""")
 
     parser.add_argument("--cpu-clock", action="store", type=str,
                         default='3GHz',
@@ -653,6 +646,13 @@ def addXiangshanCommonOptions(parser):
                         default=None, help="The path of mmc img")
     parser.add_argument("--mmc-cptbin", action="store",
                         type=str, default=None, help="The path of mmc cptbin")
+    parser.add_argument(
+        "--enable-dynamic-pf",
+        type=str,
+        choices=("True", "False"),
+        default=None,
+        metavar="{True,False}",
+        help="Enable dynamic prefetch control (True/False).")
 
     # Difftest option
     parser.set_defaults(enable_difftest=None)

--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -46,7 +46,6 @@ PF_SOURCE_BY_NAME.update({
 })
 
 PF_CONTROL_CONFIG_ENV = "GEM5_PF_CONTROL_CONFIG"
-PF_CONTROL_PROFILE_NAMES = ("off", "adaptive", "default")
 
 # Central Python-only configuration for prefetch admission control.
 # Batch scripts may point GEM5_PF_CONTROL_CONFIG at a Python file defining
@@ -84,34 +83,55 @@ PF_CONTROL_CONFIG = {
 }
 
 _LOADED_PF_CONTROL_CONFIG = None
-_PF_CONTROL_PROFILE = "off"
 
-PF_CONTROL_PROFILE_CONFIGS = {
-    "off": {
-        "control": {
-            "enabled": False,
-        },
-        "adaptive": {
-            "enabled": False,
-        },
+_ENABLE_DYNAMIC_PF = False
+
+_DYNAMIC_PF_DISABLED_CONFIG = {
+    "control": {
+        "enabled": False,
     },
     "adaptive": {
-        "control": {
-            "enabled": True,
-            "window": 8000,
-            "admit_pct": 100,
-        },
-        "adaptive": {
-            "enabled": True,
-            "pfbad_entries": {
-                "l1d": 128,
-                "l2": 512,
-                "l2_wrapper": 512,
-            },
+        "enabled": False,
+    },
+}
+
+_DYNAMIC_PF_ENABLED_CONFIG = {
+    "control": {
+        "enabled": True,
+        "window": 8000,
+        "admit_pct": 100,
+    },
+    "adaptive": {
+        "enabled": True,
+        "pfbad_entries": {
+            "l1d": 128,
+            "l2": 512,
+            "l2_wrapper": 512,
         },
     },
-    "default": {},
 }
+
+
+def _apply_dynamic_pf_config(config):
+    if _ENABLE_DYNAMIC_PF:
+        _deep_update_dict(config, _DYNAMIC_PF_ENABLED_CONFIG)
+    else:
+        _deep_update_dict(config, _DYNAMIC_PF_DISABLED_CONFIG)
+
+
+def _finalize_dynamic_pf_config(config):
+    control = config.setdefault("control", {})
+    adaptive = config.setdefault("adaptive", {})
+    control["enabled"] = _ENABLE_DYNAMIC_PF
+    adaptive["enabled"] = _ENABLE_DYNAMIC_PF
+
+
+def set_enable_dynamic_pf(enabled):
+    global _ENABLE_DYNAMIC_PF
+    global _LOADED_PF_CONTROL_CONFIG
+
+    _ENABLE_DYNAMIC_PF = bool(enabled)
+    _LOADED_PF_CONTROL_CONFIG = None
 
 
 def _get_hwp(hwp_option):
@@ -129,31 +149,13 @@ def _deep_update_dict(base, override):
             base[key] = value
 
 
-def set_pf_control_profile(profile):
-    global _PF_CONTROL_PROFILE
-    global _LOADED_PF_CONTROL_CONFIG
-
-    profile = str(profile).strip().lower()
-    if profile not in PF_CONTROL_PROFILE_NAMES:
-        valid = ", ".join(PF_CONTROL_PROFILE_NAMES)
-        fatal(f"Invalid prefetch control profile {profile!r}; valid: {valid}")
-
-    _PF_CONTROL_PROFILE = profile
-    _LOADED_PF_CONTROL_CONFIG = None
-
-
-def _apply_pf_control_profile(config):
-    profile_config = PF_CONTROL_PROFILE_CONFIGS[_PF_CONTROL_PROFILE]
-    _deep_update_dict(config, profile_config)
-
-
 def _load_pf_control_config():
     global _LOADED_PF_CONTROL_CONFIG
     if _LOADED_PF_CONTROL_CONFIG is not None:
         return _LOADED_PF_CONTROL_CONFIG
 
     config = copy.deepcopy(PF_CONTROL_CONFIG)
-    _apply_pf_control_profile(config)
+    _apply_dynamic_pf_config(config)
 
     config_path = os.environ.get(PF_CONTROL_CONFIG_ENV, "").strip()
     if config_path:
@@ -169,6 +171,7 @@ def _load_pf_control_config():
             )
         _deep_update_dict(config, override)
 
+    _finalize_dynamic_pf_config(config)
     _LOADED_PF_CONTROL_CONFIG = config
     return config
 

--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -839,6 +839,11 @@ def build_xiangshan_system(args):
     np = args.num_cpus
     assert buildEnv['TARGET_ISA'] == "riscv"
 
+    enable_dynamic_pf = getattr(args, 'enable_dynamic_pf', False)
+    PrefetcherConfig.set_enable_dynamic_pf(
+        enable_dynamic_pf is True or enable_dynamic_pf == "True"
+    )
+
     TestCPUClass = get_xiangshan_cpu_class(args)
     ruby = bool(hasattr(args, 'ruby') and args.ruby)
     num_threads = np * (2 if getattr(args, 'smt', False) else 1)
@@ -994,8 +999,6 @@ def xiangshan_system_init():
     if '--ruby' in sys.argv:
         Ruby.define_options(parser)
     args = parser.parse_args()
-
-    PrefetcherConfig.set_pf_control_profile(args.pf_control_profile)
 
     # Match the memories with the CPUs, based on the options for the test system
     TestMemClass = Simulation.setMemClass(args)

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -1,12 +1,8 @@
-import argparse
 import sys
 
-import m5
-from m5.defines import buildEnv
 from m5.objects import *
 from m5.objects.ValuePredictor import *
-from m5.util import addToPath, fatal, warn
-from m5.util.fdthelper import *
+from m5.util import addToPath
 
 addToPath('../')
 addToPath('../../')
@@ -29,6 +25,7 @@ def setPtwLevelLimitParams(args, tlb):
     tlb.walker.ptw_level2_limit = args.ptw_level2_limit
     tlb.walker.ptw_level3_limit = args.ptw_level3_limit
     tlb.walker.ptw_miss_queue_size = args.ptw_miss_queue_size
+
 
 def setKmhV3IdealParams(args, system):
     for cpu in system.cpu:
@@ -167,6 +164,8 @@ if __name__ == '__m5_main__':
 
     # Set default bp_type based on ideal_kmhv3 flag
     # If user didn't specify bp_type, set default based on ideal_kmhv3
+    if args.enable_dynamic_pf is None:
+        args.enable_dynamic_pf = True
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'

--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -164,8 +164,6 @@ if __name__ == '__m5_main__':
 
     # Set default bp_type based on ideal_kmhv3 flag
     # If user didn't specify bp_type, set default based on ideal_kmhv3
-    if args.enable_dynamic_pf is None:
-        args.enable_dynamic_pf = True
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -38,6 +38,8 @@ if __name__ == '__m5_main__':
     assert not args.external_memory_system
 
     args.smt = True
+    if args.enable_dynamic_pf is None:
+        args.enable_dynamic_pf = True
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
     args.l3_size = '32MB'


### PR DESCRIPTION
- Add --enable-dynamic-pf to Xiangshan config entrypoints
- Default idealkmhv3.py and smt_idealkmhv3.py to enable dynamic prefetch
- Remove pf_control_profile from manual-perf and the reusable perf template

Change-Id: If4412573d06cd8811f377fc00b54c53fc93ba167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `True`/`False` control for dynamic prefetching.
  * Enabled dynamic prefetching by default for IdealKMHv3 and SMT IdealKMHv3 configurations.
  * Added a GCC12 dynamic-prefetch performance benchmark.

* **Updates**
  * Performance workflows now configure prefetching through extra arguments.
  * Removed legacy prefetch profile options and simplified run and artifact naming.

* **Documentation**
  * Updated workflow guidance, regression coverage, and FAQ content for dynamic prefetch controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->