### PR TITLE
cpu-o3: Guarantee SMT LSQ bank-conflict progress

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -106,27 +106,25 @@ Commit::processTrapEvent(ThreadID tid)
 Commit::Commit(CPU *_cpu, branch_prediction::BPredUnit *_bp, const BaseO3CPUParams &params)
     : commitPolicy(params.smtCommitPolicy),
       stuckCheckEvent([this]() {
-        static std::vector<DynInstPtr> debug_insts;
-
         for (ThreadID tid = 0; tid < numThreads; tid++) {
             if (cpu->curCycle() - this->lastCommitCycle[tid] > 40000) {
                 if (traceMaybeExitOnPipelineDrainFromStuckCheck()) {
                     return;
                 }
 
-                if (auto inst = rob->readHeadInst(0)) {
-                    warn("can't commit inst %s\n", inst->genDisassembly());
-                    debug_insts.insert(
-                        debug_insts.begin(), rob->getInstList(tid).begin(),
-                        rob->getInstList(tid).end());
-                    warn("dump rob front 10 insts\n");
+                if (auto inst = rob->readHeadInst(tid)) {
+                    warn("Thread %d can't commit head inst %s\n", tid,
+                         inst->genDisassembly());
+                    const auto &debug_insts = rob->getInstList(tid);
+                    warn("dump thread %d rob front 10 insts\n", tid);
                     int i = 0;
-                    for (auto inst = debug_insts.begin();
-                        inst != debug_insts.end() && i < 10; inst++, i++) {
-                        warn("%s\n", (*inst)->genDisassembly());
+                    for (auto it = debug_insts.begin();
+                        it != debug_insts.end() && i < 10; it++, i++) {
+                        warn("%s\n", (*it)->genDisassembly());
                     }
                 } else {
-                    warn("rob was empty, may be fetch or rename stuck\n");
+                    warn("Thread %d rob was empty, may be fetch or rename "
+                         "stuck\n", tid);
                 }
                 panic(
                     "Commit stage is stucked for more than 40,000 cycles!\n"

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1247,7 +1247,7 @@ LSQ::loadBankConflictedCheck(
 }
 
 void
-LSQ::recordLoadBankGrant(const DynInstPtr &inst)
+LSQ::complete_load_bank_wait(const DynInstPtr &inst)
 {
     if (bankConflictWaiter == inst) {
         bankConflictWaiter = nullptr;

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -616,6 +616,9 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
     storeBuffer.setData(store_buffer_entries);
     storeBuffer.setMaxThread(numThreads);
     bankOccupied.resize(dcacheSetDivNum, std::vector<bool>(numBank, false));
+    bankLoadOwner.resize(
+        dcacheSetDivNum,
+        std::vector<ThreadID>(numBank, InvalidThreadID));
 }
 
 
@@ -683,6 +686,7 @@ LSQ::takeOverFrom()
 {
     usedStorePorts = 0;
     _cacheBlocked = false;
+    bankConflictWaiter = nullptr;
 
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         thread[tid].takeOverFrom();
@@ -971,6 +975,8 @@ LSQ::markDcacheMainPipeBusyBanks()
     for (unsigned div = 0; div < dcacheSetDivNum; ++div) {
         std::fill(bankOccupied.at(div).begin(), bankOccupied.at(div).end(),
                   false);
+        std::fill(bankLoadOwner.at(div).begin(), bankLoadOwner.at(div).end(),
+                  InvalidThreadID);
     }
 
     auto mark_banks = [this](const DcacheMainPipeRequest &req,
@@ -1168,11 +1174,14 @@ LSQ::getDcacheDivBankSetKey(Addr vaddr) const
 }
 
 bool
-LSQ::loadBankConflictedCheck(Addr vaddr, unsigned size)
+LSQ::loadBankConflictedCheck(
+    const DynInstPtr &inst, Addr vaddr, unsigned size)
 {
     if (!enableBankConflictCheck || size == 0) {
         return false;
     }
+
+    const ThreadID tid = inst->threadNumber;
 
     struct TouchedBank
     {
@@ -1200,23 +1209,49 @@ LSQ::loadBankConflictedCheck(Addr vaddr, unsigned size)
 
     // Probe every target bank before claiming any of them. A failed
     // multi-bank load will not update bankOccupied and recentlyloadAddr.
+    bool bank_conflict = false;
+    bool cross_thread_conflict = false;
     for (auto &bank : touched_banks) {
         bank.recentlyAccessed = recentlyloadAddr.contains(bank.key);
         if (!bank.recentlyAccessed &&
             bankOccupied[bank.div][bank.bankIndex]) {
-            return true;
+            bank_conflict = true;
+            const ThreadID owner =
+                bankLoadOwner[bank.div][bank.bankIndex];
+            cross_thread_conflict |=
+                owner != InvalidThreadID && owner != tid;
         }
+    }
+
+    if (bank_conflict) {
+        // Do not let later losers replace an unserved waiter. Once this
+        // exact load gets a cache grant, a later conflict can become next.
+        if (cross_thread_conflict &&
+            (!bankConflictWaiter || bankConflictWaiter->isSquashed() ||
+             !bankConflictWaiter->isInROB())) {
+            bankConflictWaiter = inst;
+        }
+        return true;
     }
 
     // Occupy the banks and insert new keys to recentlyloadAddr.
     for (const auto &bank : touched_banks) {
         bankOccupied[bank.div][bank.bankIndex] = true;
+        bankLoadOwner[bank.div][bank.bankIndex] = tid;
         if (!bank.recentlyAccessed) {
             recentlyloadAddr.insert(bank.key, {});
         }
     }
 
     return false;
+}
+
+void
+LSQ::recordLoadBankGrant(const DynInstPtr &inst)
+{
+    if (bankConflictWaiter == inst) {
+        bankConflictWaiter = nullptr;
+    }
 }
 
 void
@@ -1374,14 +1409,35 @@ LSQ::recordStoreQueueReplay(const DynInstPtr &inst)
 void
 LSQ::executePipeSx()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        thread[tid].executePipeSx();
+    if (!activeThreads || activeThreads->empty()) {
+        bankConflictWaiter = nullptr;
+        return;
     }
+
+    auto priority = activeThreads->end();
+    if (bankConflictWaiter && !bankConflictWaiter->isSquashed() &&
+        bankConflictWaiter->isInROB()) {
+        priority = std::find(
+            activeThreads->begin(), activeThreads->end(),
+            bankConflictWaiter->threadNumber);
+    }
+
+    if (priority == activeThreads->end()) {
+        bankConflictWaiter = nullptr;
+        priority = activeThreads->begin();
+    }
+
+    // Keep the active-thread list untouched and only choose a circular
+    // starting point for this LSQ pipeline pass.
+    auto execute_threads = [this](auto begin, auto end) {
+        while (begin != end) {
+            const ThreadID tid = *begin++;
+            thread[tid].executePipeSx();
+        }
+    };
+
+    execute_threads(priority, activeThreads->end());
+    execute_threads(activeThreads->begin(), priority);
 }
 
 Fault

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1184,8 +1184,8 @@ class LSQ
     bool loadBankConflictedCheck(
         const DynInstPtr &inst, Addr vaddr, unsigned size);
 
-    /** Release loser-first priority after the blocked load is sent. */
-    void recordLoadBankGrant(const DynInstPtr &inst);
+    /** Release loser-first priority after the blocked load makes progress. */
+    void complete_load_bank_wait(const DynInstPtr &inst);
 
     void setDcacheWriteStall(bool t) { dcacheWriteStall = t; }
     bool getDcacheWriteStall() { return dcacheWriteStall; }

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1181,7 +1181,11 @@ class LSQ
         return (a >> dcacheBankOffsetBits) & (numBank - 1);
     }
 
-    bool loadBankConflictedCheck(Addr vaddr, unsigned size);
+    bool loadBankConflictedCheck(
+        const DynInstPtr &inst, Addr vaddr, unsigned size);
+
+    /** Release loser-first priority after the blocked load is sent. */
+    void recordLoadBankGrant(const DynInstPtr &inst);
 
     void setDcacheWriteStall(bool t) { dcacheWriteStall = t; }
     bool getDcacheWriteStall() { return dcacheWriteStall; }
@@ -1414,6 +1418,10 @@ class LSQ
     struct NullStruct {};
     boost::compute::detail::lru_cache<uint64_t, NullStruct> recentlyloadAddr;
     std::vector<std::vector<bool>> bankOccupied;
+    /** Per-cycle owner for banks claimed by loads, not main-pipe traffic. */
+    std::vector<std::vector<ThreadID>> bankLoadOwner;
+    /** First cross-thread bank-conflict loser awaiting a cache grant. */
+    DynInstPtr bankConflictWaiter;
 
     void notifyDcacheRefill(
         Addr addr, bool need_data_read = true,

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -3168,16 +3168,15 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
     bool ret = true;
     bool cache_got_blocked = false;
     LSQRequest *request = dynamic_cast<LSQRequest *>(data_pkt->senderState);
+    auto inst = request->instruction();
     if (isLoad) {
         bank_conflict = lsq->loadBankConflictedCheck(
-            data_pkt->req->getVaddr(), data_pkt->req->getSize());
+            inst, data_pkt->req->getVaddr(), data_pkt->req->getSize());
     }
     // Record the tick count at the time of sending to let
     // the subsequent cache understand the request's sending time.
     data_pkt->sendTick = curTick();
     PacketPtr pkt = data_pkt;
-
-    auto inst = dynamic_cast<LSQRequest *>(data_pkt->senderState)->instruction();
 
     DPRINTF(LSQUnit, "Attempting to send packet for inst [sn:%llu], addr: %#x\n",
             inst->seqNum, data_pkt->getAddr());
@@ -3240,6 +3239,9 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
     }
 
     if (ret) {
+        if (isLoad) {
+            lsq->recordLoadBankGrant(inst);
+        }
         if (!isLoad) {
             isStoreBlocked = false;
         }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1802,6 +1802,7 @@ LSQUnit::executeLoadPipeSx()
                 DPRINTF(LoadPipeline, "Instruction was squashed. PC: %s, [tid:%i]"
                     " [sn:%llu]\n", inst->pcState(), inst->threadNumber,
                     inst->seqNum);
+                lsq->complete_load_bank_wait(inst);
                 inst->setExecuted();
                 inst->setCanCommit();
                 inst = nullptr;
@@ -1943,6 +1944,9 @@ LSQUnit::executeLoadPipeSx()
             if (i == loadPipeStages - 1 && !inst->needReplay()) {
                 // Terminal path 4: only a non-replayed load at the last pipe
                 // stage can finish the IEW side and become ready to commit.
+                // This also releases a bank-conflict waiter that completed
+                // through forwarding or another non-cache path.
+                lsq->complete_load_bank_wait(inst);
                 if (inst->isExecuted() &&
                     (inst->isNormalLd() || !inst->readMemAccPredicate())) {
                     iewStage->readyToFinish(inst);
@@ -3240,7 +3244,7 @@ LSQUnit::trySendPacket(bool isLoad, PacketPtr data_pkt, bool &bank_conflict, boo
 
     if (ret) {
         if (isLoad) {
-            lsq->recordLoadBankGrant(inst);
+            lsq->complete_load_bank_wait(inst);
         }
         if (!isLoad) {
             isStoreBlocked = false;


### PR DESCRIPTION
## Motivation

With `BankConflictCheck` enabled, the full-system dual-hart CoreMark workload can permanently stop committing. Thread 0 repeatedly polls a barrier while thread 1 has a load at the ROB head, and both loads map to the same modeled D-cache bank.

Disabling the bank-conflict check avoids the hang, but that also removes the intended contention model. This change instead makes the existing bank arbitration guarantee progress.

## Root cause

`LSQ::executePipeSx()` always traversed `activeThreads` in its fixed list order. Thread 0 therefore claimed the bank before thread 1 on every retry. Thread 1's bank-conflict replay period stayed in phase with that ordering, so an unconditional per-cycle rotation would fix this instance but would not rule out another replay/rotation phase lock.

The baseline run reproduced the issue at cycle 1,400,340. The stalled thread 1 ROB began with:

```
[sn:7167525 pc:0x80000b1c] lbu a4, 0(a4), paddr: 0x800439fc
```

The old stuck diagnostic also printed a thread 0 instruction (`pc:0x80000d24`) as the allegedly uncommittable head before dumping thread 1's ROB, because it hard-coded `readHeadInst(0)`.

## Fairness mechanism

- Track the per-cycle thread owner only for banks claimed by loads. Banks occupied by refill/store main-pipe traffic do not create a cross-thread fairness waiter.
- When a load loses to a bank already claimed by another thread, retain that exact dynamic instruction as the first unserved waiter.
- Start the next `executePipeSx()` traversal at the waiter's TID and wrap around the existing `activeThreads` list without mutating global thread order.
- Keep the priority across replay gaps. Release it only when that exact load successfully sends its cache timing request or completes through a non-cache path such as full forwarding, rather than rotating on every cycle or after another load from the same thread succeeds.
- Drop stale priority when the instruction is squashed/leaves the ROB, its thread is inactive, the active list is empty, or the CPU takes over.
- Do not let later losers overwrite the current waiter. After the waiter receives its grant, a later conflict can become the next waiter, which serializes progress for more than two threads.

This preserves the existing bank occupancy, replay, cache-port, and `BankConflictCheck` behavior. The hot-path work remains bounded by active thread count and the banks touched by one load.

## Diagnostic fix

The commit-stuck event now reads and labels `readHeadInst(tid)` and directly dumps the same thread's ROB. It can no longer report thread 0's barrier head as thread 1's stuck head.

## Scope

- LSQ load-bank ownership and loser-first `executePipeSx()` traversal
- Successful-load grant notification
- Commit-stuck thread/head reporting
- No BPU, predictor, configuration, or global `activeThreads` changes
- No new parameter; existing bank-conflict stats are reused

## Validation

Base: `8b2f38ccad` (`origin/xs-dev`)

Build:

```bash
scons build/RISCV/gem5.opt --gold-linker -j64
```

Full-system workload for the baseline and the repeated fixed A/B runs:

```bash
GCBV_MULTI_CORE_REF_SO=/nfs/home/share/gem5_ci/ref/multi/riscv64-nemu-interpreter-so \
  ./build/RISCV/gem5.opt -d <outdir> \
  ./configs/example/smt_idealkmhv3.py \
  --mem-type=DDR4_2400_8x8 \
  --raw-cpt \
  --generic-rv-cpt=/nfs/home/yanyue/workspace/GEM5_5/debug/coremark_smt/coremark-10-iteration-quiet-dual-hart-riscv64-xs-dual.bin
```

Baseline:

- Reproduced commit stuck for thread 1 at cycle 1,400,340.
- Thread 1 ROB head path included `pc=0x80000b1c`, `paddr=0x800439fc`.
- The old diagnostic mislabeled a thread 0 head before the thread 1 ROB dump.

Fixed classic-memory A/B (repeated three times, including the reviewer-fixed binary):

- Exit code 0; `m5_exit` at tick `455768775`.
- Difftest enabled for hart 0 and hart 1; no mismatch, commit-stuck, panic, fatal, or abort markers.
- `BankConflictCheck=true`, `numThreads=2`, and TID-partitioned predictor settings remained enabled in `config.ini`.
- `system.cpu.lsq0.bankConflictTimes = 4562`.
- `system.cpu.lsq1.bankConflictTimes = 7077`.
- `simInsts = 6454213`.

Default DRAMsim3 supplement:

- Built the cached DRAMsim3 dependency using the same procedure as `.github/actions/build-dramsim`, then rebuilt `gem5.opt` with the DRAMsim3 wrapper.
- Ran the same full dual-hart binary with `smt_idealkmhv3.py` and no `--mem-type` override; `config.ini` reports `type=DRAMsim3` and `BankConflictCheck=true`.
- Reached normal `m5_exit` at tick `453381498`; both harts used the multi-hart difftest reference with no mismatch, commit-stuck, panic, fatal, or abort marker.
- `system.cpu.lsq0.bankConflictTimes = 4630` and `system.cpu.lsq1.bankConflictTimes = 7356`, so bank conflicts remain modeled.
- `system.cpu.lsq0.sbufferFullForward = 94472` and `system.cpu.lsq1.sbufferFullForward = 97473`, also exercising the non-cache waiter-completion path fixed during review.
- `simInsts = 6467806`.

The normal single-hart ref at `/nfs/home/share/gem5_ci/ref/normal/riscv64-nemu-interpreter-so` lacks the SMT `difftest_set_mhartid` entry point, so validation used the repository's multi-hart ref.

`git diff --check origin/xs-dev...HEAD` passed after validation, and the worktree contains no tracked or untracked source changes from the DRAMsim3 build.

## Test strategy and remaining risk

There is no lightweight LSQ unit-test fixture that exercises the integrated load pipeline, cache request, bank occupancy, and replay timing. The full dual-hart reproducer directly covers that chain and was therefore used as the targeted regression.

The validation covers the confirmed two-thread phase-lock case, including real conflicts, full-forward waiter completion, default DRAMsim3, and clean difftest completion. More-than-two-thread contention, thread deactivate/reactivate transitions, and arbitrary squash timing are handled defensively by the bounded waiter state but were not exercised by this binary. External main-pipe/cache blockage can still delay a waiter; it cannot consume the waiter priority, which remains until the blocked load sends, completes through another path, or becomes stale.

