### PR TITLE
ci: remove distributed SSH dispatch host

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -265,7 +265,6 @@ jobs:
           CONFIG_NAME=${CONFIG_NAME:-config}
           TARGET_DIR="${BENCHMARK_DIR}/${TIMESTAMP}_${COMMIT_SHORT}_${CONFIG_NAME}_run${RUN_NUMBER}"
           DEFAULT_DISTRIBUTED_SERVERS="node020-node034,node036-node039"
-          DISTRIBUTED_DISPATCH_HOST="ci-runner@172.28.9.101"
           DISTRIBUTED_SERVERS_INPUT="$DISTRIBUTED_SERVERS_RAW"
           DISTRIBUTED_SERVERS=$(echo "$DISTRIBUTED_SERVERS_INPUT" | xargs)
           if [ "$DISTRIBUTED_SERVERS" = "default" ]; then
@@ -286,7 +285,6 @@ jobs:
             echo "distributed_servers=$DISTRIBUTED_SERVERS"
             echo "distributed_require_idle_cpus=$DISTRIBUTED_REQUIRE_IDLE_CPUS"
             echo "distributed_idle_probe_mode=$DISTRIBUTED_IDLE_PROBE_MODE"
-            echo "distributed_dispatch_host=$DISTRIBUTED_DISPATCH_HOST"
           } >> "$GITHUB_OUTPUT"
 
           echo "timestamp: $TIMESTAMP" > "$TARGET_DIR/metadata.txt"
@@ -307,7 +305,6 @@ jobs:
           echo "distributed_idle_cpu_threshold: 30" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_ssh_config: " >> "$TARGET_DIR/metadata.txt"
           echo "distributed_ssh_user: " >> "$TARGET_DIR/metadata.txt"
-          echo "distributed_dispatch_host: $DISTRIBUTED_DISPATCH_HOST" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_launch_retries: 3" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_launch_retry_delay: 30" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_launch_interval: 0.5" >> "$TARGET_DIR/metadata.txt"
@@ -387,7 +384,6 @@ jobs:
           DISTRIBUTED_JOBS_PER_SERVER: ${{ inputs.distributed_jobs_per_server }}
           DISTRIBUTED_REQUIRE_IDLE_CPUS: ${{ steps.archive.outputs.distributed_require_idle_cpus }}
           DISTRIBUTED_IDLE_PROBE_MODE: ${{ steps.archive.outputs.distributed_idle_probe_mode }}
-          DISTRIBUTED_DISPATCH_HOST: ${{ steps.archive.outputs.distributed_dispatch_host }}
           EXECUTION_MODE: ${{ steps.config.outputs.execution_mode }}
           H_REF_SO: ${{ steps.config.outputs.h_ref_so }}
           H_RESTORER: ${{ steps.config.outputs.h_restorer }}
@@ -452,7 +448,6 @@ jobs:
               runner_args+=(
                 --require-idle-cpus "$DISTRIBUTED_REQUIRE_IDLE_CPUS"
                 --idle-probe-mode "$DISTRIBUTED_IDLE_PROBE_MODE"
-                --dispatch-host "$DISTRIBUTED_DISPATCH_HOST"
                 --launch-retries 3
                 --launch-retry-delay 30
                 --launch-interval 0.5
@@ -474,7 +469,6 @@ jobs:
               --jobs-per-server "$DISTRIBUTED_JOBS_PER_SERVER" \
               --require-idle-cpus "$DISTRIBUTED_REQUIRE_IDLE_CPUS" \
               --idle-probe-mode "$DISTRIBUTED_IDLE_PROBE_MODE" \
-              --dispatch-host "$DISTRIBUTED_DISPATCH_HOST" \
               --launch-retries 3 \
               --launch-retry-delay 30 \
               --launch-interval 0.5 \

--- a/.github/workflows/manual-solve.yml
+++ b/.github/workflows/manual-solve.yml
@@ -228,7 +228,6 @@ jobs:
             --max-parallel-workloads "${{ github.event.inputs.max_parallel_workloads }}"
             --distributed-servers "${{ github.event.inputs.distributed_servers }}"
             --distributed-jobs-per-server "${{ github.event.inputs.distributed_jobs_per_server }}"
-            --distributed-dispatch-host "ci-runner@172.28.9.101"
             --distributed-ssh-option StrictHostKeyChecking=accept-new
             --distributed-ssh-option UserKnownHostsFile="${{ needs.setup.outputs.run_dir }}/known_hosts"
             --distributed-ssh-option ConnectTimeout=10

--- a/util/solver/executor/distributed.py
+++ b/util/solver/executor/distributed.py
@@ -27,7 +27,6 @@ class DistributedExecutionConfig:
     server_domain: str = ""
     ssh_config: str = ""
     ssh_user: str = ""
-    dispatch_host: str = ""
     ssh_options: tuple[str, ...] = ()
     poll_interval: float = 5.0
     load_probe_interval: float = 15.0
@@ -301,7 +300,6 @@ class DistributedWorkloadScheduler:
             "require_idle_cpus": self.require_idle_cpus,
             "idle_probe_mode": self.config.idle_probe_mode,
             "idle_cpu_threshold": self.config.idle_cpu_threshold,
-            "dispatch_host": self.config.dispatch_host,
         }
 
     def _refresh_server_capacity(self, server: _ServerState, *, force: bool = False) -> None:
