### PR TITLE
bpu: Partition SMT predictor storage by thread

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -50,6 +50,28 @@ def setDualFrontendProbeParams(system):
         cpu.branchPred.microtage.usingS3Pred = False
 
 
+def setTidPartitionedPredictorParams(system):
+    for cpu in system.cpu:
+        # RTL-oriented capacity model: large predictor tables are split into
+        # two disjoint tid-owned halves. Prediction remains ideal dual-ported,
+        # and resolve/commit training keeps the existing timing model.
+        for predictor in (
+            cpu.branchPred.abtb,
+            cpu.branchPred.microtage,
+            cpu.branchPred.mbtb,
+            cpu.branchPred.tage,
+            cpu.branchPred.ittage,
+            cpu.branchPred.mgsc,
+        ):
+            predictor.smtTidPartitioned = True
+
+        # The RTL implementation can afford to duplicate the small uBTB.
+        # Double the physical model before splitting it so each thread keeps
+        # the original 32-entry capacity.
+        cpu.branchPred.ubtb.numEntries = 64
+        cpu.branchPred.ubtb.smtTidPartitioned = True
+
+
 if __name__ == '__m5_main__':
     FutureClass = None
 
@@ -76,6 +98,7 @@ if __name__ == '__m5_main__':
     test_sys = build_xiangshan_system(args)
     setSharedLSQParams(args, test_sys)
     setDualFrontendProbeParams(test_sys)
+    setTidPartitionedPredictorParams(test_sys)
 
     root = Root(full_system=True, system=test_sys)
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -976,6 +976,9 @@ class TimedBaseBTBPredictor(SimObject):
     numDelay = Param.Unsigned(1000, "Number of bubbles to put on a prediction")
     resolvedUpdate = Param.Bool(False, "Enable resolved update, no need to wait until commit")
     enabled = Param.Bool(True, "Enable this predictor component")
+    smtTidPartitioned = Param.Bool(
+        False,
+        "Partition predictor storage equally by tid in SMT mode")
 
 class MBTB(TimedBaseBTBPredictor):
     type = 'MBTB'

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -437,7 +437,7 @@ AheadBTB::lookupSingleBlock(Addr block_pc, ThreadID tid, uint8_t asidHash,
     }
     auto &state = threadState(tid);
     state.currentLookupIndexValid = false;
-    Addr btb_idx = getIndex(block_pc, asidHash, indexPhrHash);
+    Addr btb_idx = getIndex(block_pc, asidHash, tid, indexPhrHash);
     auto btb_set = btb[btb_idx];
     assert(btb_idx < numSets);
     // AheadBTB always uses ahead-pipelined implementation:
@@ -835,7 +835,7 @@ AheadBTB::update(const FetchTarget &stream)
         // Before the ahead pipeline fills, retain the legacy PC-only fallback.
         Addr btb_idx = meta->lookupIndexValid
             ? meta->lookupIndex
-            : getIndex(previousPC, stream.asidHash);
+            : getIndex(previousPC, stream.asidHash, stream.tid);
         entry.source = getComponentIdx(); // mark the entry source as AheadBTB
         updateBTBEntry(btb_idx, btb_tag, entry, stream.exeBranchInfo, stream.exeTaken);
     }

--- a/src/cpu/pred/btb/abtb.cc
+++ b/src/cpu/pred/btb/abtb.cc
@@ -412,10 +412,11 @@ AheadBTB::refreshPredictionMeta(Addr startAddr,
                                 const boost::dynamic_bitset<> &history,
                                 FullBTBPrediction &pred)
 {
-    (void)history;
     auto &state = threadState(pred.tid);
     state.meta = std::make_shared<BTBMeta>();
-    auto found_entries = lookupNoSideEffect(startAddr);
+    const Addr indexPhrHash = foldAbtbPhrHash(history);
+    auto found_entries = lookupNoSideEffect(
+        startAddr, pred.tid, pred.asidHash, indexPhrHash);
     auto processed_entries = processEntriesNoSideEffect(found_entries, startAddr);
     for (const auto &entry : processed_entries) {
         state.meta->hit_entries.push_back(BTBEntry(entry));
@@ -490,22 +491,24 @@ AheadBTB::lookupSingleBlock(Addr block_pc, ThreadID tid, uint8_t asidHash,
 }
 
 std::vector<AheadBTB::TickedBTBEntry>
-AheadBTB::lookupSingleBlockNoSideEffect(Addr block_pc) const
+AheadBTB::lookupSingleBlockNoSideEffect(Addr block_pc, ThreadID tid,
+                                        uint8_t asidHash,
+                                        Addr indexPhrHash) const
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
         return res;
     }
 
-    Addr btb_idx = getIndex(block_pc, 0);
+    Addr btb_idx = getIndex(block_pc, asidHash, tid, indexPhrHash);
     auto btb_set = btb[btb_idx];
     assert(btb_idx < numSets);
 
-    const auto &state = threadState(0);
+    const auto &state = threadState(tid);
     auto queued_sets = state.aheadReadBtbEntries;
     queued_sets.push(std::make_tuple(block_pc, btb_idx, btb_set));
 
-    Addr tag_curStartpc = getTag(block_pc, 0);
+    Addr tag_curStartpc = getTag(block_pc, asidHash);
     BTBSet set;
     if (queued_sets.size() >= aheadPipelinedStages + 1) {
         assert(queued_sets.size() == aheadPipelinedStages + 1);
@@ -538,14 +541,17 @@ AheadBTB::lookup(Addr block_pc, ThreadID tid, uint8_t asidHash,
 }
 
 std::vector<AheadBTB::TickedBTBEntry>
-AheadBTB::lookupNoSideEffect(Addr block_pc) const
+AheadBTB::lookupNoSideEffect(Addr block_pc, ThreadID tid,
+                             uint8_t asidHash,
+                             Addr indexPhrHash) const
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
         return res;
     }
 
-    return lookupSingleBlockNoSideEffect(block_pc);
+    return lookupSingleBlockNoSideEffect(
+        block_pc, tid, asidHash, indexPhrHash);
 }
 
 

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -249,7 +249,7 @@ class AheadBTB : public TimedBaseBTBPredictor
         return folded & mask(AbtbHashBits);
     }
 
