### PR TITLE
cpu-o3: microtage 2 taken meta refresh fix

### DIFF
--- a/src/cpu/pred/btb/microtage.cc
+++ b/src/cpu/pred/btb/microtage.cc
@@ -406,6 +406,32 @@ MicroTAGE::getPredictionMeta(ThreadID tid) {
     return threadMeta[tid];
 }
 
+void
+MicroTAGE::refreshPredictionMeta(Addr startPC,
+                                 const bitset &history,
+                                 FullBTBPrediction &pred)
+{
+    const ThreadID tid = pred.tid;
+    const auto &state = historyState(tid);
+    auto meta = std::make_shared<TageMeta>();
+    meta->tagFoldedHist = state.tagFoldedHist;
+    meta->altTagFoldedHist = state.altTagFoldedHist;
+    meta->indexFoldedHist = state.indexFoldedHist;
+    meta->aheadIndexFoldedHistValid = !state.aheadIndexFoldedHist.empty();
+    if (meta->aheadIndexFoldedHistValid) {
+        meta->aheadIndexFoldedHist = state.aheadIndexFoldedHist.front();
+    }
+    meta->history = history;
+    meta->abtbEntries = getAbtbConditionalEntries(pred.btbEntries);
+
+    for (const auto &btb_entry : meta->abtbEntries) {
+        meta->preds[btb_entry.pc] = generateSinglePrediction(
+            btb_entry, startPC, nullptr, tid, pred.asidHash);
+    }
+
+    threadMeta[tid] = std::move(meta);
+}
+
 /**
  * @brief Prepare BTB entries for update by filtering and processing
  *

--- a/src/cpu/pred/btb/microtage.hh
+++ b/src/cpu/pred/btb/microtage.hh
@@ -126,6 +126,9 @@ class MicroTAGE : public TimedBaseBTBPredictor
                       std::vector<FullBTBPrediction> &stagePreds) override;
 
     std::shared_ptr<void> getPredictionMeta(ThreadID tid = 0) override;
+    void refreshPredictionMeta(Addr startAddr,
+                               const boost::dynamic_bitset<> &history,
+                               FullBTBPrediction &pred) override;
 
     // Speculatively update path folded histories.
     void specUpdatePHist(const boost::dynamic_bitset<> &history,


### PR DESCRIPTION
Change-Id: If3fcacf3d09c5e0046f34ac5b4465278b9d3519a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch prediction metadata updates using the latest execution history and branch-target information.
  * Ensured prediction entries are recalculated consistently, helping maintain accurate control-flow predictions across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->