### PR TITLE
cpu-o3: Add limited two-fetch

### DIFF
--- a/configs/example/idealkmhv3.py
+++ b/configs/example/idealkmhv3.py
@@ -39,6 +39,7 @@ def setKmhV3IdealParams(args, system):
         cpu.iewToFetchDelay = 2 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4  # maybe we need to change iewToFetchDelay to 4, but now we use commit update bpu
         cpu.fetchQueueSize = 64
+        cpu.enableTwoFetch = not args.smt
 
         # decode
         cpu.fetchToDecodeDelay = 3

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -42,6 +42,7 @@ def setKmhV3Params(args, system):
         cpu.iewToFetchDelay = 4 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4
         cpu.fetchQueueSize = 64
+        cpu.enableTwoFetch = not args.smt
 
         # decode
         cpu.fetchToDecodeDelay = 3

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -42,7 +42,6 @@ def setKmhV3Params(args, system):
         cpu.iewToFetchDelay = 4 # for resolved update, should train branch after squash
         cpu.commitToFetchDelay = 4
         cpu.fetchQueueSize = 64
-        cpu.enableTwoFetch = not args.smt
 
         # decode
         cpu.fetchToDecodeDelay = 3

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -125,6 +125,10 @@ class BaseO3CPU(BaseCPU):
     commitToFetchDelay = Param.Cycles(3, "Commit to fetch delay")
     fetchWidth = Param.Unsigned(16, "Fetch width")
     fetchBufferSize = Param.Unsigned(66, "Fetch buffer size in bytes")
+    enableTwoFetch = Param.Bool(False,
+        "Enable two consecutive FTQ targets from one fetch buffer")
+    twoFetchMaxBytes = Param.Unsigned(64,
+        "Maximum fetch-buffer window covered by two-fetch")
     fetchQueueSize = Param.Unsigned(48, "Fetch queue size in micro-ops "
                                     "per-thread")
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -98,6 +98,8 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
       iewToFetchDelay(params.iewToFetchDelay),
       commitToFetchDelay(params.commitToFetchDelay),
       fetchWidth(params.fetchWidth),
+      enableTwoFetch(params.enableTwoFetch),
+      twoFetchMaxBytes(params.twoFetchMaxBytes),
       decodeWidth(params.decodeWidth),
       retryPkt(),
       cacheBlkSize(cpu->cacheLineSize()),
@@ -118,6 +120,13 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         fatal("fetchWidth (%d) is larger than compiled limit (%d),\n"
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              fetchWidth, static_cast<int>(MaxWidth));
+    panic_if(enableTwoFetch &&
+             (twoFetchMaxBytes == 0 ||
+              fetchBufferSize < 2 ||
+              twoFetchMaxBytes > fetchBufferSize - 2),
+             "twoFetchMaxBytes (%u) requires a fetch buffer of at least "
+             "%u bytes, but fetchBufferSize is %u",
+             twoFetchMaxBytes, twoFetchMaxBytes + 2, fetchBufferSize);
     panic_if(numFetchTargetThreads == 0 ||
              numFetchTargetThreads > numThreads ||
              numFetchTargetThreads > 2,
@@ -343,6 +352,10 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "Selected FTQ heads whose thread state could not start a fetch"),
     ADD_STAT(fetchTargetRequestBlocked, statistics::units::Count::get(),
              "Prepared FTQ heads whose cache request could not be started"),