-    inline Addr getIndex(Addr instPC, uint8_t asidHash, ThreadID tid = 0,
+    inline Addr getIndex(Addr instPC, uint8_t asidHash, ThreadID tid,
                          Addr phrHash = 0) const {
         Addr baseIndex = (instPC >> idxShiftAmt) & idxMask;
         baseIndex ^= phrHash & idxMask;
@@ -265,7 +265,9 @@ class AheadBTB : public TimedBaseBTBPredictor
      *  @return Returns the tag bits.
      */
     inline Addr getTag(Addr instPC, uint8_t asidHash) const {
-        Addr baseTag = (instPC >> tagShiftAmt) & tagMask;
+        const unsigned shift = tagShiftAmt -
+            (usesTidPartitionedStorage() ? 1 : 0);
+        Addr baseTag = (instPC >> shift) & tagMask;
         return injectAsidHashIntoTag(baseTag, tagBits, asidHash);
     }
 
@@ -426,7 +428,9 @@ class AheadBTB : public TimedBaseBTBPredictor
     std::vector<TickedBTBEntry> lookup(Addr block_pc, ThreadID tid,
                                        uint8_t asidHash,
                                        Addr indexPhrHash);
-    std::vector<TickedBTBEntry> lookupNoSideEffect(Addr block_pc) const;
+    std::vector<TickedBTBEntry> lookupNoSideEffect(
+        Addr block_pc, ThreadID tid, uint8_t asidHash,
+        Addr indexPhrHash) const;
 
     /** Helper function to lookup entries in a single block
      * @param block_pc The aligned PC to lookup
@@ -435,7 +439,9 @@ class AheadBTB : public TimedBaseBTBPredictor
     std::vector<TickedBTBEntry> lookupSingleBlock(Addr block_pc, ThreadID tid,
                                                   uint8_t asidHash,
                                                   Addr indexPhrHash);
-    std::vector<TickedBTBEntry> lookupSingleBlockNoSideEffect(Addr block_pc) const;
+    std::vector<TickedBTBEntry> lookupSingleBlockNoSideEffect(
+        Addr block_pc, ThreadID tid, uint8_t asidHash,
+        Addr indexPhrHash) const;
 
     /** The BTB structure:
      *  - Organized as numSets sets

--- a/src/cpu/pred/btb/abtb.hh
+++ b/src/cpu/pred/btb/abtb.hh
@@ -249,11 +249,13 @@ class AheadBTB : public TimedBaseBTBPredictor
         return folded & mask(AbtbHashBits);
     }
 
-    inline Addr getIndex(Addr instPC, uint8_t asidHash,
+    inline Addr getIndex(Addr instPC, uint8_t asidHash, ThreadID tid = 0,
                          Addr phrHash = 0) const {
         Addr baseIndex = (instPC >> idxShiftAmt) & idxMask;
         baseIndex ^= phrHash & idxMask;
-        return xorAsidHashIntoIndex(baseIndex, floorLog2(numSets), asidHash);
+        Addr index = xorAsidHashIntoIndex(
+            baseIndex, floorLog2(numSets), asidHash);
+        return partitionIndex(index, numSets, tid);
     }
 
     /** Returns the tag bits of a given address.

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -266,7 +266,9 @@ BTBITTAGE::refreshPredictionMeta(Addr stream_start,
     lookupTags.clear();
     bitset useful_mask(numPredictors, false);
     for (int i = 0; i < numPredictors; ++i) {
-        Addr index = getTageIndex(stream_start, i, state.indexFoldedHist[i].get(), pred.asidHash);
+        Addr index = getTageIndex(
+            stream_start, i, state.indexFoldedHist[i].get(),
+            pred.asidHash, pred.tid);
         Addr tag = getTageTag(stream_start, i, state.tagFoldedHist[i].get(),
                               state.altTagFoldedHist[i].get(), pred.asidHash);
         auto &entry = tageTable[i][index];

--- a/src/cpu/pred/btb/btb_ittage.cc
+++ b/src/cpu/pred/btb/btb_ittage.cc
@@ -61,7 +61,8 @@ ittageStats(this, p.numPredictors)
             state.altTagFoldedHist.emplace_back(
                 (int)histLengths[i], (int)tableTagBits[i] - 1, (int)16);
             state.indexFoldedHist.emplace_back(
-                (int)histLengths[i], (int)tableIndexBits[i], (int)16);
+                (int)histLengths[i],
+                (int)partitionIndexBits(tableIndexBits[i]), (int)16);
         }
     }
     // useAlt.resize(128);
@@ -214,7 +215,8 @@ BTBITTAGE::putPCHistory(Addr stream_start, const bitset &history, std::vector<Fu
     // all btb entries should use the same lookup result
     // but each btb entry can use prediction from different tables
     for (int i = 0; i < numPredictors; ++i) {
-        Addr index = getTageIndex(stream_start, i, state.indexFoldedHist[i].get(), asidHash);
+        Addr index = getTageIndex(
+            stream_start, i, state.indexFoldedHist[i].get(), asidHash, tid);
         Addr tag = getTageTag(stream_start, i, state.tagFoldedHist[i].get(),
                               state.altTagFoldedHist[i].get(), asidHash);
         auto &entry = tageTable[i][index];
@@ -314,6 +316,8 @@ BTBITTAGE::refreshPredictionMeta(Addr stream_start,
 void
 BTBITTAGE::update(const FetchTarget &stream)
 {
+    int &resetCnt = usesTidPartitionedStorage() ?
+        usefulResetCntByThread[stream.tid] : usefulResetCnt;
     if (debugPC == stream.startPC || debugPC2 == stream.startPC) {
         debugFlag = true;
     }
@@ -420,27 +424,31 @@ BTBITTAGE::update(const FetchTarget &stream)
         bool canAllocate = num_tables_can_allocate > 0;
         if (needToAllocate) {
             if (canAllocate) {
-                usefulResetCnt -= 1;
-                if (usefulResetCnt <= 0) {
-                    usefulResetCnt = 0;
+                resetCnt -= 1;
+                if (resetCnt <= 0) {
+                    resetCnt = 0;
                 }
-                DPRINTF(ITTAGE, "can allocate, usefulResetCnt %d\n", usefulResetCnt);
+                DPRINTF(ITTAGE, "can allocate, usefulResetCnt %d\n", resetCnt);
             } else {
-                usefulResetCnt += 1;
-                if (usefulResetCnt >= 256) {
-                    usefulResetCnt = 256;
+                resetCnt += 1;
+                if (resetCnt >= 256) {
+                    resetCnt = 256;
                 }
-                DPRINTF(ITTAGE, "can not allocate, usefulResetCnt %d\n", usefulResetCnt);
+                DPRINTF(ITTAGE, "can not allocate, usefulResetCnt %d\n", resetCnt);
             }
-            if (usefulResetCnt == 256) {
+            if (resetCnt == 256) {
                 DPRINTF(ITTAGE, "reset useful bit of all entries\n");
                 for (auto &table : tageTable) {
-                    for (auto &entry : table) {
-                        entry.useful = 0;
+                    const unsigned begin = partitionBegin(
+                        table.size(), stream.tid);
+                    const unsigned end = partitionEnd(
+                        table.size(), stream.tid);
+                    for (unsigned index = begin; index < end; ++index) {
+                        table[index].useful = 0;
                     }
                 }
                 ittageStats.updateResetU++;
-                usefulResetCnt = 0;
+                resetCnt = 0;
             }
         }
 
@@ -471,7 +479,9 @@ BTBITTAGE::update(const FetchTarget &stream)
                 unsigned startTable = main_found ? main_info.table + 1 : 0;
 
                 for (int ti = startTable; ti < numPredictors; ti++) {
-                    Addr newIndex = getTageIndex(startAddr, ti, updateIndexFoldedHist[ti].get(), stream.asidHash);
+                    Addr newIndex = getTageIndex(
+                        startAddr, ti, updateIndexFoldedHist[ti].get(),
+                        stream.asidHash, stream.tid);
                     Addr newTag = getTageTag(startAddr, ti, updateTagFoldedHist[ti].get(),
                                              updateAltTagFoldedHist[ti].get(), stream.asidHash);
                     assert(newIndex < tageTable[ti].size());
@@ -533,20 +543,24 @@ BTBITTAGE::getTageTag(Addr pc, int t, uint8_t asidHash)
 }
 
 Addr
-BTBITTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist, uint8_t asidHash)
+BTBITTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist,
+                        uint8_t asidHash, ThreadID tid)
 {
-    // Create mask for tableIndexBits[t]
-    uint64_t mask = ((1ULL << tableIndexBits[t]) - 1);
+    const unsigned localIndexBits = partitionIndexBits(tableIndexBits[t]);
+    uint64_t mask = ((1ULL << localIndexBits) - 1);
 
     // Extract lower bits of PC and XOR with folded history
     uint64_t pcBits = (pc >> floorLog2(blockSize));
-    return xorAsidHashIntoIndex((pcBits ^ foldedHist) & mask, tableIndexBits[t], asidHash);
+    Addr localIndex = xorAsidHashIntoIndex(
+        (pcBits ^ foldedHist) & mask, localIndexBits, asidHash);
+    return partitionIndex(localIndex, tableSizes[t], tid);
 }
 
 Addr
-BTBITTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash)
+BTBITTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash, ThreadID tid)
 {
-    return getTageIndex(pc, t, historyState(0).indexFoldedHist[t].get(), asidHash);
+    return getTageIndex(pc, t, historyState(tid).indexFoldedHist[t].get(),
+                        asidHash, tid);
 }
 
 bool

--- a/src/cpu/pred/btb/btb_ittage.hh
+++ b/src/cpu/pred/btb/btb_ittage.hh
@@ -1,6 +1,7 @@
 #ifndef __CPU_PRED_BTB_ITTAGE_HH__
 #define __CPU_PRED_BTB_ITTAGE_HH__
 
+#include <array>
 #include <deque>
 #include <map>
 #include <memory>
@@ -132,10 +133,12 @@ class BTBITTAGE : public TimedBaseBTBPredictor
                       IndirectTargets& results, ThreadID tid, uint8_t asidHash);
 
     // use blockPC
-    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0);
+    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0,
+                      ThreadID tid = 0);
 
     // use blockPC (uint64_t version for performance)
-    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist, uint8_t asidHash = 0);
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist,
+                      uint8_t asidHash = 0, ThreadID tid = 0);
 
     // use blockPC
     Addr getTageTag(Addr pc, int table, uint8_t asidHash = 0);
@@ -199,6 +202,7 @@ class BTBITTAGE : public TimedBaseBTBPredictor
     bool satDecrement(int min, short &counter);
 
     int usefulResetCnt;
+    std::array<int, MaxThreads> usefulResetCntByThread{};
 
 #ifdef UNIT_TEST
     typedef uint64_t Scalar;

--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -69,7 +69,8 @@ BTBMGSC::initStorage()
         auto &state = threadHistory[tid];
         for (unsigned int i = 0; i < bwTableNum; ++i) {
             state.indexBwFoldedHist.emplace_back(
-                bwHistLen[i], bwTableIdxWidth - numCtrsPerLineBits, 16);
+                bwHistLen[i], partitionIndexBits(
+                    bwTableIdxWidth - numCtrsPerLineBits), 16);
         }
     }
     bwIndex.resize(bwTableNum);
@@ -81,7 +82,8 @@ BTBMGSC::initStorage()
         for (unsigned int i = 0; i < lTableNum; ++i) {
             for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
                 state.indexLFoldedHist[k].push_back(LocalFoldedHist(
-                    lHistLen[i], lTableIdxWidth - numCtrsPerLineBits, 16));
+                    lHistLen[i], partitionIndexBits(
+                        lTableIdxWidth - numCtrsPerLineBits), 16));
             }
         }
     }
@@ -95,7 +97,8 @@ BTBMGSC::initStorage()
             assert(static_cast<unsigned>(iHistLen[i]) < 63);
             assert(pow2(static_cast<unsigned>(iHistLen[i])) <= iTableSize);
             state.indexIFoldedHist.emplace_back(
-                iHistLen[i], iTableIdxWidth - numCtrsPerLineBits, 16);
+                iHistLen[i], partitionIndexBits(
+                    iTableIdxWidth - numCtrsPerLineBits), 16);
         }
     }
     iIndex.resize(iTableNum);
@@ -106,7 +109,8 @@ BTBMGSC::initStorage()
         for (unsigned int i = 0; i < gTableNum; ++i) {
             assert(gTable.size() >= gTableNum);
             state.indexGFoldedHist.emplace_back(
-                gHistLen[i], gTableIdxWidth - numCtrsPerLineBits, 16);
+                gHistLen[i], partitionIndexBits(
+                    gTableIdxWidth - numCtrsPerLineBits), 16);
         }
     }
     gIndex.resize(gTableNum);
@@ -117,7 +121,8 @@ BTBMGSC::initStorage()
         for (unsigned int i = 0; i < pTableNum; ++i) {
             assert(pTable.size() >= pTableNum);
             state.indexPFoldedHist.emplace_back(
-                pHistLen[i], pTableIdxWidth - numCtrsPerLineBits, 2);
+                pHistLen[i], partitionIndexBits(
+                    pTableIdxWidth - numCtrsPerLineBits), 2);
         }
     }
     pIndex.resize(pTableNum);
@@ -419,7 +424,8 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     // Calculate indices for all tables
     for (unsigned int i = 0; i < bwTableNum; ++i) {
         bwIndex[i] = getHistIndex(startPC, bwTableIdxWidth - numCtrsPerLineBits,
-                                  state.indexBwFoldedHist[i].get(), asidHash);
+                                  state.indexBwFoldedHist[i].get(), asidHash,
+                                  tid);
     }
 
     const Addr localHistoryIndex =
@@ -427,7 +433,7 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
     for (unsigned int i = 0; i < lTableNum; ++i) {
         lIndex[i] = getHistIndex(startPC, lTableIdxWidth - numCtrsPerLineBits,
                                  state.indexLFoldedHist[localHistoryIndex][i].get(),
-                                 asidHash);
+                                 asidHash, tid);
     }
     // std::string buf;
     // boost::to_string(indexLFoldedHist[getPcIndex(startPC, log2(numEntriesFirstLocalHistories))][0].getAsBitset(), buf);
@@ -435,22 +441,26 @@ BTBMGSC::generateSinglePrediction(const BTBEntry &btb_entry, const Addr &startPC
 
     for (unsigned int i = 0; i < iTableNum; ++i) {
         iIndex[i] = getHistIndex(startPC, iTableIdxWidth - numCtrsPerLineBits,
-                                 state.indexIFoldedHist[i].get(), asidHash);
+                                 state.indexIFoldedHist[i].get(), asidHash,
+                                 tid);
     }
 
     for (unsigned int i = 0; i < gTableNum; ++i) {
         gIndex[i] = getHistIndex(startPC, gTableIdxWidth - numCtrsPerLineBits,
-                                 state.indexGFoldedHist[i].get(), asidHash);
+                                 state.indexGFoldedHist[i].get(), asidHash,
+                                 tid);
     }
 
     for (unsigned int i = 0; i < pTableNum; ++i) {
         pIndex[i] = getHistIndex(startPC, pTableIdxWidth - numCtrsPerLineBits,
-                                 state.indexPFoldedHist[i].get(), asidHash);
+                                 state.indexPFoldedHist[i].get(), asidHash,
+                                 tid);
     }
 
     for (unsigned int i = 0; i < biasTableNum; ++i) {
         biasIndex[i] = getBiasIndex(startPC, biasTableIdxWidth - numCtrsPerLineBits, tage_info.tage_main_taken,
-                                    tage_info.tage_pred_conf_low, asidHash);
+                                    tage_info.tage_pred_conf_low, asidHash,
+                                    tid);
     }
 
     int bw_percsum = enableBwTable ? calculatePercsum(bwTable, bwIndex, bwTableNum, btb_entry.pc) : 0;
@@ -1064,29 +1074,34 @@ BTBMGSC::updateCounter<uint64_t>(bool taken, unsigned width, uint64_t &counter);
 
 Addr
 BTBMGSC::getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist,
-                      uint8_t asidHash)
+                      uint8_t asidHash, ThreadID tid)
 {
-    // Create mask to limit result size to tableIndexBits
-    Addr mask = (1ULL << tableIndexBits) - 1;
+    const unsigned localIndexBits = partitionIndexBits(tableIndexBits);
+    Addr mask = (1ULL << localIndexBits) - 1;
 
     // Extract lower bits of PC and XOR with folded history directly
     Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
     Addr foldedBits = foldedHist & mask;
 
-    return xorAsidHashIntoIndex(pcBits ^ foldedBits, tableIndexBits, asidHash);
+    const Addr localIndex = xorAsidHashIntoIndex(
+        pcBits ^ foldedBits, localIndexBits, asidHash);
+    return partitionIndex(localIndex, 1ULL << tableIndexBits, tid);
 }
 
 Addr
 BTBMGSC::getBiasIndex(Addr pc, unsigned tableIndexBits, bool lowbit0,
-                      bool lowbit1, uint8_t asidHash)
+                      bool lowbit1, uint8_t asidHash, ThreadID tid)
 {
-    // Create mask for tableIndexBits-2 to extract PC bits
-    Addr mask = (1ULL << (tableIndexBits - 2)) - 1;
+    const unsigned localIndexBits = partitionIndexBits(tableIndexBits);
+    assert(localIndexBits >= 2);
+    Addr mask = (1ULL << (localIndexBits - 2)) - 1;
 
     // Extract lower bits of PC directly and combine with low bits
     Addr pcBits = (pc >> floorLog2(blockSize)) & mask;
     unsigned index = (pcBits << 2) + (lowbit1 << 1) + lowbit0;
-    return xorAsidHashIntoIndex(index, tableIndexBits, asidHash);
+    const Addr localIndex = xorAsidHashIntoIndex(
+        index, localIndexBits, asidHash);
+    return partitionIndex(localIndex, 1ULL << tableIndexBits, tid);
 }
 
 Addr

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -268,11 +268,11 @@ class BTBMGSC : public TimedBaseBTBPredictor
 
     // Calculate MGSC history index with folded history
     Addr getHistIndex(Addr pc, unsigned tableIndexBits, uint64_t foldedHist,
-                      uint8_t asidHash = 0);
+                      uint8_t asidHash = 0, ThreadID tid = 0);
 
     // Calculate MGSC bias index
     Addr getBiasIndex(Addr pc, unsigned tableIndexBits, bool lowbit0, bool lowbit1,
-                      uint8_t asidHash = 0);
+                      uint8_t asidHash = 0, ThreadID tid = 0);
 
     // Get offset within a block for a given PC
     Addr getOffset(Addr pc) { return (pc & (blockSize - 1)) >> 1; }

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -183,7 +183,10 @@ tageStats(this, p.numPredictors, p.numBanks)
             auto &state = threadHistory[tid];
             state.tagFoldedHist.emplace_back((int)histLengths[i], (int)tableTagBits[i], 16, historyType);
             state.altTagFoldedHist.emplace_back((int)histLengths[i], (int)tableTagBits[i] - 1, 16, historyType);
-            state.indexFoldedHist.emplace_back((int)histLengths[i], (int)tableIndexBits[i], 16, historyType);
+            state.indexFoldedHist.emplace_back(
+                (int)histLengths[i],
+                (int)partitionIndexBits(tableIndexBits[i]), 16,
+                historyType);
         }
     }
     usefulResetCnt = 0;
@@ -317,8 +320,10 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
-        Addr index = predMeta ? getTageIndex(startPC, i, predMeta->indexFoldedHist[i].get(), asidHash)
-                          : getTageIndex(startPC, i, state.indexFoldedHist[i].get(), asidHash);
+        Addr index = predMeta ? getTageIndex(
+            startPC, i, predMeta->indexFoldedHist[i].get(), asidHash, tid)
+                              : getTageIndex(
+            startPC, i, state.indexFoldedHist[i].get(), asidHash, tid);
         Addr tag = predMeta ? getTageTag(startPC, i,
                             predMeta->tagFoldedHist[i].get(), predMeta->altTagFoldedHist[i].get(),
                             position, asidHash)
@@ -782,7 +787,10 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  unsigned start_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
+                                 ThreadID tid,
                                  AllocationTraceInfo &allocInfo) {
+    int &resetCnt = usesTidPartitionedStorage() ?
+        usefulResetCntByThread[tid] : usefulResetCnt;
     // Match RTL victim priority:
     // 1) invalid way
     // 2) weak and not-useful way
@@ -792,7 +800,8 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
-        Addr newIndex = getTageIndex(startPC, ti, meta->indexFoldedHist[ti].get(), asidHash);
+        Addr newIndex = getTageIndex(
+            startPC, ti, meta->indexFoldedHist[ti].get(), asidHash, tid);
         Addr newTag = getTageTag(startPC, ti,
             meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position, asidHash);
 
@@ -845,20 +854,22 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
             allocInfo.victimPC = victim.pc;
             set[selected_way] = TageEntry(newTag, newCounter, entry.pc); // u = 0 default
             tageStats.updateAllocSuccess++;
-            usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
+            resetCnt = resetCnt <= 0 ? 0 : resetCnt - 1;
             return true;
         }
         tageStats.updateAllocFailure++;
-        usefulResetCnt++;
+        resetCnt++;
     }
 
-    if (usefulResetCnt >= 256) {
-        usefulResetCnt = 0;
+    if (resetCnt >= 256) {
+        resetCnt = 0;
         tageStats.updateResetU++;
         DPRINTF(TAGE, "reset useful bit of all entries\n");
         for (auto &table : tageTable) {
-            for (auto &set : table) {
-                for (auto &way : set) {
+            const unsigned begin = partitionBegin(table.size(), tid);
+            const unsigned end = partitionEnd(table.size(), tid);
+            for (unsigned index = begin; index < end; ++index) {
+                for (auto &way : table[index]) {
                     way.useful = false;
                 }
             }
@@ -995,6 +1006,7 @@ BTBTAGE::update(const FetchTarget &stream) {
             }
             handleNewEntryAllocation(startAddr, btb_entry, actual_taken,
                                      start_table, predMeta, stream.asidHash,
+                                     stream.tid,
                                      allocInfo);
         }
 
@@ -1109,7 +1121,7 @@ BTBTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHist,
     Addr mask = (1ULL << tableTagBits[t]) - 1;
 
     unsigned pcShift = enableBankConflict ? indexShift : bankBaseShift;
-    pcShift += tableIndexBits[t] - 1;   // since tableIndexBits = log(2048) = 11, RTL is 10
+    pcShift += partitionIndexBits(tableIndexBits[t]) - 1;
     Addr pcBits = (pc >> pcShift) & mask;
 
     // Extract and prepare folded history bits
@@ -1132,22 +1144,26 @@ BTBTAGE::getTageTag(Addr pc, int t, Addr position, uint8_t asidHash) const
 }
 
 Addr
-BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist, uint8_t asidHash) const
+BTBTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist,
+                      uint8_t asidHash, ThreadID tid) const
 {
-    // Create mask for tableIndexBits[t] to limit result size
-    Addr mask = (1ULL << tableIndexBits[t]) - 1;
+    const unsigned localIndexBits = partitionIndexBits(tableIndexBits[t]);
+    Addr mask = (1ULL << localIndexBits) - 1;
 
     const unsigned pcShift = enableBankConflict ? indexShift : bankBaseShift;
     Addr pcBits = (pc >> pcShift) & mask;
     Addr foldedBits = foldedHist & mask;
 
-    return xorAsidHashIntoIndex(pcBits ^ foldedBits, tableIndexBits[t], asidHash) % tableSizes[t];
+    Addr localIndex = xorAsidHashIntoIndex(
+        pcBits ^ foldedBits, localIndexBits, asidHash);
+    return partitionIndex(localIndex, tableSizes[t], tid);
 }
 
 Addr
-BTBTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash) const
+BTBTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash, ThreadID tid) const
 {
-    return getTageIndex(pc, t, historyState(0).indexFoldedHist[t].get(), asidHash);
+    return getTageIndex(pc, t, historyState(tid).indexFoldedHist[t].get(),
+                        asidHash, tid);
 }
 
 bool

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -1,6 +1,7 @@
 #ifndef __CPU_PRED_BTB_TAGE_HH__
 #define __CPU_PRED_BTB_TAGE_HH__
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -195,10 +196,12 @@ class BTBTAGE : public TimedBaseBTBPredictor
                     CondTakens& results, ThreadID tid, uint8_t asidHash);
 
     // Calculate TAGE index for a given PC and table
-    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0) const;
+    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0,
+                      ThreadID tid = 0) const;
 
     // Calculate TAGE index with folded history (uint64_t version for performance)
-    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist, uint8_t asidHash = 0) const;
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist,
+                      uint8_t asidHash = 0, ThreadID tid = 0) const;
 
     // Calculate TAGE tag for a given PC and table
     // position: branch position within the block (xored into tag like RTL)
@@ -283,6 +286,7 @@ class BTBTAGE : public TimedBaseBTBPredictor
 
     // useful bit reset counter, when cnt >= 256, reset useful bit of all entries
     int usefulResetCnt{0};
+    std::array<int, MaxThreads> usefulResetCntByThread{};
 
     // Check if a tag matches
     bool matchTag(Addr expected, Addr found) const;
@@ -496,6 +500,7 @@ private:
                                  unsigned main_table,
                                  std::shared_ptr<TageMeta> meta,
                                  uint8_t asidHash,
+                                 ThreadID tid,
                                  AllocationTraceInfo &allocInfo);
 
 

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -211,7 +211,8 @@ UBTB::refreshPredictionMeta(Addr startAddr,
     assert(pred.tid < threadMeta.size());
     threadMeta[pred.tid] = std::make_shared<UBTBMeta>();
     auto &meta = threadMeta[pred.tid];
-    meta->hit_entry = lookupNoSideEffect(startAddr);
+    meta->hit_entry = lookupNoSideEffect(
+        startAddr, pred.tid, pred.asidHash);
 }
 
 UBTB::UBTBIter
@@ -254,19 +255,27 @@ UBTB::lookup(Addr startAddr, ThreadID tid, uint8_t asidHash)
 }
 
 UBTB::TickedUBTBEntry
-UBTB::lookupNoSideEffect(Addr startAddr) const
+UBTB::lookupNoSideEffect(Addr startAddr, ThreadID tid,
+                         uint8_t asidHash) const
 {
     if (startAddr & 0x1) {
         return TickedUBTBEntry();
     }
 
-    Addr current_tag = getTag(startAddr, 0);
-    auto it = std::find_if(ubtb.begin(), ubtb.end(),
-                           [current_tag](const TickedUBTBEntry &way) {
-                               return way.valid && way.tag == current_tag;
+    Addr current_tag = getTag(startAddr, asidHash);
+    Addr block_end = (startAddr + predictWidth) &
+        ~mask(floorLog2(predictWidth) - 1);
+    auto range_begin = ubtb.begin() + partitionBegin(numEntries, tid);
+    auto range_end = ubtb.begin() + partitionEnd(numEntries, tid);
+    auto it = std::find_if(range_begin, range_end,
+                           [current_tag, startAddr, block_end]
+                           (const TickedUBTBEntry &way) {
+                               return way.valid && way.tag == current_tag &&
+                                      way.pc >= startAddr &&
+                                      way.pc < block_end;
                            });
 
-    return it != ubtb.end() ? *it : TickedUBTBEntry();
+    return it != range_end ? *it : TickedUBTBEntry();
 }
 
 

--- a/src/cpu/pred/btb/btb_ubtb.cc
+++ b/src/cpu/pred/btb/btb_ubtb.cc
@@ -189,7 +189,7 @@ UBTB::putPCHistory(Addr startAddr, const boost::dynamic_bitset<> &history, std::
     assert(tid < threadMeta.size());
     threadMeta[tid] = std::make_shared<UBTBMeta>();
     const uint8_t asidHash = stagePreds.empty() ? 0 : stagePreds.front().asidHash;
-    auto it = lookup(startAddr, asidHash);
+    auto it = lookup(startAddr, tid, asidHash);
     auto& entry = threadMeta[tid]->hit_entry;
     entry = (it != ubtb.end()) ? *it : TickedUBTBEntry();
 
@@ -215,7 +215,7 @@ UBTB::refreshPredictionMeta(Addr startAddr,
 }
 
 UBTB::UBTBIter
-UBTB::lookup(Addr startAddr, uint8_t asidHash)
+UBTB::lookup(Addr startAddr, ThreadID tid, uint8_t asidHash)
 {
     if (startAddr & 0x1) {
         return ubtb.end();  // ignore false hit when lowest bit is 1
@@ -226,20 +226,21 @@ UBTB::lookup(Addr startAddr, uint8_t asidHash)
 
     DPRINTF(UBTB, "UBTB: Doing tag comparison for tag %#lx\n", current_tag);
 
-    auto it = std::find_if(ubtb.begin(), ubtb.end(),
+    auto [rangeBegin, rangeEnd] = threadRange(tid);
+    auto it = std::find_if(rangeBegin, rangeEnd,
                            [current_tag, startAddr, block_end](const TickedUBTBEntry &way) {
                                return way.valid && way.tag == current_tag &&
                                       way.pc >= startAddr && way.pc < block_end;
                            });
 
-    if (it != ubtb.end()) {
+    if (it != rangeEnd) {
         // Found a hit - verify no duplicates
-        auto duplicate = std::find_if(std::next(it), ubtb.end(),
+        auto duplicate = std::find_if(std::next(it), rangeEnd,
                                       [current_tag, startAddr, block_end](const TickedUBTBEntry &way) {
             return way.valid && way.tag == current_tag &&
                    way.pc >= startAddr && way.pc < block_end;
         });
-        if (duplicate != ubtb.end()) {
+        if (duplicate != rangeEnd) {
             DPRINTF(UBTB, "UBTB: Multiple hits found in uBTB for the same tag %#lx\n", current_tag);
             duplicate->valid = false;  // invalidate the duplicate entry
         }
@@ -249,7 +250,7 @@ UBTB::lookup(Addr startAddr, uint8_t asidHash)
         std::make_heap(mruList.begin(), mruList.end(), older());
     }
 
-    return it;
+    return it == rangeEnd ? ubtb.end() : it;
 }
 
 UBTB::TickedUBTBEntry
@@ -298,17 +299,21 @@ UBTB::updateUsingS3Pred(FullBTBPrediction &s3Pred)
         ubtbStats.s3UpdateMisses++;
     }
     auto startAddr = s3Pred.bbStart;
-    UBTBIter oldEntryIter = lastPred[s3Pred.tid].hit_entry;
+    const ThreadID tid = s3Pred.tid;
+    UBTBIter oldEntryIter = lastPred[tid].hit_entry;
     takenEntry.source = getComponentIdx();
-    updateNewEntry(oldEntryIter, takenEntry, startAddr, s3Pred.asidHash);
+    updateNewEntry(oldEntryIter, takenEntry, startAddr, tid,
+                   s3Pred.asidHash);
 
 }
 
 
 
 void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry,
-                          const Addr startAddr, uint8_t asidHash)
+                          const Addr startAddr, ThreadID tid,
+                          uint8_t asidHash)
 {
+    auto [rangeBegin, rangeEnd] = threadRange(tid);
     //using the FB final taken branch to update uBTB
     if (oldEntryIter != ubtb.end()) {
         assert(oldEntryIter->valid); //lookup() should only return valid entry
@@ -330,7 +335,7 @@ void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry,
             // First try to find an invalid entry in the set
             bool foundInvalidEntry = false;
 
-            for (auto it = ubtb.begin(); it != ubtb.end(); ++it) {
+            for (auto it = rangeBegin; it != rangeEnd; ++it) {
                 if (!it->valid) {
                     toBeReplacedIter = it;
                     foundInvalidEntry = true;
@@ -342,8 +347,11 @@ void UBTB::updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry,
             // TODO: consider using LRU only among the entries with the least confidence(smallest uctr)
             if (!foundInvalidEntry) {
                 // Find the least recently used entry
-                std::make_heap(mruList.begin(), mruList.end(), older());
-                toBeReplacedIter = mruList.front();
+                toBeReplacedIter = std::min_element(
+                    rangeBegin, rangeEnd,
+                    [](const TickedUBTBEntry &a, const TickedUBTBEntry &b) {
+                        return a.tick < b.tick;
+                    });
             }
 
             // Replace the entry with the new prediction
@@ -385,13 +393,17 @@ UBTB::update(const FetchTarget &stream)
     Addr oldtag = getTag(startAddr, stream.asidHash);
     Addr block_end = (startAddr + predictWidth) & ~mask(floorLog2(predictWidth) - 1);
 
+    auto [rangeBegin, rangeEnd] = threadRange(stream.tid);
     UBTBIter oldEntryIter = ubtb.end();
 
     oldEntryIter = meta->hit_entry.valid ?
-                    std::find_if(ubtb.begin(), ubtb.end(), [oldtag, startAddr, block_end](const TickedUBTBEntry &e) {
+                    std::find_if(rangeBegin, rangeEnd, [oldtag, startAddr, block_end](const TickedUBTBEntry &e) {
                         return e.valid && e.tag == oldtag &&
                                e.pc >= startAddr && e.pc < block_end;
-                    }) : ubtb.end();
+                    }) : rangeEnd;
+    if (oldEntryIter == rangeEnd) {
+        oldEntryIter = ubtb.end();
+    }
 
     if (stream.exeTaken) {
         if (!pred_hit_entry.valid || pred_hit_entry != stream.exeBranchInfo) {
@@ -405,7 +417,8 @@ UBTB::update(const FetchTarget &stream)
     // Verify uBTB state
     assert(ubtb.size() <= numEntries);
     if (!usingS3Pred) {
-        updateNewEntry(oldEntryIter, takenEntry, startAddr, stream.asidHash);
+        updateNewEntry(oldEntryIter, takenEntry, startAddr, stream.tid,
+                       stream.asidHash);
     }
 }
 

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -244,7 +244,8 @@ class UBTB : public TimedBaseBTBPredictor
      * @return Iterator to the matching entry if found, or ubtb.end() if not found
      */
     UBTBIter lookup(Addr startAddr, ThreadID tid, uint8_t asidHash);
-    TickedUBTBEntry lookupNoSideEffect(Addr startAddr) const;
+    TickedUBTBEntry lookupNoSideEffect(Addr startAddr, ThreadID tid,
+                                       uint8_t asidHash) const;
 
     /** helper method called by putPCHistory: Check uBTB entry pc range and update statistics
      * @param entry The uBTB entry to check

--- a/src/cpu/pred/btb/btb_ubtb.hh
+++ b/src/cpu/pred/btb/btb_ubtb.hh
@@ -243,7 +243,7 @@ class UBTB : public TimedBaseBTBPredictor
      * @param startAddr The FB start address to look up
      * @return Iterator to the matching entry if found, or ubtb.end() if not found
      */
-    UBTBIter lookup(Addr startAddr, uint8_t asidHash);
+    UBTBIter lookup(Addr startAddr, ThreadID tid, uint8_t asidHash);
     TickedUBTBEntry lookupNoSideEffect(Addr startAddr) const;
 
     /** helper method called by putPCHistory: Check uBTB entry pc range and update statistics
@@ -269,7 +269,20 @@ class UBTB : public TimedBaseBTBPredictor
 
     //using the FB final taken branch to update uBTB
     void updateNewEntry(UBTBIter oldEntryIter, const BTBEntry &takenEntry,
-                        const Addr startAddr, uint8_t asidHash);
+                        const Addr startAddr, ThreadID tid,
+                        uint8_t asidHash);
+
+    std::pair<UBTBIter, UBTBIter> threadRange(ThreadID tid)
+    {
+        if (!usesTidPartitionedStorage()) {
+            return {ubtb.begin(), ubtb.end()};
+        }
+        assert(numEntries >= 2 && numEntries % 2 == 0);
+        assert(tid < 2);
+        const auto entriesPerThread = numEntries / 2;
+        auto begin = ubtb.begin() + tid * entriesPerThread;
+        return {begin, begin + entriesPerThread};
+    }
 
 
     /** The uBTB structure:

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -827,7 +827,8 @@ DecoupledBPUWithBTB::prepareTwoTakenTraining(ThreadID tid)
     const Addr startPC = thread.s0PC;
     const uint8_t asidHash = thread.finalPred.asidHash;
     auto &btbEntries = thread.twoTakenBTBEntries;
-    btbEntries = mbtb->getPredictedEntriesNoSideEffect(startPC, asidHash);
+    btbEntries = mbtb->getPredictedEntriesNoSideEffect(
+        startPC, tid, asidHash);
 
     CondTakens condTakens;
     condTakens.reserve(btbEntries.size());

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -350,9 +350,10 @@ MBTB::putPCHistory(Addr startAddr,
 }
 
 std::vector<BTBEntry>
-MBTB::getPredictedEntriesNoSideEffect(Addr startAddr, uint8_t asidHash) const
+MBTB::getPredictedEntriesNoSideEffect(Addr startAddr, ThreadID tid,
+                                      uint8_t asidHash) const
 {
-    auto found_entries = lookupNoSideEffect(startAddr, asidHash);
+    auto found_entries = lookupNoSideEffect(startAddr, tid, asidHash);
     auto processed_entries = processEntriesNoSideEffect(found_entries, startAddr);
 
     std::vector<BTBEntry> entries;
@@ -381,7 +382,8 @@ MBTB::refreshPredictionMeta(Addr startAddr,
     assert(pred.tid < threadMeta.size());
     threadMeta[pred.tid] = std::make_shared<BTBMeta>();
     auto &meta = threadMeta[pred.tid];
-    auto found_entries = lookupNoSideEffect(startAddr);
+    auto found_entries = lookupNoSideEffect(
+        startAddr, pred.tid, pred.asidHash);
     auto processed_entries = processEntriesNoSideEffect(found_entries, startAddr);
     for (const auto &entry : processed_entries) {
         meta->hit_entries.push_back(BTBEntry(entry));
@@ -424,7 +426,8 @@ MBTB::lookupSingleBlock(Addr block_pc, ThreadID tid, uint8_t asidHash)
 }
 
 std::vector<MBTB::TickedBTBEntry>
-MBTB::lookupSingleBlockNoSideEffect(Addr block_pc, uint8_t asidHash) const
+MBTB::lookupSingleBlockNoSideEffect(Addr block_pc, ThreadID tid,
+                                    uint8_t asidHash) const
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
@@ -434,7 +437,7 @@ MBTB::lookupSingleBlockNoSideEffect(Addr block_pc, uint8_t asidHash) const
     int sram_id = getSRAMId(block_pc);
     const auto& target_sram = (sram_id == 0) ? sram0 : sram1;
 
-    Addr btb_idx = getIndex(block_pc, asidHash);
+    Addr btb_idx = getIndex(block_pc, asidHash, tid);
     const auto& btb_set = target_sram[btb_idx];
     assert(btb_idx < numSets);
 
@@ -491,7 +494,8 @@ MBTB::lookup(Addr block_pc, ThreadID tid, uint8_t asidHash,
 }
 
 std::vector<MBTB::TickedBTBEntry>
-MBTB::lookupNoSideEffect(Addr block_pc, uint8_t asidHash) const
+MBTB::lookupNoSideEffect(Addr block_pc, ThreadID tid,
+                         uint8_t asidHash) const
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
@@ -499,9 +503,10 @@ MBTB::lookupNoSideEffect(Addr block_pc, uint8_t asidHash) const
     }
 
     Addr alignedPC = block_pc & ~(blockSize - 1);
-    res = lookupSingleBlockNoSideEffect(alignedPC, asidHash);
+    res = lookupSingleBlockNoSideEffect(alignedPC, tid, asidHash);
     auto nextBlockRes =
-        lookupSingleBlockNoSideEffect(alignedPC + blockSize, asidHash);
+        lookupSingleBlockNoSideEffect(
+            alignedPC + blockSize, tid, asidHash);
     res.insert(res.end(), nextBlockRes.begin(), nextBlockRes.end());
 
     if (victimCacheSize > 0) {

--- a/src/cpu/pred/btb/mbtb.cc
+++ b/src/cpu/pred/btb/mbtb.cc
@@ -97,6 +97,9 @@ MBTB::MBTB(const Params &p)
     if (!isPowerOf2(numEntries)) {
         fatal("BTB entries is not a power of 2!");
     }
+    if (usesTidPartitionedStorage() && victimCacheSize != 0) {
+        fatal("tid-partitioned mBTB requires its shared victim cache to be disabled");
+    }
 
     // Initialize dual SRAM BTB structure and MRU tracking
     sram0.resize(numSets);
@@ -334,7 +337,7 @@ MBTB::putPCHistory(Addr startAddr,
     threadMeta[tid] = std::make_shared<BTBMeta>();
     const uint8_t asidHash = stagePreds.empty() ? 0 : stagePreds.front().asidHash;
     // Lookup all matching entries in BTB
-    auto find_entries = lookup(startAddr, asidHash, threadMeta[tid]);
+    auto find_entries = lookup(startAddr, tid, asidHash, threadMeta[tid]);
 
     // Process BTB entries
     auto processed_entries = processEntries(find_entries, startAddr);
@@ -391,7 +394,7 @@ MBTB::refreshPredictionMeta(Addr startAddr,
  * @return Vector of matching BTB entries
  */
 std::vector<MBTB::TickedBTBEntry>
-MBTB::lookupSingleBlock(Addr block_pc, uint8_t asidHash)
+MBTB::lookupSingleBlock(Addr block_pc, ThreadID tid, uint8_t asidHash)
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
@@ -402,7 +405,7 @@ MBTB::lookupSingleBlock(Addr block_pc, uint8_t asidHash)
     auto& target_sram = (sram_id == 0) ? sram0 : sram1;
     auto& target_mru = (sram_id == 0) ? mru0 : mru1;
     
-    Addr btb_idx = getIndex(block_pc, asidHash);
+    Addr btb_idx = getIndex(block_pc, asidHash, tid);
     auto& btb_set = target_sram[btb_idx];
     assert(btb_idx < numSets);
 
@@ -448,7 +451,8 @@ MBTB::lookupSingleBlockNoSideEffect(Addr block_pc, uint8_t asidHash) const
 }
 
 std::vector<MBTB::TickedBTBEntry>
-MBTB::lookup(Addr block_pc, uint8_t asidHash, std::shared_ptr<BTBMeta> meta)
+MBTB::lookup(Addr block_pc, ThreadID tid, uint8_t asidHash,
+             std::shared_ptr<BTBMeta> meta)
 {
     std::vector<TickedBTBEntry> res;
     if (block_pc & 0x1) {
@@ -459,9 +463,9 @@ MBTB::lookup(Addr block_pc, uint8_t asidHash, std::shared_ptr<BTBMeta> meta)
     // Calculate 32B aligned address
     Addr alignedPC = block_pc & ~(blockSize - 1);
     // Lookup first 32B block
-    res = lookupSingleBlock(alignedPC, asidHash);
+    res = lookupSingleBlock(alignedPC, tid, asidHash);
     // Lookup next 32B block
-    auto nextBlockRes = lookupSingleBlock(alignedPC + blockSize, asidHash);
+    auto nextBlockRes = lookupSingleBlock(alignedPC + blockSize, tid, asidHash);
     // Merge results
     res.insert(res.end(), nextBlockRes.begin(), nextBlockRes.end());
 
@@ -618,7 +622,7 @@ MBTB::updateBTBEntry(const BTBEntry& entry, const FetchTarget &stream)
     auto& target_mru = (sram_id == 0) ? mru0 : mru1;
     
     // Calculate index and tag for this entry
-    Addr btb_idx = getIndex(entry.pc, stream.asidHash);
+    Addr btb_idx = getIndex(entry.pc, stream.asidHash, stream.tid);
 
     // Look for matching entry in the target SRAM
     bool found = false;

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -148,7 +148,7 @@ class MBTB : public TimedBaseBTBPredictor
                       std::vector<FullBTBPrediction> &stagePreds) override;
 
     std::vector<BTBEntry> getPredictedEntriesNoSideEffect(
-        Addr startAddr, uint8_t asidHash = 0) const;
+        Addr startAddr, ThreadID tid, uint8_t asidHash) const;
 
     /** Get prediction BTBMeta
      *  @return Returns the prediction meta
@@ -219,7 +219,7 @@ class MBTB : public TimedBaseBTBPredictor
      *  @return Returns the index into the BTB.
      */
     inline Addr getIndex(Addr instPC, uint8_t asidHash,
-                         ThreadID tid = 0) const {
+                         ThreadID tid) const {
         Addr baseIndex = (instPC >> idxShiftAmt) & idxMask;
         Addr index = xorAsidHashIntoIndex(
             baseIndex, floorLog2(numSets), asidHash);
@@ -358,7 +358,7 @@ class MBTB : public TimedBaseBTBPredictor
                                        uint8_t asidHash,
                                        std::shared_ptr<BTBMeta> meta);
     std::vector<TickedBTBEntry> lookupNoSideEffect(
-        Addr block_pc, uint8_t asidHash = 0) const;
+        Addr block_pc, ThreadID tid, uint8_t asidHash) const;
 
     /** Helper function to lookup entries in a single block
      * @param block_pc The aligned PC to lookup
@@ -370,7 +370,7 @@ class MBTB : public TimedBaseBTBPredictor
     /** Victim cache operations */
     std::vector<TickedBTBEntry> lookupVictimCache(Addr block_pc, uint8_t asidHash);
     std::vector<TickedBTBEntry> lookupSingleBlockNoSideEffect(
-        Addr block_pc, uint8_t asidHash) const;
+        Addr block_pc, ThreadID tid, uint8_t asidHash) const;
     std::vector<TickedBTBEntry> lookupVictimCacheNoSideEffect(
         Addr block_pc, uint8_t asidHash) const;
     void insertVictimCache(const TickedBTBEntry& evicted_entry);

