### PR TITLE
cpu-o3: Modify the load pipeline code

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -183,8 +183,8 @@ class BaseO3CPU(BaseCPU):
     phySQFullCheckAtReplay = Param.Bool(True,
         "Wait for physical store queue space before starting a full-SQ replay")
 
-    LdPipeStages = Param.Unsigned(4, "Number of load pipeline stages")
-    StPipeStages = Param.Unsigned(5, "Number of store pipeline stages")
+    LdPipeStages = Param.Unsigned(4, "Number of stages in the load pipeline")
+    StPipeStages = Param.Unsigned(5, "Number of stages in the store pipeline")
 
     RARQEntries = Param.Unsigned(72, "Number of RAR queue entries")
     RAWQEntries = Param.Unsigned(32, "Number of RAW queue entries")

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -45,6 +45,7 @@
 
 #include "cpu/o3/iew.hh"
 
+#include <algorithm>
 #include <cassert>
 #include <queue>
 
@@ -947,7 +948,7 @@ IEW::canInsertLDSTQue(ThreadID tid)
 void
 IEW::setDispatchAgeCtr(const DynInstPtr& inst, int dispatch_pos)
 {
-    constexpr uint64_t dispatchAgeScale = 8;
+    const uint64_t dispatchAgeScale = std::max<uint64_t>(8, renameWidth);
 
     assert(dispatch_pos >= 0);
     assert(dispatch_pos < static_cast<int>(dispatchAgeScale));

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -208,17 +208,6 @@ IssueQue::IssueQue(const IssueQueParams& params)
     panic_if(vectorSplitUnits == 0,
              "%s: vectorSplitUnits must be greater than 0\n", iqname);
 
-    // TODO: keep this in sync with the current load IQ naming convention.
-    // This should become an explicit IssueQue parameter when the config grows
-    // more load pipes or renames the queues.
-    if (iqname == "ld0" || iqname == "load0") {
-        loadPipeId = 0;
-    } else if (iqname == "ld1" || iqname == "load1") {
-        loadPipeId = 1;
-    } else if (iqname == "ld2" || iqname == "load2") {
-        loadPipeId = 2;
-    }
-
     toIssue = inflightIssues.getWire(0);
     toFu = inflightIssues.getWire(-scheduleToExecDelay);
     if (outports > 8) {
@@ -1254,10 +1243,47 @@ Scheduler::Scheduler(const SchedulerParams& params)
     std::vector<int> wrRfportChecker(MAXVAL_TYPEPORTID, 0);
     int maxRdTypePortId = 0;
     int maxWrTypePortId = 0;
+    int nextLoadPipeId = 0;
     for (int i = 0; i < issueQues.size(); i++) {
         issueQues[i]->setIQID(i);
         issueQues[i]->scheduler = this;
         combinedFus += issueQues[i]->outports;
+
+        unsigned iq_load_ports = 0;
+        unsigned iq_store_ports = 0;
+        for (const auto& opbits : issueQues[i]->portFuDescs) {
+            bool is_load = false;
+            bool is_store = opbits.test(StoreDataOp);
+            for (int op = static_cast<int>(MemReadOp);
+                 op <= static_cast<int>(VectorWholeRegisterLoadOp); ++op) {
+                if (opbits.test(op)) {
+                    is_load = true;
+                    break;
+                }
+            }
+            for (int op = static_cast<int>(MemWriteOp);
+                 op <= static_cast<int>(VectorWholeRegisterStoreOp); ++op) {
+                if (opbits.test(op)) {
+                    is_store = true;
+                    break;
+                }
+            }
+            if (is_load) {
+                ++iq_load_ports;
+            }
+            if (is_store) {
+                ++iq_store_ports;
+            }
+        }
+        panic_if(iq_load_ports != static_cast<unsigned>(issueQues[i]->numLoadPipe),
+                 "%s: derived load ports (%u) != IssueQue load pipes (%d)\n",
+                 issueQues[i]->getName(), iq_load_ports,
+                 issueQues[i]->numLoadPipe);
+        if (iq_load_ports > 0) {
+            issueQues[i]->loadPipeId = nextLoadPipeId++;
+        }
+        loadPipeCount += iq_load_ports;
+        storePipeCount += iq_store_ports;
         panic_if(issueQues[i]->fuDescs.size() == 0, "Empty config IssueQue: " + issueQues[i]->getName());
         for (auto fu : issueQues[i]->fuDescs) {
             for (auto op : fu->opDescList) {
@@ -1290,6 +1316,8 @@ Scheduler::Scheduler(const SchedulerParams& params)
             }
         }
     }
+    DPRINTF(Schedule, "Derived LSQ pipes from scheduler: load=%u store=%u\n",
+            loadPipeCount, storePipeCount);
     maxRdTypePortId += 1;
     maxWrTypePortId += 1;
     assert(maxRdTypePortId <= MAXVAL_TYPEPORTID);

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -315,6 +315,10 @@ class Scheduler : public SimObject
     bool old_disp = false;
     const int intRegfileBanks;
 
+    /** Load/store pipe counts derived from scheduler issue ports. */
+    unsigned loadPipeCount = 0;
+    unsigned storePipeCount = 0;
+
     struct SchedulerStats : public statistics::Group
     {
         SchedulerStats(statistics::Group* parent);
@@ -375,6 +379,8 @@ class Scheduler : public SimObject
     PendingWakeEventsType specWakeEvents;
 
     Scheduler(const SchedulerParams& params);
+    unsigned getLoadPipeCount() const { return loadPipeCount; }
+    unsigned getStorePipeCount() const { return storePipeCount; }
     void setCPU(CPU* cpu, LSQ* lsq);
     void resetDepGraph(uint64_t numPhysRegs);
     void setAllScoreBoard(PhysRegIdPtr reg);

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -63,6 +63,7 @@
 #include "cpu/o3/dyn_inst.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/iew.hh"
+#include "cpu/o3/issue_queue.hh"
 #include "cpu/o3/limits.hh"
 #include "debug/Drain.hh"
 #include "debug/Fetch.hh"
@@ -601,7 +602,8 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
         thread.emplace_back(LQEntries, SQEntries, physicalSQEntries,
             params.LdPipeStages, params.StPipeStages, params.RARQEntries, params.RAWQEntries,
             params.RARDequeuePerCycle, params.RAWDequeuePerCycle, params.LoadCompletionWidth,
-            params.StoreCompletionWidth);
+            params.StoreCompletionWidth, params.scheduler->getLoadPipeCount(),
+            params.scheduler->getStorePipeCount());
         thread[tid].init(cpu, iew_ptr, params, this, tid);
         thread[tid].setDcachePort(&dcachePort);
         _storeBufferFlushing[tid] = false;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -422,7 +422,9 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
     uint32_t physicalSqEntries,
     uint32_t ldPipeStages, uint32_t stPipeStages,
     uint32_t maxRARQEntries, uint32_t maxRAWQEntries, unsigned rarDequeuePerCycle,
-    unsigned rawDequeuePerCycle, unsigned loadCompletionWidth, unsigned storeCompletionWidth)
+    unsigned rawDequeuePerCycle, unsigned loadCompletionWidth,
+    unsigned storeCompletionWidth, unsigned loadPipeCount,
+    unsigned storePipeCount)
     : numSBufferRequest(0),
       numSingleRequest(0),
       numSplitRequest(0),
