### PR TITLE
misc: Add ASan and UBSan smoke test

### DIFF
--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -138,7 +138,7 @@ jobs:
             2>/dev/null |
             head -1000 || true
 
-  valgrind_memory_check:
+  asan_memory_check:
     if: |
       github.event_name != 'pull_request_target' ||
       (github.event.label.name == 'regression' &&
@@ -146,19 +146,44 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
-    name: XS-GEM5 - Check memory corruption
+    name: XS-GEM5 - ASan smoke test
+    env:
+      ASAN_OPTIONS: detect_leaks=0
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 debug
-        run: CC=gcc CXX=g++ scons build/RISCV/gem5.debug --linker=gold -j64
-      - name: Memory check
+      - name: Build GEM5 with ASan
         run: |
-          export GEM5_HOME=$(pwd)
-          bash util/memory_check/run-xs-with-valgrind.sh
-          cd $GEM5_HOME
+          CC=clang CXX=clang++ scons build/RISCV/gem5.opt \
+            --linker=gold --without-tcmalloc --with-asan -j64
+      - name: Run CoreMark ASan smoke test
+        shell: bash
+        env:
+          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:abort_on_error=1:log_path=asan-test/asan
+        run: |
+          set -euo pipefail
+
+          mkdir -p asan-test/m5out
+          ./build/RISCV/gem5.opt \
+            --listener-mode=off \
+            -d asan-test/m5out \
+            ./configs/example/kmhv3.py \
+            --raw-cpt \
+            --generic-rv-cpt=/nfs/home/share/gem5_ci/checkpoints/coremark-riscv64-xs.bin \
+            --disable-difftest \
+            --maxinsts=10000
+      - name: Upload ASan diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: asan-diagnostics
+          path: |
+            asan-test/asan.*
+            asan-test/m5out/config.ini
+            asan-test/m5out/config.json
+          if-no-files-found: ignore
 
   new_sim_script_test_gcb_multi_core:
     if: |

--- a/.github/workflows/gem5.yml
+++ b/.github/workflows/gem5.yml
@@ -138,7 +138,7 @@ jobs:
             2>/dev/null |
             head -1000 || true
 
-  asan_memory_check:
+  sanitizer_check:
     if: |
       github.event_name != 'pull_request_target' ||
       (github.event.label.name == 'regression' &&
@@ -146,7 +146,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, open]
     continue-on-error: false
-    name: XS-GEM5 - ASan smoke test
+    name: XS-GEM5 - ASan + UBSan smoke test
     env:
       ASAN_OPTIONS: detect_leaks=0
     steps:
@@ -154,35 +154,37 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/build-dramsim
-      - name: Build GEM5 with ASan
+      - name: Build GEM5 with ASan and UBSan
         run: |
           CC=clang CXX=clang++ scons build/RISCV/gem5.opt \
-            --linker=gold --without-tcmalloc --with-asan -j64
-      - name: Run CoreMark ASan smoke test
+            --linker=gold --without-tcmalloc --with-asan --with-ubsan -j64
+      - name: Run CoreMark sanitizer smoke test
         shell: bash
         env:
-          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:abort_on_error=1:log_path=asan-test/asan
+          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:abort_on_error=1:log_path=sanitizer-test/asan
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:log_path=sanitizer-test/ubsan
         run: |
           set -euo pipefail
 
-          mkdir -p asan-test/m5out
+          mkdir -p sanitizer-test/m5out
           ./build/RISCV/gem5.opt \
             --listener-mode=off \
-            -d asan-test/m5out \
+            -d sanitizer-test/m5out \
             ./configs/example/kmhv3.py \
             --raw-cpt \
             --generic-rv-cpt=/nfs/home/share/gem5_ci/checkpoints/coremark-riscv64-xs.bin \
             --disable-difftest \
             --maxinsts=10000
-      - name: Upload ASan diagnostics
+      - name: Upload sanitizer diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
-          name: asan-diagnostics
+          name: sanitizer-diagnostics
           path: |
-            asan-test/asan.*
-            asan-test/m5out/config.ini
-            asan-test/m5out/config.json
+            sanitizer-test/asan.*
+            sanitizer-test/ubsan.*
+            sanitizer-test/m5out/config.ini
+            sanitizer-test/m5out/config.json
           if-no-files-found: ignore
 
   new_sim_script_test_gcb_multi_core:


### PR DESCRIPTION
## Motivation

The existing Valgrind full-test job depends on stale infrastructure paths and no longer provides a useful leak gate. A short blocking sanitizer smoke test provides more actionable diagnostics for memory safety and undefined behavior.

## Approach

- Replace the Valgrind full-test job with one combined Clang ASan+UBSan job.
- Build `gem5.opt` once with `--with-asan --with-ubsan --without-tcmalloc`.
- Disable leak detection and fail immediately on ASan or UBSan errors.
- Run a self-contained 10K-instruction CoreMark smoke test without difftest.
- Upload separate ASan and UBSan logs plus gem5 configuration on failure.

Using one combined build keeps the full-test cost close to the original ASan-only proposal while covering both address errors and undefined behavior.

## Merge order

Land the UBSan baseline fixes first, then merge this CI gate:

- #1076
- #1077
- #1078

This PR intentionally has no allowlist, so any sanitizer report is blocking.

## Scope

The existing `util/memory_check` scripts are left untouched. This remains a CI-only change.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- Local Clang 19 ASan+UBSan `gem5.opt` build completed successfully with the same CI flags.
- On the current pre-fix branch, the CoreMark smoke command stopped with exit code 134 at the known `mem/port.cc` UBSan issue fixed by #1076.
- UBSan wrote the expected standalone diagnostic log with a symbolized stack trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated validation to include both memory-safety and undefined-behavior checks.
  - Added sanitizer diagnostics to smoke-test runs for improved issue investigation.
  - Validation failures now preserve relevant logs and configuration details as downloadable reports.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->