--- a/src/cpu/pred/btb/mbtb.hh
+++ b/src/cpu/pred/btb/mbtb.hh
@@ -218,9 +218,12 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The branch to look up.
      *  @return Returns the index into the BTB.
      */
-    inline Addr getIndex(Addr instPC, uint8_t asidHash) const {
+    inline Addr getIndex(Addr instPC, uint8_t asidHash,
+                         ThreadID tid = 0) const {
         Addr baseIndex = (instPC >> idxShiftAmt) & idxMask;
-        return xorAsidHashIntoIndex(baseIndex, floorLog2(numSets), asidHash);
+        Addr index = xorAsidHashIntoIndex(
+            baseIndex, floorLog2(numSets), asidHash);
+        return partitionIndex(index, numSets, tid);
     }
 
     /** Returns the tag bits of a given address.
@@ -230,7 +233,9 @@ class MBTB : public TimedBaseBTBPredictor
      *  @return Returns the tag bits.
      */
     inline Addr getTag(Addr instPC, uint8_t asidHash) const {
-        Addr baseTag = (instPC >> tagShiftAmt) & tagMask;
+        const unsigned shift = tagShiftAmt -
+            (usesTidPartitionedStorage() ? 1 : 0);
+        Addr baseTag = (instPC >> shift) & tagMask;
         return injectAsidHashIntoTag(baseTag, tagBits, asidHash);
     }
 
@@ -349,7 +354,9 @@ class MBTB : public TimedBaseBTBPredictor
      *  @param inst_PC The address of the block to look up.
      *  @return Returns all hit BTB entries.
      */
-    std::vector<TickedBTBEntry> lookup(Addr block_pc, uint8_t asidHash, std::shared_ptr<BTBMeta> meta);
+    std::vector<TickedBTBEntry> lookup(Addr block_pc, ThreadID tid,
+                                       uint8_t asidHash,
+                                       std::shared_ptr<BTBMeta> meta);
     std::vector<TickedBTBEntry> lookupNoSideEffect(
         Addr block_pc, uint8_t asidHash = 0) const;
 
@@ -357,7 +364,8 @@ class MBTB : public TimedBaseBTBPredictor
      * @param block_pc The aligned PC to lookup
      * @return Vector of matching BTB entries
      */
-    std::vector<TickedBTBEntry> lookupSingleBlock(Addr block_pc, uint8_t asidHash);
+    std::vector<TickedBTBEntry> lookupSingleBlock(Addr block_pc, ThreadID tid,
+                                                  uint8_t asidHash);
 
     /** Victim cache operations */
     std::vector<TickedBTBEntry> lookupVictimCache(Addr block_pc, uint8_t asidHash);

--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -124,7 +124,8 @@ MicroTAGE::MicroTAGE(const Params& p)
             state.altTagFoldedHist.emplace_back(
                 (int)histLengths[i], (int)tableTagBits[i] - 1, 16);
             state.indexFoldedHist.emplace_back(
-                (int)histLengths[i], (int)tableIndexBits[i], 16);
+                (int)histLengths[i],
+                (int)partitionIndexBits(tableIndexBits[i]), 16);
         }
     }
     usefulResetCnt = 0;
