### PR TITLE
mem-cache: Fix duplicated L2 prefetch issue counters

### DIFF
--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -254,10 +254,14 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
   : statistics::Group(parent),
     ADD_STAT(demandMshrMisses, statistics::units::Count::get(),
         "demands not covered by prefetchs"),
+    ADD_STAT(pfDequeued, statistics::units::Count::get(),
+        "number of prefetches dequeued from the local prefetch queue"),
+    ADD_STAT(pfDequeued_srcs, statistics::units::Count::get(),
+        "number of prefetches dequeued from the local prefetch queue"),
     ADD_STAT(pfIssued, statistics::units::Count::get(),
-        "number of hwpf issued"),
+        "number of prefetches reaching the cache issue boundary"),
     ADD_STAT(pfIssued_srcs, statistics::units::Count::get(),
-        "number of hwpf issued"),
+        "number of prefetches reaching the cache issue boundary"),
     ADD_STAT(pfOffloaded, statistics::units::Count::get(),
         "number of hwpf issued"),
     ADD_STAT(pfaheadOffloaded, statistics::units::Count::get(),
@@ -309,6 +313,9 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
 {
     using namespace statistics;
 
+    pfDequeued_srcs
+        .init(NUM_PF_SOURCES)
+        .flags(total | nozero);
     pfIssued_srcs
         .init(NUM_PF_SOURCES)
         .flags(total | nozero);
@@ -340,6 +347,7 @@ Base::StatGroup::StatGroup(statistics::Group *parent)
 
     for (unsigned source = 0; source < NUM_PF_SOURCES; ++source) {
         const auto source_name = prefetchSourceTypeName(source);
+        pfDequeued_srcs.subname(source, source_name);
         pfIssued_srcs.subname(source, source_name);
         pfUnused_srcs.subname(source, source_name);
         pfBad_srcs.subname(source, source_name);
@@ -457,7 +465,8 @@ Base::nofityHitToDownStream(const PacketPtr &pkt)
 {
     // allow non-demand notify for downstream
     PrefetchSourceType pf_source = cache->getHitBlkXsMetadata(pkt).prefetchSource;
-    float acc = (prefetchStats.pfUseful_srcs[pf_source].value()) / (prefetchStats.pfIssued_srcs[pf_source].value());
+    float acc = (prefetchStats.pfUseful_srcs[pf_source].value()) /
+        (prefetchStats.pfDequeued_srcs[pf_source].value());
     DPRINTF(HWPrefetch, "Notify data read resp pkt to down stream prefetch, especially for CDP\n");
     hintDownStream->pfHitNotify(acc, pf_source, pkt);
 }

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -932,6 +932,10 @@ class Base : public ClockedObject
     {
         StatGroup(statistics::Group *parent);
         statistics::Scalar demandMshrMisses;
+        /** Prefetches dequeued from this prefetcher's local queue. */
+        statistics::Scalar pfDequeued;
+        statistics::Vector pfDequeued_srcs;
+        /** Prefetches that reached this prefetcher's cache issue boundary. */
         statistics::Scalar pfIssued;
         statistics::Vector pfIssued_srcs;
 
@@ -984,12 +988,19 @@ class Base : public ClockedObject
         statistics::Formula pfLate;
     } prefetchStats;
 
-    /** Total prefetches issued */
+    /** Total local prefetch dequeues used for runtime feedback. */
     uint64_t issuedPrefetches;
     /** Total prefetches that has been useful */
     uint64_t usefulPrefetches;
 
     uint64_t streamlatenum;
+
+    /**
+     * A forwarder owns the cache-side issue boundary for this prefetcher.
+     * This is set by PrefetcherForwarder::setRealPrefetcher(), rather than
+     * by a user-visible configuration parameter.
+     */
+    bool issueStatsAtForwarder{false};
 
     /** Registered tlb for address translations */
     BaseTLB * tlb;
@@ -1034,18 +1045,30 @@ class Base : public ClockedObject
         return pkt && pkt->req && pkt->req->requestorId() == requestorId;
     }
 
-    virtual void recordIssuedPrefetch(PrefetchSourceType source)
+    void
+    setIssueStatsAtForwarder()
+    {
+        issueStatsAtForwarder = true;
+    }
+
+    bool
+    issueStatsAreAtForwarder() const
+    {
+        return issueStatsAtForwarder;
+    }
+
+    virtual void recordPrefetchDequeued(PrefetchSourceType source)
     {
         const int source_idx = int(source);
         if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
             source = PrefetchSourceType::PF_NONE;
         }
-        prefetchStats.pfIssued++;
-        prefetchStats.pfIssued_srcs[source]++;
+        prefetchStats.pfDequeued++;
+        prefetchStats.pfDequeued_srcs[source]++;
         issuedPrefetches += 1;
     }
 
-    virtual void recordIssuedPrefetch(const PacketPtr &pkt)
+    virtual void recordPrefetchDequeued(const PacketPtr &pkt)
     {
         PrefetchSourceType source = PrefetchSourceType::PF_NONE;
         if (pkt && pkt->req) {
@@ -1055,7 +1078,42 @@ class Base : public ClockedObject
                 source = pkt->getPFSource();
             }
         }
-        recordIssuedPrefetch(source);
+        recordPrefetchDequeued(source);
+    }
+
+    virtual void recordIssuedPrefetchStats(PrefetchSourceType source)
+    {
+        const int source_idx = int(source);
+        if (source_idx < 0 || source_idx >= NUM_PF_SOURCES) {
+            source = PrefetchSourceType::PF_NONE;
+        }
+        prefetchStats.pfIssued++;
+        prefetchStats.pfIssued_srcs[source]++;
+    }
+
+    virtual void recordIssuedPrefetchStats(const PacketPtr &pkt)
+    {
+        PrefetchSourceType source = PrefetchSourceType::PF_NONE;
+        if (pkt && pkt->req) {
+            if (pkt->req->hasXsMetadata()) {
+                source = pkt->req->getXsMetadata().prefetchSource;
+            } else {
+                source = pkt->getPFSource();
+            }
+        }
+        recordIssuedPrefetchStats(source);
+    }
+
+    virtual void recordIssuedPrefetch(PrefetchSourceType source)
+    {
+        recordPrefetchDequeued(source);
+        recordIssuedPrefetchStats(source);
+    }
+
+    virtual void recordIssuedPrefetch(const PacketPtr &pkt)
+    {
+        recordPrefetchDequeued(pkt);
+        recordIssuedPrefetchStats(pkt);
     }
 
     virtual void

