### PR TITLE
cpu-o3: Add dual-thread SMT frontend upper-bound probe

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -30,6 +30,23 @@ def setSharedLSQParams(args, system):
         cpu.branchPred.smtFTQPolicy = 'Partitioned'
 
 
+def setDualFrontendProbeParams(system):
+    for cpu in system.cpu:
+        # Upper-bound probe: predict and start fetching one FTQ target from
+        # each SMT thread in the same cycle. Each target creates two I-cache
+        # line requests, so four tag read ports are required to avoid
+        # introducing an artificial thread bias in the cache model.
+        cpu.branchPred.smtNumPredictingThreads = 2
+        cpu.smtNumFetchTargetThreads = 2
+        cpu.icache.tag_load_read_ports = 4
+
+        # Keep the first probe on the S3 plus resolve/commit training path.
+        # AheadBTB and MicroTAGE multi-request behavior is left for follow-up.
+        cpu.branchPred.ubtb.usingS3Pred = False
+        cpu.branchPred.abtb.enabled = False
+        cpu.branchPred.microtage.enabled = False
+
+
 if __name__ == '__m5_main__':
     FutureClass = None
 
@@ -55,6 +72,7 @@ if __name__ == '__m5_main__':
 
     test_sys = build_xiangshan_system(args)
     setSharedLSQParams(args, test_sys)
+    setDualFrontendProbeParams(test_sys)
 
     root = Root(full_system=True, system=test_sys)
 

--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -40,11 +40,14 @@ def setDualFrontendProbeParams(system):
         cpu.smtNumFetchTargetThreads = 2
         cpu.icache.tag_load_read_ports = 4
 
-        # Keep the first probe on the S3 plus resolve/commit training path.
-        # AheadBTB and MicroTAGE multi-request behavior is left for follow-up.
+        # Keep early-predictor training on the existing resolve/commit path.
+        # Their per-thread ahead state is preserved while the shared tables
+        # are treated as ideal dual-read resources for this upper-bound probe.
         cpu.branchPred.ubtb.usingS3Pred = False
-        cpu.branchPred.abtb.enabled = False
-        cpu.branchPred.microtage.enabled = False
+        cpu.branchPred.abtb.enabled = True
+        cpu.branchPred.abtb.usingS3Pred = False
+        cpu.branchPred.microtage.enabled = True
+        cpu.branchPred.microtage.usingS3Pred = False
 
 
 if __name__ == '__m5_main__':

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -249,6 +249,9 @@ class BaseO3CPU(BaseCPU):
     phyregReleaseWidth = Param.Unsigned(6, "Physical register dealloc width")
 
     smtNumFetchingThreads = Param.Unsigned(1, "SMT Number of Fetching Threads")
+    smtNumFetchTargetThreads = Param.Unsigned(
+        1, "Maximum number of distinct SMT threads starting an FTQ fetch "
+           "per cycle")
     smtFetchPolicy = Param.SMTFetchPolicy('RoundRobin', "SMT Fetch policy")
     smtLSQMode = Param.SMTLSQMode('Independent',
                                   "SMT LSQ mode: per-thread independent or shared quota")

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -107,7 +107,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       numFetchingThreads(params.smtNumFetchingThreads),
       numFetchTargetThreads(params.smtNumFetchTargetThreads),
       icachePort(this, _cpu),
-      finishTranslationEvent(this), fetchStats(_cpu, this),
+      finishTranslationEvents(), fetchStats(_cpu, this),
       valuePred(params.valuePred)
 {
     if (numThreads > MaxThreads)
@@ -119,12 +119,20 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              fetchWidth, static_cast<int>(MaxWidth));
     panic_if(numFetchTargetThreads == 0 ||
-             numFetchTargetThreads > numThreads,
-             "smtNumFetchTargetThreads (%u) must be in [1, numThreads (%u)]",
+             numFetchTargetThreads > numThreads ||
+             numFetchTargetThreads > 2,
+             "smtNumFetchTargetThreads (%u) must be in [1, min(2, "
+             "numThreads (%u))]",
              numFetchTargetThreads, numThreads);
     panic_if(numFetchTargetThreads > 1 && numFetchingThreads > 1,
              "smtNumFetchTargetThreads and smtNumFetchingThreads cannot both "
              "exceed one because fetch() would be invoked multiple times");
+
+    finishTranslationEvents.reserve(numThreads);
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        finishTranslationEvents.emplace_back(
+            std::make_unique<FinishTranslationEvent>(this));
+    }
 
     smtBorrowThrottleHoldCycles = params.smtBorrowThrottleCycles;
     // IEW reports an early redirect before the formal Commit squash reaches
@@ -845,7 +853,9 @@ Fetch::isDrained() const
      * cycle if the finish translation event is scheduled, so make
      * sure that's not the case.
      */
-    return !finishTranslationEvent.scheduled();
+    return std::none_of(
+        finishTranslationEvents.begin(), finishTranslationEvents.end(),
+        [](const auto &event) { return event->scheduled(); });
 }
 
 void
