### PR TITLE
cpu-o3: Optimize the thread scheduling logic in the F0 stage of SMT Fetch

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1977,10 +1977,19 @@ Fetch::getEligibleFetchTargetTid()
     eligible.fill(true);
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         eligible[tid] = !redirectPending[tid];
+        if (fetchStatus[tid] == Idle || fetchStatus[tid] == Blocked ||
+            fetchStatus[tid] == TrapPending || fetchStatus[tid] == WaitingCache) {
+            eligible[tid] = false;
+        }
     }
 
     unsigned skipped = 0;
-    ThreadID tid = dbpbtb->getTargetTid(eligible, &skipped);
+    // Use fetch-queue-aware scheduling: prioritize threads with fewer queue entries
+    std::array<unsigned, MaxThreads> fetchQueueSizes;
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        fetchQueueSizes[tid] = fetchQueue[tid].size();
+    }
+    ThreadID tid = dbpbtb->getTargetTidByFetchQueueSize(eligible, &skipped, fetchQueueSizes);
     if (skipped) {
         fetchStats.redirectPendingFetchSkips += skipped;
         DPRINTF(Fetch, "Skipped %u FTQ heads while backend redirect is pending\n",
@@ -2040,7 +2049,7 @@ Fetch::fetch(bool &status_change)
     std::list<ThreadID>::iterator end = activeThreads->end();
     while (threadit != end) {
         ThreadID tid = *threadit++;
-    performInstructionFetch(tid);
+        performInstructionFetch(tid);
     }
     auto tid = getEligibleFetchTargetTid();
     if (tid == InvalidThreadID) {

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -426,6 +426,13 @@ class DecoupledBPUWithBTB : public BPredUnit
     {
         return ftq.getTargetTid(eligible, ineligibleSkips);
     }
+    
+    int getTargetTidByFetchQueueSize(const std::array<bool, MaxThreads> &eligible,
+                                     unsigned *ineligibleSkips,
+                                     const std::array<unsigned, MaxThreads> &fetchQueueSizes)
+    {
+        return ftq.getTargetTidByFetchQueueSize(eligible, ineligibleSkips, fetchQueueSizes);
+    }
 
     void dumpFsq(const char *when);
 

--- a/src/cpu/pred/btb/ftq.cc
+++ b/src/cpu/pred/btb/ftq.cc
@@ -40,6 +40,42 @@ FetchTargetQueue::getTargetTid(const std::array<bool, MaxThreads> &eligible,
     return -1;
 }
 
+int
+FetchTargetQueue::getTargetTidByFetchQueueSize(const std::array<bool, MaxThreads> &eligible,
+                                               unsigned *ineligibleSkips,
+                                               const std::array<unsigned, MaxThreads> &fetchQueueSizes)
+{
+    int selectedTid = -1;
+    unsigned minFetchQueueSize = UINT_MAX;
+    
+    // Find eligible thread with minimum fetch queue entries
+    // Use round-robin order to break ties when queue sizes are equal
+    for (int i = roundRobinPtr; i < numThreads + roundRobinPtr; ++i) {
+        ThreadID tid = i % numThreads;
+        if (!eligible[tid]) {
+            if (ineligibleSkips) {
+                ++(*ineligibleSkips);
+            }
+            continue;
+        }
+        
+        if (!queue[tid].cap.empty() && hasTarget(fetchId(tid), tid)) {
+            unsigned fqSize = fetchQueueSizes[tid];
+            if (fqSize < minFetchQueueSize) {
+                minFetchQueueSize = fqSize;
+                selectedTid = tid;
+            }
+        }
+    }
+    
+    // Update round-robin pointer for next call
+    if (selectedTid != -1) {
+        roundRobinPtr = (selectedTid + 1) % numThreads;
+    }
+    
+    return selectedTid;
+}
+
 void
 FetchTargetQueue::insert(FetchTarget& target)
 {

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -80,6 +80,20 @@ public:
     int getTargetTid();
     int getTargetTid(const std::array<bool, MaxThreads> &eligible,
                      unsigned *ineligibleSkips);
+    /**
+     * @brief Select thread with minimum fetch queue entries (load-balancing)
+     * 
+     * Prioritizes threads with fewer fetched-but-not-decoded instructions
+     * to prevent fetch queue overflow and balance decode pressure.
+     * 
+     * @param eligible Bitmask of eligible threads
+     * @param ineligibleSkips Output counter for skipped ineligible threads
+     * @param fetchQueueSizes Array of fetch queue sizes for each thread
+     * @return ThreadID of selected thread, or -1 if no eligible thread
+     */
+    int getTargetTidByFetchQueueSize(const std::array<bool, MaxThreads> &eligible,
+                                     unsigned *ineligibleSkips,
+                                     const std::array<unsigned, MaxThreads> &fetchQueueSizes);
     void insert(FetchTarget& target);
     void finishTarget(ThreadID tid);
     void commitTarget(ThreadID tid);


### PR DESCRIPTION
**Motivation**
The current Fetch F0 stage thread scheduling logic in SMT does not account for thread readiness and fetch queue pressure. Threads may be selected for fetching even when they are stalled due to TLB/cache misses or when their fetch queue is full, leading to wasted scheduling opportunities and suboptimal resource utilization.

**Changes**
1. Exclude threads in non-running states from the Fetch F0 stage scheduling selection. This prevents the previous issue where a thread selected by the scheduler would immediately stall due to waiting for TLB/cache misses.
2.Add fetch queue size consideration to the Fetch F0 stage scheduling logic. Prioritize scheduling threads with fewer occupied fetch queue entries, avoiding the previous scenario where a selected thread would stall because its fetch queue was full.

**Validation**
Performance validation: SPEC06 1c benchmark shows 0.44% IPC improvement after the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved instruction-fetch scheduling by prioritizing threads with shorter fetch queues.
  * Expanded thread eligibility checks to avoid fetching from threads that are idle, blocked, waiting on caches, or handling traps.
  * Ensured instruction fetching is performed for every active thread during each scheduling cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->