### PR TITLE
cpu-o3: Fix Clang free-list build failure

### DIFF
--- a/src/cpu/o3/free_list.hh
+++ b/src/cpu/o3/free_list.hh
@@ -241,7 +241,8 @@ class UnifiedFreeList
     void
     addRegs(InputIt first, InputIt last)
     {
-        std::for_each(first, last, [this](auto &reg) { addReg(&reg); });
+        std::for_each(first, last,
+                      [this](auto &reg) { this->addReg(&reg); });
     }
 
     /** Adds a register back to the free list, without per-thread


### PR DESCRIPTION
## Motivation

Post-merge performance workflows fail while building `gem5.fast` with Clang. The first confirmed failure is [run 32210615290, job 95942434243](https://github.com/OpenXiangShan/GEM5/actions/runs/32210615290/job/95942434243):

```
src/cpu/o3/free_list.hh:244:37: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
```

## Root cause

PR #1027 added an overloaded `UnifiedFreeList::addReg(..., ThreadID)`. The existing generic lambda in `addRegs()` still used an unqualified dependent call, `addReg(&reg)`. With the new overload set, Clang no longer treats that expression as an explicit use of the captured `this`, and `-Werror` turns the warning into a build failure.

The other two immediately preceding merges do not modify this code path.

## Fix

Explicitly qualify the member call as `this->addReg(&reg)`.

This preserves the existing initial free-list population behavior and does not change runtime resource accounting.

## Validation

- Reproduced the CI error locally with:
  `CC=clang CXX=clang++ scons -s build/RISCV/gem5.fast -j16 --gold-linker --pgo-prof`
- Re-ran the same command after the fix: the full `gem5.fast` build and link completed successfully.
- Ran the CoreMark PGO profiling workload to its normal `m5_exit`.
- `git diff --check` passes.

The final local PGO-use rebuild is not claimed as passing: Clang 19 reports unrelated SystemC profile hash mismatches in unchanged files. The failing CI compile stage itself is covered by the successful Clang PGO-instrumented build above, and the remote workflow remains the final environment-level verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal register free-list handling while preserving existing allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->