### PR TITLE
arch-riscv: Skip disabled directional TLB probes

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -2513,21 +2513,30 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
     auto recall = (double)all_used_forward_pre_num / (all_used_num + 1);
     RequestPtr pre_req = req;
 
+    // Probe directional prefetch state only when at least one direction is enabled.
+    const bool probe_directional_pre = openForwardPre || openBackPre;
+    Addr forward_pre_block = 0;
+    Addr vaddr_block = 0;
+    Addr back_pre_block = 0;
+    TlbEntry *pre_forward = nullptr;
+    TlbEntry *pre_back = nullptr;
 
-    Addr forward_pre_vaddr = vaddr + (l2tlbLineSize << PageShift);
-    Addr forward_pre_block = (forward_pre_vaddr >> (PageShift + L2TLB_BLK_OFFSET)) << (PageShift + L2TLB_BLK_OFFSET);
-    Addr vaddr_block = (vaddr >> (PageShift + L2TLB_BLK_OFFSET)) << (PageShift + L2TLB_BLK_OFFSET);
-    Addr back_pre_vaddr = vaddr - (l2tlbLineSize << PageShift);
-    Addr back_pre_block = (back_pre_vaddr >> (PageShift + L2TLB_BLK_OFFSET)) << (PageShift + L2TLB_BLK_OFFSET);
+    if (probe_directional_pre) {
+        const Addr block_shift = PageShift + L2TLB_BLK_OFFSET;
+        const Addr forward_pre_vaddr = vaddr + (l2tlbLineSize << PageShift);
+        forward_pre_block = (forward_pre_vaddr >> block_shift) << block_shift;
+        vaddr_block = (vaddr >> block_shift) << block_shift;
+        const Addr back_pre_vaddr = vaddr - (l2tlbLineSize << PageShift);
+        back_pre_block = (back_pre_vaddr >> block_shift) << block_shift;
 
-    l2tlb->lookupForwardPre(vaddr_block, satp.asid, false);
-    TlbEntry *pre_forward = l2tlb->lookupForwardPre(forward_pre_block, satp.asid, true);
+        l2tlb->lookupForwardPre(vaddr_block, satp.asid, false);
+        pre_forward = l2tlb->lookupForwardPre(forward_pre_block, satp.asid, true);
 
-    l2tlb->lookupBackPre(vaddr_block, satp.asid, false);
-    TlbEntry *pre_back = l2tlb->lookupBackPre(back_pre_block, satp.asid, true);
-    backPrePrecision = checkPrePrecision(l2tlb->removeNoUseBackPre, l2tlb->usedBackPre);
-    forwardPrePrecision = checkPrePrecision(l2tlb->removeNoUseForwardPre, l2tlb->forwardUsedPre);
-
+        l2tlb->lookupBackPre(vaddr_block, satp.asid, false);
+        pre_back = l2tlb->lookupBackPre(back_pre_block, satp.asid, true);
+        backPrePrecision = checkPrePrecision(l2tlb->removeNoUseBackPre, l2tlb->usedBackPre);
+        forwardPrePrecision = checkPrePrecision(l2tlb->removeNoUseForwardPre, l2tlb->forwardUsedPre);
+    }
 
     for (int i_e = 1; i_e < L_L2SUM; i_e++) {
         if ((satp.mode == AddrXlateMode::SV39) && (i_e == L_L2L3 || i_e == L_L2sp3))
@@ -2535,8 +2544,10 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
         if (!e[0])
             e[i_e] = l2tlb->lookupL2TLB(vaddr, satp.asid, mode, false, i_e, true, direct);
 
-        forward_pre[i_e] = l2tlb->lookupL2TLB(forward_pre_block, satp.asid, mode, true, i_e, true, direct);
-        back_pre[i_e] = l2tlb->lookupL2TLB(back_pre_block, satp.asid, mode, true, i_e, true, direct);
+        if (probe_directional_pre) {
+            forward_pre[i_e] = l2tlb->lookupL2TLB(forward_pre_block, satp.asid, mode, true, i_e, true, direct);
+            back_pre[i_e] = l2tlb->lookupL2TLB(back_pre_block, satp.asid, mode, true, i_e, true, direct);
+        }
     }
     bool return_flag = false;
     if (archDBer && req->hasPC()) {


### PR DESCRIPTION
## Background

We need to improve GEM5 simulation throughput. `TLB::doTranslate()` still performs directional prefetch-table and hidden shared-L2-TLB probes when both directional TLB prefetch controls are disabled. The hidden L2 lookup uses `sign_used=true`, so it marks an entry as used even though no directional prefetch request can be issued. This both adds hot-path work and biases removal telemetry.

## Approach

- Gate directional block-address calculation, prefetch-table probes, precision updates, and hidden L2-TLB probes on `openForwardPre || openBackPre`.
- Keep demand L2-TLB translation lookup outside the guard.
- Preserve the existing full directional probe sequence whenever either direction is enabled.
- Use defined zero/null values in the all-off path because later request predicates compare the directional addresses before testing the controls.

No parameters, data structures, or stats are added. Existing defaults remain disabled in `src/arch/riscv/RiscvTLB.py`.

## Results

Matched all-off `mcf/12568` checkpoint A/B (`2M` total instructions, `1M` warmup) keeps the functional timing model unchanged:

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| Simulated ticks | 558,489,285 | 558,489,285 |
| Committed instructions | 1,000,001 | 1,000,001 |
| IPC | 0.596252 | 0.596252 |
| `l2tlbUsedRemove` | 76,481 | 25,384 |
| `l2tlbUnusedRemove` | 105,715 | 156,812 |

The removal total remains 182,196. The expected shift from used to unused entries is the intended telemetry correction: entries are no longer marked used by a disabled directional probe.

Two pinned, alternating-order local screening pairs measured `hostTickRate` (not `hostInstRate`) at 11.42M -> 11.97M ticks/s on average (`+4.85%`; individual pairs `+7.91%` and `+1.88%`). This is a local screening result, not a suite-level performance claim.

Additional validation:

- `scons build/RISCV/gem5.fast --gold-linker -j64`
- `git diff --check`
- Matched all-off `gamess_triazolium/82016` A/B: identical simulated ticks, cycles, committed instructions, and IPC.
- Forward-only and backward-only `gamess_triazolium/82016` `200K/100K` smokes: both completed; generated configs enabled the requested caller-side direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Directional prefetch probing now runs only when forward or backward prefetching is enabled.
  * Avoids unnecessary cache lookups and precision calculations when directional prefetching is inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->