@@ -230,9 +231,10 @@ MicroTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
     for (int i = numPredictors - 1; i >= 0; --i) {
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
-        Addr index = predMeta ? getTageIndex(startPC, i,
-                            predMeta->indexFoldedHist[i].get(), asidHash)
-                          : getTageIndex(startPC, i, state.indexFoldedHist[i].get(), asidHash);
+        Addr index = predMeta ? getTageIndex(
+            startPC, i, predMeta->indexFoldedHist[i].get(), asidHash, tid)
+                              : getTageIndex(
+            startPC, i, state.indexFoldedHist[i].get(), asidHash, tid);
         Addr tag = predMeta ? getTageTag(startPC, i,
                             predMeta->tagFoldedHist[i].get(),predMeta->altTagFoldedHist[i].get(),
                             position, asidHash)
@@ -740,7 +742,10 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                                  TrainingMode mode,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
-                                 uint64_t &allocated_way) {
+                                 uint64_t &allocated_way,
+                                 ThreadID tid) {
+    int &resetCnt = usesTidPartitionedStorage() ?
+        usefulResetCntByThread[tid] : usefulResetCnt;
     // Simple set-associative allocation (no LFSR, no per-way table gating):
     // - For each table from start_table upward, check the set at computed index.
     // - Prefer invalid ways; else choose any way with useful==0 and weak counter.
@@ -779,8 +784,8 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
     unsigned position = getBranchIndexInBlock(entry.pc, startPC);
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
-        Addr newIndex = getTageIndex(startPC, ti,
-            meta->indexFoldedHist[ti].get(), asidHash);
+        Addr newIndex = getTageIndex(
+            startPC, ti, meta->indexFoldedHist[ti].get(), asidHash, tid);
         Addr newTag = getTageTag(startPC, ti,
             meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(),
             position, asidHash);
@@ -800,7 +805,7 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
                 allocated_table = ti;
                 allocated_index = newIndex;
                 allocated_way = way;
-                usefulResetCnt = usefulResetCnt <= 0 ? 0 : usefulResetCnt - 1;
+                resetCnt = resetCnt <= 0 ? 0 : resetCnt - 1;
                 return true;
             }
         }