@@ -433,6 +435,8 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
       loadCompletedIdx(loadQueue.head() - 1),
       // Use head-1 as a sentinel: no completed entry yet; advance must verify head.
       storeCompletedIdx(storeQueue.head() - 1),
+      loadPipeCount(loadPipeCount),
+      storePipeCount(storePipeCount),
       loadPipe(ldPipeStages - 1, 0),
       storePipe(stPipeStages - 1, 0),
       physicalSQEntries(physicalSqEntries),
@@ -454,8 +458,14 @@ LSQUnit::LSQUnit(uint32_t lqEntries, uint32_t sqEntries,
       rawDequeuePerCycle(rawDequeuePerCycle),
       loadCompletionWidth(loadCompletionWidth),
       storeCompletionWidth(storeCompletionWidth),
-      stats(nullptr)
+      stats(nullptr, loadPipeCount ? loadPipeCount : 1,
+            storePipeCount ? storePipeCount : 1)
 {
+    fatal_if(loadPipeCount == 0,
+             "Scheduler must provide at least one load pipe\n");
+    fatal_if(storePipeCount == 0,
+             "Scheduler must provide at least one store pipe\n");
+
     // reserve space, we want if sq will be full, sbuffer will start evicting
     sqFullUpperLimit = physicalSqEntries - 4;
 
@@ -577,7 +587,9 @@ LSQUnit::name() const
     }
 }
 
-LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
+LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent,
+                                    unsigned loadPipeCount,
+                                    unsigned storePipeCount)
     : statistics::Group(parent),
       ADD_STAT(forwLoads, statistics::units::Count::get(),
                "Number of loads that had data forwarded from stores"),
