### PR TITLE
arch-riscv: Avoid signed overflow in MUL

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1049,7 +1049,7 @@ decode QUADRANT {
                     }
                     0x01: decode BS {
                         0x0: mul({{
-                            Rd = Rs1_sd * Rs2_sd;
+                            Rd = Rs1_ud * Rs2_ud;
                         }}, IntMultOp);
                     }
                     0x18: sm4ed({{


### PR DESCRIPTION
## Motivation

An H-extension UBSan smoke run found signed overflow in the scalar RISC-V `MUL` implementation:

```text
arch/riscv/generated/exec-ns.cc.inc:8555:38:
runtime error: signed integer overflow:
1605 * -6148914691236517205 cannot be represented in type int64_t
```

RISC-V `MUL` returns the low XLEN bits of the product, while the ISA template currently performs the host operation with signed `int64_t` operands. Overflow is therefore undefined in C++, even though guest behavior is defined.

The current upstream gem5 `develop` branch still uses the equivalent `rvSext(Rs1_sd * Rs2_sd)` expression, and no fix was found across the available upstream refs, so this is not an upstream backport.

## Change

Use the unsigned register views for scalar `MUL`. Unsigned multiplication has defined modulo-2^64 behavior and produces exactly the low XLEN product bits required by the ISA.

## Validation

- `CC=clang CXX=clang++ scons build/RISCV/gem5.opt --gold-linker -j64 --with-ubsan --without-tcmalloc`
- `gcbh_test.zstd`, RVH restore, 250,000 instructions:
  - before: UBSan reports signed overflow in `Mul::execute`
  - after: the MUL report is absent and the run reaches the instruction limit normally
- With #1077 applied locally for a clean combined probe, the same H run reports no additional execution-time UB; only the startup issues handled by #1076 remain on the `xs-dev` base.

This PR intentionally changes only the dynamically reproduced scalar `MUL` site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the RISC-V `mul` instruction to perform unsigned 64-bit multiplication.
  - Results are now calculated correctly when either source operand has its high bit set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->