### PR TITLE
cpu-o3: Avoid redundant ROB scans and FTQ copies

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -2270,7 +2270,7 @@ Commit::markCompletedInsts()
             fromIEW->insts[inst_num]->setCanCommit();
             auto &inst = fromIEW->insts[inst_num];
 
-            panic_if(!rob->findInst(inst->threadNumber, inst->seqNum),
+            panic_if(!inst->isInROB(),
                      "[tid:%i] [sn:%llu] Committed instruction not found in ROB",
                      inst->threadNumber,
                      inst->seqNum);

--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <utility>
 
 #include "arch/riscv/regs/misc.hh"
 #include "base/debug_helper.hh"
@@ -616,7 +617,7 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
     }
 
     // 5. Add entry to fetch target queue
-    ftq.insert(entry);
+    ftq.insert(std::move(entry));
     threads[tid].nextPredictionAfterSquash = false;
     advancePairPhase(threads[tid].s0PairPhase);
     threads[tid].validprediction = false;
@@ -625,10 +626,10 @@ DecoupledBPUWithBTB::processNewPrediction(ThreadID tid)
     // 6. Debug output and update statistics
     dumpFsq("after insert new target");
     DPRINTF(DecoupleBP, "Inserted fetch target %lu starting at PC %#lx\n",
-            ftq.backId(tid), entry.startPC);
+            ftq.backId(tid), ftq.back(tid).startPC);
 
     // 7. Increment statistics
-    printTarget(entry);
+    printTarget(ftq.back(tid));
     dbpBtbStats.fsqEntryEnqueued++;
 
 }
@@ -749,16 +750,16 @@ DecoupledBPUWithBTB::processTwoTakenBlock(ThreadID tid)
     thread.s0PC = secondPred.getTarget(predictWidth);
     updateHistoryForPrediction(entry, secondPred);
     fillAheadPipeline(entry);
-    ftq.insert(entry);
+    ftq.insert(std::move(entry));
     pairtage->recordTwoTakenBlockEnqueued();
     advancePairPhase(thread.s0PairPhase);
 
     DPRINTF(DecoupleBP,
             "Inserted PairTAGE second block %lu for thread %u: startPC %#lx, branchPC %#lx, target %#lx, taken %d\n",
-            ftq.backId(tid), tid, entry.startPC, secondBlock.branchPC,
+            ftq.backId(tid), tid, ftq.back(tid).startPC, secondBlock.branchPC,
             secondBlock.targetPC, secondBlock.taken);
 
-    printTarget(entry);
+    printTarget(ftq.back(tid));
     dbpBtbStats.fsqEntryEnqueued++;
 }
 

--- a/src/cpu/pred/btb/ftq.cc
+++ b/src/cpu/pred/btb/ftq.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "ftq.hh"
 
@@ -77,11 +78,11 @@ FetchTargetQueue::getTargetTidByFetchQueueSize(const std::array<bool, MaxThreads
 }
 
 void
-FetchTargetQueue::insert(FetchTarget& target)
+FetchTargetQueue::insert(FetchTarget&& target)
 {
     ThreadID tid = target.tid;
     assert(queue[tid].cap.size() < ftqSize[tid]);
-    queue[tid].cap.push_back(target);
+    queue[tid].cap.push_back(std::move(target));
 }
 
 void

--- a/src/cpu/pred/btb/ftq.hh
+++ b/src/cpu/pred/btb/ftq.hh
@@ -101,7 +101,7 @@ public:
     int getTargetTidByFetchQueueSize(const std::array<bool, MaxThreads> &eligible,
                                      unsigned *ineligibleSkips,
                                      const std::array<unsigned, MaxThreads> &fetchQueueSizes);
-    void insert(FetchTarget& target);
+    void insert(FetchTarget&& target);
     void finishTarget(ThreadID tid);
     void commitTarget(ThreadID tid);
     void squashAfter(FetchTargetId targetId, ThreadID tid);


### PR DESCRIPTION
## Background

GEM5 host simulation throughput is reduced by avoidable work in hot paths.
This change keeps only optimizations that preserve final-ROI simulation
statistics while reducing that host-side work.

Simulator speed is measured with `hostTickRate` (simulated ticks per host
second).  The evaluated CPU clock is 333 ticks/cycle, so simulated cycles per
second are `hostTickRate / 333`.  `hostInstRate` is not used because it also
varies with workload IPC.

## Method

`perf` was used to identify high-cost code, then every candidate was evaluated
independently.  The acceptance gate was identical final-ROI non-host statistics
between baseline and variant; host timing fields were excluded from that
comparison.  The retained candidates replace a linear membership scan with an
existing per-instruction bit and move a temporary `FetchTarget` into the FTQ.

## Results

The 40M total / 20M warmup screening runs used
`gamess_triazolium/82016`, a pinned but non-exclusive host CPU, and source
`747824cd2b1e9317caad8fc27a366e5fccde0d3d`.  Speedups are final-ROI
`hostTickRate` ratios; `hostTickRate / 333` has the same relative change.

| Candidate | Independent result | Decision |
| --- | --- | --- |
| ROB completion membership | median `+6.501%` (`+6.477%` to `+8.154%`); strict stats equal | Keep |
| FTQ move insertion | median `+2.257%` (`+1.811%` to `+3.310%`); strict stats equal | Keep |
| FullBTB reset | median `-0.096%`; The improvement is not obvious enough | Drop |
| MGSC constructor `const&` | median `+1.050%`; The improvement is not obvious enough | Drop |
| Disabled TLB directional probe | median `+5.094%`, will be added in other PR | Drop |
| Worker event-driven transfer | changes timing model behavior | Drop |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of completed instructions to more reliably detect missing entries.

* **Performance Improvements**
  * Reduced overhead when adding fetch targets to the prediction queue by moving entries instead of copying them.
  * Updated related diagnostics and statistics to reflect the queued entries accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->