### PR TITLE
configs: Enable CDP for KMH-aligned L2 prefetcher

### DIFF
--- a/configs/common/PrefetcherConfig.py
+++ b/configs/common/PrefetcherConfig.py
@@ -493,9 +493,9 @@ def _configure_l2_composite_default(prefetcher):
 
 def _configure_l2_composite_kmh_align(prefetcher):
     # RTL-aligned L2CompositeWithWorker profile.
-    prefetcher.enable_cmc = True
+    prefetcher.enable_cmc = False
     prefetcher.enable_bop = True
-    prefetcher.enable_cdp = False
+    prefetcher.enable_cdp = True
     prefetcher.enable_despacito_stream = False
     prefetcher.bop_large = XSVirtualLargeBOP(is_sub_prefetcher=True,
                                              enable_adaptoffset=False)


### PR DESCRIPTION
## Motivation

The KMH-aligned L2 composite prefetcher profile currently enables CMC and disables CDP. Align the profile with the intended CMC-off/CDP-on configuration.

## Changes

- Disable CMC in `_configure_l2_composite_kmh_align`.
- Enable CDP in `_configure_l2_composite_kmh_align`.
- Preserve the existing BOP, Despacito stream, and BOP instance settings.

## Validation

- `python3 -m py_compile configs/common/PrefetcherConfig.py`
- Instantiated `L2CompositeWithWorkerPrefetcher` with the KMH-align helper and checked: CMC disabled, CDP enabled, BOP enabled, Despacito stream disabled.
- `scons build/RISCV/gem5.opt --gold-linker -j8`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the L2 composite prefetcher profile to enable CDP and disable CMC.
  * Kept BOP enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->