@@ -688,32 +700,28 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
     RAWQueueLatency
         .init(0, 500, 20)
         .flags(statistics::nozero);
-    // TODO: load-pipe PMU vectors currently assume exactly three load pipes.
-    // Extend the vector sizing and IssueQue loadPipeId mapping together if the
-    // model grows more load pipes; the replay pipe counters below share this
-    // same assumption.
     loadPipeAccepted
-        .init(3)
+        .init(loadPipeCount)
         .flags(statistics::total | statistics::nozero);
-    for (int i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < loadPipeCount; i++) {
         loadPipeAccepted.subname(i, csprintf("pipe%d", i));
     }
     storePipeAccepted
-        .init(MaxPipeWidth)
+        .init(storePipeCount)
         .flags(statistics::total | statistics::nozero);
-    for (int i = 0; i < MaxPipeWidth; i++) {
+    for (unsigned i = 0; i < storePipeCount; i++) {
         storePipeAccepted.subname(i, csprintf("pipe%d", i));
     }
     loadPipeReplayAccepted
-        .init(3)
+        .init(loadPipeCount)
         .flags(statistics::total | statistics::nozero);
-    for (int i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < loadPipeCount; i++) {
         loadPipeReplayAccepted.subname(i, csprintf("pipe%d", i));
     }
     loadPipeFastReplayAccepted
-        .init(3)
+        .init(loadPipeCount)
         .flags(statistics::total | statistics::nozero);
-    for (int i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < loadPipeCount; i++) {
         loadPipeFastReplayAccepted.subname(i, csprintf("pipe%d", i));
     }
     loadReplayEvents
@@ -1339,31 +1347,35 @@ LSQUnit::storeSetReplay(const DynInstPtr& inst, LSQRequest* request)
 void
 LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
 {
-    // S0 is the single load-pipe entry point. First issues, slow replays, and
+    // S0 is shared by all load issue sources. First issues, slow replays, and
     // fast replays all enter here; LoadPipeSource records which path fed the
     // pipe for RTL-aligned stats.
-    assert(loadPipeSx[0]->size < MaxPipeWidth);
+    panic_if(loadPipeSx[0]->size >= loadPipeCount,
+             "load pipe S0 exceeds configured pipe count (%u)\n",
+             loadPipeCount);
     panic_if(inst->inPipe(), "load [sn:%llu] is already in pipeline", inst->seqNum);
     inst->beginPipelining();
     inst->setSkipRawCheck();
 
-    int idx = loadPipeSx[0]->size;
-    loadPipeSx[0]->insts[idx] = inst;
-    loadPipeSx[0]->size++;
+    loadPipeSx[0]->insts.push_back(inst);
+    loadPipeSx[0]->size = static_cast<int>(loadPipeSx[0]->insts.size());
     // Order S0 by age so older loads have higher priority when S1 performs
     // the bank-conflict check.
     std::stable_sort(
-        loadPipeSx[0]->insts,
-        loadPipeSx[0]->insts + loadPipeSx[0]->size,
+        loadPipeSx[0]->insts.begin(),
+        loadPipeSx[0]->insts.end(),
         [](const DynInstPtr &lhs, const DynInstPtr &rhs) {
             return lhs->seqNum < rhs->seqNum;
         });
 
     const int load_pipe_id = inst->issueQue->getLoadPipeId();
-    panic_if(load_pipe_id < 0,
-        "Per-load-pipe PMU stats require dedicated load IQ naming; "
-        "unsupported issue queue %s for load [sn:%llu]\n",
-        inst->issueQue->getName().c_str(), inst->seqNum);
+    panic_if(load_pipe_id < 0 ||
+                 static_cast<unsigned>(load_pipe_id) >= loadPipeCount,
+        "Per-load-pipe PMU stats require a scheduler-assigned load pipe ID; "
+        "unsupported or out-of-range issue queue %s for load [sn:%llu] "
+        "(id=%d, count=%u)\n",
+        inst->issueQue->getName().c_str(), inst->seqNum, load_pipe_id,
+        loadPipeCount);
     stats.loadPipeAccepted[load_pipe_id]++;
     const auto load_pipe_source = inst->getLoadPipeSource();
     if (load_pipe_source == DynInst::LoadPipeSource::ReplayQueue) {
@@ -1378,14 +1390,16 @@ LSQUnit::issueToLoadPipe(const DynInstPtr &inst)
 void
 LSQUnit::issueToStorePipe(const DynInstPtr &inst)
 {
-    // push to storePipeS0
-    assert(storePipeSx[0]->size < MaxPipeWidth);
+    // S0 is shared by all store issue sources in the current cycle.
+    panic_if(storePipeSx[0]->size >= storePipeCount,
+             "store pipe S0 exceeds scheduler-derived pipe count (%u)\n",
+             storePipeCount);
     panic_if(inst->inPipe(), "load [sn:%llu] is already in pipeline", inst->seqNum);
     inst->beginPipelining();
 
-    int idx = storePipeSx[0]->size;
-    storePipeSx[0]->insts[idx] = inst;
-    storePipeSx[0]->size++;
+    const int idx = storePipeSx[0]->size;
+    storePipeSx[0]->insts.push_back(inst);
+    storePipeSx[0]->size = static_cast<int>(storePipeSx[0]->insts.size());
     stats.storePipeAccepted[idx]++;
 
     DPRINTF(LSQUnit, "issueToStorePipe: [sn:%lli]\n", inst->seqNum);

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -283,17 +283,20 @@ class LSQUnit
       uint32_t physicalSqEntries,
       uint32_t ldPipeStages, uint32_t stPipeStages, uint32_t maxRARQEntries, uint32_t maxRAWQEntries,
       unsigned rarDequeuePerCycle, unsigned rawDequeuePerCycle,
-      unsigned loadCompletionWidth, unsigned storeCompletionWidth);
+      unsigned loadCompletionWidth, unsigned storeCompletionWidth,
+      unsigned loadPipeCount, unsigned storePipeCount);
 
     /** We cannot copy LSQUnit because it has stats for which copy
      * contructor is deleted explicitly. However, STL vector requires
      * a valid copy constructor for the base type at compile time.
      */
-    LSQUnit(const LSQUnit &l) : physicalSQEntries(0),
+    LSQUnit(const LSQUnit &l) : loadPipeCount(0), storePipeCount(0),
+        physicalSQEntries(0),
         virtualSQEnabled(false), addrOrDataReadyNums(0),
         maxRARQEntries(0), maxRAWQEntries(0),
         rarDequeuePerCycle(0), rawDequeuePerCycle(0), loadCompletionWidth(0),
-        storeCompletionWidth(0), stats(nullptr)
+        storeCompletionWidth(0),
+        stats(nullptr, 1, 1)
     {
         panic("LSQUnit is not copy-able");
     }
@@ -710,21 +713,30 @@ class LSQUnit
     /** Points to the last position of continuously completed instructions from the beginning in storeQueue */
     size_t storeCompletedIdx;
 
-    const static int MaxPipeWidth = 4;
+    /** Load pipeline lanes and PMU channels, derived from scheduler ports. */
+    const unsigned loadPipeCount;
+    /** Store S0 lanes, derived from scheduler STA+STD ports. */
+    const unsigned storePipeCount;
 
     /** Struct that defines the information passed through Load Pipeline. */
     struct LoadPipeStruct
     {
+        LoadPipeStruct() : size(0), insts() {}
+
+        // S0 is shared by all load issue sources in the current cycle.
         int size;
 
-        DynInstPtr insts[MaxPipeWidth];
+        std::vector<DynInstPtr> insts;
     };
     /** Struct that defines the information passed through Store Pipeline. */
     struct StorePipeStruct
     {
+        StorePipeStruct() : size(0), insts() {}
+
+        // S0 is shared by all store issue sources in the current cycle.
         int size;
 
-        DynInstPtr insts[MaxPipeWidth];
+        std::vector<DynInstPtr> insts;
     };
 
 
@@ -847,7 +859,8 @@ class LSQUnit
     // the appropriate number of times.
     struct LSQUnitStats : public statistics::Group
     {
-        LSQUnitStats(statistics::Group *parent);
+        LSQUnitStats(statistics::Group *parent, unsigned loadPipeCount,
+                     unsigned storePipeCount);
 
         /** Total number of loads forwaded from LSQ stores. */
         statistics::Scalar forwLoads;


### PR DESCRIPTION
Make the number of load pipelines configurable.

Change-Id: I38415ca0d7f4a9e9c24c1d9eacbff4083308cf96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Out-of-order CPU memory pipelines now adapt to configured load and store pipeline counts.
  * Pipeline resources and performance statistics are sized dynamically for different configurations.

* **Bug Fixes**
  * Improved support for wider rename configurations by preventing age-counter encoding limitations.
  * Added validation for invalid pipeline counts and load-pipeline assignments.

* **Documentation**
  * Clarified descriptions for load and store pipeline configuration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->