--- a/src/mem/cache/prefetch/cdp.hh
+++ b/src/mem/cache/prefetch/cdp.hh
@@ -456,9 +456,9 @@ class CDP : public Queued
     float getCdpTrueAccuracy() const
     {
         float trueAccuracy = 1;
-        if (prefetchStatsPtr->pfIssued_srcs[PrefetchSourceType::CDP].value() > 100) {
+        if (prefetchStatsPtr->pfDequeued_srcs[PrefetchSourceType::CDP].value() > 100) {
             trueAccuracy = (prefetchStatsPtr->pfUseful_srcs[PrefetchSourceType::CDP].value() * 1.0) /
-                            (prefetchStatsPtr->pfIssued_srcs[PrefetchSourceType::CDP].value());
+                            (prefetchStatsPtr->pfDequeued_srcs[PrefetchSourceType::CDP].value());
         }
         return trueAccuracy;
     }

--- a/src/mem/cache/prefetch/forwarder.cc
+++ b/src/mem/cache/prefetch/forwarder.cc
@@ -147,8 +147,8 @@ PrefetcherForwarder::getPacket()
     }
     PacketPtr pkt = prefetch_queue.front();
     prefetch_queue.pop();
-    if (real_pf && !real_pf->ownsPrefetchRequest(pkt)) {
-        real_pf->recordIssuedPrefetch(pkt);
+    if (real_pf) {
+        real_pf->recordIssuedPrefetchStats(pkt);
     }
     return pkt;
 }

--- a/src/mem/cache/prefetch/forwarder.hh
+++ b/src/mem/cache/prefetch/forwarder.hh
@@ -29,7 +29,14 @@ class PrefetcherForwarder : public Base
   public:
     PrefetcherForwarder(const PrefetcherForwarderParams &p);
 
-    void setRealPrefetcher(Base* real_pf_ptr) { real_pf = real_pf_ptr; }
+    void
+    setRealPrefetcher(Base* real_pf_ptr)
+    {
+        real_pf = real_pf_ptr;
+        if (real_pf) {
+            real_pf->setIssueStatsAtForwarder();
+        }
+    }
 
     bool observeAccess(const PacketPtr &pkt, bool miss) const override;
 

