### PR TITLE
misc: ignore envrc file to be compatible when GEM5 is submodule

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake path:nix

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ m5out
 configs/example/memcheck.cfg
 configs/dram/lowp_sweep.cfg
 .pyenv
+.envrc
 .vscode
 typings
 .DS_Store


### PR DESCRIPTION
Change-Id: I7d345406c406848099aefbb537e110ca75f13df6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic loading of the Nix development environment.
  * Added local environment configuration files to the ignored files list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->