### PR TITLE
cpu: Split commit-squash stalls by squash cause

### DIFF
--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -100,12 +100,53 @@ enum StallReason {
     VectorReadyButNotIssued,  // B
     ScalarReadyButNotIssued,  // B
     ResumeUnblock,  // B
-    CommitSquash,  // BS
+    CommitSquash,  // BS, cause not attributable
+    ControlRecovery,  // BS
+    MemVioRecovery,  // BS
+    VPRecovery,  // BS
+    TrapRecovery,  // BS
     ROBFull,  // B
     RegFull,  // B
     OtherStall,  // B
     NumStallReasons
 };
+
+/**
+ * Why commit squashed. IEW cannot derive this itself: `squashAll()` clears
+ * `mispredictInst`, and nothing cause-bearing is live during the
+ * `robSquashing` tail.
+ *
+ * `None` must stay zero; TimeBuffer::advance() memsets new slots.
+ */
+enum class SquashCause
+{
+    None = 0,
+    BranchMispredict,
+    MemOrderViolation,
+    ValuePrediction,
+    Trap,
+    ThreadContext,
+    SquashAfter,
+};
+
+inline StallReason
+squashCauseToStallReason(SquashCause cause)
+{
+    switch (cause) {
+      case SquashCause::BranchMispredict:
+        return StallReason::ControlRecovery;
+      case SquashCause::MemOrderViolation:
+        return StallReason::MemVioRecovery;
+      case SquashCause::ValuePrediction:
+        return StallReason::VPRecovery;
+      case SquashCause::Trap:
+        return StallReason::TrapRecovery;
+      // TC writes / squash-after are simulator-side clears, not
+      // microarchitectural events worth their own bucket.
+      default:
+        return StallReason::CommitSquash;
+    }
+}
 
 /** Struct that defines the information passed from fetch to decode. */
 struct FetchStruct
@@ -325,6 +366,9 @@ struct TimeStruct
         bool squash; // *F, D, R, I
         bool robSquashing; // *F, D, R, I
 
+        /// Re-published on every `robSquashing` cycle, so IEW needs no copy.
+        SquashCause squashCause; // *I
+
         SquashVersion squashVersion; // *F, D, R, I
 
         /// Rename should re-read number of free rob entries
@@ -366,6 +410,10 @@ smtCanDonateRobHeadroom(StallReason reason)
       case VectorReadyButNotIssued:
       case ScalarReadyButNotIssued:
       case CommitSquash:
+      case ControlRecovery:
+      case MemVioRecovery:
+      case VPRecovery:
+      case TrapRecovery:
         return false;
       default:
         return true;

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -181,6 +181,7 @@ Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUPara
         borrowingDonorCycles[tid] = 0;
         trapSquash[tid] = false;
         tcSquash[tid] = false;
+        curSquashCause[tid] = SquashCause::None;
         squashAfterInst[tid] = nullptr;
         pc[tid].reset(params.isa[0]->newPCState());
         youngestSeqNum[tid] = 0;
@@ -573,6 +574,7 @@ Commit::clearStates(ThreadID tid)
     committedStores[tid] = false;
     trapSquash[tid] = false;
     tcSquash[tid] = false;
+    curSquashCause[tid] = SquashCause::None;
     pc[tid].reset(cpu->tcBase(tid)->getIsaPtr()->newPCState());
     lastCommitedSeqNum[tid] = 0;
     squashAfterInst[tid] = NULL;
@@ -640,6 +642,7 @@ Commit::takeOverFrom()
         borrowingDonorCycles[tid] = 0;
         trapSquash[tid] = false;
         tcSquash[tid] = false;
+        curSquashCause[tid] = SquashCause::None;
         squashAfterInst[tid] = NULL;
     }
     rob->takeOverFrom();
@@ -797,6 +800,8 @@ Commit::squashAll(ThreadID tid)
     // the ROB is in the process of squashing.
     toIEW->commitInfo[tid].robSquashing = true;
 
+    toIEW->commitInfo[tid].squashCause = curSquashCause[tid];
+
     toIEW->commitInfo[tid].mispredictInst = NULL;
     toIEW->commitInfo[tid].squashInst = NULL;
 
@@ -819,6 +824,7 @@ Commit::squashFromTrap(ThreadID tid)
             (unsigned long long)curTick(),
             (unsigned long)committedPC[tid],
             *pc[tid]);
+    curSquashCause[tid] = SquashCause::Trap;
     squashAll(tid);
 
     toIEW->commitInfo[tid].isTrapSquash = true;