--- a/src/mem/cache/prefetch/l2_composite_with_worker.cc
+++ b/src/mem/cache/prefetch/l2_composite_with_worker.cc
@@ -85,9 +85,10 @@ L2CompositeWithWorkerPrefetcher::rxHint(BaseMMU::Translation *dpp)
     if (offloadLowAccuracy) {
         auto ptr = reinterpret_cast<DeferredPacket *>(dpp);
         float cdp_ratio =
-            (prefetchStats.pfIssued_srcs[PrefetchSourceType::CDP].value()) / (prefetchStats.pfIssued.total());
+            (prefetchStats.pfDequeued_srcs[PrefetchSourceType::CDP].value()) /
+            (prefetchStats.pfDequeued.value());
         float acc = (prefetchStats.pfUseful_srcs[ptr->pfInfo.getXsMetadata().prefetchSource].value()) /
-                    (prefetchStats.pfIssued_srcs[ptr->pfInfo.getXsMetadata().prefetchSource].value());
+                    (prefetchStats.pfDequeued_srcs[ptr->pfInfo.getXsMetadata().prefetchSource].value());
 
         if (hasHintDownStream() && cdp_ratio > 0.5 && acc < 0.5) {
             hintDownStream->rxHint(dpp);

--- a/src/mem/cache/prefetch/multi.cc
+++ b/src/mem/cache/prefetch/multi.cc
@@ -88,8 +88,11 @@ Multi::getPacket()
         if (prefetchers[pf_turn]->nextPrefetchReadyTime() <= curTick()) {
             PacketPtr pkt = prefetchers[pf_turn]->getPacket();
             panic_if(!pkt, "Prefetcher is ready but didn't return a packet.");
-            prefetchStats.pfIssued++;
-            issuedPrefetches++;
+            if (issueStatsAreAtForwarder()) {
+                recordPrefetchDequeued(pkt);
+            } else {
+                recordIssuedPrefetch(pkt);
+            }
             return pkt;
         }
         pf_turn = (pf_turn + 1) % prefetchers.size();

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -1145,7 +1145,11 @@ Queued::getPacket()
     pfq.pop_front();
 
     assert(pkt != nullptr);
-    recordIssuedPrefetch(pkt);
+    if (issueStatsAreAtForwarder()) {
+        recordPrefetchDequeued(pkt);
+    } else {
+        recordIssuedPrefetch(pkt);
+    }
     DPRINTF(HWPrefetch, "Generating prefetch for %#x.\n", pkt->getAddr());
 
     return pkt;


### PR DESCRIPTION
## Motivation

In the aligned L2 topology, L1-generated prefetches pass through both the
L2 wrapper prefetch queue and an inner-slice PrefetcherForwarder queue.
Both stages recorded the same packet as `pfIssued`, causing L1 sources such
as `SPht`, `SStream`, and `SStride` to be counted twice.

## Approach

- Add `pfDequeued` and `pfDequeued_srcs` to represent local prefetch-queue
  dequeues and preserve their use for runtime feedback.
- Define `pfIssued` and `pfIssued_srcs` as requests reaching the cache-side
  issue boundary.
- When a real prefetcher is attached through `PrefetcherForwarder`, record
  only a local dequeue at the real prefetcher and record issue once when the
  forwarder dequeues the request.
- Keep incoming prefetch admission based on `ownsPrefetchRequest()` and
  `admitIncomingPrefetchPacket()` unchanged.
- Update CDP and downstream-hint feedback to use the local dequeue counter.

## Scope

This does not add configuration switches or alter the aligned L2 topology,
prefetch request generation, routing, admission, or queue behavior. Directly
attached prefetchers continue to record local dequeue and cache issue together.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- The corrected wrapper-level source counts satisfy:
  `SStream + SStride + SPht = pfaheadProcess`.
- Full `gcc15-spec06-1.0c` test with `kmhv3.py`:
  [Manual Performance Test #32226137706](https://github.com/OpenXiangShan/GEM5/actions/runs/32226137706)
  completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added aggregate and per-source statistics for prefetches removed from local queues.
  - Added support for tracking whether issue statistics are collected at a forwarding layer.
- **Improvements**
  - Prefetch accuracy and CDP metrics now use dequeued prefetches, providing more representative measurements.
  - Improved attribution of prefetch statistics across forwarding and local queue paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->