@@ -818,16 +823,18 @@ MicroTAGE::handleNewEntryAllocation(const Addr &startPC,
         }
 
         count_alloc_failure();
-        usefulResetCnt++;
+        resetCnt++;
     }
 
-    if (usefulResetCnt >= 256) {
-        usefulResetCnt = 0;
+    if (resetCnt >= 256) {
+        resetCnt = 0;
         count_reset_u();
         DPRINTF(UTAGE, "reset useful bit of all entries\n");
         for (auto &table : tageTable) {
-            for (auto &set : table) {
-                for (auto &way : set) {
+            const unsigned begin = partitionBegin(table.size(), tid);
+            const unsigned end = partitionEnd(table.size(), tid);
+            for (unsigned index = begin; index < end; ++index) {
+                for (auto &way : table[index]) {
                     way.useful = false;
                 }
             }
@@ -1034,7 +1041,7 @@ MicroTAGE::trainEntries(const std::vector<BTBEntry> &entries_to_update,
         handleNewEntryAllocation(startPC, btb_entry, actual_taken,
                                  start_table, predMeta, asidHash, mode,
                                  allocated_table, allocated_index,
-                                 allocated_way);
+                                 allocated_way, tid);
 
 #ifndef UNIT_TEST
         // Optional per-entry miss tracing is only kept for the resolved update path.
@@ -1142,22 +1149,26 @@ MicroTAGE::getTageTag(Addr pc, int t, uint64_t foldedHist, uint64_t altFoldedHis
 }
 
 Addr
-MicroTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist, uint8_t asidHash)
+MicroTAGE::getTageIndex(Addr pc, int t, uint64_t foldedHist,
+                        uint8_t asidHash, ThreadID tid)
 {
-    // Create mask for tableIndexBits[t] to limit result size
-    Addr mask = (1ULL << tableIndexBits[t]) - 1;
+    const unsigned localIndexBits = partitionIndexBits(tableIndexBits[t]);
+    Addr mask = (1ULL << localIndexBits) - 1;
 
     const unsigned pcShift = enableBankConflict ? indexShift : bankBaseShift;
     Addr pcBits = (pc >> pcShift) & mask;
     Addr foldedBits = foldedHist & mask;
 
-    return xorAsidHashIntoIndex(pcBits ^ foldedBits, tableIndexBits[t], asidHash);
+    Addr localIndex = xorAsidHashIntoIndex(
+        pcBits ^ foldedBits, localIndexBits, asidHash);
+    return partitionIndex(localIndex, tableSizes[t], tid);
 }
 
 Addr
-MicroTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash)
+MicroTAGE::getTageIndex(Addr pc, int t, uint8_t asidHash, ThreadID tid)
 {
-    return getTageIndex(pc, t, historyState(0).indexFoldedHist[t].get(), asidHash);
+    return getTageIndex(pc, t, historyState(tid).indexFoldedHist[t].get(),
+                        asidHash, tid);
 }
 
 bool

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -1,6 +1,7 @@
 #ifndef __CPU_PRED_BTB_MICROTAGE_HH__
 #define __CPU_PRED_BTB_MICROTAGE_HH__
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -163,10 +164,12 @@ class MicroTAGE : public TimedBaseBTBPredictor
                       CondTakens& results, ThreadID tid, uint8_t asidHash);
 
     // Calculate TAGE index for a given PC and table
-    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0);
+    Addr getTageIndex(Addr pc, int table, uint8_t asidHash = 0,
+                      ThreadID tid = 0);
 
     // Calculate TAGE index with folded history (uint64_t version for performance)
-    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist, uint8_t asidHash = 0);
+    Addr getTageIndex(Addr pc, int table, uint64_t foldedHist,
+                      uint8_t asidHash = 0, ThreadID tid = 0);
 
     // Calculate TAGE tag with folded history (uint64_t version for performance)
     // position: branch position within the block (xored into tag like RTL)
