### PR TITLE
sim,mem: Backport upstream UBSan fixes

### DIFF
--- a/src/arch/amdgpu/common/tlb.hh
+++ b/src/arch/amdgpu/common/tlb.hh
@@ -214,7 +214,7 @@ namespace X86ISA
           public:
             CpuSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                         PortID _index)
-                : ResponsePort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+                : ResponsePort(_name), tlb(gpu_TLB), index(_index) { }
 
           protected:
             GpuTLB *tlb;
@@ -241,7 +241,7 @@ namespace X86ISA
           public:
             MemSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                         PortID _index)
-                : RequestPort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+                : RequestPort(_name), tlb(gpu_TLB), index(_index) { }
 
             std::deque<PacketPtr> retries;
 

--- a/src/arch/amdgpu/common/tlb_coalescer.hh
+++ b/src/arch/amdgpu/common/tlb_coalescer.hh
@@ -124,7 +124,7 @@ class TLBCoalescer : public ClockedObject
       public:
         CpuSidePort(const std::string &_name, TLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : ResponsePort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : ResponsePort(_name), coalescer(tlb_coalescer),
               index(_index) { }
 
       protected:
@@ -152,7 +152,7 @@ class TLBCoalescer : public ClockedObject
       public:
         MemSidePort(const std::string &_name, TLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : RequestPort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : RequestPort(_name), coalescer(tlb_coalescer),
               index(_index) { }
 
         std::deque<PacketPtr> retries;

--- a/src/arch/amdgpu/vega/pagetable_walker.hh
+++ b/src/arch/amdgpu/vega/pagetable_walker.hh
@@ -59,7 +59,7 @@ class Walker : public ClockedObject
     {
       public:
         WalkerPort(const std::string &_name, Walker * _walker) :
-            RequestPort(_name, _walker), walker(_walker)
+            RequestPort(_name), walker(_walker)
         {}
 
       protected:

--- a/src/arch/amdgpu/vega/tlb.hh
+++ b/src/arch/amdgpu/vega/tlb.hh
@@ -215,7 +215,7 @@ class GpuTLB : public ClockedObject
       public:
         CpuSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                     PortID _index)
-            : ResponsePort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+            : ResponsePort(_name), tlb(gpu_TLB), index(_index) { }
 
       protected:
         GpuTLB *tlb;
@@ -242,7 +242,7 @@ class GpuTLB : public ClockedObject
       public:
         MemSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                     PortID _index)
-            : RequestPort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+            : RequestPort(_name), tlb(gpu_TLB), index(_index) { }
 
         std::deque<PacketPtr> retries;
 

--- a/src/arch/amdgpu/vega/tlb_coalescer.hh
+++ b/src/arch/amdgpu/vega/tlb_coalescer.hh
@@ -138,7 +138,7 @@ class VegaTLBCoalescer : public ClockedObject
       public:
         CpuSidePort(const std::string &_name, VegaTLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : ResponsePort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : ResponsePort(_name), coalescer(tlb_coalescer),
               index(_index) { }
 
       protected:
@@ -166,7 +166,7 @@ class VegaTLBCoalescer : public ClockedObject
       public:
         MemSidePort(const std::string &_name, VegaTLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : RequestPort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : RequestPort(_name), coalescer(tlb_coalescer),
               index(_index) { }
 
         std::deque<PacketPtr> retries;

--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -474,8 +474,9 @@ void
 PMU::RegularEvent::enable()
 {
     for (auto& subEvents: microArchitectureEventSet) {
-        attachedProbePointList.emplace_back(
-            new RegularProbe(this, subEvents.first, subEvents.second));
+        attachedProbePointList.push_back(
+            subEvents.first->getProbeManager()->connect<RegularProbe>(
+                this, subEvents.second));
     }
 }
 

--- a/src/arch/arm/pmu.hh
+++ b/src/arch/arm/pmu.hh
@@ -358,12 +358,11 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
         }
 
       protected:
-        struct RegularProbe: public  ProbeListenerArgBase<uint64_t>
+        struct RegularProbe : public ProbeListenerArgBase<uint64_t>
         {
-            RegularProbe(RegularEvent *parent, SimObject* obj,
-                std::string name)
-                : ProbeListenerArgBase(obj->getProbeManager(), name),
-                  parentEvent(parent) {}
+            RegularProbe(RegularEvent *parent, std::string name)
+                : ProbeListenerArgBase(std::move(name)), parentEvent(parent)
+            {}
 
             RegularProbe() = delete;
 
@@ -379,7 +378,7 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
         /** Set of probe listeners tapping onto each of the input micro-arch
          *  events which compose this pmu event
          */
-        std::vector<std::unique_ptr<RegularProbe>> attachedProbePointList;
+        std::vector<ProbeListenerPtr<>> attachedProbePointList;
 
         void enable() override;
 

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -62,7 +62,7 @@ using namespace ArmISA;
 TableWalker::TableWalker(const Params &p)
     : ClockedObject(p),
       requestorId(p.sys->getRequestorId(this)),
-      port(new Port(this, requestorId)),
+      port(new Port(*this, requestorId)),
       isStage2(p.is_stage2), tlb(NULL),
       currState(NULL), pending(false),
       numSquashable(p.num_squash_per_cycle),
@@ -138,10 +138,11 @@ TableWalker::WalkerState::WalkerState() :
 {
 }
 
-TableWalker::Port::Port(TableWalker *_walker, RequestorID id)
-  : QueuedRequestPort(_walker->name() + ".port", _walker,
-        reqQueue, snoopRespQueue),
-    reqQueue(*_walker, *this), snoopRespQueue(*_walker, *this),
+TableWalker::Port::Port(TableWalker& _walker, RequestorID id)
+  : QueuedRequestPort(_walker.name() + ".port", reqQueue, snoopRespQueue),
+    owner{_walker},
+    reqQueue(_walker, *this),
+    snoopRespQueue(_walker, *this),
     requestorId(id)
 {
 }

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -939,7 +939,7 @@ class TableWalker : public ClockedObject
     class Port : public QueuedRequestPort
     {
       public:
-        Port(TableWalker* _walker, RequestorID id);
+        Port(TableWalker& _walker, RequestorID id);
 
         void sendFunctionalReq(Addr desc_addr, int size,
             uint8_t *data, Request::Flags flag);
@@ -961,6 +961,8 @@ class TableWalker : public ClockedObject
                                Tick delay, Event *event);
 
       private:
+        TableWalker& owner;
+
         /** Packet queue used to store outgoing requests. */
         ReqPacketQueue reqQueue;
 

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -72,7 +72,7 @@ namespace RiscvISA
         {
           public:
             WalkerPort(const std::string &_name, Walker * _walker) :
-                  RequestPort(_name, _walker), walker(_walker)
+                  RequestPort(_name), walker(_walker)
             {}
 
           protected:

--- a/src/arch/x86/pagetable_walker.hh
+++ b/src/arch/x86/pagetable_walker.hh
@@ -65,7 +65,7 @@ namespace X86ISA
         {
           public:
             WalkerPort(const std::string &_name, Walker * _walker) :
-                  RequestPort(_name, _walker), walker(_walker)
+                  RequestPort(_name), walker(_walker)
             {}
 
           protected:

--- a/src/cpu/kvm/base.hh
+++ b/src/cpu/kvm/base.hh
@@ -601,7 +601,7 @@ class BaseKvmCPU : public BaseCPU
 
       public:
         KVMCpuPort(const std::string &_name, BaseKvmCPU *_cpu)
-            : RequestPort(_name, _cpu), cpu(_cpu), activeMMIOReqs(0)
+            : RequestPort(_name), cpu(_cpu), activeMMIOReqs(0)
         { }
         /**
          * Interface to send Atomic or Timing IO request.  Assumes that the pkt

--- a/src/cpu/minor/cpu.hh
+++ b/src/cpu/minor/cpu.hh
@@ -111,7 +111,7 @@ class MinorCPU : public BaseCPU
 
       public:
         MinorCPUPort(const std::string& name_, MinorCPU &cpu_)
-            : RequestPort(name_, &cpu_), cpu(cpu_)
+            : RequestPort(name_), cpu(cpu_)
         { }
 
     };

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -83,7 +83,7 @@ namespace o3
 {
 
 Fetch::IcachePort::IcachePort(Fetch *_fetch, CPU *_cpu) :
-        RequestPort(_cpu->name() + ".icache_port", _cpu), fetch(_fetch)
+        RequestPort(_cpu->name() + ".icache_port"), fetch(_fetch)
 {}
 
 

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -87,7 +87,7 @@ namespace o3
 {
 
 LSQ::DcachePort::DcachePort(LSQ *_lsq, CPU *_cpu) :
-    RequestPort(_cpu->name() + ".dcache_port", _cpu), lsq(_lsq), cpu(_cpu)
+    RequestPort(_cpu->name() + ".dcache_port"), lsq(_lsq), cpu(_cpu)
 {}
 
 std::list<LSQ::SingleDataRequest*> LSQ::SingleDataRequest::singleList;

--- a/src/cpu/o3/probe/elastic_trace.cc
+++ b/src/cpu/o3/probe/elastic_trace.cc
@@ -125,25 +125,20 @@ ElasticTrace::regEtraceListeners()
         " probe listeners", curTick(), cpu->numSimulatedInsts());
     // Create new listeners: provide method to be called upon a notify() for
     // each probe point.
-    listeners.push_back(new ProbeListenerArg<ElasticTrace, RequestPtr>(this,
-                        "FetchRequest", &ElasticTrace::fetchReqTrace));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Execute",
-                &ElasticTrace::recordExecTick));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "ToCommit",
-                &ElasticTrace::recordToCommTick));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Rename",
-                &ElasticTrace::updateRegDep));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace, SeqNumRegPair>(this,
-                        "SquashInRename", &ElasticTrace::removeRegDepMapEntry));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Squash",
-                &ElasticTrace::addSquashedInst));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Commit",
-                &ElasticTrace::addCommittedInst));
+    connectListener<ProbeListenerArg<ElasticTrace, RequestPtr>>(
+        this, "FetchRequest", &ElasticTrace::fetchReqTrace);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Execute", &ElasticTrace::recordExecTick);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "ToCommit", &ElasticTrace::recordToCommTick);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Rename", &ElasticTrace::updateRegDep);
+    connectListener<ProbeListenerArg<ElasticTrace, SeqNumRegPair>>(
+        this, "SquashInRename", &ElasticTrace::removeRegDepMapEntry);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Squash", &ElasticTrace::addSquashedInst);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Commit", &ElasticTrace::addCommittedInst);
     allProbesReg = true;
 }
 

--- a/src/cpu/o3/probe/simple_trace.cc
+++ b/src/cpu/o3/probe/simple_trace.cc
@@ -68,10 +68,9 @@ SimpleTrace::regProbeListeners()
 {
     typedef ProbeListenerArg<SimpleTrace,
             DynInstConstPtr> DynInstListener;
-    listeners.push_back(new DynInstListener(this, "Commit",
-                &SimpleTrace::traceCommit));
-    listeners.push_back(new DynInstListener(this, "Fetch",
-                &SimpleTrace::traceFetch));
+    connectListener<DynInstListener>(this, "Commit",
+                                     &SimpleTrace::traceCommit);
+    connectListener<DynInstListener>(this, "Fetch", &SimpleTrace::traceFetch);
 }
 
 } // namespace o3

--- a/src/cpu/simple/atomic.cc
+++ b/src/cpu/simple/atomic.cc
@@ -79,7 +79,7 @@ AtomicSimpleCPU::AtomicSimpleCPU(const BaseAtomicSimpleCPUParams &p)
       width(p.width), locked(false),
       simulate_data_stalls(p.simulate_data_stalls),
       simulate_inst_stalls(p.simulate_inst_stalls),
-      icachePort(name() + ".icache_port", this),
+      icachePort(name() + ".icache_port"),
       dcachePort(name() + ".dcache_port", this),
       dcache_access(false), dcache_latency(0),
       ppCommit(nullptr)
@@ -286,8 +286,6 @@ AtomicSimpleCPU::AtomicCPUDPort::recvAtomicSnoop(PacketPtr pkt)
             __func__, pkt->getAddr(), pkt->cmdString());
 
     // X86 ISA: Snooping an invalidation for monitor/mwait
-    AtomicSimpleCPU *cpu = (AtomicSimpleCPU *)(&owner);
-
     for (ThreadID tid = 0; tid < cpu->numThreads; tid++) {
         if (cpu->getCpuAddrMonitor(tid)->doMonitor(pkt)) {
             cpu->wakeup(tid);
@@ -317,7 +315,6 @@ AtomicSimpleCPU::AtomicCPUDPort::recvFunctionalSnoop(PacketPtr pkt)
             __func__, pkt->getAddr(), pkt->cmdString());
 
     // X86 ISA: Snooping an invalidation for monitor/mwait
-    AtomicSimpleCPU *cpu = (AtomicSimpleCPU *)(&owner);
     for (ThreadID tid = 0; tid < cpu->numThreads; tid++) {
         if (cpu->getCpuAddrMonitor(tid)->doMonitor(pkt)) {
             cpu->wakeup(tid);

--- a/src/cpu/simple/atomic.hh
+++ b/src/cpu/simple/atomic.hh
@@ -117,8 +117,8 @@ class AtomicSimpleCPU : public BaseSimpleCPU
 
       public:
 
-        AtomicCPUPort(const std::string &_name, BaseSimpleCPU* _cpu)
-            : RequestPort(_name, _cpu)
+        AtomicCPUPort(const std::string &_name)
+            : RequestPort(_name)
         { }
 
       protected:
@@ -142,7 +142,7 @@ class AtomicSimpleCPU : public BaseSimpleCPU
 
       public:
         AtomicCPUDPort(const std::string &_name, BaseSimpleCPU *_cpu)
-            : AtomicCPUPort(_name, _cpu), cpu(_cpu)
+            : AtomicCPUPort(_name), cpu(_cpu)
         {
             cacheBlockMask = ~(cpu->cacheLineSize() - 1);
         }

--- a/src/cpu/simple/probes/simpoint.cc
+++ b/src/cpu/simple/probes/simpoint.cc
@@ -70,8 +70,7 @@ SimPoint::regProbeListeners()
 {
     typedef ProbeListenerArg<SimPoint, std::pair<SimpleThread*,StaticInstPtr>>
         SimPointListener;
-    listeners.push_back(new SimPointListener(this, "Commit",
-                                             &SimPoint::profile));
+    connectListener<SimPointListener>(this, "Commit", &SimPoint::profile);
 }
 
 void

--- a/src/cpu/simple/timing.hh
+++ b/src/cpu/simple/timing.hh
@@ -164,7 +164,7 @@ class TimingSimpleCPU : public BaseSimpleCPU
       public:
 
         TimingCPUPort(const std::string& _name, TimingSimpleCPU* _cpu)
-            : RequestPort(_name, _cpu), cpu(_cpu),
+            : RequestPort(_name), cpu(_cpu),
               retryRespEvent([this]{ sendRetryResp(); }, name())
         { }
 

--- a/src/cpu/testers/directedtest/RubyDirectedTester.hh
+++ b/src/cpu/testers/directedtest/RubyDirectedTester.hh
@@ -58,7 +58,7 @@ class RubyDirectedTester : public ClockedObject
       public:
         CpuPort(const std::string &_name, RubyDirectedTester *_tester,
                 PortID _id)
-            : RequestPort(_name, _tester, _id), tester(_tester)
+            : RequestPort(_name, _id), tester(_tester)
         {}
 
       protected:

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
@@ -84,7 +84,7 @@ class GarnetSyntheticTraffic : public ClockedObject
       public:
 
         CpuPort(const std::string &_name, GarnetSyntheticTraffic *_tester)
-            : RequestPort(_name, _tester), tester(_tester)
+            : RequestPort(_name), tester(_tester)
         { }
 
       protected:

--- a/src/cpu/testers/gpu_ruby_test/protocol_tester.hh
+++ b/src/cpu/testers/gpu_ruby_test/protocol_tester.hh
@@ -74,7 +74,7 @@ class ProtocolTester : public ClockedObject
       public:
         SeqPort(const std::string &_name, ProtocolTester *_tester, PortID _id,
                 PortID _index)
-            : RequestPort(_name, _tester, _id)
+            : RequestPort(_name, _id)
         {}
 
       protected:

--- a/src/cpu/testers/memtest/memtest.hh
+++ b/src/cpu/testers/memtest/memtest.hh
@@ -100,7 +100,7 @@ class MemTest : public ClockedObject
       public:
 
         CpuPort(const std::string &_name, MemTest &_memtest)
-            : RequestPort(_name, &_memtest), memtest(_memtest)
+            : RequestPort(_name), memtest(_memtest)
         { }
 
       protected:

--- a/src/cpu/testers/rubytest/RubyTester.hh
+++ b/src/cpu/testers/rubytest/RubyTester.hh
@@ -76,7 +76,7 @@ class RubyTester : public ClockedObject
 
         CpuPort(const std::string &_name, RubyTester *_tester, PortID _id,
                 PortID _index)
-            : RequestPort(_name, _tester, _id), tester(_tester),
+            : RequestPort(_name, _id), tester(_tester),
               globalIdx(_index)
         {}
 

--- a/src/cpu/testers/traffic_gen/base.hh
+++ b/src/cpu/testers/traffic_gen/base.hh
@@ -132,7 +132,7 @@ class BaseTrafficGen : public ClockedObject
       public:
 
         TrafficGenPort(const std::string& name, BaseTrafficGen& traffic_gen)
-            : RequestPort(name, &traffic_gen), trafficGen(traffic_gen)
+            : RequestPort(name), trafficGen(traffic_gen)
         { }
 
       protected:

--- a/src/cpu/testers/traffic_gen/gups_gen.hh
+++ b/src/cpu/testers/traffic_gen/gups_gen.hh
@@ -87,7 +87,7 @@ class GUPSGen : public ClockedObject
       public:
 
         GenPort(const std::string& name, GUPSGen *owner) :
-            RequestPort(name, owner), owner(owner), _blocked(false),
+            RequestPort(name), owner(owner), _blocked(false),
             blockedPacket(nullptr)
         {}
 

--- a/src/cpu/trace/trace_cpu.hh
+++ b/src/cpu/trace/trace_cpu.hh
@@ -218,7 +218,7 @@ class TraceCPU : public BaseCPU
       public:
         /** Default constructor. */
         IcachePort(TraceCPU* _cpu) :
-            RequestPort(_cpu->name() + ".icache_port", _cpu), owner(_cpu)
+            RequestPort(_cpu->name() + ".icache_port"), owner(_cpu)
         {}
 
       public:
@@ -258,7 +258,7 @@ class TraceCPU : public BaseCPU
       public:
         /** Default constructor. */
         DcachePort(TraceCPU* _cpu) :
-            RequestPort(_cpu->name() + ".dcache_port", _cpu), owner(_cpu)
+            RequestPort(_cpu->name() + ".dcache_port"), owner(_cpu)
         {}
 
       public:

--- a/src/dev/arm/gic_v3_its.hh
+++ b/src/dev/arm/gic_v3_its.hh
@@ -94,7 +94,7 @@ class Gicv3Its : public BasicPioDevice
 
       public:
         DataPort(const std::string &_name, Gicv3Its &_its) :
-            RequestPort(_name, &_its),
+            RequestPort(_name),
             its(_its)
         {}
 

--- a/src/dev/arm/smmu_v3_ports.cc
+++ b/src/dev/arm/smmu_v3_ports.cc
@@ -45,7 +45,7 @@ namespace gem5
 {
 
 SMMURequestPort::SMMURequestPort(const std::string &_name, SMMUv3 &_smmu) :
-    RequestPort(_name, &_smmu),
+    RequestPort(_name),
     smmu(_smmu)
 {}
 
@@ -63,7 +63,7 @@ SMMURequestPort::recvReqRetry()
 
 SMMUTableWalkPort::SMMUTableWalkPort(const std::string &_name,
                                                  SMMUv3 &_smmu) :
-    RequestPort(_name, &_smmu),
+    RequestPort(_name),
     smmu(_smmu)
 {}
 
@@ -83,7 +83,7 @@ SMMUDevicePort::SMMUDevicePort(const std::string &_name,
                              SMMUv3DeviceInterface &_ifc,
                              PortID _id)
 :
-    QueuedResponsePort(_name, &_ifc, respQueue, _id),
+    QueuedResponsePort(_name, respQueue, _id),
     ifc(_ifc),
     respQueue(_ifc, *this)
 {}
@@ -141,7 +141,7 @@ SMMUControlPort::getAddrRanges() const
 
 SMMUATSMemoryPort::SMMUATSMemoryPort(const std::string &_name,
                                      SMMUv3DeviceInterface &_ifc) :
-    QueuedRequestPort(_name, &_ifc, reqQueue, snoopRespQueue),
+    QueuedRequestPort(_name, reqQueue, snoopRespQueue),
     ifc(_ifc),
     reqQueue(_ifc, *this),
     snoopRespQueue(_ifc, *this)
@@ -155,7 +155,7 @@ SMMUATSMemoryPort::recvTimingResp(PacketPtr pkt)
 
 SMMUATSDevicePort::SMMUATSDevicePort(const std::string &_name,
                                    SMMUv3DeviceInterface &_ifc) :
-    QueuedResponsePort(_name, &_ifc, respQueue),
+    QueuedResponsePort(_name, respQueue),
     ifc(_ifc),
     respQueue(_ifc, *this)
 {}

--- a/src/dev/dma_device.cc
+++ b/src/dev/dma_device.cc
@@ -57,7 +57,7 @@ namespace gem5
 
 DmaPort::DmaPort(ClockedObject *dev, System *s,
                  uint32_t sid, uint32_t ssid)
-    : RequestPort(dev->name() + ".dma", dev),
+    : RequestPort(dev->name() + ".dma"),
       device(dev), sys(s), requestorId(s->getRequestorId(dev)),
       sendEvent([this]{ sendDma(); }, dev->name()),
       defaultSid(sid), defaultSSid(ssid), cacheLineSize(s->cacheLineSize())

--- a/src/dev/x86/intdev.hh
+++ b/src/dev/x86/intdev.hh
@@ -118,7 +118,7 @@ class IntRequestPort : public QueuedRequestPort
   public:
     IntRequestPort(const std::string& _name, SimObject* _parent,
                   Device* dev, Tick _latency) :
-        QueuedRequestPort(_name, _parent, reqQueue, snoopRespQueue),
+        QueuedRequestPort(_name, reqQueue, snoopRespQueue),
         reqQueue(*_parent, *this), snoopRespQueue(*_parent, *this),
         device(dev), latency(_latency)
     {

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -512,7 +512,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         DataPort(const std::string &_name, ComputeUnit *_cu, PortID id)
-            : RequestPort(_name, _cu, id), computeUnit(_cu) { }
+            : RequestPort(_name, id), computeUnit(_cu) { }
 
         bool snoopRangeSent;
 
@@ -584,7 +584,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         ScalarDataPort(const std::string &_name, ComputeUnit *_cu)
-            : RequestPort(_name, _cu), computeUnit(_cu)
+            : RequestPort(_name), computeUnit(_cu)
         {
         }
 
@@ -655,7 +655,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         SQCPort(const std::string &_name, ComputeUnit *_cu)
-            : RequestPort(_name, _cu), computeUnit(_cu) { }
+            : RequestPort(_name), computeUnit(_cu) { }
 
         bool snoopRangeSent;
 
@@ -696,7 +696,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         DTLBPort(const std::string &_name, ComputeUnit *_cu, PortID id)
-            : RequestPort(_name, _cu, id), computeUnit(_cu),
+            : RequestPort(_name, id), computeUnit(_cu),
               stalled(false)
         { }
 
@@ -743,7 +743,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         ScalarDTLBPort(const std::string &_name, ComputeUnit *_cu)
-            : RequestPort(_name, _cu), computeUnit(_cu), stalled(false)
+            : RequestPort(_name), computeUnit(_cu), stalled(false)
         {
         }
 
@@ -771,7 +771,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         ITLBPort(const std::string &_name, ComputeUnit *_cu)
-            : RequestPort(_name, _cu), computeUnit(_cu), stalled(false) { }
+            : RequestPort(_name), computeUnit(_cu), stalled(false) { }
 
 
         bool isStalled() { return stalled; }
@@ -813,7 +813,7 @@ class ComputeUnit : public ClockedObject
     {
       public:
         LDSPort(const std::string &_name, ComputeUnit *_cu)
-        : RequestPort(_name, _cu), computeUnit(_cu)
+        : RequestPort(_name), computeUnit(_cu)
         {
         }
 

--- a/src/gpu-compute/lds_state.hh
+++ b/src/gpu-compute/lds_state.hh
@@ -162,7 +162,7 @@ class LdsState: public ClockedObject
     {
       public:
         CuSidePort(const std::string &_name, LdsState *_ownerLds) :
-                ResponsePort(_name, _ownerLds), ownerLds(_ownerLds)
+                ResponsePort(_name), ownerLds(_ownerLds)
         {
         }
 

--- a/src/learning_gem5/part2/simple_cache.hh
+++ b/src/learning_gem5/part2/simple_cache.hh
@@ -74,7 +74,7 @@ class SimpleCache : public ClockedObject
          * Constructor. Just calls the superclass constructor.
          */
         CPUSidePort(const std::string& name, int id, SimpleCache *owner) :
-            ResponsePort(name, owner), id(id), owner(owner), needRetry(false),
+            ResponsePort(name), id(id), owner(owner), needRetry(false),
             blockedPacket(nullptr)
         { }
 
@@ -154,7 +154,7 @@ class SimpleCache : public ClockedObject
          * Constructor. Just calls the superclass constructor.
          */
         MemSidePort(const std::string& name, SimpleCache *owner) :
-            RequestPort(name, owner), owner(owner), blockedPacket(nullptr)
+            RequestPort(name), owner(owner), blockedPacket(nullptr)
         { }
 
         /**

--- a/src/learning_gem5/part2/simple_memobj.hh
+++ b/src/learning_gem5/part2/simple_memobj.hh
@@ -68,7 +68,7 @@ class SimpleMemobj : public SimObject
          * Constructor. Just calls the superclass constructor.
          */
         CPUSidePort(const std::string& name, SimpleMemobj *owner) :
-            ResponsePort(name, owner), owner(owner), needRetry(false),
+            ResponsePort(name), owner(owner), needRetry(false),
             blockedPacket(nullptr)
         { }
 
@@ -147,7 +147,7 @@ class SimpleMemobj : public SimObject
          * Constructor. Just calls the superclass constructor.
          */
         MemSidePort(const std::string& name, SimpleMemobj *owner) :
-            RequestPort(name, owner), owner(owner), blockedPacket(nullptr)
+            RequestPort(name), owner(owner), blockedPacket(nullptr)
         { }
 
         /**

--- a/src/mem/addr_mapper.hh
+++ b/src/mem/addr_mapper.hh
@@ -101,7 +101,7 @@ class AddrMapper : public SimObject
     {
       public:
         MapperRequestPort(const std::string& _name, AddrMapper& _mapper)
-            : RequestPort(_name, &_mapper), mapper(_mapper)
+            : RequestPort(_name), mapper(_mapper)
         { }
 
       protected:
@@ -158,7 +158,7 @@ class AddrMapper : public SimObject
     {
       public:
         MapperResponsePort(const std::string& _name, AddrMapper& _mapper)
-            : ResponsePort(_name, &_mapper), mapper(_mapper)
+            : ResponsePort(_name), mapper(_mapper)
         {}
 
       protected:

--- a/src/mem/bridge.cc
+++ b/src/mem/bridge.cc
@@ -58,7 +58,7 @@ Bridge::BridgeResponsePort::BridgeResponsePort(const std::string& _name,
                                          BridgeRequestPort& _memSidePort,
                                          Cycles _delay, int _resp_limit,
                                          std::vector<AddrRange> _ranges)
-    : ResponsePort(_name, &_bridge), bridge(_bridge),
+    : ResponsePort(_name), bridge(_bridge),
       memSidePort(_memSidePort), delay(_delay),
       ranges(_ranges.begin(), _ranges.end()),
       outstandingResponses(0), retryReq(false), respQueueLimit(_resp_limit),
@@ -70,7 +70,7 @@ Bridge::BridgeRequestPort::BridgeRequestPort(const std::string& _name,
                                            Bridge& _bridge,
                                            BridgeResponsePort& _cpuSidePort,
                                            Cycles _delay, int _req_limit)
-    : RequestPort(_name, &_bridge), bridge(_bridge),
+    : RequestPort(_name), bridge(_bridge),
       cpuSidePort(_cpuSidePort),
       delay(_delay), reqQueueLimit(_req_limit),
       sendEvent([this]{ trySendTiming(); }, _name)

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -124,10 +124,11 @@ BaseCache::SendCustomEvent::description() const
 }
 
 BaseCache::CacheResponsePort::CacheResponsePort(const std::string &_name,
-                                          BaseCache *_cache,
+                                          BaseCache& _cache,
                                           const std::string &_label)
-    : QueuedResponsePort(_name, _cache, queue),
-      queue(*_cache, *this, true, _label),
+    : QueuedResponsePort(_name, queue),
+      cache{_cache},
+      queue(_cache, *this, true, _label),
       blocked(false), mustSendRetry(false),
       sendRetryEvent([this]{ processSendRetry(); }, _name)
 {
@@ -135,7 +136,7 @@ BaseCache::CacheResponsePort::CacheResponsePort(const std::string &_name,
 
 BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
     : ClockedObject(p),
-      cpuSidePort (p.name + ".cpu_side_port", this, "CpuSidePort"),
+      cpuSidePort (p.name + ".cpu_side_port", *this, "CpuSidePort"),
       memSidePort(p.name + ".mem_side_port", this, "MemSidePort"),
       mshrQueue("MSHRs", p.mshrs, 0, p.demand_mshr_reserve, p.name),
       writeBuffer("write buffer", p.write_buffers, p.mshrs, p.name),
@@ -266,7 +267,7 @@ BaseCache::CacheResponsePort::setBlocked()
     // if we already scheduled a retry in this cycle, but it has not yet
     // happened, cancel it
     if (sendRetryEvent.scheduled()) {
-        owner.deschedule(sendRetryEvent);
+        cache.deschedule(sendRetryEvent);
         DPRINTF(CachePort, "Port descheduled retry\n");
         mustSendRetry = true;
     }
@@ -280,7 +281,7 @@ BaseCache::CacheResponsePort::clearBlocked()
     blocked = false;
     if (mustSendRetry) {
         // @TODO: need to find a better time (next cycle?)
-        owner.schedule(sendRetryEvent, curTick() + 1);
+        cache.schedule(sendRetryEvent, curTick() + 1);
     }
 }
 
@@ -3456,12 +3457,12 @@ bool
 BaseCache::CpuSidePort::recvTimingSnoopResp(PacketPtr pkt)
 {
     // Snoops shouldn't happen when bypassing caches
-    assert(!cache->system->bypassCaches());
+    assert(!cache.system->bypassCaches());
 
     assert(pkt->isResponse());
 
     // Express snoop responses from requestor to responder, e.g., from L1 to L2
-    cache->recvTimingSnoopResp(pkt);
+    cache.recvTimingSnoopResp(pkt);
     return true;
 }
 
@@ -3469,7 +3470,7 @@ BaseCache::CpuSidePort::recvTimingSnoopResp(PacketPtr pkt)
 bool
 BaseCache::CpuSidePort::tryTiming(PacketPtr pkt)
 {
-    if (cache->system->bypassCaches() || pkt->isExpressSnoop()
+    if (cache.system->bypassCaches() || pkt->isExpressSnoop()
         || pkt->isStorePFTrain()) {
         // always let express snoop packets through even if blocked
         return true;
@@ -3478,18 +3479,18 @@ BaseCache::CpuSidePort::tryTiming(PacketPtr pkt)
         mustSendRetry = true;
         return false;
     }
-    if (!cache->tryAccessTag(pkt)) {
+    if (!cache.tryAccessTag(pkt)) {
         DPRINTF(TagReadFail, "tryAccessTag fails addr: %lx\n", pkt->getAddr());
         return false;
     }
-    int sliceidx = cache->getSliceIdx(pkt->getAddr());
-    if (sliceidx >= 0 && cache->cacheLevel != 1) {
-        if (cache->checkSLiceBusy(pkt, sliceidx)) {
+    int sliceidx = cache.getSliceIdx(pkt->getAddr());
+    if (sliceidx >= 0 && cache.cacheLevel != 1) {
+        if (cache.checkSLiceBusy(pkt, sliceidx)) {
             //no more buffer
             if (sendRetryEvent.scheduled()) {
-                owner.reschedule(sendRetryEvent, cache->nextCycle());
+                cache.reschedule(sendRetryEvent, cache.nextCycle());
             } else {
-                owner.schedule(sendRetryEvent, cache->nextCycle());
+                cache.schedule(sendRetryEvent, cache.nextCycle());
             }
             return false;
         }
@@ -3504,25 +3505,25 @@ BaseCache::CpuSidePort::recvTimingReq(PacketPtr pkt)
 {
     assert(pkt->isRequest());
 
-    if (cache->system->bypassCaches()) {
+    if (cache.system->bypassCaches()) {
         // Just forward the packet if caches are disabled.
         // @todo This should really enqueue the packet rather
-        [[maybe_unused]] bool success = cache->memSidePort.sendTimingReq(pkt);
+        [[maybe_unused]] bool success = cache.memSidePort.sendTimingReq(pkt);
         assert(success);
         return true;
     } else if (tryTiming(pkt)) {
         pkt->clearMshrArbFailed();
         pkt->clearMshrAliasFailed();
         pkt->clearHitInWriteBuffer();
-        cache->recvTimingReq(pkt);
+        cache.recvTimingReq(pkt);
         if (pkt->mshrArbFailed() || pkt->mshrAliasFailed() ||
             pkt->isHitInWriteBuffer()) {
             // If the MSHR arbitration failed, we need to retry later.
             // We will schedule a retry event to try again.
             if (sendRetryEvent.scheduled()) {
-                owner.reschedule(sendRetryEvent, cache->nextCycle());
+                cache.reschedule(sendRetryEvent, cache.nextCycle());
             } else {
-                owner.schedule(sendRetryEvent, cache->nextCycle());
+                cache.schedule(sendRetryEvent, cache.nextCycle());
             }
             DPRINTF(Cache, "MSHR arbitration failed for pkt %s, retrying later\n",
                     pkt->print());
@@ -3536,39 +3537,39 @@ BaseCache::CpuSidePort::recvTimingReq(PacketPtr pkt)
 Tick
 BaseCache::CpuSidePort::recvAtomic(PacketPtr pkt)
 {
-    if (cache->system->bypassCaches()) {
+    if (cache.system->bypassCaches()) {
         // Forward the request if the system is in cache bypass mode.
-        return cache->memSidePort.sendAtomic(pkt);
+        return cache.memSidePort.sendAtomic(pkt);
     } else {
-        return cache->recvAtomic(pkt);
+        return cache.recvAtomic(pkt);
     }
 }
 
 void
 BaseCache::CpuSidePort::recvFunctional(PacketPtr pkt)
 {
-    if (cache->system->bypassCaches()) {
+    if (cache.system->bypassCaches()) {
         // The cache should be flushed if we are in cache bypass mode,
         // so we don't need to check if we need to update anything.
-        cache->memSidePort.sendFunctional(pkt);
+        cache.memSidePort.sendFunctional(pkt);
         return;
     }
 
     // functional request
-    cache->functionalAccess(pkt, true);
+    cache.functionalAccess(pkt, true);
 }
 
 AddrRangeList
 BaseCache::CpuSidePort::getAddrRanges() const
 {
-    return cache->getAddrRanges();
+    return cache.getAddrRanges();
 }
 
 
 BaseCache::
-CpuSidePort::CpuSidePort(const std::string &_name, BaseCache *_cache,
+CpuSidePort::CpuSidePort(const std::string &_name, BaseCache& _cache,
                          const std::string &_label)
-    : CacheResponsePort(_name, _cache, _label), cache(_cache)
+    : CacheResponsePort(_name, _cache, _label)
 {
 }
 
@@ -3679,7 +3680,7 @@ BaseCache::CacheReqPacketQueue::sendDeferredPacket()
 BaseCache::MemSidePort::MemSidePort(const std::string &_name,
                                     BaseCache *_cache,
                                     const std::string &_label)
-    : CacheRequestPort(_name, _cache, _reqQueue, _snoopRespQueue),
+    : CacheRequestPort(_name, _reqQueue, _snoopRespQueue),
       _reqQueue(*_cache, *this, _snoopRespQueue, _label),
       _snoopRespQueue(*_cache, *this, true, _label), cache(_cache)
 {

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -182,10 +182,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
       protected:
 
-        CacheRequestPort(const std::string &_name, BaseCache *_cache,
+        CacheRequestPort(const std::string &_name,
                         ReqPacketQueue &_reqQueue,
                         SnoopRespPacketQueue &_snoopRespQueue) :
-            QueuedRequestPort(_name, _cache, _reqQueue, _snoopRespQueue)
+            QueuedRequestPort(_name, _reqQueue, _snoopRespQueue)
         { }
 
         /**
@@ -311,8 +311,10 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
       protected:
 
-        CacheResponsePort(const std::string &_name, BaseCache *_cache,
+        CacheResponsePort(const std::string &_name, BaseCache& _cache,
                        const std::string &_label);
+
+        BaseCache& cache;
 
         /** A normal packet queue used to store responses. */
         RespPacketQueue queue;
@@ -333,11 +335,6 @@ class BaseCache : public ClockedObject, public CacheAccessor
      */
     class CpuSidePort : public CacheResponsePort
     {
-      private:
-
-        // a pointer to our specific cache implementation
-        BaseCache *cache;
-
       protected:
         virtual bool recvTimingSnoopResp(PacketPtr pkt) override;
 
@@ -353,7 +350,7 @@ class BaseCache : public ClockedObject, public CacheAccessor
 
       public:
 
-        CpuSidePort(const std::string &_name, BaseCache *_cache,
+        CpuSidePort(const std::string &_name, BaseCache& _cache,
                     const std::string &_label);
 
     };

--- a/src/mem/cache/compressors/frequent_values.cc
+++ b/src/mem/cache/compressors/frequent_values.cc
@@ -290,8 +290,9 @@ FrequentValues::regProbeListeners()
 {
     assert(listeners.empty());
     assert(cache != nullptr);
-    listeners.push_back(new FrequentValuesListener(
-        *this, cache->getProbeManager(), "Data Update"));
+    listeners.push_back(
+        cache->getProbeManager()->connect<FrequentValuesListener>(
+            *this, "Data Update"));
 }
 
 void

--- a/src/mem/cache/compressors/frequent_values.hh
+++ b/src/mem/cache/compressors/frequent_values.hh
@@ -72,14 +72,14 @@ class FrequentValues : public Base
         FrequentValues &parent;
 
       public:
-        FrequentValuesListener(FrequentValues &_parent, ProbeManager *pm,
-            const std::string &name)
-          : ProbeListenerArgBase(pm, name), parent(_parent)
+        FrequentValuesListener(FrequentValues &_parent, std::string name)
+            : ProbeListenerArgBase(std::move(name)), parent(_parent)
         {
         }
         void notify(const DataUpdate &data_update) override;
     };
-    std::vector<FrequentValuesListener*> listeners;
+
+    std::vector<ProbeListenerPtr<FrequentValuesListener>> listeners;
 
     /** Whether Huffman encoding is applied to the VFT indices. */
     const bool useHuffmanEncoding;

--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -808,18 +808,22 @@ Base::regProbeListeners()
      * cache is configured to prefetch on accesses.
      */
     if (listeners.empty() && !isSubPrefetcher && probeManager != nullptr) {
-        listeners.push_back(new PrefetchListener(*this, probeManager, "StorePFtrain", false, true, true));
-        listeners.push_back(new PrefetchListener(*this, probeManager, "Miss", false, true, false));
-        listeners.push_back(new PrefetchListener(*this, probeManager, "Fill", true, false, false));
-        listeners.push_back(new PrefetchListener(*this, probeManager, "Hit", false, false, false));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "StorePFtrain", false, true, true));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Miss", false, true, false));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Fill", true, false, false));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Hit", false, false, false));
     }
 }
 
 void
 Base::addEventProbe(SimObject *obj, const char *name)
 {
-    ProbeManager *pm(obj->getProbeManager());
-    listeners.push_back(new PrefetchListener(*this, pm, name));
+    ProbeManager *pm = obj->getProbeManager();
+    listeners.push_back(pm->connect<PrefetchListener>(*this, name));
 }
 
 void

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -90,11 +90,13 @@ class Base : public ClockedObject
     class PrefetchListener : public ProbeListenerArgBase<PacketPtr>
     {
       public:
-        PrefetchListener(Base &_parent, ProbeManager *pm,
-                         const std::string &name, bool _isFill = false,
+        PrefetchListener(Base &_parent, std::string name,
+                         bool _isFill = false,
                          bool _miss = false, bool _pftrain = false)
-            : ProbeListenerArgBase(pm, name),
-              parent(_parent), isFill(_isFill), miss(_miss), coreDirectNotify(_pftrain) {}
+            : ProbeListenerArgBase(std::move(name)),
+              parent(_parent), isFill(_isFill), miss(_miss),
+              coreDirectNotify(_pftrain)
+        {}
         void notify(const PacketPtr &pkt) override;
       protected:
         Base& parent;
@@ -105,7 +107,7 @@ class Base : public ClockedObject
         const bool coreDirectNotify;
     };
 
-    std::vector<PrefetchListener *> listeners;
+    std::vector<ProbeListenerPtr<PrefetchListener>> listeners;
 
   public:
     struct PFtriggerInfo{

--- a/src/mem/cache/prefetch/pif.cc
+++ b/src/mem/cache/prefetch/pif.cc
@@ -244,8 +244,8 @@ PIF::PrefetchListenerPC::notify(const Addr& pc)
 void
 PIF::addEventProbeRetiredInsts(SimObject *obj, const char *name)
 {
-    ProbeManager *pm(obj->getProbeManager());
-    listenersPC.push_back(new PrefetchListenerPC(*this, pm, name));
+    ProbeManager *pm = obj->getProbeManager();
+    listenersPC.push_back(pm->connect<PrefetchListenerPC>(*this, name));
 }
 
 } // namespace prefetch

--- a/src/mem/cache/prefetch/pif.hh
+++ b/src/mem/cache/prefetch/pif.hh
@@ -165,17 +165,16 @@ class PIF : public Queued
         class PrefetchListenerPC : public ProbeListenerArgBase<Addr>
         {
           public:
-            PrefetchListenerPC(PIF &_parent, ProbeManager *pm,
-                             const std::string &name)
-                : ProbeListenerArgBase(pm, name),
-                  parent(_parent) {}
+            PrefetchListenerPC(PIF &_parent, std::string name)
+                : ProbeListenerArgBase(std::move(name)), parent(_parent)
+            {}
             void notify(const Addr& pc) override;
           protected:
             PIF &parent;
         };
 
         /** Array of probe listeners */
-        std::vector<PrefetchListenerPC *> listenersPC;
+        std::vector<ProbeListenerPtr<PrefetchListenerPC>> listenersPC;
 
 
     public:

--- a/src/mem/cache/xs_l2/CacheWrapper.cc
+++ b/src/mem/cache/xs_l2/CacheWrapper.cc
@@ -34,7 +34,7 @@ CacheWrapper::getPort(const std::string &if_name, PortID idx)
 // --- CPUSidePort (Slave) - Receives from L1/CPU ---
 CacheWrapper::CPUSidePort::CPUSidePort(const std::string& name,
                                          CacheWrapper *owner)
-    : ResponsePort(name, owner), owner(owner)
+    : ResponsePort(name), owner(owner)
 {
 }
 
@@ -85,7 +85,7 @@ CacheWrapper::cpuSidePortRecvAtomic(PacketPtr pkt)
 // --- InnerCPUSidePort (Master) - Sends to inner cache CPU-side ---
 CacheWrapper::InnerCPUSidePort::InnerCPUSidePort(const std::string& name,
                                             CacheWrapper* owner)
-    : RequestPort(name, owner), owner(owner)
+    : RequestPort(name), owner(owner)
 {
 }
 
@@ -139,7 +139,7 @@ CacheWrapper::innerCpuPortRecvRangeChange()
 // --- InnerMemSidePort (Slave) - Receives from inner cache Mem-side ---
 CacheWrapper::InnerMemSidePort::InnerMemSidePort(const std::string& name,
                                             CacheWrapper* owner)
-    : ResponsePort(name, owner), owner(owner)
+    : ResponsePort(name), owner(owner)
 {
 }
 
@@ -190,7 +190,7 @@ CacheWrapper::innerMemPortRecvAtomic(PacketPtr pkt)
 // --- MemSidePort (Master) - Sends to memory ---
 CacheWrapper::MemSidePort::MemSidePort(const std::string& name,
                                         CacheWrapper* owner)
-    : RequestPort(name, owner), owner(owner)
+    : RequestPort(name), owner(owner)
 {
 }
 

--- a/src/mem/cache/xs_l2/L2CacheWrapper.cc
+++ b/src/mem/cache/xs_l2/L2CacheWrapper.cc
@@ -109,7 +109,7 @@ L2CacheWrapper::getPort(const std::string &if_name, PortID idx)
 
 // --- CPUSidePort ---
 L2CacheWrapper::CPUSidePort::CPUSidePort(const std::string &name, L2CacheWrapper &owner)
-    : ResponsePort(name, &owner), owner(owner) {}
+    : ResponsePort(name), owner(owner) {}
 
 bool
 L2CacheWrapper::CPUSidePort::recvTimingSnoopResp(PacketPtr pkt)
@@ -175,7 +175,7 @@ L2CacheWrapper::CPUSidePort::getAddrRanges() const
 
 // --- SliceCPUSidePort ---
 L2CacheWrapper::SliceCPUSidePort::SliceCPUSidePort(const std::string& name, L2CacheWrapper &owner, PortID id)
-    : RequestPort(name, &owner), owner(owner), id(id) {}
+    : RequestPort(name), owner(owner), id(id) {}
 
 void
 L2CacheWrapper::SliceCPUSidePort::recvTimingSnoopReq(PacketPtr pkt)

--- a/src/mem/cfi_mem.cc
+++ b/src/mem/cfi_mem.cc
@@ -456,7 +456,7 @@ CfiMemory::unserialize(CheckpointIn &cp)
 
 CfiMemory::MemoryPort::MemoryPort(const std::string& _name,
                                      CfiMemory& _memory)
-    : ResponsePort(_name, &_memory), mem(_memory)
+    : ResponsePort(_name), mem(_memory)
 { }
 
 AddrRangeList

--- a/src/mem/coherent_xbar.hh
+++ b/src/mem/coherent_xbar.hh
@@ -101,7 +101,7 @@ class CoherentXBar : public BaseXBar
 
         CoherentXBarResponsePort(const std::string &_name,
                              CoherentXBar &_xbar, PortID _id)
-            : QueuedResponsePort(_name, &_xbar, queue, _id), xbar(_xbar),
+            : QueuedResponsePort(_name, queue, _id), xbar(_xbar),
               queue(_xbar, *this)
         { }
 
@@ -160,7 +160,7 @@ class CoherentXBar : public BaseXBar
 
         CoherentXBarRequestPort(const std::string &_name,
                               CoherentXBar &_xbar, PortID _id)
-            : RequestPort(_name, &_xbar, _id), xbar(_xbar)
+            : RequestPort(_name, _id), xbar(_xbar)
         { }
 
       protected:
@@ -222,7 +222,7 @@ class CoherentXBar : public BaseXBar
          */
         SnoopRespPort(QueuedResponsePort& cpu_side_port,
                       CoherentXBar& _xbar) :
-            RequestPort(cpu_side_port.name() + ".snoopRespPort", &_xbar),
+            RequestPort(cpu_side_port.name() + ".snoopRespPort"),
             cpuSidePort(cpu_side_port) { }
 
         /**

--- a/src/mem/comm_monitor.hh
+++ b/src/mem/comm_monitor.hh
@@ -124,7 +124,7 @@ class CommMonitor : public SimObject
       public:
 
         MonitorRequestPort(const std::string& _name, CommMonitor& _mon)
-            : RequestPort(_name, &_mon), mon(_mon)
+            : RequestPort(_name), mon(_mon)
         { }
 
       protected:
@@ -190,7 +190,7 @@ class CommMonitor : public SimObject
       public:
 
         MonitorResponsePort(const std::string& _name, CommMonitor& _mon)
-            : ResponsePort(_name, &_mon), mon(_mon)
+            : ResponsePort(_name), mon(_mon)
         { }
 
       protected:

--- a/src/mem/dramsim2.cc
+++ b/src/mem/dramsim2.cc
@@ -359,7 +359,7 @@ DRAMSim2::drain()
 
 DRAMSim2::MemoryPort::MemoryPort(const std::string& _name,
                                  DRAMSim2& _memory)
-    : ResponsePort(_name, &_memory), mem(_memory)
+    : ResponsePort(_name), mem(_memory)
 { }
 
 AddrRangeList

--- a/src/mem/dramsim3.cc
+++ b/src/mem/dramsim3.cc
@@ -377,7 +377,7 @@ DRAMsim3::drain()
 
 DRAMsim3::MemoryPort::MemoryPort(const std::string& _name,
                                  DRAMsim3& _memory)
-    : ResponsePort(_name, &_memory), mem(_memory)
+    : ResponsePort(_name), mem(_memory)
 { }
 
 AddrRangeList

--- a/src/mem/external_master.hh
+++ b/src/mem/external_master.hh
@@ -75,7 +75,7 @@ class ExternalMaster : public SimObject
       public:
         ExternalPort(const std::string &name_,
             ExternalMaster &owner_) :
-            RequestPort(name_, &owner_), owner(owner_)
+            RequestPort(name_), owner(owner_)
         { }
 
         ~ExternalPort() { }

--- a/src/mem/external_slave.hh
+++ b/src/mem/external_slave.hh
@@ -77,7 +77,7 @@ class ExternalSlave : public SimObject
       public:
         ExternalPort(const std::string &name_,
             ExternalSlave &owner_) :
-            ResponsePort(name_, &owner_), owner(owner_)
+            ResponsePort(name_), owner(owner_)
         { }
 
         ~ExternalPort() { }

--- a/src/mem/mem_checker_monitor.hh
+++ b/src/mem/mem_checker_monitor.hh
@@ -95,7 +95,7 @@ class MemCheckerMonitor : public SimObject
       public:
 
         MonitorRequestPort(const std::string& _name, MemCheckerMonitor& _mon)
-            : RequestPort(_name, &_mon), mon(_mon)
+            : RequestPort(_name), mon(_mon)
         { }
 
       protected:
@@ -156,7 +156,7 @@ class MemCheckerMonitor : public SimObject
       public:
 
         MonitorResponsePort(const std::string& _name, MemCheckerMonitor& _mon)
-            : ResponsePort(_name, &_mon), mon(_mon)
+            : ResponsePort(_name), mon(_mon)
         { }
 
       protected:

--- a/src/mem/mem_ctrl.cc
+++ b/src/mem/mem_ctrl.cc
@@ -1446,7 +1446,7 @@ MemCtrl::getAddrRanges()
 
 MemCtrl::MemoryPort::
 MemoryPort(const std::string& name, MemCtrl& _ctrl)
-    : QueuedResponsePort(name, &_ctrl, queue), queue(_ctrl, *this, true),
+    : QueuedResponsePort(name, queue), queue(_ctrl, *this, true),
       ctrl(_ctrl)
 { }
 

--- a/src/mem/mem_delay.cc
+++ b/src/mem/mem_delay.cc
@@ -81,8 +81,7 @@ MemDelay::trySatisfyFunctional(PacketPtr pkt)
 }
 
 MemDelay::RequestPort::RequestPort(const std::string &_name, MemDelay &_parent)
-    : QueuedRequestPort(_name, &_parent,
-                       _parent.reqQueue, _parent.snoopRespQueue),
+    : QueuedRequestPort(_name, _parent.reqQueue, _parent.snoopRespQueue),
       parent(_parent)
 {
 }
@@ -129,7 +128,7 @@ MemDelay::RequestPort::recvTimingSnoopReq(PacketPtr pkt)
 
 MemDelay::ResponsePort::
 ResponsePort(const std::string &_name, MemDelay &_parent)
-    : QueuedResponsePort(_name, &_parent, _parent.respQueue),
+    : QueuedResponsePort(_name, _parent.respQueue),
       parent(_parent)
 {
 }

--- a/src/mem/noncoherent_xbar.hh
+++ b/src/mem/noncoherent_xbar.hh
@@ -96,7 +96,7 @@ class NoncoherentXBar : public BaseXBar
 
         NoncoherentXBarResponsePort(const std::string &_name,
                                 NoncoherentXBar &_xbar, PortID _id)
-            : QueuedResponsePort(_name, &_xbar, queue, _id), xbar(_xbar),
+            : QueuedResponsePort(_name, queue, _id), xbar(_xbar),
               queue(_xbar, *this)
         { }
 
@@ -149,7 +149,7 @@ class NoncoherentXBar : public BaseXBar
 
         NoncoherentXBarRequestPort(const std::string &_name,
                                  NoncoherentXBar &_xbar, PortID _id)
-            : RequestPort(_name, &_xbar, _id), xbar(_xbar)
+            : RequestPort(_name, _id), xbar(_xbar)
         { }
 
       protected:

--- a/src/mem/port.cc
+++ b/src/mem/port.cc
@@ -64,7 +64,7 @@ class DefaultRequestPort : public RequestPort
     }
 
   public:
-    DefaultRequestPort() : RequestPort("default_request_port", nullptr) {}
+    DefaultRequestPort() : RequestPort("default_request_port") {}
 
     // Atomic protocol.
     Tick recvAtomicSnoop(PacketPtr) override { blowUp(); }
@@ -89,7 +89,7 @@ class DefaultResponsePort : public ResponsePort
     }
 
   public:
-    DefaultResponsePort() : ResponsePort("default_response_port", nullptr) {}
+    DefaultResponsePort() : ResponsePort("default_response_port") {}
 
     // Atomic protocol.
     Tick recvAtomic(PacketPtr) override { blowUp(); }
@@ -112,12 +112,8 @@ DefaultResponsePort defaultResponsePort;
 
 } // anonymous namespace
 
-/**
- * Request port
- */
-RequestPort::RequestPort(const std::string& name, SimObject* _owner,
-    PortID _id) : Port(name, _id), _responsePort(&defaultResponsePort),
-    owner(*_owner)
+RequestPort::RequestPort(const std::string &name, PortID _id)
+    : Port(name, _id), _responsePort(&defaultResponsePort)
 {
 }
 
@@ -170,9 +166,11 @@ RequestPort::printAddr(Addr a)
 /**
  * Response port
  */
-ResponsePort::ResponsePort(const std::string& name, SimObject* _owner,
-    PortID id) : Port(name, id), _requestPort(&defaultRequestPort),
-    defaultBackdoorWarned(false), owner(*_owner)
+
+ResponsePort::ResponsePort(const std::string &name, PortID id)
+    : Port(name, id),
+      _requestPort(&defaultRequestPort),
+      defaultBackdoorWarned(false)
 {
 }
 

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -83,12 +83,9 @@ class RequestPort: public Port, public AtomicRequestProtocol,
   private:
     ResponsePort *_responsePort;
 
-  protected:
-    SimObject &owner;
-
   public:
-    RequestPort(const std::string& name, SimObject* _owner,
-               PortID id=InvalidPortID);
+    RequestPort(const std::string& name, PortID id=InvalidPortID);
+
     virtual ~RequestPort();
 
     /**
@@ -256,9 +253,7 @@ class RequestPort: public Port, public AtomicRequestProtocol,
 class [[deprecated]] MasterPort : public RequestPort
 {
   public:
-    MasterPort(const std::string& name, SimObject* _owner,
-               PortID id=InvalidPortID) : RequestPort(name, _owner, id)
-               {}
+    using RequestPort::RequestPort;
 };
 
 /**
@@ -280,12 +275,9 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
 
     bool defaultBackdoorWarned;
 
-  protected:
-    SimObject& owner;
-
   public:
-    ResponsePort(const std::string& name, SimObject* _owner,
-              PortID id=InvalidPortID);
+    ResponsePort(const std::string& name, PortID id=InvalidPortID);
+
     virtual ~ResponsePort();
 
     /**
@@ -481,9 +473,7 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
 class [[deprecated]] SlavePort : public ResponsePort
 {
   public:
-    SlavePort(const std::string& name, SimObject* _owner,
-              PortID id=InvalidPortID) : ResponsePort(name, _owner, id)
-              {}
+    using ResponsePort::ResponsePort;
 };
 
 inline void

--- a/src/mem/port_terminator.cc
+++ b/src/mem/port_terminator.cc
@@ -34,11 +34,11 @@ PortTerminator::PortTerminator(const PortTerminatorParams &params):
     SimObject(params)
 {
     for (int i = 0; i < params.port_req_ports_connection_count; ++i) {
-        reqPorts.emplace_back(name() + ".req_ports" + std::to_string(i), this);
+        reqPorts.emplace_back(name() + ".req_ports" + std::to_string(i));
     }
     for (int j = 0; j < params.port_resp_ports_connection_count; ++j) {
         reqPorts.emplace_back(name() + ".resp_ports" +
-                                std::to_string(j), this);
+                                std::to_string(j));
     }
 }
 

--- a/src/mem/port_terminator.hh
+++ b/src/mem/port_terminator.hh
@@ -66,8 +66,8 @@ class PortTerminator : public SimObject
     class ReqPort : public RequestPort
     {
       public:
-        ReqPort(const std::string &name, PortTerminator *owner):
-            RequestPort(name, owner)
+        ReqPort(const std::string &name):
+            RequestPort(name)
         {}
       protected:
         bool recvTimingResp(PacketPtr pkt) override
@@ -97,8 +97,8 @@ class PortTerminator : public SimObject
     class RespPort : public ResponsePort
     {
       public:
-        RespPort(const std::string &name, PortTerminator *owner):
-            ResponsePort(name, owner)
+        RespPort(const std::string &name):
+            ResponsePort(name)
         {}
     };
 

--- a/src/mem/probes/base.cc
+++ b/src/mem/probes/base.cc
@@ -53,10 +53,10 @@ BaseMemProbe::regProbeListeners()
     const BaseMemProbeParams &p =
         dynamic_cast<const BaseMemProbeParams &>(params());
 
-    listeners.resize(p.manager.size());
+    listeners.reserve(p.manager.size());
     for (int i = 0; i < p.manager.size(); i++) {
         ProbeManager *const mgr(p.manager[i]->getProbeManager());
-        listeners[i].reset(new PacketListener(*this, mgr, p.probe_name));
+        listeners.push_back(mgr->connect<PacketListener>(*this, p.probe_name));
     }
 }
 

--- a/src/mem/probes/base.hh
+++ b/src/mem/probes/base.hh
@@ -78,10 +78,9 @@ class BaseMemProbe : public SimObject
     class PacketListener : public ProbeListenerArgBase<probing::PacketInfo>
     {
       public:
-        PacketListener(BaseMemProbe &_parent,
-                       ProbeManager *pm, const std::string &name)
-            : ProbeListenerArgBase(pm, name),
-              parent(_parent) {}
+        PacketListener(BaseMemProbe &_parent, std::string name)
+            : ProbeListenerArgBase(std::move(name)), parent(_parent)
+        {}
 
         void notify(const probing::PacketInfo &pkt_info) override {
             parent.handleRequest(pkt_info);
@@ -91,7 +90,7 @@ class BaseMemProbe : public SimObject
         BaseMemProbe &parent;
     };
 
-    std::vector<std::unique_ptr<PacketListener>> listeners;
+    std::vector<ProbeListenerPtr<>> listeners;
 };
 
 } // namespace gem5

--- a/src/mem/qos/mem_sink.cc
+++ b/src/mem/qos/mem_sink.cc
@@ -353,7 +353,7 @@ MemSinkCtrl::MemSinkCtrlStats::MemSinkCtrlStats(statistics::Group *parent)
 
 MemSinkCtrl::MemoryPort::MemoryPort(const std::string& n,
                                     MemSinkCtrl& m)
-  : QueuedResponsePort(n, &m, queue, true),
+  : QueuedResponsePort(n, queue, true),
    mem(m), queue(mem, *this, true)
 {}
 

--- a/src/mem/qport.hh
+++ b/src/mem/qport.hh
@@ -77,9 +77,10 @@ class QueuedResponsePort : public ResponsePort
      * behaviuor in a subclass, and provide the latter to the
      * QueuePort constructor.
      */
-    QueuedResponsePort(const std::string& name, SimObject* owner,
-                    RespPacketQueue &resp_queue, PortID id = InvalidPortID) :
-        ResponsePort(name, owner, id), respQueue(resp_queue)
+    QueuedResponsePort(const std::string& name,
+                       RespPacketQueue &resp_queue,
+                       PortID id = InvalidPortID) :
+        ResponsePort(name, id), respQueue(resp_queue)
     { }
 
     virtual ~QueuedResponsePort() { }
@@ -132,17 +133,17 @@ class QueuedRequestPort : public RequestPort
   public:
 
     /**
-     * Create a QueuedPort with a given name, owner, and a supplied
+     * Create a QueuedPort with a given name, and a supplied
      * implementation of two packet queues. The external definition of
      * the queues enables e.g. the cache to implement a specific queue
      * behaviuor in a subclass, and provide the latter to the
      * QueuePort constructor.
      */
-    QueuedRequestPort(const std::string& name, SimObject* owner,
+    QueuedRequestPort(const std::string& name,
                      ReqPacketQueue &req_queue,
                      SnoopRespPacketQueue &snoop_resp_queue,
                      PortID id = InvalidPortID) :
-        RequestPort(name, owner, id), reqQueue(req_queue),
+        RequestPort(name, id), reqQueue(req_queue),
         snoopRespQueue(snoop_resp_queue)
     { }
 

--- a/src/mem/ramulator2.cc
+++ b/src/mem/ramulator2.cc
@@ -318,7 +318,7 @@ Ramulator2::drain()
 
 Ramulator2::MemorySystemPort::MemorySystemPort(const std::string& _name,
                                  Ramulator2& _ramulator2)
-    : ResponsePort(_name, & _ramulator2), ramulator2(_ramulator2)
+    : ResponsePort(_name), ramulator2(_ramulator2)
 { }
 
 

--- a/src/mem/ruby/slicc_interface/AbstractController.cc
+++ b/src/mem/ruby/slicc_interface/AbstractController.cc
@@ -462,7 +462,7 @@ AbstractController::MemoryPort::recvReqRetry()
 AbstractController::MemoryPort::MemoryPort(const std::string &_name,
                                            AbstractController *_controller,
                                            PortID id)
-    : RequestPort(_name, _controller, id), controller(_controller)
+    : RequestPort(_name, id), controller(_controller)
 {
 }
 

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -64,10 +64,10 @@ RubyPort::RubyPort(const Params &p)
     : ClockedObject(p), m_ruby_system(p.ruby_system), m_version(p.version),
       m_controller(NULL), m_mandatory_q_ptr(NULL),
       m_usingRubyTester(p.using_ruby_tester), system(p.system),
-      pioRequestPort(csprintf("%s.pio-request-port", name()), this),
-      pioResponsePort(csprintf("%s.pio-response-port", name()), this),
-      memRequestPort(csprintf("%s.mem-request-port", name()), this),
-      memResponsePort(csprintf("%s-mem-response-port", name()), this,
+      pioRequestPort(csprintf("%s.pio-request-port", name()), *this),
+      pioResponsePort(csprintf("%s.pio-response-port", name()), *this),
+      memRequestPort(csprintf("%s.mem-request-port", name()), *this),
+      memResponsePort(csprintf("%s-mem-response-port", name()), *this,
                    p.ruby_system->getAccessBackingStore(), -1,
                    p.no_retry_on_stall),
       gotAddrRanges(p.port_interrupt_out_port_connection_count),
@@ -80,7 +80,7 @@ RubyPort::RubyPort(const Params &p)
     // create the response ports based on the number of connected ports
     for (size_t i = 0; i < p.port_in_ports_connection_count; ++i) {
         response_ports.push_back(new MemResponsePort(csprintf
-            ("%s.response_ports%d", name(), i), this,
+            ("%s.response_ports%d", name(), i), *this,
             p.ruby_system->getAccessBackingStore(),
             i, p.no_retry_on_stall));
     }
@@ -88,7 +88,7 @@ RubyPort::RubyPort(const Params &p)
     // create the request ports based on the number of connected ports
     for (size_t i = 0; i < p.port_interrupt_out_port_connection_count; ++i) {
         request_ports.push_back(new PioRequestPort(csprintf(
-                    "%s.request_ports%d", name(), i), this));
+                    "%s.request_ports%d", name(), i), *this));
     }
 }
 
@@ -138,35 +138,41 @@ RubyPort::getPort(const std::string &if_name, PortID idx)
 }
 
 RubyPort::PioRequestPort::PioRequestPort(const std::string &_name,
-                           RubyPort *_port)
-    : QueuedRequestPort(_name, _port, reqQueue, snoopRespQueue),
-      reqQueue(*_port, *this), snoopRespQueue(*_port, *this)
+                                         RubyPort& _port) :
+    QueuedRequestPort(_name, reqQueue, snoopRespQueue),
+    owner{_port},
+    reqQueue(_port, *this),
+    snoopRespQueue(_port, *this)
 {
     DPRINTF(RubyPort, "Created request pioport on sequencer %s\n", _name);
 }
 
 RubyPort::PioResponsePort::PioResponsePort(const std::string &_name,
-                           RubyPort *_port)
-    : QueuedResponsePort(_name, _port, queue), queue(*_port, *this)
+                                           RubyPort& _port)
+    : QueuedResponsePort(_name, queue), owner{_port}, queue(_port, *this)
 {
     DPRINTF(RubyPort, "Created response pioport on sequencer %s\n", _name);
 }
 
 RubyPort::MemRequestPort::MemRequestPort(const std::string &_name,
-                           RubyPort *_port)
-    : QueuedRequestPort(_name, _port, reqQueue, snoopRespQueue),
-      reqQueue(*_port, *this), snoopRespQueue(*_port, *this)
+                                         RubyPort& _port):
+    QueuedRequestPort(_name, reqQueue, snoopRespQueue),
+    owner{_port},
+    reqQueue(_port, *this),
+    snoopRespQueue(_port, *this)
 {
     DPRINTF(RubyPort, "Created request memport on ruby sequencer %s\n", _name);
 }
 
 RubyPort::