@@ -845,6 +851,7 @@ Commit::squashFromTC(ThreadID tid)
             tid,
             (unsigned long long)curTick(),
             *pc[tid]);
+    curSquashCause[tid] = SquashCause::ThreadContext;
     squashAll(tid);
 
     DPRINTF(Commit, "Squashing from TC, restarting at PC %s\n", *pc[tid]);
@@ -877,6 +884,7 @@ Commit::squashFromSquashAfter(ThreadID tid)
                 *pc[tid]);
     }
 
+    curSquashCause[tid] = SquashCause::SquashAfter;
     squashAll(tid);
     // Make sure to inform the fetch stage of which instruction caused
     // the squash. It'll try to re-fetch an instruction executing in
@@ -897,6 +905,7 @@ Commit::squashAfter(ThreadID tid, const DynInstPtr &head_inst)
 
     assert(!squashAfterInst[tid] || squashAfterInst[tid] == head_inst);
     commitStatus[tid] = SquashAfterPending;
+    curSquashCause[tid] = SquashCause::SquashAfter;
     squashAfterInst[tid] = head_inst;
 }
 
@@ -946,6 +955,7 @@ Commit::tick()
                 rob->doSquash(tid);
                 changedROBNumEntries[tid] = true;
                 toIEW->commitInfo[tid].robSquashing = true;
+                toIEW->commitInfo[tid].squashCause = curSquashCause[tid];
                 wroteToTimeBuffer = true;
             }
         }
@@ -1142,16 +1152,19 @@ Commit::commit()
                     fromIEW->mispredictInst[tid]->pcState().instAddr(),
                     fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToBranch[tid]++;
+                curSquashCause[tid] = SquashCause::BranchMispredict;
             } else if (fromIEW->valuePredictionError[tid]) {
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to value prediction error [sn:%llu]\n",
                     tid, fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToValuePrediction[tid]++;
+                curSquashCause[tid] = SquashCause::ValuePrediction;
             } else {
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to order violation [sn:%llu]\n",
                     tid, fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToOrderViolation[tid]++;
+                curSquashCause[tid] = SquashCause::MemOrderViolation;
             }
 
             DPRINTF(Commit, "[tid:%i] Redirecting to PC %#x\n",
@@ -1185,6 +1198,8 @@ Commit::commit()
             // Send back the rob squashing signal so other stages know that
             // the ROB is in the process of squashing.
             toIEW->commitInfo[tid].robSquashing = true;
+
+            toIEW->commitInfo[tid].squashCause = curSquashCause[tid];
 
             toIEW->commitInfo[tid].mispredictInst =
                 fromIEW->mispredictInst[tid];
@@ -1894,6 +1909,8 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         thread[tid]->noSquashFromTC = false;
 
         commitStatus[tid] = TrapPending;
+        // Blocks dispatch a cycle before squashFromTrap runs.
+        curSquashCause[tid] = SquashCause::Trap;
 
         DPRINTF(
             Commit,
@@ -2138,7 +2155,7 @@ Commit::moveInstsToBuffer()
         bool active = !block && !fixedbuffer[i].empty();
         StallReason block_reason = StallReason::NoStall;
         if (robblock) {
-            block_reason = StallReason::CommitSquash;
+            block_reason = squashCauseToStallReason(curSquashCause[i]);
         } else if (block) {
             block_reason = robInfoFromIEW->iewInfo[i].robHeadStallReason;
             stats.ROBFull[i]++;

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -737,6 +737,11 @@ Commit::generateTrapEvent(ThreadID tid, Fault inst_fault)
 {
     DPRINTF(Commit, "Generating trap event for [tid:%i]\n", tid);
 
+    // TrapPending already blocks dispatch; latch Trap here so both the
+    // instruction-fault and interrupt paths attribute those slots correctly
+    // before squashFromTrap() runs.
+    curSquashCause[tid] = SquashCause::Trap;
+
     EventFunctionWrapper *trap = new EventFunctionWrapper(
         [this, tid]{ processTrapEvent(tid); },
         "Trap", true, Event::CPU_Tick_Pri);
@@ -1909,8 +1914,6 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
         thread[tid]->noSquashFromTC = false;
 
         commitStatus[tid] = TrapPending;
-        // Blocks dispatch a cycle before squashFromTrap runs.
-        curSquashCause[tid] = SquashCause::Trap;
 
         DPRINTF(
             Commit,

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -475,6 +475,12 @@ class Commit
      */
     DynInstPtr squashAfterInst[MaxThreads];
 
+    /**
+     * Cause of the in-progress squash. Latched because the ROB walk spans
+     * several cycles and TrapPending precedes the squash by one.
+     */
+    SquashCause curSquashCause[MaxThreads];
+
     /** Priority List used for Commit Policy */
     std::list<ThreadID> priority_list;
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -330,6 +330,10 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::Atomic,"Atomic"},
         {StallReason::ResumeUnblock, "ResumeUnblock"},
         {StallReason::CommitSquash, "CommitSquash"},
+        {StallReason::ControlRecovery, "ControlRecovery"},
+        {StallReason::MemVioRecovery, "MemVioRecovery"},
+        {StallReason::VPRecovery, "VPRecovery"},
+        {StallReason::TrapRecovery, "TrapRecovery"},
         {StallReason::ROBFull, "ROBFull"},
         {StallReason::RegFull, "RegFull"},
         {StallReason::OtherStall, "OtherStall"},
@@ -866,7 +870,8 @@ IEW::checkSquash()
             fetchRedirect[i] = false;
             iewStats.stallEvents[ROBWalk]++;
             iewStats.smtStallEvents[ROBWalk].sample(i);
-            setAllStalls(StallReason::CommitSquash);
+            setAllStalls(
+                squashCauseToStallReason(fromCommit->commitInfo[i].squashCause));
         }
 
         if (fromCommit->commitInfo[i].robSquashing) {
@@ -876,7 +881,8 @@ IEW::checkSquash()
             wroteToTimeBuffer = true;
             iewStats.stallEvents[ROBWalk]++;
             iewStats.smtStallEvents[ROBWalk].sample(i);
-            setAllStalls(StallReason::CommitSquash);
+            setAllStalls(
+                squashCauseToStallReason(fromCommit->commitInfo[i].squashCause));
         }
     }
 }
@@ -2323,8 +2329,6 @@ IEW::checkDispatchStall(ThreadID tid, int dq_stall, const DynInstPtr &dispatch_i
             }
         }
     }
