### PR TITLE
dev-serial: Make UARTLite friendlier to OpenSBI/Linux polling

### DIFF
--- a/src/dev/serial/uartlite.cc
+++ b/src/dev/serial/uartlite.cc
@@ -1,8 +1,17 @@
+#include <cstdio>
+
+#include "base/logging.hh"
 #include "mem/packet_access.hh"
 #include "uartlite.hh"
 
 namespace gem5
 {
+
+// Xilinx UART Lite TXEMPTY bit. OpenSBI polls TXFULL before putc (cleared when
+// status==0 also works); Linux/other firmwares may wait on TXEMPTY. Always
+// report idle TX so both polling styles make progress.
+static constexpr uint8_t UARTLITE_STATUS_TXEMPTY = 0x04;
+
 Tick UartLite::read(PacketPtr pkt)
 {
     assert(pkt->getAddr() >= pioAddr && pkt->getAddr() < pioAddr + pioSize);
@@ -11,11 +20,17 @@ Tick UartLite::read(PacketPtr pkt)
 
     switch (offset) {
         case UARTLITE_STAT_REG:
+            // Instant TX drain model: always ready for the next byte.
+            pkt->setRaw((uint8_t)(UARTLITE_STATUS_TXEMPTY));
+            break;
+        case UARTLITE_RX_FIFO:
+            // No RX data modeled; RXVALID stays clear.
             pkt->setRaw((uint8_t)0);
             break;
         default:
             warn("Read to other uartlite addr %i is not implemented\n",
                  offset);
+            pkt->setRaw((uint8_t)0);
     }
     pkt->makeAtomicResponse();
     return pioDelay;
@@ -28,8 +43,17 @@ Tick UartLite::write(PacketPtr pkt)
     assert(pkt->getSize() == 1);
 
     switch (offset) {
-        case UARTLITE_TX_FIFO:
-            putc(pkt->getRaw<uint8_t>(), stdout);
+        case UARTLITE_TX_FIFO: {
+            // Flush on newline only: per-byte fflush on the PIO path slows
+            // console-heavy boots (OpenSBI/Linux) without buying correctness.
+            const uint8_t ch = pkt->getRaw<uint8_t>();
+            putc(ch, stdout);
+            if (ch == '\n')
+                fflush(stdout);
+            break;
+        }
+        case UARTLITE_CTRL_REG:
+            // Soft reset / IE bits: accept and ignore for bare-metal boot.
             break;
         default:
             warn("Write to other uartlite addr %i is not implemented\n",


### PR DESCRIPTION
## Summary

Split out of #1017 per review request.

- Status reads report `TXEMPTY` so firmwares that poll TX empty (not only TX full) make progress.
- Accept `CTRL` writes (soft reset / IE) and ignore them.
- Unimplemented RX / other reads return 0 instead of leaving the packet unset.
- `fflush(stdout)` only on newline to avoid slowing console-heavy OpenSBI/Linux boots with per-byte flush.

## Test plan

- [ ] Rebuild `gem5.opt` and smoke an OpenSBI banner / Linux console path with `--raw-cpt`
- [ ] CI Quick Check

Related: #1017, #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UART Lite behavior by accurately reporting transmit readiness.
  * Updated output handling so transmitted text is flushed when a newline is received.
  * Added support for accepting control-register writes without unintended effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->