@@ -1116,15 +1126,18 @@ Fetch::handleTranslationFault(ThreadID tid, const RequestPtr &mem_req, const Fau
 
     // Don't send an instruction to decode if we can't handle it.
     if (!(numInst < fetchWidth) || !(fetchQueue[tid].size() < fetchQueueSize)) {
-        if (finishTranslationEvent.scheduled() && finishTranslationEvent.getReq() != mem_req) {
-            DPRINTF(FetchFault, "fault, finishTranslationEvent.getReq().addr=%#lx, mem_req.addr=%#lx\n",
-                    finishTranslationEvent.getReq()->getVaddr(), mem_req->getVaddr());
+        auto &finish_event = *finishTranslationEvents[tid];
+        if (finish_event.scheduled() && finish_event.getReq() != mem_req) {
+            DPRINTF(FetchFault,
+                    "fault, finish_event.getReq().addr=%#lx, "
+                    "mem_req.addr=%#lx\n",
+                    finish_event.getReq()->getVaddr(), mem_req->getVaddr());
             return;
         }
-        assert(!finishTranslationEvent.scheduled());
-        finishTranslationEvent.setFault(fault);
-        finishTranslationEvent.setReq(mem_req);
-        cpu->schedule(finishTranslationEvent, cpu->clockEdge(Cycles(1)));
+        assert(!finish_event.scheduled());
+        finish_event.setFault(fault);
+        finish_event.setReq(mem_req);
+        cpu->schedule(finish_event, cpu->clockEdge(Cycles(1)));
         return;
     }
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -105,6 +105,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       fetchQueueSize(params.fetchQueueSize),
       numThreads(params.numThreads),
       numFetchingThreads(params.smtNumFetchingThreads),
+      numFetchTargetThreads(params.smtNumFetchTargetThreads),
       icachePort(this, _cpu),
       finishTranslationEvent(this), fetchStats(_cpu, this),
       valuePred(params.valuePred)
@@ -117,6 +118,13 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         fatal("fetchWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              fetchWidth, static_cast<int>(MaxWidth));
+    panic_if(numFetchTargetThreads == 0 ||
+             numFetchTargetThreads > numThreads,
+             "smtNumFetchTargetThreads (%u) must be in [1, numThreads (%u)]",
+             numFetchTargetThreads, numThreads);
+    panic_if(numFetchTargetThreads > 1 && numFetchingThreads > 1,
+             "smtNumFetchTargetThreads and smtNumFetchingThreads cannot both "
+             "exceed one because fetch() would be invoked multiple times");
 
     smtBorrowThrottleHoldCycles = params.smtBorrowThrottleCycles;
     // IEW reports an early redirect before the formal Commit squash reaches
@@ -317,6 +325,16 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "Number of FTQ heads skipped because IEW reported a pending redirect"),
     ADD_STAT(redirectPendingOnlyFetchCycles, statistics::units::Count::get(),
              "Number of fetch attempts blocked because all FTQ heads were redirect-pending"),
+    ADD_STAT(fetchTargetsStartedPerCycle, statistics::units::Count::get(),
+             "Number of distinct SMT thread FTQ fetches started in one cycle"),
+    ADD_STAT(fetchTargetsStartedByThread, statistics::units::Count::get(),
+             "Number of FTQ fetches started for each SMT thread"),
+    ADD_STAT(fetchLineRequestsCreatedPerCycle, statistics::units::Count::get(),
+             "Number of cache-line requests created by FTQ fetches in one cycle"),
+    ADD_STAT(fetchTargetThreadNotReady, statistics::units::Count::get(),
+             "Selected FTQ heads whose thread state could not start a fetch"),
+    ADD_STAT(fetchTargetRequestBlocked, statistics::units::Count::get(),
+             "Prepared FTQ heads whose cache request could not be started"),
     ADD_STAT(traceMetaStores, statistics::units::Count::get(),
              "Number of stored trace metadata records (seqNum -> traceInst)"),
     ADD_STAT(traceMetaCleanupSquashCalls, statistics::units::Count::get(),
@@ -394,6 +412,13 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
         smtblockedCycles
             .init(fetch->numThreads)
             .flags(statistics::total);     
+        fetchTargetsStartedPerCycle
+            .init(0, fetch->numThreads, 1);
+        fetchTargetsStartedByThread
+            .init(fetch->numThreads)
+            .flags(statistics::total);
+        fetchLineRequestsCreatedPerCycle
+            .init(0, 2 * fetch->numThreads, 1);
         decodeStallRate
             .flags(statistics::total);
         fetchBubbles
@@ -1971,31 +1996,37 @@ Fetch::checkDecoupledFrontend(ThreadID tid)
 }
 
 ThreadID
-Fetch::getEligibleFetchTargetTid()
+Fetch::getEligibleFetchTargetTid(
+    const std::array<bool, MaxThreads> &excluded,
+    bool record_redirect_skips)
 {
     std::array<bool, MaxThreads> eligible;
     eligible.fill(true);
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        eligible[tid] = !redirectPending[tid];
+        eligible[tid] = !redirectPending[tid] && !excluded[tid];
         if (fetchStatus[tid] == Idle || fetchStatus[tid] == Blocked ||
-            fetchStatus[tid] == TrapPending || fetchStatus[tid] == WaitingCache) {
+            fetchStatus[tid] == TrapPending ||
+            fetchStatus[tid] == WaitingCache) {
             eligible[tid] = false;
         }
     }
 
     unsigned skipped = 0;
-    // Use fetch-queue-aware scheduling: prioritize threads with fewer queue entries
+    // Use fetch-queue-aware scheduling: prioritize threads with fewer queue
+    // entries.
     std::array<unsigned, MaxThreads> fetchQueueSizes;
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         fetchQueueSizes[tid] = fetchQueue[tid].size();
     }
-    ThreadID tid = dbpbtb->getTargetTidByFetchQueueSize(eligible, &skipped, fetchQueueSizes);
-    if (skipped) {
+    ThreadID tid = dbpbtb->getTargetTidByFetchQueueSize(
+        eligible, record_redirect_skips ? &skipped : nullptr,
+        fetchQueueSizes);
+    if (record_redirect_skips && skipped) {
         fetchStats.redirectPendingFetchSkips += skipped;
         DPRINTF(Fetch, "Skipped %u FTQ heads while backend redirect is pending\n",
                 skipped);
     }
-    if (tid == InvalidThreadID && skipped) {
+    if (record_redirect_skips && tid == InvalidThreadID && skipped) {
         fetchStats.redirectPendingOnlyFetchCycles++;
     }
     return tid;
@@ -2051,19 +2082,51 @@ Fetch::fetch(bool &status_change)
         ThreadID tid = *threadit++;
         performInstructionFetch(tid);
     }
-    auto tid = getEligibleFetchTargetTid();
-    if (tid == InvalidThreadID) {
-        return;
+
+    std::array<bool, MaxThreads> attempted{};
+    unsigned fetch_targets_started = 0;
+    bool fetch_attempted = false;
+
+    // This loop widens only FTQ-to-I-cache target selection. Instruction
+    // decoding above still visits all active threads once, independent of
+    // smtNumFetchTargetThreads. Charge each selected thread against the
+    // target-width budget even if it cannot start a request, so width one
+    // retains the baseline single-selection scheduling behavior.
+    for (unsigned attempt = 0;
+         attempt < numFetchTargetThreads &&
+         fetch_targets_started < numFetchTargetThreads;
+         ++attempt) {
+        const ThreadID tid = getEligibleFetchTargetTid(
+            attempted, attempt == 0);
+        if (tid == InvalidThreadID) {
+            break;
+        }
+        attempted[tid] = true;
+
+        if (!checkDecoupledFrontend(tid)) {
+            continue;
+        }
+        if (!prepareFetchAddress(tid, status_change)) {
+            fetchStats.fetchTargetThreadNotReady++;
+            continue;
+        }
+
+        fetch_attempted = true;
+        if (!sendNextCacheRequest(tid, *threads[tid].fetchpc)) {
+            fetchStats.fetchTargetRequestBlocked++;
+            continue;
+        }
+
+        fetch_targets_started++;
+        fetchStats.fetchTargetsStartedByThread[tid]++;
     }
-    if (!checkDecoupledFrontend(tid)) {
-        return;
+
+    if (fetch_attempted) {
+        ++fetchStats.cycles;
     }
-    if (!prepareFetchAddress(tid, status_change)) {
-        return;
-    }
-    ++fetchStats.cycles;
-    sendNextCacheRequest(tid, *threads[tid].fetchpc);
-    
+    fetchStats.fetchTargetsStartedPerCycle.sample(fetch_targets_started);
+    fetchStats.fetchLineRequestsCreatedPerCycle.sample(
+        2 * fetch_targets_started);
 }
 
 StallReason
@@ -2291,16 +2354,16 @@ Fetch::performInstructionFetch(ThreadID tid)
    // assert(fetchStatus[tid] == Running && "Fetch should be running");
 }
 
-void
+bool
 Fetch::sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state) {
     if (threads[tid].valid) {
-        return;
+        return false;
     }
 
     if (ftqEmpty(tid)) {
         ++fetchStats.smtftqempty[tid];
         DPRINTF(Fetch, "[tid:%i] No FSQ entry available for next fetch\n", tid);
-        return;
+        return false;
     }
 
     assert(dbpbtb);
@@ -2325,7 +2388,7 @@ Fetch::sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state) {
     DPRINTF(Fetch, "[tid:%i] Issuing a pipelined I-cache access for new FSQ entry, "
                   "starting at PC %#x (endPC %#x; original PC %s)\n",
             tid, start_pc, stream.predEndPC, pc_state);
-    fetchCacheLine(start_pc, tid, pc_state.instAddr());
+    return fetchCacheLine(start_pc, tid, pc_state.instAddr());
 }
 
 void

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -2061,8 +2061,8 @@ Fetch::prepareFetchAddress(ThreadID tid, bool &status_change)
         status_change = true;
         return true;
     } else if (canFetchInstructions(tid)) {
-        // If the decoder needs bytes, performInstructionFetch() will issue an
-        // I-cache request via sendNextCacheRequest().
+        // If the decoder needs bytes, keep this thread eligible for the
+        // FTQ-to-I-cache request phase that follows instruction decoding.
         if (!macroop[tid] && !threads[tid].valid) {
             return true;
         } else if (checkInterrupt(this_pc.instAddr()) && !delayedCommit[tid]) {

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -405,8 +405,9 @@ class Fetch
      * Send a pipelined I-cache access request for the next FTQ entry.
      * @param tid Thread ID
      * @param pc_state The PC state of the current instruction.
+     * @return true if the request group was started, false if it was blocked.
      */
-    void sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state);
+    bool sendNextCacheRequest(ThreadID tid, const PCStateBase &pc_state);
 
     void finishTranslation(const Fault &fault, const RequestPtr &mem_req);
 
@@ -547,7 +548,9 @@ class Fetch
      * @return true if frontend is ready for fetch, false otherwise
      */
     bool checkDecoupledFrontend(ThreadID tid);
-    ThreadID getEligibleFetchTargetTid();
+    ThreadID getEligibleFetchTargetTid(
+        const std::array<bool, MaxThreads> &excluded,
+        bool record_redirect_skips);
     void clearRedirectPending(ThreadID tid);
 
     /** Prepare fetch address and handle status transitions.
@@ -961,6 +964,9 @@ class Fetch
     /** Number of threads that are actively fetching. */
     ThreadID numFetchingThreads;
 
+    /** Maximum number of threads that may start an FTQ fetch each cycle. */
+    const unsigned numFetchTargetThreads;
+
     /** Thread ID being fetched. */
     ThreadID threadFetched;
 
@@ -1138,6 +1144,16 @@ class Fetch
         statistics::Scalar redirectPendingFetchSkips;
         /** Cycles where only redirect-pending FTQ heads were available to fetch. */
         statistics::Scalar redirectPendingOnlyFetchCycles;
+        /** Number of FTQ fetch groups started in one cycle. */
+        statistics::Distribution fetchTargetsStartedPerCycle;
+        /** Number of FTQ fetch groups started for each SMT thread. */
+        statistics::Vector fetchTargetsStartedByThread;
+        /** Number of cache-line requests created by FTQ fetches per cycle. */
+        statistics::Distribution fetchLineRequestsCreatedPerCycle;
+        /** Selected FTQ heads whose thread state could not start a fetch. */
+        statistics::Scalar fetchTargetThreadNotReady;
+        /** Prepared FTQ heads whose cache request could not be started. */
+        statistics::Scalar fetchTargetRequestBlocked;
 
         // Trace metadata accounting (trace mode)
         /** Number of stored trace metadata records (seqNum -> traceInst). */

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -978,8 +978,9 @@ class Fetch
     /** Instruction port. Note that it has to appear after the fetch stage. */
     IcachePort icachePort;
 
-    /** Event used to delay fault generation of translation faults */
-    FinishTranslationEvent finishTranslationEvent;
+    /** Per-thread events used to delay translation fault generation. */
+    std::vector<std::unique_ptr<FinishTranslationEvent>>
+        finishTranslationEvents;
 
     // NOTE: This Fetch implementation is decoupled+BTB-only; no coupled mode.
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1224,6 +1224,8 @@ class DecoupledBPUWithBTB(BranchPredictor):
     smtFTQPolicy = Param.SMTFTQPolicy('Partitioned',
                                       "SMT shared FTQ allocation policy")
     smtFTQThreshold = Param.Int(100, "SMT FTQ Threshold Sharing Parameter")
+    smtNumPredictingThreads = Param.Unsigned(
+        1, "Maximum number of distinct SMT threads predicted per cycle")
     fsq_size = Param.Unsigned(64, "Fetch stream queue size")
     maxHistLen = Param.Unsigned(970, "The length of history")
 

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -614,9 +614,12 @@ BTBITTAGE::doUpdateHist(const boost::dynamic_bitset<> &history, bool taken,
 }
 
 bool
-BTBITTAGE::tageHit()
+BTBITTAGE::tageHit(ThreadID tid)
 {
-    auto meta = getPredictionMeta(0);
+    auto meta = getPredictionMeta(tid);
+    if (!meta) {
+        return false;
+    }
     auto preds = std::static_pointer_cast<TageMeta>(meta)->preds;
     bool hit = false;
     for (auto & [pc, pred] : preds) {

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -289,7 +289,7 @@ public:
     bool debugFlag = false;
 
     void recoverFoldedHist(const bitset& history);
-    bool tageHit();
+    bool tageHit(ThreadID tid);
 
     // void checkFoldedHist(const bitset& history);
 };

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -94,7 +94,7 @@ boolBucket(bool value)
 UBTB::UBTB(const Params &p)
     : TimedBaseBTBPredictor(p),
       lastPred(),
-      meta(),
+      threadMeta(),
       ubtb(),
       mruList(),
       numEntries(p.numEntries),
@@ -118,6 +118,8 @@ UBTB::UBTB(const Params &p)
 
     hasDB = true;
     dbName = "ubtb";
+
+    threadMeta.resize(o3::MaxThreads);
 }
 
 
@@ -183,10 +185,12 @@ UBTB::fillStagePredictions(const TickedUBTBEntry &entry, std::vector<FullBTBPred
 void
 UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::vector<FullBTBPrediction> &stagePreds)
 {
-    meta = std::make_shared<UBTBMeta>();
+    const ThreadID tid = stagePreds.empty() ? 0 : stagePreds.front().tid;
+    assert(tid < threadMeta.size());
+    threadMeta[tid] = std::make_shared<UBTBMeta>();
     const uint8_t asidHash = stagePreds.empty() ? 0 : stagePreds.front().asidHash;
     auto it = lookup(startAddr, asidHash);
-    auto& entry = meta->hit_entry;
+    auto& entry = threadMeta[tid]->hit_entry;
     entry = (it != ubtb.end()) ? *it : TickedUBTBEntry();
 
     PredStatistics(entry, startAddr);
@@ -204,9 +208,9 @@ UBTB::refreshPredictionMeta(Addr startAddr,
                             FullBTBPrediction &pred)
 {
     (void)history;
-    (void)pred;
-
-    meta = std::make_shared<UBTBMeta>();
+    assert(pred.tid < threadMeta.size());
+    threadMeta[pred.tid] = std::make_shared<UBTBMeta>();
+    auto &meta = threadMeta[pred.tid];
     meta->hit_entry = lookupNoSideEffect(startAddr);
 }
 

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -93,7 +93,7 @@ boolBucket(bool value)
 
 UBTB::UBTB(const Params &p)
     : TimedBaseBTBPredictor(p),
-      lastPred(),
+      lastPred(o3::MaxThreads),
       threadMeta(),
       ubtb(),
       mruList(),
@@ -199,7 +199,7 @@ UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::
     fillStagePredictions(entry, stagePreds);
 
     // Update metadata for later stages
-    lastPred.hit_entry = it;
+    lastPred[tid].hit_entry = it;
 }
 
 void
@@ -298,7 +298,7 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
         ubtbStats.s3UpdateMisses++;
     }
     auto startAddr = s3Pred.bbStart;