-MemResponsePort::MemResponsePort(const std::string &_name, RubyPort *_port,
-                                     bool _access_backing_store, PortID id,
-                                     bool _no_retry_on_stall)
-    : QueuedResponsePort(_name, _port, queue, id), queue(*_port, *this),
-      access_backing_store(_access_backing_store),
-      no_retry_on_stall(_no_retry_on_stall)
+MemResponsePort::MemResponsePort(const std::string &_name, RubyPort& _port,
+                                 bool _access_backing_store, PortID id,
+                                 bool _no_retry_on_stall):
+    QueuedResponsePort(_name, queue, id),
+    owner{_port},
+    queue(_port, *this),
+    access_backing_store(_access_backing_store),
+    no_retry_on_stall(_no_retry_on_stall)
 {
     DPRINTF(RubyPort, "Created response memport on ruby sequencer %s\n",
             _name);
@@ -175,12 +181,11 @@ MemResponsePort::MemResponsePort(const std::string &_name, RubyPort *_port,
 bool
 RubyPort::PioRequestPort::recvTimingResp(PacketPtr pkt)
 {
-    RubyPort *rp = static_cast<RubyPort *>(&owner);
     DPRINTF(RubyPort, "Response for address: 0x%#x\n", pkt->getAddr());
 
     // send next cycle
-    rp->pioResponsePort.schedTimingResp(
-            pkt, curTick() + rp->m_ruby_system->clockPeriod());
+    owner.pioResponsePort.schedTimingResp(
+            pkt, curTick() + owner.m_ruby_system->clockPeriod());
     return true;
 }
 
@@ -203,8 +208,7 @@ bool RubyPort::MemRequestPort::recvTimingResp(PacketPtr pkt)
             pkt->getAddr(), port->name());
 
     // attempt to send the response in the next cycle
-    RubyPort *rp = static_cast<RubyPort *>(&owner);
-    port->schedTimingResp(pkt, curTick() + rp->m_ruby_system->clockPeriod());
+    port->schedTimingResp(pkt, curTick() + owner.m_ruby_system->clockPeriod());
 
     return true;
 }
