### PR TITLE
tests: Remove obsolete full-test jobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,13 +100,16 @@
 ### 包含的测试 Workflows
 
 #### 1. `gem5.yml` - 功能回归测试
-8个并行 jobs（遵循DRY原则，排除已在 Tier 1 运行的测试）
+5 个并行 jobs（遵循 DRY 原则，排除已在 Tier 1 运行的测试）
 
 维护者可以在 PR 上添加 `regression` 标签，提前运行与合入后相同的完整功能回归。为避免 `pull_request_target` 执行外部代码，该入口仅接受目标分支为 `xs-dev` 的同仓库 PR。
 
 **已移除**（避免重复）:
 - ~~`unit_tests`~~ → 在 `pr-quick-check.yml`
 - ~~`difftest_check`~~ → 在 `pr-quick-check.yml`
+- ~~legacy GC/GCB checkpoint suite~~ → 覆盖陈旧且失败定位成本高
+- ~~standalone RV64GCBV checkpoint smoke~~ → 已有 vector micro-tests 和 RVV checkpoint 性能回归
+- ~~L2TLB checkpoint regression~~ → 长期未发现测试本体失败
 
 #### 2. `gem5-ideal-btb-perf.yml` - Ideal BTB 性能测试
 默认跑 `gcc15-spec06-1.0c`，在 `xs-dev`、`*-perf` 分支和 PR `perf` 标签上自动触发

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -13,77 +13,6 @@ permissions:
   pull-requests: read
 
 jobs:
-  paralel_cpt_test:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      (github.event.label.name == 'regression' &&
-       github.event.pull_request.base.ref == 'xs-dev' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
-    # gem5.cfg 使用的切片 ck_path 位于小机房
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Running test checkpoints
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-      - uses: ./.github/actions/build-dramsim
-
-      - name: Build GEM5 opt
-        run: |
-          CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-
-      - name: Run paralel autotest script
-        shell: bash
-        run: |
-          python3 .github/workflows/autotest/script/autotest.py \
-            -f .github/workflows/autotest/gem5.cfg
-
-      - name: Dump normal checkpoint failure details
-        if: ${{ failure() }}
-        shell: bash
-        run: |
-          set -uo pipefail
-
-          for case_dir in \
-            "./log_root/rungem5/take_cpt/namd_100000000_0.003233" \
-            "./log_root/rungem5/take_cpt/mcf_17520000000_0.126350"
-          do
-            echo
-            echo "=================================================="
-            echo "CASE: $case_dir"
-            echo "=================================================="
-
-            if [[ ! -d "$case_dir" ]]; then
-              echo "Directory not found"
-              continue
-            fi
-
-            find "$case_dir" \
-              -type f \
-              \( \
-                -name 'taskerr.txt' -o \
-                -name 'taskout.txt' -o \
-                -name 'other.txt' -o \
-                -name 'gem5.log' -o \
-                -name 'simerr' -o \
-                -name 'simout' \
-              \) \
-              -print \
-              -exec sh -c '
-                echo "---------- $1 ----------"
-                tail -n 1000 "$1" || true
-              ' sh {} \;
-          done
-
-          echo
-          echo "===== important errors ====="
-
-          grep -RniE \
-            'fatal|panic|difftest|mismatch|assert|segmentation|killed|out of memory|timeout|cannot open|no such file|error' \
-            ./log_root/rungem5/take_cpt \
-            2>/dev/null |
-            head -2000 || true
 
   paralel_cpt_h_test:
     if: |
@@ -231,32 +160,6 @@ jobs:
           bash util/memory_check/run-xs-with-valgrind.sh
           cd $GEM5_HOME
 
-
-  new_sim_script_test_gcbv:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      (github.event.label.name == 'regression' &&
-       github.event.pull_request.base.ref == 'xs-dev' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test new simulation script on RV64GCBV
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64 --rvv-impl=simple
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GCBV_RESTORER="/nfs/home/share/gem5_ci/tools/gcbv-restorer.bin"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_v
-          cd $GEM5_HOME/util/xs_scripts/test_v
-          bash ../kmh_6wide_vector.sh /nfs/home/share/gem5_ci/checkpoints/gcbv_test.zstd
-
   new_sim_script_test_gcb_multi_core:
     if: |
       github.event_name != 'pull_request_target' ||
@@ -281,31 +184,6 @@ jobs:
           mkdir -p $GEM5_HOME/util/xs_scripts/test_multi_core
           cd $GEM5_HOME/util/xs_scripts/test_multi_core
           bash ../kmh-ruby-dual.sh /nfs/home/share/gem5_ci/checkpoints/multi_core_test.gz
-
-
-  test_fix_l2tlb_bugs:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      (github.event.label.name == 'regression' &&
-       github.event.pull_request.base.ref == 'xs-dev' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, open]
-    continue-on-error: false
-    name: XS-GEM5 - Test fix L2TLB bugs
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-      - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 opt
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.opt --linker=gold -j64
-      - name: XS-GEM5 - Test xiangshan.py simulation scripts
-        run: |
-          export GCBV_REF_SO="/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so"
-          export GEM5_HOME=$(pwd)
-          mkdir -p $GEM5_HOME/util/xs_scripts/test_l2tlb
-          cd $GEM5_HOME/util/xs_scripts/test_l2tlb
-          bash ../kmh_6wide.sh /nfs/home/share/gem5_ci/checkpoints/l2tlb_test.zstd
 
   new_sim_script_test_gcbh:
     if: |


### PR DESCRIPTION
## 背景

Full test 中以下三个独立 job 的维护收益已经不足以覆盖 runner 成本：

- legacy GC/GCB checkpoint suite：覆盖陈旧，失败日志难以定位根因；
- standalone RV64GCBV checkpoint smoke：已有 vector micro-tests 与 RVV checkpoint 性能回归覆盖；
- L2TLB checkpoint regression：近期没有测试本体失败。

## 改动

- 从 `gem5.yml` 删除上述三个 job，full test 从 8 个 job 精简为 5 个；
- 同步 workflow README 中的 job 数量与删除原因。

本 PR 不包含 Valgrind 重写、performance template 重构或其他 CI 行为修改，这些内容后续拆分处理。

## 验证

- 14 个 workflow/action YAML 文件均可解析；
- `gem5.yml` 解析后恰好包含 5 个 job；
- 三个目标 job 名称均已不存在；
- `git diff --check` 通过。
