### PR TITLE
cpu-o3:Calibrate RAS config

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1031,7 +1031,7 @@ class BTBRAS(TimedBaseBTBPredictor):
     cxx_header = 'cpu/pred/btb/ras.hh'
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
-    numEntries = Param.Unsigned(32, "Number of entries in the RAS")
+    numEntries = Param.Unsigned(16, "Number of entries in the RAS")
     ctrWidth = Param.Unsigned(8, "Width of the counter")
     numInflightEntries = Param.Unsigned(384, "Number of inflight entries")
     numDelay = 2


### PR DESCRIPTION
calibrate XS-GEM5 RAS against XS-RTL, CommitStackSize is 16. https://github.com/OpenXiangShan/XiangShan/blob/kunminghu-v3/src/main/scala/xiangshan/frontend/bpu/ras/Parameters.scala#L22

Change-Id: I5a0a9578e24ba5d8538d553108ae83f9611be8fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default return address stack capacity from 32 to 16 entries for improved compatibility with the intended predictor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->