### PR TITLE
cpu-o3: fix UBSAN errors exposed by Fetch class layout change

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -147,6 +147,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         static_cast<unsigned>(commitToFetchDelay - iewToFetchDelay) : 0;
     redirectPendingHoldCycles = redirect_pending_gap + 1;
     for (int i = 0; i < MaxThreads; i++) {
+        fetchStatus[i] = Idle;
         setThreadStatus(i, Idle);
         decoder[i] = nullptr;
         threads[i].fetchpc.reset(params.isa[0]->newPCState());

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -968,7 +968,7 @@ IssueQue::selectInst()
                 continue;
             }
 
-            int lat = scheduler->getCorrectedOpLat(inst);
+            uint32_t lat = scheduler->getCorrectedOpLat(inst);
             uint64_t busy_bit = (lat > 63 ? -1 : (1llu << lat));
             if (!(portBusy[pi] & busy_bit)) {
                 DPRINTF(Schedule, "[sn %ld] was selected\n", inst->seqNum);
@@ -1755,7 +1755,9 @@ Scheduler::specWakeUpDependents(const DynInstPtr& inst, IssueQue* from_issue_que
     }
 
     for (auto to : wakeMatrix[from_issue_queue->getId()]) {
-        int oplat = getCorrectedOpLat(inst);
+        uint32_t oplat = getCorrectedOpLat(inst);
+        panic_if(oplat == 0, "[sn:%d] opClass:%d lat:%d\n",
+            inst->seqNum, (int)(inst->opClass()), oplat);
         int wakeDelay = oplat - 1;
         assert(oplat < 64);
         int diff = std::abs(from_issue_queue->getIssueStages() - to->getIssueStages());
@@ -1893,7 +1895,7 @@ Scheduler::useRfWrPort(const DynInstPtr& inst, const PhysRegIdPtr& regid, int ty
     auto& t_inst = std::get<0>(wrRfPortOccupancy[typePortId]);
     auto& t_pri = std::get<1>(wrRfPortOccupancy[typePortId]);
     auto& t_lat = std::get<2>(wrRfPortOccupancy[typePortId]);
-    int lat = getCorrectedOpLat(inst);
+    uint32_t lat = getCorrectedOpLat(inst);
 
     if (t_inst) {
         if ((t_lat == lat) && (t_pri < pri)) {  // smaller is higher priority

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -357,7 +357,7 @@ class Scheduler : public SimObject
     };
     using IQGroup = std::vector<IssueQue*>;
 
-    std::vector<int> opExecTimeTable;
+    std::vector<uint32_t> opExecTimeTable;
     std::vector<bool> opPipelined;
     std::vector<IQGroup> dispTable;
     std::vector<IssueQue*> issueQues;
@@ -377,7 +377,7 @@ class Scheduler : public SimObject
     using OccupancyType = std::vector<std::pair<DynInstPtr, int>>;
     std::vector<OccupancyType> rdRfPortOccupancy;
     // typePortId : [inst : priority : time]
-    std::vector<std::tuple<DynInstPtr, int, int>> wrRfPortOccupancy;
+    std::vector<std::tuple<DynInstPtr, int, uint32_t>> wrRfPortOccupancy;
 
     struct NullStruct {};
 

--- a/src/mem/cache/prefetch/xs_stride.hh
+++ b/src/mem/cache/prefetch/xs_stride.hh
@@ -68,7 +68,8 @@ class XSStridePrefetcher : public Queued
               lateConf(4, 7),
               longStride(4, 7),
               pc(0),
-              contextId(InvalidContextID)
+              contextId(InvalidContextID),
+              matchedSinceAlloc(false)
         {}
     };
 


### PR DESCRIPTION
# Fix UBSAN errors exposed by Fetch class layout change

## Summary

Fix 3 pre-existing undefined behaviors (UBs) in the O3 CPU pipeline and the stride prefetcher that were exposed when adding a 4-byte member to the `Fetch` class. The layout change caused the compiler to generate different code for other stages (IEW, issue queue), turning benign UBs into stable difftest failures.

## Background

While developing the `SMTFetchBlockPolicy` feature (a new fetch throttling mechanism for SMT long-latency loads), adding a single `SMTFetchBlockPolicy fetchBlockPolicy;` member (4 bytes) to the `Fetch` class caused difftest to **stably fail** at tick 12910743 on the `mcf` SPEC06 checkpoint — but only in the regression script, not in the single-checkpoint script. The only difference between these two scripts is whether the output path is explicitly specified.

Further experiments showed that **any** 4-byte member added at that position (even a plain `int dummyPadding = 0;`) triggered the same failure, ruling out the `SMTFetchBlockPolicy` type itself. ASAN found no memory errors (no buffer overflows, no use-after-free), and ASAN instrumentation itself "accidentally fixed" the difftest by changing the memory layout.

UBSAN identified the real culprits: **3 latent undefined behaviors** in unrelated code paths that the layout change exposed.

## Root Cause

Adding a 4-byte member between `fetchPolicy` and `priorityList` in `Fetch` shifts the offsets of all subsequent members:
- `priorityList` (std::list<ThreadID>)
- `ppFetch`, `ppFetchRequestSent` (probe points)
- `decodeScheduler` (SMTScheduler*)
- `lsqCounter`, `iqCounter`, `robCounter` (InstsCounter*)
- `smtBorrowThrottleCycles[MaxThreads]` (unsigned[4])
- `fetchStats` (large statistics struct)
- `localSquashVer[MaxThreads]`, `waitForVsetvl[MaxThreads]`, `valuePred`

This layout change causes the compiler to:
1. Generate different register allocation and instruction scheduling
2. Use different addressing modes for member access
3. Apply different optimizations based on assumed value ranges

Code with latent UB (uninitialized reads, signed overflow, negative shifts) that happened to "work" under the original layout now produces incorrect results under the new layout.

## Fixes

### 1. `fetch.cc`: Initialize `fetchStatus[i]` before first `setThreadStatus()`

**UBSAN error**: `fetch.cc:2437: load of value 22675557, which is not a valid value for type 'ThreadStatus'`

**Root cause**: `setThreadStatus(tid, status)` reads `fetchStatus[tid]` as `oldStatus` for debug printing. On the first call, `fetchStatus[tid]` is uninitialized.

**Functional impact**: None. The old status is only used for debug output and does not affect control flow. This fix is purely to silence the UBSAN false positive.

**Fix**: Explicitly initialize `fetchStatus[i] = Idle;` before calling `setThreadStatus(i, Idle);` in the constructor.

```cpp
for (int i = 0; i < MaxThreads; i++) {
+   fetchStatus[i] = Idle;
    setThreadStatus(i, Idle);
    ...
}
```

### 2. `issue_queue.cc/hh`: Use `uint32_t` for `opExecTimeTable` and `lat`

**UBSAN error**: `issue_queue.cc:794: shift exponent -1 is negative`

**Root cause**: `IntDiv` is configured with `opLat=sys.maxsize` (Python) as a sentinel for "uncertain cycles" (with `pipelined=False`). Through pybind11, this becomes `UINT_MAX` in C++ `uint32_t`, but `opExecTimeTable` was `std::vector<int>`, truncating to `-1`. The subsequent `(1llu << lat)` with `lat=-1` is undefined behavior.

**Design intent** (from `FuncUnitConfig.py`):
```python
class IntDiv(FUDesc):
    # for instructions with uncertain cycle
    # just set opLat = sys.maxsize
    # it can help us find potential bugs
    opList = [ OpDesc(opClass='IntDiv', opLat=sys.maxsize, pipelined=False) ]
```

**Fix**: Change `opExecTimeTable` to `std::vector<uint32_t>` and `lat` to `uint32_t`. The expression `(lat > 63 ? -1 : (1llu << lat))` now correctly catches `UINT_MAX > 63` as `true` and sets `busy_bit = (uint64_t)-1` (mark port busy for all 64 representable cycles). A `panic_if(oplat == 0, ...)` is also added in `specWakeUpDependents` to catch zero-latency operations early.

```cpp
// issue_queue.hh
- std::vector<int> opExecTimeTable;
+ std::vector<uint32_t> opExecTimeTable;
- std::vector<std::tuple<DynInstPtr, int, int>> wrRfPortOccupancy;
+ std::vector<std::tuple<DynInstPtr, int, uint32_t>> wrRfPortOccupancy;

// issue_queue.cc
- int lat = scheduler->getCorrectedOpLat(inst);
+ uint32_t lat = scheduler->getCorrectedOpLat(inst);
  uint64_t busy_bit = (lat > 63 ? -1 : (1llu << lat));
```

### 3. `xs_stride.hh`: Initialize `matchedSinceAlloc` in `StrideEntry` constructor

**UBSAN error**: `xs_stride.hh:49: load of value 8, which is not a valid value for type 'bool'`

**Root cause**: `bool matchedSinceAlloc;` is declared in `StrideEntry` but omitted from the constructor's initializer list.

**Fix**: Add `matchedSinceAlloc(false)` to the initializer list.

```cpp
StrideEntry()
    : TaggedEntry(),
      stride(0),
      lastAddr(0),
      conf(2, 0),
      depth(1),
      lateConf(4, 7),
      longStride(4, 7),
      pc(0),
      contextId(InvalidContextID),
+     matchedSinceAlloc(false)
{}
```

### Note on `iew.cc`

The original investigation also found that `enableSelectiveVPFlush` was uninitialized in the `IEW` constructor. This fix is **already present** in the current upstream `xs-dev` branch, so it is not included in this PR.

## Impact

- **Correctness**: These UBs could cause incorrect simulation results (wrong instruction scheduling, missed squashes, wrong wakeup logic) that only manifest under specific class layouts or compiler optimizations.
- **Stability**: Fixes stable difftest failures when modifying the `Fetch` class (e.g., adding new members for SMT features).
- **Future-proofing**: Eliminates latent UBs that could resurface with future code changes or different compiler versions.

## Testing

- ✅ UBSAN no longer reports any of the 3 fixed errors
- ✅ Difftest passes for `mcf` SPEC06 checkpoint under both single-checkpoint and regression (`parallel_sim.sh`) scripts
- ✅ Adding a 4-byte dummy member to `Fetch` no longer causes difftest failure
- ✅ No regression in other SPEC06 benchmarks

## Investigation Process

1. **Initial observation**: Adding `int dummyPadding = 0;` (4 bytes) to `Fetch` class caused stable difftest failure at tick 12910743
2. **Bisect experiments**: Replacing with `int dummyPadding = 0;` at 3 different positions all failed → confirmed layout-sensitive, not type-specific
3. **ASAN**: No memory errors detected; ASAN instrumentation "fixed" the issue → suggested layout-sensitive UB
4. **UBSAN**: Identified 3 specific UBs (invalid enum/bool values, negative shift)
5. **Root cause analysis**: Layout change shifted member offsets, causing compiler to generate different code that exposed latent UBs
6. **Fix and verify**: Applied targeted fixes, verified with UBSAN and difftest

## Files Changed

```
src/cpu/o3/fetch.cc                 | 1 +
src/cpu/o3/issue_queue.cc           | 8 +++++---
src/cpu/o3/issue_queue.hh           | 4 ++--
src/mem/cache/prefetch/xs_stride.hh | 3 ++-
4 files changed, 10 insertions(+), 6 deletions(-)
```

## Related

- Original feature branch: `SMTFetchBlockPolicy` (fetch throttling for SMT long-latency loads)
- Commit that exposed the issue: any commit adding ≥4 bytes to `Fetch` class between `fetchPolicy` and `priorityList`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU instruction scheduling reliability by handling operation latencies and resource occupancy with safer numeric values.
  * Added validation to reject invalid zero-latency speculative wakeups.
  * Ensured fetch threads and stride prefetch entries start in well-defined initial states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->