@@ -324,7 +322,6 @@ class DistributedWorkloadScheduler:
             ssh_config=self.config.ssh_config,
             ssh_options=list(self.config.ssh_options),
             ssh_user=self.config.ssh_user,
-            dispatch_host=self.config.dispatch_host,
             timeout=self.config.load_probe_timeout,
         )
         server.idle_cpus = idle_cpus
@@ -403,13 +400,6 @@ class DistributedWorkloadScheduler:
                     "ServerAliveCountMax=576",
                 ],
             )
-            if self.config.dispatch_host:
-                ssh_cmd = dist.wrap_with_dispatch_host(
-                    ssh_cmd=ssh_cmd,
-                    dispatch_host=self.config.dispatch_host,
-                    ssh_config=self.config.ssh_config,
-                    ssh_options=list(self.config.ssh_options),
-                )
             proc = subprocess.Popen(
                 ssh_cmd,
                 stdout=subprocess.PIPE,

--- a/util/solver/run_solver.py
+++ b/util/solver/run_solver.py
@@ -235,7 +235,6 @@ def build_argparser() -> argparse.ArgumentParser:
     parser.add_argument("--distributed-server-domain", default="")
     parser.add_argument("--distributed-ssh-config", default="")
     parser.add_argument("--distributed-ssh-user", default="")
-    parser.add_argument("--distributed-dispatch-host", default="")
     parser.add_argument(
         "--distributed-ssh-option",
         action="append",
@@ -568,7 +567,6 @@ def main() -> int:
             server_domain=args.distributed_server_domain,
             ssh_config=args.distributed_ssh_config,
             ssh_user=args.distributed_ssh_user,
-            dispatch_host=args.distributed_dispatch_host,
             ssh_options=tuple(args.distributed_ssh_option or []),
         )
         execution_mode = "distributed" if distributed_config.enabled() else "local"
@@ -598,7 +596,6 @@ def main() -> int:
             "distributed_require_idle_cpus": args.distributed_require_idle_cpus,
             "distributed_idle_probe_mode": args.distributed_idle_probe_mode,
             "distributed_idle_cpu_threshold": args.distributed_idle_cpu_threshold,
-            "distributed_dispatch_host": args.distributed_dispatch_host,
             "dry_run": args.dry_run,
             "stop_reason": None,
             "partial_summary": False,

--- a/util/xs_scripts/distributed_sim.py
+++ b/util/xs_scripts/distributed_sim.py
@@ -192,7 +192,7 @@ def parse_launcher_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]
         default=DEFAULT_LAUNCH_INTERVAL_SEC,
         help=(
             "Seconds to wait between starting jobs. This avoids large SSH "
-            "connection bursts through a dispatch host."
+            "connection bursts."
         ),
     )
     parser.add_argument(
@@ -212,16 +212,6 @@ def parse_launcher_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]
         help=(
             "Optional SSH user for worker servers. If omitted, ssh uses its "
             "normal user/config resolution."
-        ),
-    )
-    parser.add_argument(
-        "--dispatch-host",
-        default="",
-        help=(
-            "Optional SSH host used as a dispatch point. When set, worker "
-            "commands are launched by first ssh'ing to this host, then ssh'ing "
-            "from there to the worker server. This is useful when compute nodes "
-            "are only reachable from a login host."
         ),
     )
     parser.add_argument(
@@ -533,7 +523,6 @@ def launch_job(
     ssh_config: str,
     ssh_options: list[str],
     ssh_user: str,
-    dispatch_host: str,
     attempt: int,
 ) -> PendingJob:
     if server.name == "local":
@@ -557,13 +546,6 @@ def launch_job(
                 "ServerAliveCountMax=576",
             ],
         )
