### PR TITLE
cpu: Window simInsts and simOps by stats reset

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -873,9 +873,11 @@ BaseCPU::traceFunctionsInternal(Addr pc)
 BaseCPU::GlobalStats::GlobalStats(statistics::Group *parent)
     : statistics::Group(parent),
     ADD_STAT(simInsts, statistics::units::Count::get(),
-             "Number of instructions simulated"),
+             "Number of instructions simulated since the last statistics "
+             "reset"),
     ADD_STAT(simOps, statistics::units::Count::get(),
-             "Number of ops (including micro ops) simulated"),
+             "Number of ops (including micro ops) simulated since the last "
+             "statistics reset"),
     ADD_STAT(hostInstRate, statistics::units::Rate<
                 statistics::units::Count, statistics::units::Second>::get(),
              "Simulator instruction rate (inst/s)"),
@@ -884,13 +886,17 @@ BaseCPU::GlobalStats::GlobalStats(statistics::Group *parent)
              "Simulator op (including micro ops) rate (op/s)")
 {
     simInsts
-        .functor(BaseCPU::numSimulatedInsts)
+        .functor([this] {
+            return BaseCPU::numSimulatedInsts() - instsAtLastReset;
+        })
         .precision(0)
         .prereq(simInsts)
         ;
 
     simOps
-        .functor(BaseCPU::numSimulatedOps)
+        .functor([this] {
+            return BaseCPU::numSimulatedOps() - opsAtLastReset;
+        })
         .precision(0)
         .prereq(simOps)
         ;
@@ -907,6 +913,12 @@ BaseCPU::GlobalStats::GlobalStats(statistics::Group *parent)
 
     hostInstRate = simInsts / hostSeconds;
     hostOpRate = simOps / hostSeconds;
+
+    // Run after the complete statistics reset, including CPU-specific stats.
+    statistics::registerResetCallback([this] {
+        instsAtLastReset = BaseCPU::numSimulatedInsts();
+        opsAtLastReset = BaseCPU::numSimulatedOps();
+    });
 }
 
 int

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -204,6 +204,10 @@ class BaseCPU : public ClockedObject
 
         statistics::Formula hostInstRate;
         statistics::Formula hostOpRate;
+
+      private:
+        Counter instsAtLastReset = 0;
+        Counter opsAtLastReset = 0;
     };
 
     /**


### PR DESCRIPTION
## Motivation

`hostSeconds` resets with statistics, while global `simInsts` and `simOps` were process cumulative. Post-warmup host rates therefore used a cross-window numerator.

## Approach

Record total instruction and op baselines after every complete statistics reset, then expose the existing global values as total minus baseline. CPU control counters remain monotonic; the existing host-rate formulas are unchanged.

## Scope

`simInsts` and `simOps` now mean values since the last statistics reset. Consumers that require lifetime totals must source them separately.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- bzip2 GCPT with 20M warmup and `--maxinsts=40000000`, difftest disabled. The clean build excludes optional DRAMsim3, so the semantic check used `DDR4_2400_8x8`.
  - Block 1: `simInsts=committedInsts=20,000,001`; `simOps=committedOps=19,966,441`.
  - Block 2: `simInsts=committedInsts=19,999,999`; `simOps=committedOps=19,999,953`.
  - The run exited at the global 40M instruction limit.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated simulated instruction and operation statistics to report counts since the most recent statistics reset.
  * Ensured statistics reset handling correctly establishes the baseline for subsequent measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->