-
-    return StallReason::OtherStall;
 }
 
 StallReason


### PR DESCRIPTION
## Motivation

`dispatchStallReason::CommitSquash` lumps together every stall caused by a squash, so top-down analysis cannot tell *why* the pipeline is recovering. On coremark this single bucket accounts for ~10% of dispatch stall ticks (and up to ~27% on some workloads), making it one of the largest un-attributed items under Bad Speculation.

Commit already counts the individual causes (`squashDueToBranch`, `squashDueToOrderViolation`, ...), but that information never reaches the stage that records stall reasons.

## Implementation

IEW cannot derive the cause on its own: `squashAll()` clears `mispredictInst`, and no cause-bearing state is live during the multi-cycle `robSquashing` tail. Therefore:

- Add `enum class SquashCause` plus a per-thread latch in commit, set at every squash initiation point (branch mispredict, value-prediction error, memory-order violation, trap, thread-context write, squash-after). `TrapPending` sets it one cycle before `squashFromTrap()` runs, which is where the stall actually starts.
- Republish it through `CommitComm` on every squashing cycle, so IEW needs no latch of its own. `SquashCause::None` is kept at zero because `TimeBuffer::advance()` memsets new slots.
- Map it onto four new stall reasons: `ControlRecovery`, `MemVioRecovery`, `VPRecovery`, `TrapRecovery`. `CommitSquash` is retained as the fallback for simulator-side clears (TC writes, squash-after), so no existing stat name disappears and old/new runs remain comparable.
- Also drop an unreachable `return` at the end of `IEW::checkDispatchStall()`.

## Test plan

- `scons build/RISCV/gem5.opt` builds clean.
- `scons build/RISCV/unittests.opt --unit-test`: 90 tests from 6 suites passed.
- Coremark (2 iterations) with difftest against NEMU: passes, CoreMark CRCs correct, and IPC is bit-identical to the base branch (0.785744), confirming this is a pure attribution change.
- The new buckets agree with the pre-existing event counters:

| commit event counter | resulting stall bucket (dispatch) |
|---|---|
| `squashDueToBranch` = 2809 | `ControlRecovery` = 672929 ticks (9.96%) |
| `squashDueToOrderViolation` = 2 | `MemVioRecovery` = 160 ticks |
| `squashDueToTC` = 1 | `CommitSquash` = 1544 ticks (fallback, by design) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance and Diagnostics**
  * Improved processor pipeline stall reporting with distinct reasons for control-flow, memory-order, value-prediction, and trap recovery.
  * Recovery-related stalls are now classified more accurately in performance statistics.
  * Enhanced multi-threaded resource handling by preventing recovery stalls from being treated as shareable capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->