@@ -212,16 +216,15 @@ bool RubyPort::MemRequestPort::recvTimingResp(PacketPtr pkt)
 bool
 RubyPort::PioResponsePort::recvTimingReq(PacketPtr pkt)
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
 
-    for (size_t i = 0; i < ruby_port->request_ports.size(); ++i) {
-        AddrRangeList l = ruby_port->request_ports[i]->getAddrRanges();
+    for (size_t i = 0; i < owner.request_ports.size(); ++i) {
+        AddrRangeList l = owner.request_ports[i]->getAddrRanges();
         for (auto it = l.begin(); it != l.end(); ++it) {
             if (it->contains(pkt->getAddr())) {
                 // generally it is not safe to assume success here as
                 // the port could be blocked
                 [[maybe_unused]] bool success =
-                    ruby_port->request_ports[i]->sendTimingReq(pkt);
+                    owner.request_ports[i]->sendTimingReq(pkt);
                 assert(success);
                 return true;
             }
@@ -233,17 +236,16 @@ RubyPort::PioResponsePort::recvTimingReq(PacketPtr pkt)
 Tick
 RubyPort::PioResponsePort::recvAtomic(PacketPtr pkt)
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
     // Only atomic_noncaching mode supported!
-    if (!ruby_port->system->bypassCaches()) {
+    if (!owner.system->bypassCaches()) {
         panic("Ruby supports atomic accesses only in noncaching mode\n");
     }
 
-    for (size_t i = 0; i < ruby_port->request_ports.size(); ++i) {
-        AddrRangeList l = ruby_port->request_ports[i]->getAddrRanges();
+    for (size_t i = 0; i < owner.request_ports.size(); ++i) {
+        AddrRangeList l = owner.request_ports[i]->getAddrRanges();
         for (auto it = l.begin(); it != l.end(); ++it) {
             if (it->contains(pkt->getAddr())) {
-                return ruby_port->request_ports[i]->sendAtomic(pkt);
+                return owner.request_ports[i]->sendAtomic(pkt);
             }
         }
     }
@@ -255,7 +257,6 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
 {
     DPRINTF(RubyPort, "Timing request for address %#x on port %d\n",
             pkt->getAddr(), id);
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
 
     if (pkt->cacheResponding())
         panic("RubyPort should never see request with the "
@@ -273,7 +274,7 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
     // pio port.
     if (pkt->cmd != MemCmd::MemSyncReq) {
         if (!pkt->req->isMemMgmt() && !isPhysMemAddress(pkt)) {
-            assert(ruby_port->memRequestPort.isConnected());
+            assert(owner.memRequestPort.isConnected());
             DPRINTF(RubyPort, "Request address %#x assumed to be a "
                     "pio address\n", pkt->getAddr());
 
@@ -282,8 +283,8 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
             pkt->pushSenderState(new SenderState(this));
 
             // send next cycle
-            RubySystem *rs = ruby_port->m_ruby_system;
-            ruby_port->memRequestPort.schedTimingReq(pkt,
+            RubySystem *rs = owner.m_ruby_system;
+            owner.memRequestPort.schedTimingReq(pkt,
                 curTick() + rs->clockPeriod());
             return true;
         }
@@ -291,8 +292,8 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
 
     // set cpu here
     // when receiving a request, set sequencer(rubyport)'s cpu
-    if (ruby_port->m_isDataSequencer && !ruby_port->cpu) {
-        ruby_port->cpu = (BaseCPU *)(this->sendGetCPUPtr());
+    if (owner.m_isDataSequencer && !owner.cpu) {
+        owner.cpu = (BaseCPU *)(this->sendGetCPUPtr());
     }
 
     // Save the port in the sender state object to be used later to
@@ -300,7 +301,7 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
     pkt->pushSenderState(new SenderState(this));
 
     // Submit the ruby request
-    RequestStatus requestStatus = ruby_port->makeRequest(pkt);
+    RequestStatus requestStatus = owner.makeRequest(pkt);
 
     // If the request successfully issued then we should return true.
     // Otherwise, we need to tell the port to retry at a later point
@@ -330,9 +331,8 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
 Tick
 RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
     // Only atomic_noncaching mode supported!
-    if (!ruby_port->system->bypassCaches()) {
+    if (!owner.system->bypassCaches()) {
         panic("Ruby supports atomic accesses only in noncaching mode\n");
     }
 
@@ -340,7 +340,7 @@ RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
     // pio port.
     if (pkt->cmd != MemCmd::MemSyncReq) {
         if (!isPhysMemAddress(pkt)) {
-            assert(ruby_port->memRequestPort.isConnected());
+            assert(owner.memRequestPort.isConnected());
             DPRINTF(RubyPort, "Request address %#x assumed to be a "
                     "pio address\n", pkt->getAddr());
 
@@ -349,8 +349,8 @@ RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
             pkt->pushSenderState(new SenderState(this));
 
             // send next cycle
-            Tick req_ticks = ruby_port->memRequestPort.sendAtomic(pkt);
-            return ruby_port->ticksToCycles(req_ticks);
+            Tick req_ticks = owner.memRequestPort.sendAtomic(pkt);
+            return owner.ticksToCycles(req_ticks);
         }
 
         assert(getOffset(pkt->getAddr()) + pkt->getSize() <=
@@ -358,7 +358,7 @@ RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
     }
 
     // Find the machine type of memory controller interface
-    RubySystem *rs = ruby_port->m_ruby_system;
+    RubySystem *rs = owner.m_ruby_system;
     static int mem_interface_type = -1;
     if (mem_interface_type == -1) {
         if (rs->m_abstract_controls[MachineType_Directory].size() != 0) {
@@ -373,7 +373,7 @@ RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
     }
 
     // Find the controller for the target address
-    MachineID id = ruby_port->m_controller->mapAddressToMachine(
+    MachineID id = owner.m_controller->mapAddressToMachine(
                     pkt->getAddr(), (MachineType)mem_interface_type);
     AbstractController *mem_interface =
         rs->m_abstract_controls[mem_interface_type][id.getNum()];
@@ -386,15 +386,14 @@ RubyPort::MemResponsePort::recvAtomic(PacketPtr pkt)
 void
 RubyPort::MemResponsePort::addToRetryList()
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
 
     //
     // Unless the request port do not want retries (e.g., the Ruby tester),
     // record the stalled M5 port for later retry when the sequencer
     // becomes free.
     //
-    if (!no_retry_on_stall && !ruby_port->onRetryList(this)) {
-        ruby_port->addToRetryList(this);
+    if (!no_retry_on_stall && !owner.onRetryList(this)) {
+        owner.addToRetryList(this);
     }
 }
 
@@ -403,15 +402,14 @@ RubyPort::MemResponsePort::recvFunctional(PacketPtr pkt)
 {
     DPRINTF(RubyPort, "Functional access for address: %#x\n", pkt->getAddr());
 
-    [[maybe_unused]] RubyPort *rp = static_cast<RubyPort *>(&owner);
-    RubySystem *rs = rp->m_ruby_system;
+    RubySystem *rs = owner.m_ruby_system;
 
     // Check for pio requests and directly send them to the dedicated
     // pio port.
     if (!isPhysMemAddress(pkt)) {
         DPRINTF(RubyPort, "Pio Request for address: 0x%#x\n", pkt->getAddr());
-        assert(rp->pioRequestPort.isConnected());
-        rp->pioRequestPort.sendFunctional(pkt);
+        assert(owner.pioRequestPort.isConnected());
+        owner.pioRequestPort.sendFunctional(pkt);
         return;
     }
 
@@ -653,15 +651,14 @@ RubyPort::MemResponsePort::hitCallback(PacketPtr pkt)
 
     DPRINTF(RubyPort, "Hit callback needs response %d\n", needsResponse);
 
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
-    RubySystem *rs = ruby_port->m_ruby_system;
+    RubySystem *rs = owner.m_ruby_system;
     if (accessPhysMem) {
         // We must check device memory first in case it overlaps with the
         // system memory range.
-        if (ruby_port->system->isDeviceMemAddr(pkt)) {
-            auto dmem = ruby_port->system->getDeviceMemory(pkt);
+        if (owner.system->isDeviceMemAddr(pkt)) {
+            auto dmem = owner.system->getDeviceMemory(pkt);
             dmem->access(pkt);
-        } else if (ruby_port->system->isMemAddr(pkt->getAddr())) {
+        } else if (owner.system->isMemAddr(pkt->getAddr())) {
             rs->getPhysMem()->access(pkt);
         } else {
             panic("Packet is in neither device nor system memory!");
@@ -694,11 +691,10 @@ RubyPort::PioResponsePort::getAddrRanges() const
 {
     // at the moment the assumption is that the request port does not care
     AddrRangeList ranges;
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
 
-    for (size_t i = 0; i < ruby_port->request_ports.size(); ++i) {
+    for (size_t i = 0; i < owner.request_ports.size(); ++i) {
         ranges.splice(ranges.begin(),
-                ruby_port->request_ports[i]->getAddrRanges());
+                owner.request_ports[i]->getAddrRanges());
     }
     for ([[maybe_unused]] const auto &r : ranges)
         DPRINTF(RubyPort, "%s\n", r.to_string());
@@ -708,8 +704,7 @@ RubyPort::PioResponsePort::getAddrRanges() const
 bool
 RubyPort::MemResponsePort::isShadowRomAddress(Addr addr) const
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
-    AddrRangeList ranges = ruby_port->system->getShadowRomRanges();
+    AddrRangeList ranges = owner.system->getShadowRomRanges();
 
     for (auto it = ranges.begin(); it != ranges.end(); ++it) {
         if (it->contains(addr)) {
@@ -723,10 +718,9 @@ RubyPort::MemResponsePort::isShadowRomAddress(Addr addr) const
 bool
 RubyPort::MemResponsePort::isPhysMemAddress(PacketPtr pkt) const
 {
-    RubyPort *ruby_port = static_cast<RubyPort *>(&owner);
     Addr addr = pkt->getAddr();
-    return (ruby_port->system->isMemAddr(addr) && !isShadowRomAddress(addr))
-           || ruby_port->system->isDeviceMemAddr(pkt);
+    return (owner.system->isMemAddr(addr) && !isShadowRomAddress(addr))
+           || owner.system->isDeviceMemAddr(pkt);
 }
 
 void

--- a/src/mem/ruby/system/RubyPort.hh
+++ b/src/mem/ruby/system/RubyPort.hh
@@ -68,11 +68,12 @@ class RubyPort : public ClockedObject
     class MemRequestPort : public QueuedRequestPort
     {
       private:
+        RubyPort& owner;
         ReqPacketQueue reqQueue;
         SnoopRespPacketQueue snoopRespQueue;
 
       public:
-        MemRequestPort(const std::string &_name, RubyPort *_port);
+        MemRequestPort(const std::string &_name, RubyPort& _port);
 
       protected:
         bool recvTimingResp(PacketPtr pkt);
@@ -82,14 +83,16 @@ class RubyPort : public ClockedObject
     class MemResponsePort : public QueuedResponsePort
     {
       private:
+        RubyPort& owner;
         RespPacketQueue queue;
         bool access_backing_store;
         bool no_retry_on_stall;
 
       public:
-        MemResponsePort(const std::string &_name, RubyPort *_port,
-                     bool _access_backing_store,
-                     PortID id, bool _no_retry_on_stall);
+        MemResponsePort(const std::string &_name,
+                        RubyPort& _port,
+                        bool _access_backing_store,
+                        PortID id, bool _no_retry_on_stall);
         void hitCallback(PacketPtr pkt);
         void customSignalCallback(PacketPtr pkt);
         void evictionCallback(Addr address);
@@ -114,11 +117,12 @@ class RubyPort : public ClockedObject
     class PioRequestPort : public QueuedRequestPort
     {
       private:
+        RubyPort& owner;
         ReqPacketQueue reqQueue;
         SnoopRespPacketQueue snoopRespQueue;
 
       public:
-        PioRequestPort(const std::string &_name, RubyPort *_port);
+        PioRequestPort(const std::string &_name, RubyPort& _port);
 
       protected:
         bool recvTimingResp(PacketPtr pkt);
@@ -128,10 +132,11 @@ class RubyPort : public ClockedObject
     class PioResponsePort : public QueuedResponsePort
     {
       private:
+        RubyPort& owner;
         RespPacketQueue queue;
 
       public:
-        PioResponsePort(const std::string &_name, RubyPort *_port);
+        PioResponsePort(const std::string &_name, RubyPort& _port);
 
       protected:
         bool recvTimingReq(PacketPtr pkt);

--- a/src/mem/serial_link.cc
+++ b/src/mem/serial_link.cc
@@ -61,7 +61,7 @@ SerialLinkResponsePort(const std::string& _name,
                                          Cycles _delay, int _resp_limit,
                                          const std::vector<AddrRange>&
                                          _ranges)
-    : ResponsePort(_name, &_serial_link), serial_link(_serial_link),
+    : ResponsePort(_name), serial_link(_serial_link),
       mem_side_port(_mem_side_port), delay(_delay),
       ranges(_ranges.begin(), _ranges.end()),
       outstandingResponses(0), retryReq(false),
@@ -75,7 +75,7 @@ SerialLink::SerialLinkRequestPort::SerialLinkRequestPort(const std::string&
                                            SerialLinkResponsePort&
                                            _cpu_side_port, Cycles _delay,
                                            int _req_limit)
-    : RequestPort(_name, &_serial_link), serial_link(_serial_link),
+    : RequestPort(_name), serial_link(_serial_link),
       cpu_side_port(_cpu_side_port), delay(_delay), reqQueueLimit(_req_limit),
       sendEvent([this]{ trySendTiming(); }, _name)
 {

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -264,7 +264,7 @@ SimpleMemory::drain()
 
 SimpleMemory::MemoryPort::MemoryPort(const std::string& _name,
                                      SimpleMemory& _memory)
-    : ResponsePort(_name, &_memory), mem(_memory)
+    : ResponsePort(_name), mem(_memory)
 { }
 
 AddrRangeList

--- a/src/mem/sys_bridge.cc
+++ b/src/mem/sys_bridge.cc
@@ -43,9 +43,9 @@ SysBridge::BridgingPort::replaceReqID(PacketPtr pkt)
 }
 
 SysBridge::SysBridge(const SysBridgeParams &p) : SimObject(p),
-    sourcePort(p.name + ".source_port", this, &targetPort,
+    sourcePort(p.name + ".source_port", &targetPort,
             p.target->getRequestorId(this)),
-    targetPort(p.name + ".target_port", this, &sourcePort,
+    targetPort(p.name + ".target_port", &sourcePort,
             p.source->getRequestorId(this))
 {}
 

--- a/src/mem/sys_bridge.hh
+++ b/src/mem/sys_bridge.hh
@@ -130,9 +130,9 @@ class SysBridge : public SimObject
         SysBridgeSourcePort *sourcePort;
 
       public:
-        SysBridgeTargetPort(const std::string &_name, SimObject *owner,
+        SysBridgeTargetPort(const std::string &_name,
                 SysBridgeSourcePort *source_port, RequestorID _id) :
-            RequestPort(_name, owner), BridgingPort(_id),
+            RequestPort(_name), BridgingPort(_id),
             sourcePort(source_port)
         {
             DPRINTF(SysBridge, "Target side requestor ID = %s.\n", _id);
@@ -223,9 +223,9 @@ class SysBridge : public SimObject
         SysBridgeTargetPort *targetPort;
 
       public:
-        SysBridgeSourcePort(const std::string &_name, SimObject *owner,
+        SysBridgeSourcePort(const std::string &_name,
                 SysBridgeTargetPort *target_port, RequestorID _id) :
-            ResponsePort(_name, owner), BridgingPort(_id),
+            ResponsePort(_name), BridgingPort(_id),
             targetPort(target_port)
         {
             DPRINTF(SysBridge, "Source side requestor ID = %s.\n", _id);

--- a/src/mem/token_port.hh
+++ b/src/mem/token_port.hh
@@ -50,7 +50,7 @@ class TokenRequestPort : public RequestPort
   public:
     TokenRequestPort(const std::string& name, SimObject* owner,
                     PortID id = InvalidPortID) :
-        RequestPort(name, owner, id), tokenManager(nullptr)
+        RequestPort(name, id), tokenManager(nullptr)
     { }
 
     /**
@@ -98,9 +98,9 @@ class TokenResponsePort : public ResponsePort
     void recvRespRetry() override;
 
   public:
-    TokenResponsePort(const std::string& name, ClockedObject *owner,
+    TokenResponsePort(const std::string& name,
                    PortID id = InvalidPortID) :
-        ResponsePort(name, owner, id), tokenRequestPort(nullptr)
+        ResponsePort(name, id), tokenRequestPort(nullptr)
     { }
     ~TokenResponsePort() { }
 

--- a/src/mem/tport.cc
+++ b/src/mem/tport.cc
@@ -46,7 +46,7 @@ namespace gem5
 
 SimpleTimingPort::SimpleTimingPort(const std::string& _name,
                                    SimObject* _owner) :
-    QueuedResponsePort(_name, _owner, queueImpl), queueImpl(*_owner, *this)
+    QueuedResponsePort(_name, queueImpl), queueImpl(*_owner, *this)
 {
 }
 

--- a/src/sim/power/power_model.cc
+++ b/src/sim/power/power_model.cc
@@ -102,9 +102,9 @@ PowerModel::thermalUpdateCallback(const Temperature &temp)
 void
 PowerModel::regProbePoints()
 {
-    thermalListener.reset(new ThermalProbeListener (
-        *this, this->subsystem->getProbeManager(), "thermalUpdate"
-    ));
+    thermalListener =
+        subsystem->getProbeManager()->connect<ThermalProbeListener>(
+            *this, "thermalUpdate");
 }
 
 double

--- a/src/sim/power/power_model.hh
+++ b/src/sim/power/power_model.hh
@@ -136,9 +136,9 @@ class PowerModel : public SimObject
     class ThermalProbeListener : public ProbeListenerArgBase<Temperature>
     {
       public:
-        ThermalProbeListener(PowerModel &_pm, ProbeManager *pm,
-                      const std::string &name)
-            : ProbeListenerArgBase(pm, name), pm(_pm) {}
+        ThermalProbeListener(PowerModel &_pm, std::string name)
+            : ProbeListenerArgBase(std::move(name)), pm(_pm)
+        {}
 
         void notify(const Temperature &temp)
         {
@@ -153,7 +153,7 @@ class PowerModel : public SimObject
     std::vector<PowerModelState*> states_pm;
 
     /** Listener to catch temperature changes in the SubSystem */
-    std::unique_ptr<ThermalProbeListener> thermalListener;
+    ProbeListenerPtr<ThermalProbeListener> thermalListener;
 
     /** The subsystem this power model belongs to */
     SubSystem * subsystem;

--- a/src/sim/probe/probe.cc
+++ b/src/sim/probe/probe.cc
@@ -63,21 +63,7 @@ ProbeListenerObject::ProbeListenerObject(
 
 ProbeListenerObject::~ProbeListenerObject()
 {
-    for (auto l = listeners.begin(); l != listeners.end(); ++l) {
-        delete (*l);
-    }
     listeners.clear();
-}
-
-ProbeListener::ProbeListener(ProbeManager *_manager, const std::string &_name)
-    : manager(_manager), name(_name)
-{
-    manager->addListener(name, *this);
-}
-
-ProbeListener::~ProbeListener()
-{
-    manager->removeListener(name, *this);
 }
 
 bool

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -63,7 +63,9 @@
 #ifndef __SIM_PROBE_PROBE_HH__
 #define __SIM_PROBE_PROBE_HH__
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/compiler.hh"
@@ -96,50 +98,27 @@ namespace probing
 }
 
 /**
- * This class is a minimal wrapper around SimObject. It is used to declare
- * a python derived object that can be added as a ProbeListener to any other
- * SimObject.
- *
- * It instantiates manager from a call to Parent.any.
- * The vector of listeners is used simply to hold onto listeners until the
- * ProbeListenerObject is destroyed.
- */
-class ProbeListenerObject : public SimObject
-{
-  protected:
-    ProbeManager *manager;
-    std::vector<ProbeListener *> listeners;
-
-  public:
-    ProbeListenerObject(const ProbeListenerObjectParams &params);
-    virtual ~ProbeListenerObject();
-    ProbeManager* getProbeManager() { return manager; }
-};
-
-/**
  * ProbeListener base class; here to simplify things like containers
  * containing multiple types of ProbeListener.
- *
- * Note a ProbeListener is added to the ProbePoint in constructor by
- * using the ProbeManager passed in.
  */
 class ProbeListener
 {
   public:
-    ProbeListener(ProbeManager *manager, const std::string &name);
-    virtual ~ProbeListener();
+    ProbeListener(std::string _name) : name(std::move(_name)) {}
+
+    virtual ~ProbeListener() = default;
     ProbeListener(const ProbeListener& other) = delete;
     ProbeListener& operator=(const ProbeListener& other) = delete;
     ProbeListener(ProbeListener&& other) noexcept = delete;
-    ProbeListener& operator=(ProbeListener&& other) noexcept = delete;
+    ProbeListener &operator=(ProbeListener &&other) noexcept = delete;
+    const std::string &getName() const { return name; }
 
   protected:
-    ProbeManager *const manager;
     const std::string name;
 };
 
 /**
- * ProbeListener base class; again used to simplify use of ProbePoints
+ * ProbePoint base class; again used to simplify use of ProbePoints
  * in containers and used as to define interface for adding removing
  * listeners to the ProbePoint.
  */
@@ -153,8 +132,30 @@ class ProbePoint
 
     virtual void addListener(ProbeListener *listener) = 0;
     virtual void removeListener(ProbeListener *listener) = 0;
-    std::string getName() const { return name; }
+    const std::string &getName() const { return name; }
 };
+
+struct ProbeListenerCleanup
+{
+    ProbeListenerCleanup() : manager(nullptr) {};
+    explicit ProbeListenerCleanup(ProbeManager *m) : manager(m) {};
+    void operator()(ProbeListener *listener) const;
+
+  private:
+    ProbeManager *manager;
+};
+
+/**
+ * This typedef should be used instead of a raw std::unique_ptr<> since
+ * we have to disconnect the listener from the manager before calling
+ * the ProbeListener destructor. If we were to use a raw
+ * std::unique_ptr<Listener> and call disconnect() inside the
+ * ProbeListener destructor, we would end up accessing a partially
+ * destructed object inside disconnect(), which undefined behaviour and
+ * therefore is likely to crash or behave incorrectly.
+ */
+template <typename Listener = ProbeListener>
+using ProbeListenerPtr = std::unique_ptr<Listener, ProbeListenerCleanup>;
 
 /**
  * ProbeManager is a conduit class that lives on each SimObject,
@@ -198,6 +199,52 @@ class ProbeManager
      * @param point the ProbePoint to add.
      */
     void addPoint(ProbePoint &point);
+
+    template <typename Listener, typename... Args>
+    ProbeListenerPtr<Listener> connect(Args &&...args)
+    {
+        ProbeListenerPtr<Listener> result(
+            new Listener(std::forward<Args>(args)...),
+            ProbeListenerCleanup(this));
+        addListener(result->getName(), *result);
+        return result;
+    }
+};
+
+inline void
+ProbeListenerCleanup::operator()(ProbeListener *listener) const
+{
+    manager->removeListener(listener->getName(), *listener);
+    delete listener;
+}
+
+/**
+ * This class is a minimal wrapper around SimObject. It is used to declare
+ * a python derived object that can be added as a ProbeListener to any other
+ * SimObject.
+ *
+ * It instantiates manager from a call to Parent.any.
+ * The vector of listeners is used simply to hold onto listeners until the
+ * ProbeListenerObject is destroyed.
+ */
+class ProbeListenerObject : public SimObject
+{
+  protected:
+    ProbeManager *manager;
+    std::vector<ProbeListenerPtr<>> listeners;
+
+  public:
+    ProbeListenerObject(const ProbeListenerObjectParams &params);
+    virtual ~ProbeListenerObject();
+    ProbeManager *getProbeManager() { return manager; }
+
+    template <typename T, typename... Args>
+    void
+    connectListener(Args &&...args)
+    {
+        listeners.push_back(
+            getProbeManager()->connect<T>(std::forward<Args>(args)...));
+    }
 };
 
 /**
@@ -211,9 +258,7 @@ template <class Arg>
 class ProbeListenerArgBase : public ProbeListener
 {
   public:
-    ProbeListenerArgBase(ProbeManager *pm, const std::string &name)
-        : ProbeListener(pm, name)
-    {}
+    ProbeListenerArgBase(std::string name) : ProbeListener(std::move(name)) {}
     virtual void notify(const Arg &val) = 0;
 };
 
@@ -237,9 +282,8 @@ class ProbeListenerArg : public ProbeListenerArgBase<Arg>
      * @param name the name of the ProbePoint to add this listener to.
      * @param func a pointer to the function on obj (called on notify).
      */
-    ProbeListenerArg(T *obj, const std::string &name,
-        void (T::* func)(const Arg &))
-        : ProbeListenerArgBase<Arg>(obj->getProbeManager(), name),
+    ProbeListenerArg(T *obj, std::string name, void (T::*func)(const Arg &))
+        : ProbeListenerArgBase<Arg>(std::move(name)),
           object(obj),
           function(func)
     {}

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -177,7 +177,7 @@ System::Threads::quiesceTick(ContextID id, Tick when)
 int System::numSystemsRunning = 0;
 
 System::System(const Params &p)
-    : SimObject(p), _systemPort("system_port", this),
+    : SimObject(p), _systemPort("system_port"),
       multiThread(p.multi_thread),
       init_param(p.init_param),
       physProxy(_systemPort, p.cache_line_size),

--- a/src/sim/system.hh
+++ b/src/sim/system.hh
@@ -91,8 +91,8 @@ class System : public SimObject, public PCEventScope
         /**
          * Create a system port with a name and an owner.
          */
-        SystemPort(const std::string &_name, SimObject *_owner)
-            : RequestPort(_name, _owner)
+        SystemPort(const std::string &_name)
+            : RequestPort(_name)
         { }
 
         bool

--- a/src/sst/outgoing_request_bridge.cc
+++ b/src/sst/outgoing_request_bridge.cc
@@ -52,7 +52,7 @@ OutgoingRequestBridge::~OutgoingRequestBridge()
 OutgoingRequestBridge::
 OutgoingRequestPort::OutgoingRequestPort(const std::string &name_,
                                          OutgoingRequestBridge* owner_) :
-    ResponsePort(name_, owner_)
+    ResponsePort(name_)
 {
     owner = owner_;
 }

--- a/src/systemc/tlm_bridge/gem5_to_tlm.hh
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.hh
@@ -137,7 +137,7 @@ class Gem5ToTlmBridge : public Gem5ToTlmBridgeBase
       public:
         BridgeResponsePort(const std::string &name_,
                         Gem5ToTlmBridge<BITWIDTH> &bridge_) :
-            ResponsePort(name_, nullptr), bridge(bridge_)
+            ResponsePort(name_), bridge(bridge_)
         {}
     };
 

--- a/src/systemc/tlm_bridge/tlm_to_gem5.hh
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.hh
@@ -113,7 +113,7 @@ class TlmToGem5Bridge : public TlmToGem5BridgeBase
       public:
         BridgeRequestPort(const std::string &name_,
                          TlmToGem5Bridge<BITWIDTH> &bridge_) :
-            RequestPort(name_, nullptr), bridge(bridge_)
+            RequestPort(name_), bridge(bridge_)
         {}
     };
 


### PR DESCRIPTION
## Motivation

After #1070 fixed two XiangShan-specific UBSan reports, the remaining CoreMark startup reports came from issues inherited from upstream gem5:

- a probe listener registered while its derived object was only partially constructed
- default memory ports binding a `SimObject&` owner to `*nullptr`

## Changes

- Backport upstream probe-listener lifetime fix from gem5/gem5@e693c4fb8f. Listeners are now fully constructed before registration and unregistered before destruction.
- Backport the upstream port-owner migration and removal from gem5/gem5@d40ed0f826, gem5/gem5@7f4c92c910, and gem5/gem5@71bcb54af4. Derived ports retain typed owners where needed.
- Adapt the upstream changes to XiangShan-specific cache wrappers, prefetch paths, and RubyPort code without changing their behavior.

The two fixes are kept as independent commits for review.

## Validation

- `CC=clang CXX=clang++ scons build/RISCV/gem5.opt --gold-linker -j64 --with-ubsan --without-tcmalloc`
- CoreMark raw checkpoint, 10,000 committed instructions, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=0`
- The run exits normally and produces no UBSan report; the previous probe and port-owner reports are gone.