-        if dispatch_host:
-            ssh_cmd = wrap_with_dispatch_host(
-                ssh_cmd=ssh_cmd,
-                dispatch_host=dispatch_host,
-                ssh_config=ssh_config,
-                ssh_options=ssh_options,
-            )
         proc = subprocess.Popen(
             ssh_cmd,
             stdout=subprocess.PIPE,
@@ -588,7 +570,6 @@ def run_host_command(
     ssh_config: str,
     ssh_options: list[str],
     ssh_user: str,
-    dispatch_host: str,
     timeout: float,
 ) -> subprocess.CompletedProcess[bytes]:
     if server_name == "local":
@@ -611,13 +592,6 @@ def run_host_command(
             "TCPKeepAlive=yes",
         ],
     )
-    if dispatch_host:
-        ssh_cmd = wrap_with_dispatch_host(
-            ssh_cmd=ssh_cmd,
-            dispatch_host=dispatch_host,
-            ssh_config=ssh_config,
-            ssh_options=ssh_options,
-        )
     return subprocess.run(
         ssh_cmd,
         stdout=subprocess.PIPE,
@@ -662,13 +636,10 @@ def _idle_probe_context(
     *,
     server_name: str,
     ssh_user: str,
-    dispatch_host: str,
 ) -> str:
     if server_name == "local":
         return "locally"
     target = _idle_probe_target(server_name, ssh_user)
-    if dispatch_host:
-        return f"to {target} via dispatch host {dispatch_host}"
     return f"to {target}"
 
 
@@ -700,27 +671,6 @@ def build_ssh_command(
     return ssh_cmd
 
 
-def wrap_with_dispatch_host(
-    ssh_cmd: list[str],
-    dispatch_host: str,
-    ssh_config: str,
-    ssh_options: list[str],
-) -> list[str]:
-    validate_ssh_target_name(dispatch_host, "--dispatch-host")
-    dispatch_script = "exec " + " ".join(shlex.quote(part) for part in ssh_cmd)
-    return build_ssh_command(
-        target=dispatch_host,
-        remote_command=["bash", "-lc", dispatch_script],
-        ssh_config=ssh_config,
-        ssh_options=ssh_options,
-        fixed_options=[
-            "BatchMode=yes",
-            "ConnectionAttempts=1",
-            "TCPKeepAlive=yes",
-        ],
-    )
-
-
 def probe_idle_cpus(
     server_name: str,
     idle_probe_mode: str,
@@ -728,7 +678,6 @@ def probe_idle_cpus(
     ssh_config: str,
     ssh_options: list[str],
     ssh_user: str,
-    dispatch_host: str,
     timeout: float = 10.0,
 ) -> tuple[int | None, str]:
     script = (
@@ -804,21 +753,18 @@ def probe_idle_cpus(
             ssh_config=ssh_config,
             ssh_options=ssh_options,
             ssh_user=ssh_user,
-            dispatch_host=dispatch_host,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
         context = _idle_probe_context(
             server_name=server_name,
             ssh_user=ssh_user,
-            dispatch_host=dispatch_host,
         )
         return None, f"idle probe {context} timed out after {_format_seconds(timeout)}"
     except OSError as exc:
         context = _idle_probe_context(
             server_name=server_name,
             ssh_user=ssh_user,
-            dispatch_host=dispatch_host,
         )
         detail = _compact_message(str(exc))
         return None, f"idle probe {context} failed: {detail}"
@@ -829,7 +775,6 @@ def probe_idle_cpus(
         context = _idle_probe_context(
             server_name=server_name,
             ssh_user=ssh_user,
-            dispatch_host=dispatch_host,
         )
         detail = _compact_message(stderr or stdout or "no output")
         return None, f"idle probe {context} failed: exit={result.returncode}, {detail}"
@@ -863,7 +808,6 @@ def filter_servers_by_idle(
     ssh_config: str,
     ssh_options: list[str],
     ssh_user: str,
-    dispatch_host: str,
 ) -> list[ServerState]:
     if require_idle_cpus <= 0:
         return servers
@@ -877,7 +821,6 @@ def filter_servers_by_idle(
             ssh_config=ssh_config,
             ssh_options=ssh_options,
             ssh_user=ssh_user,
-            dispatch_host=dispatch_host,
         )
         server.idle_cpus = idle_cpus
         if idle_cpus is None:
@@ -1097,7 +1040,6 @@ def run_scheduler(
     ssh_config: str,
     ssh_options: list[str],
     ssh_user: str,
-    dispatch_host: str,
     launch_retries: int,
     launch_retry_delay: float,
     launch_interval: float,
@@ -1197,7 +1139,6 @@ def run_scheduler(
                     ssh_config=ssh_config,
                     ssh_options=ssh_options,
                     ssh_user=ssh_user,
-                    dispatch_host=dispatch_host,
                     attempt=scheduled.attempt,
                 )
                 launch_attempts += 1
@@ -1263,8 +1204,6 @@ def run_scheduler(
 
 def main(argv: list[str]) -> int:
     args, rest = parse_launcher_args(argv)
-    if args.dispatch_host:
-        validate_ssh_target_name(args.dispatch_host, "--dispatch-host")
 
     first_param = rest[0]
     workload_list = Path(rest[1]).resolve()
@@ -1292,7 +1231,6 @@ def main(argv: list[str]) -> int:
         ssh_config=args.ssh_config,
         ssh_options=args.ssh_option,
         ssh_user=args.ssh_user,
-        dispatch_host=args.dispatch_host,
     )
 
     full_work_dir = Path.cwd().resolve() / tag
@@ -1352,7 +1290,6 @@ def main(argv: list[str]) -> int:
         ssh_config=args.ssh_config,
         ssh_options=args.ssh_option,
         ssh_user=args.ssh_user,
-        dispatch_host=args.dispatch_host,
         launch_retries=args.launch_retries,
         launch_retry_delay=args.launch_retry_delay,
         launch_interval=args.launch_interval,

--- a/util/xs_scripts/h_spec06_perf.py
+++ b/util/xs_scripts/h_spec06_perf.py
@@ -198,8 +198,6 @@ def command_run(args: argparse.Namespace) -> int:
     if args.require_idle_cpus:
         command.extend(["--require-idle-cpus", str(args.require_idle_cpus)])
         command.extend(["--idle-probe-mode", args.idle_probe_mode])
-    if args.dispatch_host:
-        command.extend(["--dispatch-host", args.dispatch_host])
     for ssh_option in args.ssh_option:
         command.extend(["--ssh-option", ssh_option])
     command.extend([
@@ -479,7 +477,6 @@ def make_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--require-idle-cpus", type=int, default=0)
     run_parser.add_argument("--idle-probe-mode", default="physical",
                             choices=("physical", "logical"))
-    run_parser.add_argument("--dispatch-host", default="")
     run_parser.add_argument("--ssh-option", action="append", default=[])
     run_parser.add_argument("--launch-retries", type=int, default=2)
     run_parser.add_argument("--launch-retry-delay", type=float, default=20.0)


### PR DESCRIPTION
## What changed

- route distributed performance and solver workloads directly from the self-hosted runner to worker nodes
- remove the `--dispatch-host` interface and two-hop SSH wrapper from the distributed runner, H runner, and solver executor
- remove the hardcoded `ci-runner@172.28.9.101` workflow configuration and stale metadata

## Why

The self-hosted runners and node020-node039 are in the same machine room. Batch-mode tests from the `cirunner` account successfully connected directly to node020, node021, node029, node030, node038, and node039. Routing every probe and launch through 172.28.9.101 adds an unnecessary cross-room hop and makes that host a single point of failure.

The failing SMT run 31688035148 showed the issue: the job ran on node029, but even probing node029 was sent through 101 and timed out.

## Impact

Distributed CI now uses the existing direct SSH path and preserves idle probing, launch retries, bad-node handling, SSH options, server-domain, ssh-config, and ssh-user support.

## Validation

- Python syntax compile for the four modified Python files
- YAML parse for both modified workflows
- CLI help checks for `distributed_sim.py` and `h_spec06_perf.py`
- repository search confirms no remaining dispatch-host/101 references in the affected call chain
- direct BatchMode SSH confirmed by the CI `cirunner` account on node020, node021, node029, node030, node038, and node039


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Distributed workloads now connect directly to worker servers using the configured SSH settings.
  * Removed support for configuring a separate dispatch host from distributed simulation and solver commands.
  * Existing distributed SSH options and execution behavior remain available without dispatch-host routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->