### PR TITLE
cpu: align BTB predictor parameters with XiangShan RTL

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -983,7 +983,7 @@ class MBTB(TimedBaseBTBPredictor):
     cxx_header = 'cpu/pred/btb/mbtb.hh'
 
     numEntries = Param.Unsigned(8192, "Number of entries in the MBTB")
-    tagBits = Param.Unsigned(20, "Number of bits in the tag")
+    tagBits = Param.Unsigned(16, "Number of bits in the tag")
     instShiftAmt = Param.Unsigned(1, "Amount to shift PC to get inst bits")
     numThreads = Param.Unsigned(1, "Number of threads")
     numWays = Param.Unsigned(4, "Number of ways per set") # for 2 SRAMs, 4 ways per SRAM
@@ -998,10 +998,10 @@ class AheadBTB(TimedBaseBTBPredictor):
     cxx_header = 'cpu/pred/btb/abtb.hh'
 
     numEntries = Param.Unsigned(1024, "Number of entries in the BTB")
-    tagBits = Param.Unsigned(38, "Number of bits in the tag")
+    tagBits = Param.Unsigned(24, "Number of bits in the tag")
     instShiftAmt = Param.Unsigned(1, "Amount to shift PC to get inst bits")
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
-    numWays = Param.Unsigned(8, "Number of ways per set")
+    numWays = Param.Unsigned(4, "Number of ways per set")
     aheadPipelinedStages = Param.Unsigned(1, "Number of stages ahead pipelined")
     entryHalfAligned = Param.Bool(False, "Whether the entries are half-aligned")
     blockSize = 64
@@ -1014,7 +1014,7 @@ class UBTB(TimedBaseBTBPredictor):
     cxx_header = 'cpu/pred/btb/btb_ubtb.hh'
 
     numEntries = Param.Unsigned(32, "Number of entries in the uBTB")
-    tagBits = Param.Unsigned(38, "Number of bits in the tag")
+    tagBits = Param.Unsigned(22, "Number of bits in the tag")
 
     aheadPipelinedStages = Param.Unsigned(0, "Number of stages ahead pipelined")
     numDelay = 0
@@ -1086,17 +1086,17 @@ class MicroTAGE(TimedBaseBTBPredictor):
     updateOnRead = Param.Bool(True,"Enable update on read, no need to save tage meta in FTQ")
     usingS3Pred = Param.Bool(False, "Whether using final-stage prediction to teacher-update MicroTAGE")
     # Keep vector parameters consistent with numPredictors to avoid constructor asserts.
-    numPredictors = Param.Unsigned(4, "Number of TAGE predictors")
-    tableSizes = VectorParam.Unsigned([512] * 4,"the TAGE T0~Tn length")
-    TTagBitSizes = VectorParam.Unsigned([16] * 4 ,"the T0~Tn entry's tag bit size")
-    TTagPcShifts = VectorParam.Unsigned([1] * 4 ,"when the T0~Tn entry's tag generating, PC right shift")
+    numPredictors = Param.Unsigned(2, "Number of TAGE predictors")
+    tableSizes = VectorParam.Unsigned([512] * 2,"the TAGE T0~Tn length")
+    TTagBitSizes = VectorParam.Unsigned([16] * 2 ,"the T0~Tn entry's tag bit size")
+    TTagPcShifts = VectorParam.Unsigned([1] * 2 ,"when the T0~Tn entry's tag generating, PC right shift")
     blockSize = Param.Unsigned(32,"tage index function uses 32B aligned block address")
 
-    histLengths = VectorParam.Unsigned([5,9,17,27] ,"the BTB TAGE T0~Tn history length")
+    histLengths = VectorParam.Unsigned([5,9] ,"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970,"The length of history passed from DBP")
     numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
     numWays = Param.Unsigned(1, "Number of ways per set")
-    baseTableSize = Param.Unsigned(256,"Base table size")
+    baseTableSize = Param.Unsigned(512,"Base table size")
     maxBranchPositions = Param.Unsigned(32,"Maximum branch positions per 64-byte block")
     useAltOnNaSize = Param.Unsigned(128,"Size of the useAltOnNa table")
     useAltOnNaWidth = Param.Unsigned(7,"Width of the useAltOnNa table")


### PR DESCRIPTION
Align UBTB, ABTB, MBTB, and MicroTAGE sizes and tag widths with the RTL defaults.

Change-Id: Ief5930dd04bd454edfcf4d8270522b7d33716cf8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated branch prediction configuration to reduce prediction-table complexity and adjust storage allocation.
  * Increased the base prediction table capacity while simplifying advanced prediction tables.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->