@@ -225,6 +228,7 @@ class MicroTAGE : public TimedBaseBTBPredictor
 
     // useful bit reset counter, when cnt >= 256, reset useful bit of all entries
     int usefulResetCnt{0};
+    std::array<int, MaxThreads> usefulResetCntByThread{};
 
     // Instruction shift amount
     unsigned instShiftAmt {1};
@@ -423,7 +427,8 @@ public:
                                  TrainingMode mode,
                                  uint64_t &allocated_table,
                                  uint64_t &allocated_index,
-                                 uint64_t &allocated_way);
+                                 uint64_t &allocated_way,
+                                 ThreadID tid = 0);
 
     int abtbComponentIdx{-1};
     std::vector<std::shared_ptr<TageMeta>> threadMeta;

--- a/src/cpu/pred/btb/test/btb.test.cc
+++ b/src/cpu/pred/btb/test/btb.test.cc
@@ -55,8 +55,10 @@ BranchInfo createBranchInfo(Addr pc, Addr target, bool isCond = false,
  * @return FetchTarget Initialized fetch stream
  */
 FetchTarget setupStream(Addr startPC, const BranchInfo& branch, bool taken,
-                       std::shared_ptr<void> meta, Addr endInstPC) {
+                       std::shared_ptr<void> meta, Addr endInstPC,
+                       ThreadID tid = 0) {
     FetchTarget stream;
+    stream.tid = tid;
     stream.startPC = startPC;
     stream.resolved = true;
     stream.exeBranchInfo = branch;
@@ -114,7 +116,8 @@ predictUpdateCycle(MBTB* btb,
      const BranchInfo& branch,
      bool taken,
      const boost::dynamic_bitset<>& history = boost::dynamic_bitset<>(8, 0),
-     Addr endInstPC = 0) {
+     Addr endInstPC = 0,
+     ThreadID tid = 0) {
     // If endInstPC not specified, use branch.pc + branch.size
     if (endInstPC == 0) {
         endInstPC = branch.pc + branch.size;
@@ -122,11 +125,15 @@ predictUpdateCycle(MBTB* btb,
 
     // Prediction phase
     std::vector<FullBTBPrediction> stagePreds(4);
+    for (auto &pred : stagePreds) {
+        pred.tid = tid;
+    }
     btb->putPCHistory(startPC, history, stagePreds);
-    auto meta = btb->getPredictionMeta();
+    auto meta = btb->getPredictionMeta(tid);
 
     // Update phase
-    FetchTarget stream = setupStream(startPC, branch, taken, meta, endInstPC);
+    FetchTarget stream = setupStream(
+        startPC, branch, taken, meta, endInstPC, tid);
     // Populate predicted BTB entries in stream from stage predictions
     // Use entries from the first valid stage (delay)
     if (btb->getDelay() < stagePreds.size()) {
@@ -145,6 +152,9 @@ predictUpdateCycle(MBTB* btb,
     // Return final predictions after update
     stagePreds.clear();
     stagePreds.resize(4);
+    for (auto &pred : stagePreds) {
+        pred.tid = tid;
+    }
     btb->putPCHistory(startPC, history, stagePreds);
 
     return stagePreds;
@@ -232,6 +242,36 @@ TEST_F(BTBTest, PredictionMetadataIsPerThread) {
     EXPECT_NE(thread0Meta, thread1Meta);
     EXPECT_EQ(mbtb->getPredictionMeta(0), thread0Meta);
     EXPECT_EQ(mbtb->getPredictionMeta(1), thread1Meta);
+}
+
+TEST_F(BTBTest, TidPartitionKeepsSamePcEntriesIndependent) {
+    MBTB partitionedBtb(16, 8, 4, 1);
+    partitionedBtb.setSmtTidPartitioned(true);
+
+    constexpr Addr startPC = 0x1000;
+    constexpr Addr branchPC = 0x1004;
+    auto thread0Branch = createBranchInfo(branchPC, 0x2000, true);
+    auto thread1Branch = createBranchInfo(branchPC, 0x3000, true);
+
+    predictUpdateCycle(
+        &partitionedBtb, startPC, thread0Branch, true,
+        boost::dynamic_bitset<>(8, 0), 0, 0);
+    predictUpdateCycle(
+        &partitionedBtb, startPC, thread1Branch, true,
+        boost::dynamic_bitset<>(8, 0), 0, 1);
+
+    for (ThreadID tid = 0; tid < 2; ++tid) {
+        std::vector<FullBTBPrediction> predictions(4);
+        for (auto &pred : predictions) {
+            pred.tid = tid;
+        }
+        partitionedBtb.putPCHistory(
+            startPC, boost::dynamic_bitset<>(8, 0), predictions);
+
+        ASSERT_EQ(predictions[partitionedBtb.getDelay()].btbEntries.size(), 1);
+        EXPECT_EQ(predictions[partitionedBtb.getDelay()].btbEntries[0].target,
+                  tid == 0 ? thread0Branch.target : thread1Branch.target);
+    }
 }
 
 // BTB actual update process:

--- a/src/cpu/pred/btb/timed_base_pred.cc
+++ b/src/cpu/pred/btb/timed_base_pred.cc
@@ -17,7 +17,8 @@ TimedBaseBTBPredictor::TimedBaseBTBPredictor()
       predictWidth(64),
       numDelay(0),
       resolvedUpdate(false),
-      enabled(true)
+      enabled(true),
+      smtTidPartitioned(false)
 {}
 }  // namespace test
 #else
@@ -27,7 +28,8 @@ TimedBaseBTBPredictor::TimedBaseBTBPredictor(const Params &p)
       predictWidth(p.predictWidth),
       numDelay(p.numDelay),
       resolvedUpdate(p.resolvedUpdate),
-      enabled(p.enabled)
+      enabled(p.enabled),
+      smtTidPartitioned(p.smtTidPartitioned)
 {
 }
 #endif

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -114,10 +114,53 @@ class TimedBaseBTBPredictor: public SimObject
     // Check if this component is enabled
     bool isEnabled() const { return enabled; }
 
+    /**
+     * Map an index into one of two equal per-thread storage partitions.
+     * The underlying vector keeps its original total size; only ownership and
+     * replacement domains change when partitioning is enabled.
+     */
+    unsigned partitionIndex(unsigned index, unsigned totalEntries,
+                            ThreadID tid) const
+    {
+        if (!smtTidPartitioned) {
+            return index % totalEntries;
+        }
+        assert(totalEntries >= 2 && totalEntries % 2 == 0);
+        assert(tid < 2);
+        const unsigned entriesPerThread = totalEntries / 2;
+        return tid * entriesPerThread + index % entriesPerThread;
+    }
+
+    unsigned partitionIndexBits(unsigned fullIndexBits) const
+    {
+        assert(!smtTidPartitioned || fullIndexBits > 0);
+        return fullIndexBits - (smtTidPartitioned ? 1 : 0);
+    }
+
+    unsigned partitionBegin(unsigned totalEntries, ThreadID tid) const
+    {
+        if (!smtTidPartitioned) {
+            return 0;
+        }
+        assert(totalEntries >= 2 && totalEntries % 2 == 0);
+        assert(tid < 2);
+        return tid * (totalEntries / 2);
+    }
+
+    unsigned partitionEnd(unsigned totalEntries, ThreadID tid) const
+    {
+        return smtTidPartitioned ?
+            partitionBegin(totalEntries, tid) + totalEntries / 2 :
+            totalEntries;
+    }
+
+    bool usesTidPartitionedStorage() const { return smtTidPartitioned; }
+
 private:
     unsigned numDelay;
     bool resolvedUpdate;
     bool enabled;
+    bool smtTidPartitioned;
 };
 
 // Close conditional namespace wrapper for testing

--- a/src/cpu/pred/btb/timed_base_pred.hh
+++ b/src/cpu/pred/btb/timed_base_pred.hh
@@ -47,6 +47,10 @@ class TimedBaseBTBPredictor: public SimObject
 #ifdef UNIT_TEST
     TimedBaseBTBPredictor();
     void setNumDelay(unsigned delay) { numDelay = delay; }
+    void setSmtTidPartitioned(bool partitioned)
+    {
+        smtTidPartitioned = partitioned;
+    }
 #else
     typedef TimedBaseBTBPredictorParams Params;
 


### PR DESCRIPTION
## Motivation

PR #1052 models two same-cycle SMT predictions with ideal shared predictor read capability. This stacked PR adds an RTL-oriented storage model: T0 and T1 own disjoint banks, so both predictions can proceed without duplicating the large predictor arrays or encountering cross-thread read-bank conflicts.

## Storage model

- Add `smtTidPartitioned` to `TimedBaseBTBPredictor`; it defaults to `false`.
- When enabled, map T0 and T1 lookup, update, allocation, replacement, and useful-reset domains into disjoint halves of:
  - mBTB and AheadBTB;
  - TAGE, MicroTAGE, and ITTAGE;
  - MGSC direction-correction tables.
- Reduce the local index by one bit and retain the removed PC bit in the BTB/TAGE tag where applicable, avoiding extra aliasing beyond the intended capacity reduction.
- Carry TID and ASID through no-side-effect metadata refreshes, including future PairTAGE second-block teacher lookups.
- Model uBTB duplication by doubling its physical entries from 32 to 64 and assigning 32 entries to each TID.
- Reuse the already per-thread RAS/uRAS and ahead-pipeline state.
- Enable the model in `smt_idealkmhv3.py`.

The underlying large arrays keep their original total size, so each thread receives half of the original SMT-shared capacity. Index mapping remains O(1). The small uBTB keeps its existing linear lookup/replacement style but scans only the requesting thread's half.

## Accuracy and RTL boundaries

- Prediction is conflict-free because TID selects a disjoint physical bank.
- Training-port/bank conflicts are intentionally not modeled in this first version; resolve/commit training keeps the existing timing model.
- Small auxiliary adaptive control, such as TAGE alternate-selection state and MGSC weight/threshold control, remains shared. The main capacity-bearing prediction tables are partitioned.
- PairTAGE remains disabled for dual-thread prediction and is guarded by #1052 until complete TID support is added.
- Single-thread and non-opt-in configurations retain the existing full capacity and indexing because the parameter defaults to false.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j8`
- Predictor unit suites passed:
  - mBTB: 21/21, including same-PC T0/T1 entries with different targets;
  - AheadBTB: 3/3;
  - TAGE: 28/28;
  - MGSC: 14/14;
  - MicroTAGE: 7/7.
- A short dual-hart `ldstorm` run completed with difftest enabled; both harts reported success and exited normally.
- Strict post-review A/B on head `9fa42ef162`, both 148/148 checkpoints and zero aborts:
  - [2x2 TID-partitioned run 32708067388](https://github.com/OpenXiangShan/GEM5/actions/runs/32708067388): SPECint 27.0409, SPECfp 25.0301, Overall 25.8433;
  - [1x1 full-capacity control run 32708426126](https://github.com/OpenXiangShan/GEM5/actions/runs/32708426126): SPECint 26.3578, SPECfp 24.9987, Overall 25.5523;
  - relative gain: SPECint **+2.592%**, SPECfp +0.126%, Overall **+1.139%**.
- The complete benchmark and counter breakdown is in the [final analysis comment](https://github.com/OpenXiangShan/GEM5/pull/1062#issuecomment-5394890441).

### CoreMark exposed an existing SMT LSQ starvation bug

The full TID-partitioned 10-iteration dual-hart CoreMark deterministically reaches the 40K-cycle commit-stuck detector at tick 466,313,220 without a difftest mismatch. Pipeline tracing shows that this is not a predictor metadata failure:

- T1 stops at ROB head `sn=7200436`, PC `0x80000b1c`, an `lbu` from `0x800439fc`.
- T0 repeatedly loads `0x800033f8`; both addresses map to the same modeled D-cache div/bank.
- `LSQ::executePipeSx()` visits active threads in fixed T0-to-T1 order in full-system mode. T0 claims the bank first, while every T1 replay reports `bank conflict=1`, `cache blocked=0`, and `MSHR=0`.
- Disabling only `BankConflictCheck` exits normally at tick 451,975,572.
- A temporary thread-round-robin LSQ issue-order probe exits normally at tick 455,975,901 with difftest clean while retaining thousands of modeled bank conflicts.

Predictor partitioning changes the deterministic thread phase and exposes the pre-existing fixed-priority LSQ starvation; removing individual predictor partitions merely changes that phase. The fairness fix belongs in a separate SMT LSQ PR, not in this predictor-storage PR. The commit-stuck diagnostic also uses `rob->readHeadInst(0)` while reporting another TID, so its first printed head instruction can be misleading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SMT branch-predictor storage partitioning, providing each thread with independent predictor capacity.
  * Extended partitioning support across BTB, TAGE, ITTAGE, MGSC, MicroTAGE, and uBTB predictors.
  * Updated example SMT configuration to enable partitioned predictor modeling and preserve uBTB capacity.

* **Bug Fixes**
  * Improved thread-aware prediction lookups, updates, history handling, and replacement behavior.
  * Added coverage confirming identical program counters maintain independent branch targets across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->