### PR TITLE
mem-cache: Avoid shifting negative strides

### DIFF
--- a/src/mem/cache/prefetch/xs_stride.cc
+++ b/src/mem/cache/prefetch/xs_stride.cc
@@ -180,20 +180,29 @@ XSStridePrefetcher::strideLookup(AssociativeSet<StrideEntry> &stride, const Pref
             unsigned start_depth = pfi.isCacheMiss() ? std::max(1, (entry->depth - 4)) : entry->depth;
             Addr pf_addr = 0;
             if (useXsDepth) {
-                sendPFWithFilter(pfi, blockAddress(lookupAddr + (entry->stride << 2)), addresses, 0,
+                // Keep negative-stride address arithmetic in the unsigned
+                // Addr domain instead of left-shifting a signed value.
+                const Addr stride_offset = static_cast<Addr>(entry->stride);
+                const Addr depth4_addr = lookupAddr + stride_offset * 4;
+                const Addr depth32_addr = lookupAddr + stride_offset * 32;
+                sendPFWithFilter(pfi, blockAddress(depth4_addr), addresses, 0,
                                  PrefetchSourceType::SStride, 1);
-                sendPFWithFilter(pfi, blockAddress(lookupAddr + (entry->stride << 5)), addresses, 0,
+                sendPFWithFilter(pfi, blockAddress(depth32_addr), addresses, 0,
                                  PrefetchSourceType::SStride, 2);
                 if (is_first_shot) {
                     stats.strideUniquepfCount += 2;
                 } else {
                     stats.strideRedundantpfCount += 2;
                 }
-                if (archDBer){
-                    archDBer->strideTraceWrite(curTick(),  blockAddress(lookupAddr + (entry->stride << 2)), pfi.getPC(), stride_hash_pc,
-                                            true, is_first_shot, pfi.isCacheMiss(), false);
-                    archDBer->strideTraceWrite(curTick(),  blockAddress(lookupAddr + (entry->stride << 5)), pfi.getPC(), stride_hash_pc,
-                                            true, is_first_shot, pfi.isCacheMiss(), false);
+                if (archDBer) {
+                    archDBer->strideTraceWrite(
+                        curTick(), blockAddress(depth4_addr), pfi.getPC(),
+                        stride_hash_pc, true, is_first_shot,
+                        pfi.isCacheMiss(), false);
+                    archDBer->strideTraceWrite(
+                        curTick(), blockAddress(depth32_addr), pfi.getPC(),
+                        stride_hash_pc, true, is_first_shot,
+                        pfi.isCacheMiss(), false);
                 }
             } else {
                 for (unsigned i = start_depth; i <= entry->depth; i++) {


### PR DESCRIPTION
## Motivation

Extended UBSan runs after #1070 found two reports in the XiangShan-specific XSStride prefetcher:

```text
src/mem/cache/prefetch/xs_stride.cc:183:80: runtime error: left shift of negative value -16
src/mem/cache/prefetch/xs_stride.cc:185:80: runtime error: left shift of negative value -16
```

The issue reproduces with both gobmk and sjeng. XSStride is not present in upstream gem5, so there is no upstream fix to backport.

## Change

Compute the 4x and 32x lookahead addresses in the unsigned `Addr` domain. Converting the signed stride to `Addr` makes wraparound explicit and defined, preserving the existing backward-prefetch address semantics without signed left-shift UB. The same computed addresses are shared with ArchDB tracing.

## Validation

- `CC=clang CXX=clang++ scons build/RISCV/gem5.opt --gold-linker -j64 --with-ubsan --without-tcmalloc`
- gobmk_nngs, 250,000 instructions: XSStride UBSan reports removed
- sjeng, 250,000 instructions: XSStride UBSan reports removed
- Before/after execution is unchanged:
  - gobmk: `simTicks=94047525`, `simInsts=250001`, `numCycles=282426`
  - sjeng: `simTicks=70412517`, `simInsts=250006`, `numCycles=211450`

On the current `xs-dev` base, the remaining startup reports are limited to the upstream issues addressed separately by #1076.