### PR TITLE
tests: Add Clang fast build to quick CI

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -13,6 +13,19 @@ permissions:
   contents: read
 
 jobs:
+  clang_fast_build:
+    runs-on: [self-hosted, node]
+    continue-on-error: false
+    name: Clang GEM5 Fast Build
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/build-dramsim
+
+      - name: Build GEM5 fast with Clang
+        run: |
+          CC=clang CXX=clang++ scons build/RISCV/gem5.fast --gold-linker --pgo-prof -j64
+
   quick_check:
     runs-on: [self-hosted, node]
     continue-on-error: false


### PR DESCRIPTION
## Motivation

The existing Tier 1 quick check only builds `gem5.opt` with GCC. A recent change compiled successfully there but failed later when the performance workflow built `gem5.fast` with Clang under `-Werror`.

## Approach

Add a parallel compile-only job to `PR Quick Check (Tier 1)` that:

- checks out the PR commit independently;
- builds DRAMSim3;
- builds `build/RISCV/gem5.fast` with Clang and `--pgo-prof`.

The existing GCC build, unit tests, difftest smoke, and CoreMark IPC comparison remain unchanged.

## Impact

This adds one independent compile job and does not change simulator behavior or performance measurements.

## Validation

- Parsed `.github/workflows/pr-quick-check.yml` with PyYAML.
- Passed `git diff --check`.
- Passed the exact local build command:
  `CC=clang CXX=clang++ scons -s build/RISCV/gem5.fast --gold-linker --pgo-prof -j64`.