+    ADD_STAT(twoFetchAttempts, statistics::units::Count::get(),
+             "Predicted-taken FTQ boundaries considered for limited two-fetch"),
+    ADD_STAT(twoFetchSuccesses, statistics::units::Count::get(),
+             "FTQ boundaries crossed using the current fetch buffer"),
     ADD_STAT(traceMetaStores, statistics::units::Count::get(),
              "Number of stored trace metadata records (seqNum -> traceInst)"),
     ADD_STAT(traceMetaCleanupSquashCalls, statistics::units::Count::get(),
@@ -605,6 +618,7 @@ Fetch::handleMultiCacheLineFetch(Addr vaddr, ThreadID tid, Addr pc)
 
     // Reset cache request state for this thread
     threads[tid].cacheReq.reset();
+    threads[tid].usedForTwoFetch = false;
     threads[tid].cacheReq.baseAddr = vaddr;
     threads[tid].cacheReq.totalSize = fetchBufferSize;
 
@@ -744,6 +758,7 @@ Fetch::processMultiCacheLineCompletion(ThreadID tid, PacketPtr pkt)
     // Copy merged data directly into fetchBuffer
     memcpy(threads[tid].data, firstPkt->getConstPtr<uint8_t>(), firstPkt->getSize());
     memcpy(threads[tid].data + firstPkt->getSize(), secondPkt->getConstPtr<uint8_t>(), secondPkt->getSize());
+    threads[tid].usedForTwoFetch = false;
     threads[tid].valid = true;
 
     // Clean up the packets
@@ -915,12 +930,15 @@ Fetch::deactivateThread(ThreadID tid)
 }
 
 bool
-Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
+Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc,
+                             bool allow_two_fetch,
+                             bool &continued_to_next_target)
 {
     // Do branch prediction check here.
     // A bit of a misnomer...next_PC is actually the current PC until
     // this function updates it.
     bool predict_taken = false;
+    continued_to_next_target = false;
 
     // Decoupled+BTB-only: compute next PC directly from the supplying FSQ entry.
     ThreadID tid = inst->threadNumber;
@@ -972,10 +990,45 @@ Fetch::lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc)
         ftqEntryFetchedInsts[tid] = 0;
         threads[tid].valid = false;
     } else if (run_out) {
+        if (enableTwoFetch && !isTraceMode() &&
+            allow_two_fetch && predict_taken) {
+            ++fetchStats.twoFetchAttempts;
+
+            if (dbpbtb->ftqHasNext(tid)) {
+                const auto &next_stream = dbpbtb->ftqNextTarget(tid);
+                const bool target_matches =
+                    next_pc.instAddr() == next_stream.startPC;
+                const bool valid_range =
+                    next_stream.startPC >= stream.startPC &&
+                    next_stream.predEndPC >= next_stream.startPC;
+                const bool fits_window = valid_range &&
+                    next_stream.predEndPC - stream.startPC <=
+                        twoFetchMaxBytes;
+                const bool has_fetch_capacity =
+                    numInst < fetchWidth &&
+                    fetchQueue[tid].size() < fetchQueueSize;
+                const bool can_cross_boundary =
+                    !redirectPending[tid] &&
+                    (!checkInterrupt(next_pc.instAddr()) ||
+                     delayedCommit[tid]);
+
+                continued_to_next_target = target_matches && fits_window &&
+                    has_fetch_capacity && can_cross_boundary;
+            }
+        }
+
         dbpbtb->consumeFetchTarget(ftqEntryFetchedInsts[tid], tid);
         ftqEntryFetchedInsts[tid] = 0;
-        threads[tid].valid = false;
-        DPRINTF(DecoupleBP, "Used up fetch targets.\n");
+        if (continued_to_next_target) {
+            threads[tid].usedForTwoFetch = true;
+            ++fetchStats.twoFetchSuccesses;
+            DPRINTF(DecoupleBP,
+                    "2Fetch: continue with FTQ %lu in the current buffer.\n",
+                    dbpbtb->ftqHeadId(tid));
+        } else {
+            threads[tid].valid = false;
+            DPRINTF(DecoupleBP, "Used up fetch targets.\n");
+        }
     }
 
     inst->setLoopIteration(currentLoopIter);
@@ -2191,7 +2244,9 @@ Fetch::checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
 
 bool
 Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