-    UBTBIter oldEntryIter = lastPred.hit_entry;
+    UBTBIter oldEntryIter = lastPred[s3Pred.tid].hit_entry;
     takenEntry.source = getComponentIdx();
     updateNewEntry(oldEntryIter, takenEntry, startAddr, s3Pred.asidHash);
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -194,7 +194,7 @@ class UBTB : public TimedBaseBTBPredictor
             // Default constructor - will be assigned proper value later
         }
     };
-    LastPred lastPred;
+    std::vector<LastPred> lastPred;
 
     /** this struct holds the metadata for uBTB,
      * note that unlike other predictors, the ubtb meta serves only statistical purpose

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -46,11 +46,13 @@
 #define __CPU_PRED_BTB_UBTB_HH__
 
 #include <queue>
+#include <vector>
 
 #include "arch/generic/pcstate.hh"
 #include "base/logging.hh"
 #include "base/types.hh"
 #include "config/the_isa.hh"
+#include "cpu/o3/limits.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
 #include "debug/UBTB.hh"
@@ -150,7 +152,10 @@ class UBTB : public TimedBaseBTBPredictor
      */
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override
     {
-        return meta;
+        if (tid >= threadMeta.size()) {
+            return nullptr;
+        }
+        return threadMeta[tid];
     }
     void refreshPredictionMeta(Addr startAddr,
                                const boost::dynamic_bitset<> &history,
@@ -203,7 +208,7 @@ class UBTB : public TimedBaseBTBPredictor
             hit_entry = TickedUBTBEntry();
         }
     };
