### PR TITLE
cpu: Fix dispatch FetchFrag recount and split leftover fetch cuts

### DIFF
--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -104,6 +104,8 @@ enum StallReason {
     ROBFull,  // B
     RegFull,  // B
     OtherStall,  // B
+    FetchStreamFrag,  // F, unused slots after taken branch / FTQ stream end
+    FetchBufFrag,  // F, unused slots after walking off the fetch buffer
     NumStallReasons
 };
 

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -108,6 +108,8 @@ enum StallReason {
     ROBFull,  // B
     RegFull,  // B
     OtherStall,  // B
+    FetchStreamFrag,  // F
+    FetchBufFrag,  // F
     NumStallReasons
 };
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -82,6 +82,21 @@ namespace gem5
 namespace o3
 {
 
+StallReason
+Fetch::fragReasonFromCut(FetchCut cut)
+{
+    switch (cut) {
+      case FetchCut::Stream:
+        return StallReason::FetchStreamFrag;
+      case FetchCut::Buf:
+        return StallReason::FetchBufFrag;
+      case FetchCut::Icache:
+        return StallReason::IcacheStall;
+      default:
+        return StallReason::FetchFragStall;
+    }
+}
+
 Fetch::IcachePort::IcachePort(Fetch *_fetch, CPU *_cpu) :
         RequestPort(_cpu->name() + ".icache_port", _cpu), fetch(_fetch)
 {}
@@ -1414,6 +1429,10 @@ Fetch::initializeTickState()
 void
 Fetch::fetchAndProcessInstructions(bool status_change)
 {
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        fetchCut[tid] = FetchCut::None;
+    }
+
     // Fetch instructions from active threads
     for (threadFetched = 0; threadFetched < numFetchingThreads;
          threadFetched++) {
@@ -1613,20 +1632,22 @@ Fetch::updateStallReasons(unsigned insts_to_decode, ThreadID tid)
     if (stallSig->blockFetch[tid]) {
         setAllFetchStalls(stallSig->fetchBlockReason[tid]);
     } else if (insts_to_decode == 0) {
-        // fetch stalled
-        if (stallReason[0] != StallReason::NoStall) {
-            // previously set stall reason
+        // Prefer the latched cut; buffer-end used to return IcacheStall
+        // and this branch then painted the whole vector I$.
+        if (fetchCut[tid] != FetchCut::None) {
+            setAllFetchStalls(fragReasonFromCut(fetchCut[tid]));
+        } else if (stallReason[0] != StallReason::NoStall) {
             setAllFetchStalls(stallReason[0]);
         } else {
             setAllFetchStalls(StallReason::OtherFetchStall);
         }
     } else {
-        // fetch partially stalled or no stall
+        const StallReason unused = fragReasonFromCut(fetchCut[tid]);
         for (int i = 0; i < stallReason.size(); i++) {
             if (i < insts_to_decode)
                 stallReason[i] = StallReason::NoStall;
             else {
-                stallReason[i] = StallReason::FetchFragStall;
+                stallReason[i] = unused;
             }
         }
     }
@@ -2078,6 +2099,7 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
     // Check if fetch buffer is valid and contains this PC
     if (!threads[tid].valid) {
         DPRINTF(Fetch, "[tid:%i] Fetch buffer invalid, stalling on ICache\n", tid);
+        fetchCut[tid] = FetchCut::Icache;
         return StallReason::IcacheStall;
     }
 
@@ -2087,6 +2109,8 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
         fetch_pc + 4 > threads[tid].startPC + fetchBufferSize) {
         DPRINTF(Fetch, "[tid:%i] PC %#x outside fetch buffer range [%#x, %#x), stalling on ICache\n",
                 tid, fetch_pc, threads[tid].startPC, threads[tid].startPC + fetchBufferSize);
+        // Buffer still valid: this is a line/stream cut, not an I$ miss.
+        fetchCut[tid] = FetchCut::Buf;
         return StallReason::IcacheStall;
     }
 
@@ -2253,6 +2277,14 @@ Fetch::performInstructionFetch(ThreadID tid)
     DPRINTF(FetchVerbose, "FetchQue start dumping\n");
     for (auto it : fetchQueue[tid]) {
         DPRINTF(FetchVerbose, "inst: %s\n", it->staticInst->disassemble(it->pcState().instAddr()));
+    }
+
+    if (predictedBranch) {
+        fetchCut[tid] = FetchCut::Stream;
+    } else if (fetchCut[tid] == FetchCut::None && ftqEmpty(tid) &&
+               numInst < fetchWidth &&
+               fetchQueue[tid].size() < fetchQueueSize) {
+        fetchCut[tid] = FetchCut::Stream;
     }
 
     // Handle stall conditions and update statistics

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -82,6 +82,21 @@ namespace gem5
 namespace o3
 {
 
+StallReason
+Fetch::fragReasonFromCut(FetchCut cut)
+{
+    switch (cut) {
+      case FetchCut::Stream:
+        return StallReason::FetchStreamFrag;
+      case FetchCut::Buf:
+        return StallReason::FetchBufFrag;
+      case FetchCut::Icache:
+        return StallReason::IcacheStall;
+      default:
+        return StallReason::FetchFragStall;
+    }
+}
+
 Fetch::IcachePort::IcachePort(Fetch *_fetch, CPU *_cpu) :
         RequestPort(_cpu->name() + ".icache_port"), fetch(_fetch)
 {}
@@ -1571,6 +1586,10 @@ Fetch::initializeTickState()
 void
 Fetch::fetchAndProcessInstructions(bool status_change)
 {
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        fetchCut[tid] = FetchCut::None;
+    }
+
     // Fetch instructions from active threads
     for (threadFetched = 0; threadFetched < numFetchingThreads;
          threadFetched++) {
@@ -1758,6 +1777,22 @@ Fetch::sendInstructionsToDecode()
 
     if (primary_tid == InvalidThreadID) {
         DPRINTF(Fetch, "All threads are stalled, no thread selected.\n");
+        ThreadID blocked_tid = InvalidThreadID;
+        ThreadID idle_tid = InvalidThreadID;
+        for (int i = 0; i < numThreads; i++) {
+            if (stallSig->blockFetch[i]) {
+                if (blocked_tid == InvalidThreadID)
+                    blocked_tid = i;
+            } else if (idle_tid == InvalidThreadID) {
+                idle_tid = i;
+            }
+        }
+        if (blocked_tid != InvalidThreadID) {
+            setAllFetchStalls(stallSig->fetchBlockReason[blocked_tid]);
+        } else if (idle_tid != InvalidThreadID) {
+            updateStallReasons(0, idle_tid);
+        }
+        toDecode->fetchStallReason = stallReason;
         for (int i = 0; i < numThreads; i++) {
             measureFrontendBubbles(0, i);
         }
@@ -1822,20 +1857,20 @@ Fetch::updateStallReasons(unsigned insts_to_decode, ThreadID tid)
     if (stallSig->blockFetch[tid]) {
         setAllFetchStalls(stallSig->fetchBlockReason[tid]);
     } else if (insts_to_decode == 0) {
-        // fetch stalled
-        if (stallReason[0] != StallReason::NoStall) {
-            // previously set stall reason
+        if (fetchCut[tid] != FetchCut::None) {
+            setAllFetchStalls(fragReasonFromCut(fetchCut[tid]));
+        } else if (stallReason[0] != StallReason::NoStall) {
             setAllFetchStalls(stallReason[0]);
         } else {
             setAllFetchStalls(StallReason::OtherFetchStall);
         }
     } else {
-        // fetch partially stalled or no stall
+        const StallReason fragReason = fragReasonFromCut(fetchCut[tid]);
         for (int i = 0; i < stallReason.size(); i++) {
             if (i < insts_to_decode)
                 stallReason[i] = StallReason::NoStall;
             else {
-                stallReason[i] = StallReason::FetchFragStall;
+                stallReason[i] = fragReason;
             }
         }
     }
@@ -2395,6 +2430,7 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
     // Check if fetch buffer is valid and contains this PC
     if (!threads[tid].valid) {
         DPRINTF(Fetch, "[tid:%i] Fetch buffer invalid, stalling on ICache\n", tid);
+        fetchCut[tid] = FetchCut::Icache;
         return StallReason::IcacheStall;
     }
 
@@ -2404,6 +2440,7 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
         fetch_pc + 4 > threads[tid].startPC + fetchBufferSize) {
         DPRINTF(Fetch, "[tid:%i] PC %#x outside fetch buffer range [%#x, %#x), stalling on ICache\n",
                 tid, fetch_pc, threads[tid].startPC, threads[tid].startPC + fetchBufferSize);
+        fetchCut[tid] = FetchCut::Buf;
         return StallReason::IcacheStall;
     }
 
@@ -2578,6 +2615,14 @@ Fetch::performInstructionFetch(ThreadID tid)
     DPRINTF(FetchVerbose, "FetchQue start dumping\n");
     for (auto it : fetchQueue[tid]) {
         DPRINTF(FetchVerbose, "inst: %s\n", it->staticInst->disassemble(it->pcState().instAddr()));
+    }
+
+    if (stopFetchThisCycle) {
+        fetchCut[tid] = FetchCut::Stream;
+    } else if (fetchCut[tid] == FetchCut::None && ftqEmpty(tid) &&
+               numInst < fetchWidth &&
+               fetchQueue[tid].size() < fetchQueueSize) {
+        fetchCut[tid] = FetchCut::Stream;
     }
 
     // Handle stall conditions and update statistics

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -990,6 +990,13 @@ class Fetch
     /** fetch stall reasons */
     std::vector<StallReason> stallReason;
 
+    // Why fetch stopped short of decodeWidth. Per Fetch instance (not
+    // file-static) so cores/SMT do not share the latch. Reset only in
+    // fetchAndProcessInstructions.
+    enum class FetchCut { None, Stream, Buf, Icache };
+    FetchCut fetchCut[MaxThreads]{};
+    static StallReason fragReasonFromCut(FetchCut cut);
+
     /**
      * Check if the thread can fetch instructions
      * @param tid Thread ID

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -1030,6 +1030,11 @@ class Fetch
     /** fetch stall reasons */
     std::vector<StallReason> stallReason;
 
+    /** fetch cut reason */
+    enum class FetchCut { None, Stream, Buf, Icache };
+    FetchCut fetchCut[MaxThreads]{};
+    static StallReason fragReasonFromCut(FetchCut cut);
+
     /**
      * Check if the thread can fetch instructions
      * @param tid Thread ID

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -333,6 +333,8 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::ROBFull, "ROBFull"},
         {StallReason::RegFull, "RegFull"},
         {StallReason::OtherStall, "OtherStall"},
+        {StallReason::FetchStreamFrag, "FetchStreamFrag"},
+        {StallReason::FetchBufFrag, "FetchBufFrag"},
         {StallReason::OtherFetchStall, "OtherFetchStall"},
         {StallReason::FTQBubble, "FTQBubble"},
         {StallReason::MemDQBandwidth, "MemDQBandwidth"},
@@ -1089,6 +1091,39 @@ IEW::dispatchInsts()
         toRename->iewInfo[tid].ldstqCount = ldstQueue.getCount(tid);
         toRename->iewInfo[tid].robCount = rob->getThreadEntries(tid);
         toRename->iewInfo[tid].iqCount = scheduler->getIQInsts(tid);
+    } else {
+        // tick() still counts this vector. Do not keep last cycle's
+        // FetchFrag across idle / backend-blocked beats.
+        bool squashing = false;
+        for (ThreadID t = 0; t < numThreads; ++t) {
+            if (fromCommit->commitInfo[t].squash ||
+                fromCommit->commitInfo[t].robSquashing) {
+                squashing = true;
+                break;
+            }
+        }
+        if (!squashing) {
+            StallReason blocked = StallReason::NoStall;
+            for (int i = 0; i < numThreads; i++) {
+                if (stallSig->blockRename[i] &&
+                    stallSig->renameBlockReason[i] != StallReason::NoStall) {
+                    blocked = stallSig->renameBlockReason[i];
+                    break;
+                }
+            }
+            if (blocked != StallReason::NoStall) {
+                setAllStalls(blocked);
+            } else {
+                for (int i = 0; i < dispatchStalls.size(); i++) {
+                    if (fromRename->renameStallReason.size() == 0) {
+                        dispatchStalls.at(i) = StallReason::NoStall;
+                    } else {
+                        dispatchStalls.at(i) =
+                            fromRename->renameStallReason.at(i);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -364,6 +364,8 @@ IEW::IEWStats::IEWStats(CPU *cpu)
         {StallReason::ROBFull, "ROBFull"},
         {StallReason::RegFull, "RegFull"},
         {StallReason::OtherStall, "OtherStall"},
+        {StallReason::FetchStreamFrag, "FetchStreamFrag"},
+        {StallReason::FetchBufFrag, "FetchBufFrag"},
         {StallReason::OtherFetchStall, "OtherFetchStall"},
         {StallReason::FTQBubble, "FTQBubble"},
         {StallReason::MemDQBandwidth, "MemDQBandwidth"},
@@ -1162,6 +1164,37 @@ IEW::dispatchInsts()
             iewStats.dispDist.sample(0);
         }
         iewStats.dispatchThreadsPerCycle.sample(0);
+        // no selected thread, pass rename stall
+        bool squashing = false;
+        for (ThreadID t = 0; t < numThreads; ++t) {
+            if (fromCommit->commitInfo[t].squash ||
+                fromCommit->commitInfo[t].robSquashing) {
+                squashing = true;
+                break;
+            }
+        }
+        if (!squashing) {
+            StallReason blocked = StallReason::NoStall;
+            for (int i = 0; i < numThreads; i++) {
+                if (stallSig->blockRename[i] &&
+                    stallSig->renameBlockReason[i] != StallReason::NoStall) {
+                    blocked = stallSig->renameBlockReason[i];
+                    break;
+                }
+            }
+            if (blocked != StallReason::NoStall) {
+                setAllStalls(blocked);
+            } else {
+                for (int i = 0; i < dispatchStalls.size(); i++) {
+                    if (fromRename->renameStallReason.size() == 0) {
+                        dispatchStalls.at(i) = StallReason::NoStall;
+                    } else {
+                        dispatchStalls.at(i) =
+                            fromRename->renameStallReason.at(i);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Refresh `dispatchStalls` on idle cycles so FetchFrag is not recounted (`tick()` still accumulates the vector). Keep squash recovery, else the current `blockRename` reason, else this cycle's rename reasons.
- Classify unused fetch slots as `FetchStreamFrag` / `FetchBufFrag` / `IcacheStall`; the fetch control path still returns `IcacheStall`. `FetchFragStall` stays as the unknown leftover.
- After SMT / two-fetch: empty queues refresh fetch stall (blocked echo first, else the first idle thread); taken cuts use `stopFetchThisCycle`. New enums are appended after `OtherStall` so existing StallReason indices stay stable. Accounting only.

## Test plan
- [x] hello / coremark / microbench 100k+300k vs xs-dev: exec identical; dispatch FetchFrag 18/39/43% → 0
- [x] SMT hello + SMT coremark: exec identical
- [x] flash_recursion: same commit-stuck as baseline
- [ ] CI dramsim3 + official NEMU difftest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch stall reporting by distinguishing instruction-stream, fetch-buffer, and instruction-cache interruptions.
  * Enhanced dispatch stall statistics to more accurately reflect squashing, backend blocking, and rename-related delays.
  * Reduced misleading stall classifications during instruction fetching and dispatch.
  * Improved visibility into cycles where instruction delivery is interrupted or no dispatch thread is selected.
  * Ensured stall statistics remain accurate across changing fetch and dispatch conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->