### PR TITLE
tests,util: Exclude RTL nodes from distributed defaults

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -264,7 +264,7 @@ jobs:
           CONFIG_NAME=$(printf '%s' "$CONFIG_NAME" | tr -c 'A-Za-z0-9._-' '_')
           CONFIG_NAME=${CONFIG_NAME:-config}
           TARGET_DIR="${BENCHMARK_DIR}/${TIMESTAMP}_${COMMIT_SHORT}_${CONFIG_NAME}_run${RUN_NUMBER}"
-          DEFAULT_DISTRIBUTED_SERVERS="node020-node034,node036-node039"
+          DEFAULT_DISTRIBUTED_SERVERS="node020-node029,node033-node034,node036-node039"
           DISTRIBUTED_SERVERS_INPUT="$DISTRIBUTED_SERVERS_RAW"
           DISTRIBUTED_SERVERS=$(echo "$DISTRIBUTED_SERVERS_INPUT" | xargs)
           if [ "$DISTRIBUTED_SERVERS" = "default" ]; then

--- a/.github/workflows/manual-h-spec06-perf.yml
+++ b/.github/workflows/manual-h-spec06-perf.yml
@@ -38,7 +38,7 @@ on:
         type: string
         default: ''
       distributed_servers:
-        description: 'Optional distributed server list. Use default for node020-node034,node036-node039; leave empty for the local H runner.'
+        description: 'Optional distributed server list. Use default for node020-node029,node033-node034,node036-node039; leave empty for the local H runner.'
         required: false
         type: string
         default: ''

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -57,7 +57,7 @@ on:
         type: string
         default: ''
       distributed_servers:
-        description: 'Optional distributed server list. Use default for node020-node034,node036-node039; leave empty for old single-runner parallel path'
+        description: 'Optional distributed server list. Use default for node020-node029,node033-node034,node036-node039; leave empty for old single-runner parallel path'
         required: false
         type: string
         default: ''

--- a/.github/workflows/manual-solve.yml
+++ b/.github/workflows/manual-solve.yml
@@ -50,7 +50,7 @@ on:
         type: string
         default: "4"
       distributed_servers:
-        description: "Optional distributed server list. Empty runs only on the current CI runner; default uses node020-node034,node036-node039."
+        description: "Optional distributed server list. Empty runs only on the current CI runner; default uses node020-node029,node033-node034,node036-node039."
         required: false
         type: string
         default: ""

--- a/util/solver/executor/distributed.py
+++ b/util/solver/executor/distributed.py
@@ -13,7 +13,7 @@ from typing import Callable
 import util.xs_scripts.distributed_sim as dist
 
 
-DEFAULT_DISTRIBUTED_SERVERS = "node020-node034,node036-node039"
+DEFAULT_DISTRIBUTED_SERVERS = "node020-node029,node033-node034,node036-node039"
 DEFAULT_IDLE_CPU_THRESHOLD = 30.0
 
 


### PR DESCRIPTION
## Motivation

Keep gem5 distributed CI workloads off node030, node031, and node032 so they do not contend with RTL CI. node035 remains excluded as before.

## Approach

- Change the shared performance workflow default pool to node020-node029,node033-node034,node036-node039.
- Keep the solver default pool aligned with the performance workflow.
- Update manual workflow input descriptions to show the effective default.
- Leave explicitly supplied server lists unchanged.

## Scope

Only default server expansion and its user-facing descriptions change. Scheduling, idle probing, and explicit server selection are unchanged.

## Validation

- Parsed the default solver configuration and confirmed node030-node032 and node035 are absent while adjacent nodes remain present.
- Parsed all four modified workflow YAML files with PyYAML BaseLoader.
- Ran Python bytecode compilation for the modified solver executor and CLI.
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default distributed server list to include the correct node ranges.
  * Aligned performance and solve workflow descriptions with the revised server defaults.
  * Preserved existing server nodes while adding the previously omitted nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->