### PR TITLE
configs: fix GCPT restorer size limit typo for multi-core/SMT

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -370,7 +370,7 @@ def config_xiangshan_inputs(args: argparse.Namespace, sys):
 
     if args.num_cpus > 1 or args.smt:
         print("Simulating a multi-context system, demanding a larger GCPT restorer size (2M).")
-        sys.gcpt_restorer_size_limit = 2**20
+        sys.gcpt_restorer_size_limit = 2**21
     elif args.restore_rvv_cpt:
         print("Simulating single core with RVV, demanding GCPT restorer size of 0x1000.")
         sys.gcpt_restorer_size_limit = 0x1000


### PR DESCRIPTION


gcpt-restorer-pr-description-v2.txt
· 文本



# configs: fix GCPT restorer size limit typo for multi-core/SMT

## Summary

Fix a typo in `configs/common/xiangshan.py` where the multi-context GCPT restorer size limit was set to 1MB (`2**20`) while the adjacent comment says "2M". Change it to 2MB (`2**21`) to match the comment and avoid partial restorer loading.

## Problem

In `configs/common/xiangshan.py`, the code says:

```python
print("Simulating a multi-context system, demanding a larger GCPT restorer size (2M).")
sys.gcpt_restorer_size_limit = 2**20
```

The comment claims the limit is 2MB, but `2**20 = 1048576` bytes is only 1MB. Because of this typo, the following warning is emitted when the actual GCPT restorer file exceeds 1MB:

```
build/RISCV/mem/physical.cc:727: warn: Gcpt restorer file size 1048584 is larger than limit 1048576, is partially loaded
```

The restorer is then partially loaded, which may lead to incorrect restoration behavior.

## Fix

Change `2**20` to `2**21` so the limit matches the "2M" comment:

```python
if args.num_cpus > 1 or args.smt:
    print("Simulating a multi-context system, demanding a larger GCPT restorer size (2M).")
-   sys.gcpt_restorer_size_limit = 2**20
+   sys.gcpt_restorer_size_limit = 2**21
```

## Files Changed

```
configs/common/xiangshan.py | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing

- ✅ The warning `Gcpt restorer file size ... is larger than limit ... is partially loaded` no longer appears for multi-core/SMT simulations.
- ✅ Restorer is loaded in full.

## Related

- Warning source: `build/RISCV/mem/physical.cc:727`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the GCPT restorer size limit for multi-context Xiangshan configurations from 1 MiB to 2 MiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->