-    std::shared_ptr<UBTBMeta> meta;
+    std::vector<std::shared_ptr<UBTBMeta>> threadMeta;
 
     // helper methods
     /*

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -94,6 +94,9 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
              "smtNumPredictingThreads (%u) must be in [1, min(2, "
              "numThreads (%u))]",
              numPredictingThreads, numThreads);
+    panic_if(numPredictingThreads > 1 && pairtage->isEnabled(),
+             "PairTAGE does not yet support concurrent SMT predictions; "
+             "disable PairTAGE or set smtNumPredictingThreads to one");
     panic_if(ftqMode == SMTFTQMode::Shared &&
              ftqPolicy == SMTFTQPolicy::Threshold &&
              smtFTQThreshold > ftqEntries,

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -88,8 +88,11 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       resolveBlockThreshold(p.resolveBlockThreshold),
       dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum, p.numThreads)
 {
-    panic_if(numPredictingThreads == 0 || numPredictingThreads > numThreads,
-             "smtNumPredictingThreads (%u) must be in [1, numThreads (%u)]",
+    panic_if(numPredictingThreads == 0 ||
+             numPredictingThreads > numThreads ||
+             numPredictingThreads > 2,
+             "smtNumPredictingThreads (%u) must be in [1, min(2, "
+             "numThreads (%u))]",
              numPredictingThreads, numThreads);
     panic_if(ftqMode == SMTFTQMode::Shared &&
              ftqPolicy == SMTFTQPolicy::Threshold &&

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -64,6 +64,7 @@ DecoupledBPUWithBTB::consumeFetchTarget(unsigned fetched_inst_num, ThreadID tid)
 DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
     : BPredUnit(p),
 
+      numPredictingThreads(p.smtNumPredictingThreads),
       predictWidth(p.predictWidth),
       maxInstsNum(p.predictWidth / 2),
       historyBits(p.maxHistLen),
@@ -85,8 +86,11 @@ DecoupledBPUWithBTB::DecoupledBPUWithBTB(const DecoupledBPUWithBTBParams &p)
       smtFTQThreshold(p.smtFTQThreshold),
       ftq(p.numThreads, p.ftq_size),
       resolveBlockThreshold(p.resolveBlockThreshold),
-      dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum)
+      dbpBtbStats(this, p.numStages, p.fsq_size, maxInstsNum, p.numThreads)
 {
+    panic_if(numPredictingThreads == 0 || numPredictingThreads > numThreads,
+             "smtNumPredictingThreads (%u) must be in [1, numThreads (%u)]",
+             numPredictingThreads, numThreads);
     panic_if(ftqMode == SMTFTQMode::Shared &&
              ftqPolicy == SMTFTQPolicy::Threshold &&
              smtFTQThreshold > ftqEntries,
@@ -271,9 +275,12 @@ DecoupledBPUWithBTB::canStartPrediction(ThreadID tid) const
            !ftqFull(tid);
 }
 
-ThreadID
-DecoupledBPUWithBTB::scheduleThread()
+std::vector<ThreadID>
+DecoupledBPUWithBTB::scheduleThreads()
 {
+    std::vector<ThreadID> scheduled;
+    scheduled.reserve(numPredictingThreads);
+
     for (ThreadID offset = 0; offset < numThreads; ++offset) {
         const ThreadID tid = (nextPredictTid + offset) % numThreads;
 
@@ -289,12 +296,19 @@ DecoupledBPUWithBTB::scheduleThread()
             continue;
         }
 
-        nextPredictTid = (tid + 1) % numThreads;
-        return tid;
+        scheduled.push_back(tid);
+        if (scheduled.size() == numPredictingThreads) {
+            break;
+        }
     }
 
-    dbpBtbStats.scheduleNoEligibleThread++;
-    return InvalidThreadID;
+    if (scheduled.empty()) {
+        dbpBtbStats.scheduleNoEligibleThread++;
+    } else {
+        nextPredictTid = (scheduled.back() + 1) % numThreads;
+    }
+
+    return scheduled;
 }
 
 
@@ -312,7 +326,7 @@ DecoupledBPUWithBTB::tick()
         thread.twoTakenTrainReady = false;
     }
 
-    ThreadID curTid = scheduleThread();
+    const auto scheduledTids = scheduleThreads();
     bool anyActiveThread = false;
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         if (isThreadActive(tid)) {
@@ -325,12 +339,8 @@ DecoupledBPUWithBTB::tick()
     }
 
     // On squash, reset state if there was a valid prediction.
-    bool squashOccurred = false;
     for (int tid = 0; tid < numThreads; tid++) {
         if (threads[tid].squashing) {
-            if (tid == curTid) {
-                squashOccurred = true;
-            }
             threads[tid].validprediction = false;
             threads[tid].numOverrideBubbles = 0;
             threads[tid].nextPredictionAfterSquash = true;
@@ -342,20 +352,19 @@ DecoupledBPUWithBTB::tick()
         }
     }
 
-    if (squashOccurred) {
-        DPRINTF(Override, "Squash occurred for current thread, skip predict.\n");
-        return;
-    }
-
-    if (curTid != InvalidThreadID) {
-        if (threads[curTid].blockPredictionPending) {
+    unsigned predictionsStarted = 0;
+    for (const ThreadID tid : scheduledTids) {
+        if (threads[tid].blockPredictionPending) {
             DPRINTF(Override, "Prediction blocked to prioritize resolve update\n");
             dbpBtbStats.predictionBlockedForUpdate++;
-            threads[curTid].blockPredictionPending = false;
+            threads[tid].blockPredictionPending = false;
         } else {
-            requestNewPrediction(curTid);
+            requestNewPrediction(tid);
+            predictionsStarted++;
+            dbpBtbStats.predictionsStartedByThread[tid]++;
         }
     }
+    dbpBtbStats.predictionsStartedPerCycle.sample(predictionsStarted);
 
     for (int tid = 0; tid < numThreads; tid++) {
         processNewPrediction(tid);

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -486,7 +486,7 @@ DecoupledBPUWithBTB::generateFinalPredAndCreateBubbles(ThreadID tid)
         if (pred_taken_entry.valid) {
             if (pred_taken_entry.isReturn) {
                 finalPred.s3Source = ras->getComponentIdx();
-            } else if (pred_taken_entry.isIndirect && ittage->tageHit()) {
+            } else if (pred_taken_entry.isIndirect && ittage->tageHit(tid)) {
                 finalPred.s3Source = ittage->getComponentIdx();
             }else if (pred_taken_entry.isCond) {
                 finalPred.s3Source = tage->getComponentIdx();

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -77,6 +77,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     CPU *cpu;
     ThreadID nextPredictTid = 0;
+    const unsigned numPredictingThreads;
     unsigned predictWidth;  // max predict width, default 64
     unsigned maxInstsNum;
 
@@ -168,7 +169,7 @@ class DecoupledBPUWithBTB : public BPredUnit
 
     bool isThreadActive(ThreadID tid) const;
     bool canStartPrediction(ThreadID tid) const;
-    ThreadID scheduleThread();
+    std::vector<ThreadID> scheduleThreads();
 
     void processNewPrediction(ThreadID tid);
     void prepareTwoTakenTraining(ThreadID tid);
@@ -326,6 +327,8 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar scheduleIneligibleThreadSkips;
         statistics::Scalar scheduleNoEligibleThread;
         statistics::Scalar redirectPendingPredictionSkips;
+        statistics::Distribution predictionsStartedPerCycle;
+        statistics::Vector predictionsStartedByThread;
 
         statistics::Scalar s1PredWrongFallthrough;
         statistics::Scalar s1PredWrongUbtb;
@@ -336,7 +339,9 @@ class DecoupledBPUWithBTB : public BPredUnit
         statistics::Scalar s3PredWrongIttage;
         statistics::Scalar s3PredWrongRas;
 
-        DBPBTBStats(statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum);
+        DBPBTBStats(statistics::Group* parent, unsigned numStages,
+                    unsigned fsqSize, unsigned maxInstsNum,
+                    unsigned numThreads);
     } dbpBtbStats;
 
   public:

--- a/src/cpu/pred/btb/decoupled_bpred_stats.cc
+++ b/src/cpu/pred/btb/decoupled_bpred_stats.cc
@@ -439,7 +439,8 @@ classifyBranchImpl(const InstPtr &inst)
 } // anonymous namespace
 
 DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
-    statistics::Group* parent, unsigned numStages, unsigned fsqSize, unsigned maxInstsNum):
+    statistics::Group* parent, unsigned numStages, unsigned fsqSize,
+    unsigned maxInstsNum, unsigned numThreads):
     statistics::Group(parent),
     ADD_STAT(condNum, statistics::units::Count::get(), "the number of cond branches"),
     ADD_STAT(uncondNum, statistics::units::Count::get(), "the number of uncond branches"),
@@ -498,6 +499,10 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     "round-robin BPU scheduler found no thread eligible to start a new prediction"),
     ADD_STAT(redirectPendingPredictionSkips, statistics::units::Count::get(),
     "round-robin BPU scheduler skipped prediction because a redirect was pending"),
+    ADD_STAT(predictionsStartedPerCycle, statistics::units::Count::get(),
+    "number of distinct SMT thread predictions started in one cycle"),
+    ADD_STAT(predictionsStartedByThread, statistics::units::Count::get(),
+    "number of predictions started for each SMT thread"),
     ADD_STAT(s1PredWrongFallthrough, statistics::units::Count::get(), "S1pred wrong full throughs"),
     ADD_STAT(s1PredWrongUbtb, statistics::units::Count::get(),"S1pred wrong using ubtb "),
     ADD_STAT(s1PredWrongAbtb, statistics::units::Count::get(), "S1pred wrong using abtb "),
@@ -518,6 +523,8 @@ DecoupledBPUWithBTB::DBPBTBStats::DBPBTBStats(
     commitFsqEntryFetchedInsts.init(0, maxInstsNum >> 1, 1);
     s1PredWrongBySourceAndReason.init(NumS1SourceBuckets, NumOverrideReasonBuckets);
     branchClassCounts.init(NumBranchClasses);
+    predictionsStartedPerCycle.init(0, numThreads, 1);
+    predictionsStartedByThread.init(numThreads);
     branchClassMisses.init(NumBranchClasses);
     controlSquashByClass.init(NumBranchClasses);
     for (int i = 0; i < NumS1SourceBuckets; ++i) {

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -142,6 +142,8 @@ MBTB::MBTB(const Params &p)
         entry.tick = 0;
     }
 
+    threadMeta.resize(o3::MaxThreads);
+
     DPRINTF(BTB, "numEntries %d, numSets %d, numWays %d, tagBits %d, tagShiftAmt %d, "
         "idxMask %#lx, tagMask %#lx, victimCacheSize %d\n",
         numEntries, numSets, numWays, tagBits, tagShiftAmt, idxMask, tagMask, victimCacheSize);
@@ -313,9 +315,12 @@ void
 MBTB::updatePredictionMeta(const std::vector<TickedBTBEntry>& entries,
                                    std::vector<FullBTBPrediction>& stagePreds)
 {
+    const ThreadID tid = stagePreds.empty() ? 0 : stagePreds.front().tid;
+    assert(tid < threadMeta.size());
+
     // Save current BTB entries
     for (auto e: entries) {
-        meta->hit_entries.push_back(BTBEntry(e));
+        threadMeta[tid]->hit_entries.push_back(BTBEntry(e));
     }
 }
 
@@ -324,10 +329,12 @@ MBTB::putPCHistory(Addr startAddr,
                          const boost::dynamic_bitset<> &history,
                          std::vector<FullBTBPrediction> &stagePreds)
 {
-    meta = std::make_shared<BTBMeta>();
+    const ThreadID tid = stagePreds.empty() ? 0 : stagePreds.front().tid;
+    assert(tid < threadMeta.size());
+    threadMeta[tid] = std::make_shared<BTBMeta>();
     const uint8_t asidHash = stagePreds.empty() ? 0 : stagePreds.front().asidHash;
     // Lookup all matching entries in BTB
-    auto find_entries = lookup(startAddr, asidHash, meta);
+    auto find_entries = lookup(startAddr, asidHash, threadMeta[tid]);
 
     // Process BTB entries
     auto processed_entries = processEntries(find_entries, startAddr);
@@ -356,8 +363,10 @@ MBTB::getPredictedEntriesNoSideEffect(Addr startAddr, uint8_t asidHash) const
 std::shared_ptr<void>
 MBTB::getPredictionMeta(ThreadID tid)
 {
-    (void)tid;
-    return meta;
+    if (tid >= threadMeta.size()) {
+        return nullptr;
+    }
+    return threadMeta[tid];
 }
 
 void
@@ -366,9 +375,9 @@ MBTB::refreshPredictionMeta(Addr startAddr,
                             FullBTBPrediction &pred)
 {
     (void)history;
-    (void)pred;
-
-    meta = std::make_shared<BTBMeta>();
+    assert(pred.tid < threadMeta.size());
+    threadMeta[pred.tid] = std::make_shared<BTBMeta>();
+    auto &meta = threadMeta[pred.tid];
     auto found_entries = lookupNoSideEffect(startAddr);
     auto processed_entries = processEntriesNoSideEffect(found_entries, startAddr);
     for (const auto &entry : processed_entries) {

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -41,8 +41,10 @@
 #define __CPU_PRED_BTB_MBTB_HH__
 
 #include <queue>
+#include <vector>
 
 #include "base/types.hh"
+#include "cpu/o3/limits.hh"
 #include "cpu/pred/btb/common.hh"
 #include "cpu/pred/btb/test_stats.hh"
 #include "cpu/pred/btb/timed_base_pred.hh"
@@ -250,7 +252,9 @@ class MBTB : public TimedBaseBTBPredictor
         }
     }BTBMeta;
 
-    std::shared_ptr<BTBMeta> meta; // metadata for BTB, set in putPCHistory, used in update
+    // Prediction metadata lives until the top level copies it into an FTQ
+    // entry, so concurrent SMT lookups must not overwrite another thread.
+    std::vector<std::shared_ptr<BTBMeta>> threadMeta;
 
     /** Process BTB entries for prediction
      *  @param entries Vector of BTB entries to process

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -207,6 +207,33 @@ TEST_F(BTBTest, EmptyPrediction) {
     }
 }
 
+// Interleaved SMT predictions must retain each thread's metadata until the
+// corresponding FetchTarget is created.
+TEST_F(BTBTest, PredictionMetadataIsPerThread) {
+    boost::dynamic_bitset<> history(8, 0);
+    std::vector<FullBTBPrediction> thread0Preds(4);
+    std::vector<FullBTBPrediction> thread1Preds(4);
+
+    for (auto &pred : thread0Preds) {
+        pred.tid = 0;
+    }
+    for (auto &pred : thread1Preds) {
+        pred.tid = 1;
+    }
+
+    mbtb->putPCHistory(0x1000, history, thread0Preds);
+    auto thread0Meta = mbtb->getPredictionMeta(0);
+    ASSERT_NE(thread0Meta, nullptr);
+
+    mbtb->putPCHistory(0x2000, history, thread1Preds);
+    auto thread1Meta = mbtb->getPredictionMeta(1);
+    ASSERT_NE(thread1Meta, nullptr);
+
+    EXPECT_NE(thread0Meta, thread1Meta);
+    EXPECT_EQ(mbtb->getPredictionMeta(0), thread0Meta);
+    EXPECT_EQ(mbtb->getPredictionMeta(1), thread1Meta);
+}
+
 // BTB actual update process:
 // 1. putPCHistory, store result in stagePreds, update meta
 // 2. getPredictionMeta, set to stream.predMetas[0]


### PR DESCRIPTION
## Motivation

The SMT frontend can currently start only one branch prediction and one FTQ-to-I-cache fetch target per cycle. Short basic blocks therefore leave frontend bandwidth unused even when both hardware threads are ready.

This PR adds a behavioral upper-bound model for serving two SMT threads in the same model cycle. The implementation is parameterized and defaults to the existing single-thread-per-cycle behavior.

## Approach

- Keep uBTB/mBTB prediction metadata, uBTB teacher state, ITTAGE attribution, and deferred fetch-translation completion state per thread.
- Add `smtNumPredictingThreads` (default 1, maximum 2).
  - Select distinct eligible threads with bounded round-robin arbitration.
  - Start one prediction for each selected thread in the same model cycle.
- Add `smtNumFetchTargetThreads` (default 1, maximum 2).
  - Select up to two distinct FTQ heads in the FTQ-to-I-cache request phase.
  - Preserve the existing per-thread request state machine and shared I-cache retry/backpressure path.
  - Each selected candidate consumes the width budget even if it is blocked, so width 1 does not become a work-conserving oracle that retries the other thread for free.
  - One target may request two cache lines for the existing 66-byte fetch buffer; the 2x2 profile therefore provides four I-cache tag-read ports.
- Add prediction/fetch utilization and blocking statistics.
- Reject `PairTAGE + smtNumPredictingThreads > 1` until PairTAGE gains complete TID support.

`performInstructionFetch()` and the fetchQueue-to-decode path still consume the existing shared `fetchWidth`; decode, rename, IEW, and commit resources are not widened. The gain comes from overlapping BPU and FTQ-to-I-cache latency across the two threads, not from decoding two full-width thread bundles in one cycle.

## Upper-bound profile

`configs/example/smt_idealkmhv3.py` enables:

- two prediction threads and two FTQ fetch-target threads;
- four I-cache tag-read ports;
- uBTB, AheadBTB, and MicroTAGE with their existing resolve/commit training path (`usingS3Pred=False`).

The predictor tables are treated as ideal shared dual-read resources in this PR. Predictor bank/capacity effects are intentionally separated into stacked PR #1062.

## Model boundaries

- Predictor read-port and bank conflicts are not modeled here.
- Training-port conflicts are not modeled.
- The two BPU calls execute sequentially inside the simulator but are charged to the same modeled cycle.
- Decode and all backend widths remain unchanged.
- Parameters are bounded to two threads; this is not a generalized N-thread model.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j8`
- `BTBTest.PredictionMetadataIsPerThread` passed locally.
- PR quick build, unit tests, and smoke test passed on head `e608c26b94`: [run 32705292099](https://github.com/OpenXiangShan/GEM5/actions/runs/32705292099).
- Dual-hart CoreMark 1x1/1x2/2x1/2x2 exploration completed with difftest enabled; 2x2 reduced cycles by 0.79% on this backend-bound workload and substantially reduced fetch bubbles.
- Full Ahead-on SMT SPEC06 feature-control A/B measured 1x1 to 2x2 at SPECint +2.123%, SPECfp +0.282%, and Overall +1.039%: [detailed results and bottleneck analysis](https://github.com/OpenXiangShan/GEM5/pull/1052#issuecomment-5339361776).

The SPEC result is an upper-bound result, not an RTL cost claim. After 2x2, the average bottleneck shifts toward backend/core/memory resources, while several frontend-sensitive integer workloads retain larger gains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable SMT prediction and fetch concurrency, allowing multiple eligible threads to begin work in the same cycle.
  - Added per-thread prediction and fetch statistics for improved performance analysis.
  - Added dual-frontend probe configuration with increased prediction and fetch capacity.

- **Bug Fixes**
  - Improved SMT correctness by maintaining independent branch-prediction metadata for each thread.
  - Improved handling of translation completion, redirects, and concurrent fetch requests.

- **Tests**
  - Added coverage confirming prediction metadata remains isolated across interleaved SMT threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->