### PR TITLE
cpu-o3:Modify the decode stage backpressure logic

### DIFF
--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -634,7 +634,8 @@ Decode::tick()
         // Apply per-thread FIFO backpressure
         bool this_thread_fifo_bp = thread_fifo_bp[i];
         
-        stallSig->blockFetch[i] = block || this_thread_fifo_bp;
+        //stallSig->blockFetch[i] = block || this_thread_fifo_bp;
+        stallSig->blockFetch[i] = this_thread_fifo_bp;
         stallSig->fetchBlockReason[i] =
             stallSig->blockFetch[i] ?
                 (block ? stallSig->decodeBlockReason[i] : 
@@ -644,12 +645,6 @@ Decode::tick()
         if (active) {
             const auto freeze = active_arbiter.observe(
                 i, smtBorrowPriority(fromIEW->iewInfo[i]));
-            if (freeze.previousActive != InvalidThreadID) {
-                freezeActiveThread(freeze.previousActive);
-            }
-            if (freeze.freezeCurrent) {
-                freezeActiveThread(i);
-            }
         } else if (block && blocked_tid == InvalidThreadID) {
             blocked_tid = i;
         }
@@ -943,14 +938,6 @@ Decode::decodeInsts(ThreadID tid)
     }
     for (auto &fused_inst : fusionInst) {
         toRename->insts[toRename->size++] = fused_inst;
-    }
-
-    if (insts_available) {
-        // current cycle insts was not all processed, need to block fetch in next cycle
-        stallSig->blockFetch[tid] = true;
-        if (breakDecode == StallReason::NoStall) {
-            breakDecode = StallReason::OtherFragStall;
-        }
     }
 
     // this stage is totally stalled, set all decode stalls

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -414,7 +414,7 @@ Rename::tick()
                 i, stallSig->blockRename[i], can_rename, block, active);
 
         // if rename has no insts, no need to block decode, even if rename is blocked for other reasons
-        stallSig->blockDecode[i] = block && !fixedbuffer[i].empty();
+        stallSig->blockDecode[i] = block ;
         stallSig->decodeBlockReason[i] =
             stallSig->blockDecode[i] ? block_reason : StallReason::NoStall;
         toDecode->renameInfo[i].blockReason = stallSig->decodeBlockReason[i];


### PR DESCRIPTION
**Motivation**
The current decode stage backpressure logic includes redundant signals from both the stallbuffer and skidbuffer. Since the skidbuffer backpressure has already been equivalently incorporated into the stallbuffer logic, maintaining separate skidbuffer backpressure paths creates unnecessary complexity and potential timing issues.

**Changes**
1. Remove all decode skidbuffer backpressure logic from the decode stage.
2. Remove the condition in the decode scheduler that marks unselected active threads as stalled.
3. Simplify the decode-to-fetch backpressure signal to only reflect stallbuffer status.

**Validation**
Performance validation: SPEC06 1c benchmark shows 0.92% IPC improvement after the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved instruction pipeline flow by preventing unnecessary fetch and decode stalls.
  - Refined thread blocking behavior to ensure decode pauses consistently when required.
  - Reduced interruptions during partial instruction decoding and backend congestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->