-                               StaticInstPtr &curMacroop)
+                                StaticInstPtr &curMacroop,
+                                bool allow_two_fetch,
+                                bool &continued_to_next_target)
 {
     auto *dec_ptr = decoder[tid];
     bool predictedBranch = false;
@@ -2251,7 +2306,8 @@ Fetch::processSingleInstruction(ThreadID tid, PCStateBase &pc,
     set(next_pc, pc);
 
     // Handle branch prediction and update next_pc for both modes
-    predictedBranch = lookupAndUpdateNextPC(instruction, *next_pc);
+    predictedBranch = lookupAndUpdateNextPC(
+        instruction, *next_pc, allow_two_fetch, continued_to_next_target);
 
     if (predictedBranch) {
         DPRINTF(Fetch, "[tid:%i] Branch detected with PC = %s, target = %s\n",
@@ -2306,15 +2362,14 @@ Fetch::performInstructionFetch(ThreadID tid)
     StaticInstPtr &curMacroop = macroop[tid];
 
     // Control flags for main fetch loop
-    bool predictedBranch = false;
-
+    bool stopFetchThisCycle = false;
     DPRINTF(Fetch, "[tid:%i] Adding instructions to queue to decode.\n", tid);
 
     // Main instruction fetch loop - process until fetch width or other limits
     // For decoupled frontend (including trace mode), check FTQ availability
     StallReason stall = StallReason::NoStall;
     while (numInst < fetchWidth && fetchQueue[tid].size() < fetchQueueSize &&
-           !predictedBranch && !ftqEmpty(tid) && !waitForVsetvl[tid]) {
+           !stopFetchThisCycle && !ftqEmpty(tid) && !waitForVsetvl[tid]) {
 
         // Check memory needs and supply bytes to decoder if required
         stall = checkMemoryNeeds(tid, pc_state, curMacroop);
@@ -2327,7 +2382,13 @@ Fetch::performInstructionFetch(ThreadID tid)
         // into multiple micro-ops.
         do {
             // Process a single instruction, from decoding to PC update.
-            predictedBranch = processSingleInstruction(tid, pc_state, curMacroop);
+            bool continued_to_next_target = false;
+            const bool predicted_taken = processSingleInstruction(
+                tid, pc_state, curMacroop,
+                !threads[tid].usedForTwoFetch,
+                continued_to_next_target);
+            stopFetchThisCycle =
+                predicted_taken && !continued_to_next_target;
 
         } while (curMacroop &&
                  numInst < fetchWidth &&
@@ -2346,7 +2407,7 @@ Fetch::performInstructionFetch(ThreadID tid)
     }
 
     // Log why fetch stopped
-    if (predictedBranch) {
+    if (stopFetchThisCycle) {
         DPRINTF(Fetch, "[tid:%i] Done fetching, predicted branch instruction encountered.\n", tid);
     } else if (numInst >= fetchWidth) {
         DPRINTF(Fetch, "[tid:%i] Done fetching, reached fetch bandwidth for this cycle.\n", tid);

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -384,9 +384,14 @@ class Fetch
      * Looks up the branch predictor, gets a prediction, and updates the PC.
      * @param inst The dynamic instruction object.
      * @param next_pc The PC state to update with the prediction.
+     * @param allow_two_fetch Whether this buffer may cross an FTQ boundary.
+     * @param continued_to_next_target Whether the current buffer was retained
+     *        for the next FTQ target.
      * @return true if a branch was predicted taken.
      */
-    bool lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc);
+    bool lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc,
+                               bool allow_two_fetch,
+                               bool &continued_to_next_target);
 
     /**
      * Fetches the cache line that contains the fetch PC.  Returns any
@@ -575,11 +580,15 @@ class Fetch
      * @param tid The thread ID of the instruction.
      * @param pc The current program counter state (will be updated).
      * @param curMacroop The current macro-op being processed (if any).
+     * @param allow_two_fetch Whether this buffer may cross an FTQ boundary.
+     * @param continued_to_next_target Whether the current buffer was retained
+     *        for the next FTQ target.
      * @return true if a branch was predicted.
      */
-    bool
-    processSingleInstruction(ThreadID tid, PCStateBase &pc,
-                             StaticInstPtr &curMacroop);
+    bool processSingleInstruction(ThreadID tid, PCStateBase &pc,
+                                  StaticInstPtr &curMacroop,
+                                  bool allow_two_fetch,
+                                  bool &continued_to_next_target);
 
     /**
      * Checks if the decoder requires more memory to proceed and fetches
@@ -592,17 +601,6 @@ class Fetch
     StallReason checkMemoryNeeds(ThreadID tid, const PCStateBase &this_pc,
                                  const StaticInstPtr &curMacroop);
 
-
-    /**
-     * Looks up the branch predictor, gets a prediction, and updates the PC.
-     * @param inst The dynamic instruction object.
-     * @param next_pc The PC state to update with the prediction.
-     * @param predictedBranch Flag indicating if a branch was predicted.
-     * @param newMacro Flag indicating if we are moving to a new macro-op.
-     */
-    void
-    lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &next_pc,
-                         bool &predictedBranch, bool &newMacro);
 
   private:
     /** Pointer to the O3CPU. */
@@ -687,6 +685,12 @@ class Fetch
 
     /** The width of fetch in instructions. */
     unsigned fetchWidth;
+
+    /** Enable consuming two consecutive FTQ targets from one fetch buffer. */
+    const bool enableTwoFetch;
+
+    /** Maximum byte window covered by limited two-fetch. */
+    const unsigned twoFetchMaxBytes;
 
     /** The width of decode in instructions. */
     unsigned decodeWidth;
@@ -896,11 +900,17 @@ class Fetch
         /** Whether the fetch buffer data is valid */
         bool valid;
 
+        /** Whether this buffer has already crossed one FTQ boundary. */
+        bool usedForTwoFetch;
+
         /** Size of the fetch buffer in bytes. Set by Fetch class during init. */
         unsigned size;
 
         /** Constructor initializes buffer with default size */
-        FetchBuffer() : data(nullptr), startPC(0), valid(false), size(0) {
+        FetchBuffer()
+            : data(nullptr), startPC(0), valid(false),
+              usedForTwoFetch(false), size(0)
+        {
         }
 
         /** Destructor is not needed as Fetch class manages memory */
@@ -911,6 +921,7 @@ class Fetch
         void reset() {
             valid = false;
             startPC = 0;
+            usedForTwoFetch = false;
             // No need to clear data as it will be overwritten
         }
 
@@ -1155,6 +1166,10 @@ class Fetch
         statistics::Scalar fetchTargetThreadNotReady;
         /** Prepared FTQ heads whose cache request could not be started. */
         statistics::Scalar fetchTargetRequestBlocked;
+        /** Predicted-taken FTQ boundaries considered for limited two-fetch. */
+        statistics::Scalar twoFetchAttempts;
+        /** FTQ boundaries crossed using the current fetch buffer. */
+        statistics::Scalar twoFetchSuccesses;
 
         // Trace metadata accounting (trace mode)
         /** Number of stored trace metadata records (seqNum -> traceInst). */

--- a/src/cpu/pred/btb/decoupled_bpred.hh
+++ b/src/cpu/pred/btb/decoupled_bpred.hh
@@ -440,6 +440,15 @@ class DecoupledBPUWithBTB : public BPredUnit
     bool ftqHasFetching(ThreadID tid) const { return ftq.hasTarget(ftq.fetchId(tid), tid); }
     FetchTargetId ftqHeadId(ThreadID tid) const { assert(ftqHasFetching(tid)); return ftq.fetchId(tid); }
     const FetchTarget &ftqFetchingTarget(ThreadID tid) { assert(ftqHasFetching(tid)); return ftq.fetching(tid); }
+    bool ftqHasNext(ThreadID tid) const
+    {
+        return ftq.hasTarget(ftq.fetchId(tid) + 1, tid);
+    }
+    const FetchTarget &ftqNextTarget(ThreadID tid) const
+    {
+        assert(ftqHasNext(tid));
+        return ftq.get(ftq.fetchId(tid) + 1, tid);
+    }
     int getTargetTid(const std::array<bool, MaxThreads> &eligible,
                      unsigned *ineligibleSkips)
     {


### PR DESCRIPTION
## Motivation

The single-thread frontend currently stops at every predicted-taken FTQ
boundary even when the next target is already covered by the same fetch
buffer. This leaves fetch bandwidth unused for short taken blocks.

## Approach

- Allow Fetch to consume the next consecutive FTQ target after a predicted
  taken branch when:
  - the predicted target matches the next FTQ start PC;
  - both targets fit in a forward 64-byte window;
  - fetch width and queue capacity remain; and
  - no interrupt or backend redirect prevents the continuation.
- Reuse the existing 66-byte FetchBuffer and its two cache-line requests.
- Track one persistent bit per thread so one buffer can cross at most one FTQ
  boundary, including when the second target spans multiple gem5 cycles.
- Keep the base CPU parameter and RTL-aligned `kmhv3.py` disabled by default.
  Enable it only for the non-SMT `idealkmhv3.py` experiment configuration.
- Add only attempt and success counters for the initial model.

## Modeling scope

This is intentionally the limited, same-buffer model. It does not add another
I-cache request group, model RTL I-cache bank conflicts, or latch both FTQ
targets when the first request starts. The next target may become available
while the current buffer is waiting for I-cache, which is a deliberate coarse
approximation for this first KISS version. Trace replay is excluded because it
bypasses the normal FetchBuffer/I-cache path.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- `git diff --check`
- `python3 -m py_compile src/cpu/o3/BaseO3CPU.py configs/example/kmhv3.py configs/example/idealkmhv3.py`
- nexus-am `2fetch-riscv64-xs.bin`, with difftest enabled:
  - `idealkmhv3.py`: normal `m5_exit`, 60,111 committed instructions,
    10,037 attempts and 10,004 successes;
  - default `kmhv3.py`: normal `m5_exit`, zero attempts and successes;
  - window reduced to 8 bytes: normal `m5_exit`, attempts remain visible and
    successes fall to zero, matching the disabled-cycle result;
  - `fetchWidth=4`: normal `m5_exit`, 60,111 committed instructions and 9,998
    successes, covering a second FTQ target that remains active across cycles.
- Fetch debug trace confirms the taken instruction from FTQ N is followed by
  instructions from FTQ N+1 in the same tick, without consuming FTQ N+2.

### GCC16 RVA23 SPEC06 0.3c

[Run 32832916984](https://github.com/OpenXiangShan/GEM5/actions/runs/32832916984)
completed successfully on commit `a19984d9a9` with `idealkmhv3.py`, all
benchmarks, and no extra gem5 arguments. Compared with the same-config
[baseline run 32822775193](https://github.com/OpenXiangShan/GEM5/actions/runs/32822775193)
at `b58103e63f`:

- overall 3.0 GHz score: `69.928364 -> 69.924341` (`-0.005754%`);
- INT: `67.640823 -> 67.557057` (`-0.123839%`);
- FP: `71.589525 -> 71.645138` (`+0.077684%`);
- across 145 slices: 635,897,351 attempts and 106,885,150 successes
  (`16.81%` success rate).

The aggregate result is neutral without a stable two-taken producer. The main
positive benchmark deltas are dealII (`+0.787%`) and zeusmp (`+0.729%`); the
main negative deltas are omnetpp (`-0.489%`) and gcc (`-0.440%`). The baseline
used the local parallel runner while the new run used the distributed runner;
the workload, configuration, and gem5 arguments are otherwise aligned.

PairTAGE first-block-only mode also completes normally. Enabling PairTAGE
second-block production currently reaches a FoldedHist consistency assertion
on this microtest; PairTAGE remains disabled by default and that predictor-side
issue is outside this KISS Fetch change.
