### PR TITLE
cpu-o3: Skip idle vector-ready processing

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -676,6 +676,19 @@ IssueQue::releaseVectorSplitUnits(VectorSplitKind kind)
 void
 IssueQue::processVectorReadyQ()
 {
+    // Fast path for issue queues with no vector-split work in flight, which is
+    // all of them on scalar-only workloads. With the per-kind ready queues, the
+    // delayed-ready queue and every per-unit split queue empty, each step below
+    // is a no-op and scheduleVectorReadyQEvent() resolves to MaxTick and
+    // schedules nothing. Returning early is therefore bit-identical, including
+    // host-side event scheduling, while dropping the per-cycle vector
+    // bookkeeping every issue queue would otherwise run.
+    if (vectorLoadReadyQ.empty() && vectorStoreReadyQ.empty() &&
+        vectorDelayedReadyQ.empty() &&
+        nextVectorSplitReleaseTick() == MaxTick) {
+        return;
+    }
+
     tryStartVectorMemSplit();
 
     releaseVectorSplitUnits(VectorSplitKind::Load);


### PR DESCRIPTION
## Background

`IssueQue::tick()` calls `processVectorReadyQ()` every cycle for every issue
queue. On scalar workloads the vector load/store ready queues, delayed-ready
queue, and per-unit split queues remain empty, but the function still walks
those structures and recomputes the next event time.

## Approach

Return early when all vector-ready queues are empty and no split unit has a
pending release. In that state every operation in the existing path is a no-op
and `scheduleVectorReadyQEvent()` resolves to `MaxTick`, so no event would be
scheduled.

The vector-active path is unchanged. This change adds no parameters, stats, or
data structures and does not change issue, wakeup, replay, or release timing.

## Host-performance result

The A/B test used:

- baseline: `f63979dc6c` (`xs-dev` after #1067)
- candidate: `5a9dbccd90`
- default GCC `gem5.opt`, no `--march` or PGO
- `configs/example/kmhv3.py`
- full CoreMark raw checkpoint with difftest enabled
- AMD EPYC 9684X, pinned to CPU 103
- five runs per variant measured with `perf stat`

| Metric | Baseline median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| task-clock | 43.066 s | 41.756 s | +3.14% throughput |
| host retired instructions | 321.382 B | 304.896 B | -5.13% |

One candidate run experienced host interference; the median above includes it.
Retired-instruction counts remained stable across all five runs.

## Guest equivalence

All runs completed difftest successfully. `simTicks`, `simInsts`, `simOps`, CPU
cycles, IPC, branch counts, and branch-miss counts were identical. The
normalized full-stats SHA256 was identical across all ten runs after excluding
host-only fields and the existing layout-sensitive `decodeEfficiency` formula.

## Validation

```text
scons build/RISCV/gem5.opt --gold-linker -j64
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary processing during cycles with no pending vector-split work.
  * Avoided redundant vector bookkeeping and event scheduling when the vector queues are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->