### PR TITLE
mem-cache: Schedule worker transfer on demand

### DIFF
--- a/src/mem/cache/prefetch/worker.cc
+++ b/src/mem/cache/prefetch/worker.cc
@@ -54,6 +54,10 @@ WorkerPrefetcher::rxHint(BaseMMU::Translation *dpp)
     DPRINTF(WorkerPref, "Worker: put [%lx, %d] into localBuffer(size:%lu)\n", ptr->pfInfo.getAddr(), ptr->pfahead_host,
             localBuffer.size());
     localBuffer.push_back(*ptr);
+
+    if (!transferEvent->scheduled()) {
+        schedule(transferEvent, nextCycle());
+    }
 }
 
 void
@@ -103,7 +107,9 @@ WorkerPrefetcher::transfer()
         count++;
         latestTransferTick = curTick();
     }
-    schedule(transferEvent, nextCycle());
+    if (!localBuffer.empty() && !transferEvent->scheduled()) {
+        schedule(transferEvent, nextCycle());
+    }
 }
 
 }  // namespace prefetch

--- a/src/mem/cache/prefetch/worker.hh
+++ b/src/mem/cache/prefetch/worker.hh
@@ -29,7 +29,6 @@ namespace prefetch
 
 class WorkerPrefetcher : public Queued
 {
-    bool firstCall = false;
     Event *transferEvent;
 
   public:
@@ -40,13 +39,7 @@ class WorkerPrefetcher : public Queued
 
     virtual void transfer();
 
-    void notify(const PacketPtr &pkt, const PrefetchInfo &pfi) override
-    {
-        if (!firstCall) {
-            firstCall = true;
-            schedule(transferEvent, nextCycle());
-        }
-    };
+    void notify(const PacketPtr &pkt, const PrefetchInfo &pfi) override {}
 
     void rxHint(BaseMMU::Translation *dpp) override;
     std::pair<long, long> rxMembusRatio(RequestorID requestorId) override


### PR DESCRIPTION
## Summary

Worker transfer does not need to be scheduled every cycle. Schedule it when an entry is inserted into `localBuffer`, and reschedule it only when the previous transfer leaves buffered work.

The former first-notification startup path is removed, so idle Worker prefetchers no longer create an empty polling event.

## Scope

No parameters, statistics, or data structures change. Each transfer event retains the existing `depth = 4` bound.

## Validation

- Built `build/RISCV/gem5.fast`
- Ran a short Worker-enabled `mcf` checkpoint smoke to the configured max instruction count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefetch event scheduling to prevent duplicate transfers.
  * Ensured pending prefetch hints are processed reliably across cycles.
  * Removed unnecessary initial-notification scheduling behavior for more consistent cache operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->