### PR TITLE
cpu-o3: block store publication past possible load violations

### DIFF
--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -625,7 +625,13 @@ ROB::getHeadGroupLastDoneSeq(ThreadID tid)
         for (int i = 0; i < threadGroups[tid].front(); i++, it++) {
             auto& inst = *it;
             if (!inst->readyToCommit() || !inst->isExecuted() || inst->faulted() ||
-                 inst->memDepInfo.violationPending) {
+                 // If this inst contains a raw violation that is only 
+                 // handled during a commit, do not bypass it.
+                 inst->memDepInfo.violationPending ||
+                 // An external snoop can still turn a possible violation into a
+                 // ReExec fault. Keep younger stores out of the SBuffer until the
+                 // load either commits or is squashed.
+                 inst->possibleLoadViolation()) {
                 break;
             }
             seqnum = inst->seqNum;


### PR DESCRIPTION
## Summary

`ROB::getHeadGroupLastDoneSeq()` can publish younger stores while an older load is marked `possibleLoadViolation`. An external snoop can then convert that load into a `ReExec` fault after IEW has already marked a younger store `canWB`. The store is offloaded to the SBuffer and removed from the SQ, so the subsequent squash cannot restore the store state.

This change treats `possibleLoadViolation` as a head-group memory-publication barrier. Younger stores remain in the SQ until the load commits or the recovery squash removes them.

## Failure evidence

- CI run: https://github.com/OpenXiangShan/GEM5/actions/runs/32944321846
- Failing slice: `spec_all/bzip2_combined_2560` (the only failing slice)
- First difftest mismatch: tick `2003104557`, `sn=28046520`, PC `0x1464a`, `lbu a4, 385(sp)`; NEMU read `0x11`, gem5 read `0x12` at paddr `0x12ad6b4c1`
- Debug trace shows an older same-address load marked `possibleLoadViolation`, a stale `doneMemSeqNum` marking the younger store `canWB`, SBuffer offload, then a ReExec squash that stops at the already-published store
- The Worker `notify` scheduling change alters arbitration timing and exposes this pre-existing rollback hole; the failing request is an L1 CMC request, not a Worker request
- Generated CI configuration has all directional TLB prefetch probes disabled, so the TLB probe change is not the causal mechanism

## Validation

- `python3 util/style.py -m src/cpu/o3/rob.cc`
- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Exact checkpoint A/B with the new guard ran through tick `2004000000` without a difftest failure (`simInsts=18495166`)

No Worker or TLB behavior is changed by this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of possible load violations during instruction processing.
  * Prevented younger stores from entering the store buffer prematurely, improving memory-ordering correctness when loads are later re-executed or invalidated.
  * Reduced the risk of incorrect results caused by memory operations being processed before pending dependencies are fully resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->