### PR TITLE
bpu: Gate folded-history checks behind debug flag

### DIFF
--- a/src/cpu/pred/btb/decoupled_bpred.cc
+++ b/src/cpu/pred/btb/decoupled_bpred.cc
@@ -14,6 +14,7 @@
 #include "debug/BTB.hh"
 #include "debug/DecoupleBPHist.hh"
 #include "debug/DecoupleBPVerbose.hh"
+#include "debug/FoldedHist.hh"
 #include "debug/Override.hh"
 #include "debug/Profiling.hh"
 #include "sim/core.hh"
@@ -1432,18 +1433,19 @@ DecoupledBPUWithBTB::updateHistoryForPrediction(FetchTarget &entry,
         s0LHistory[localHistoryIndex]);
 
 #ifndef NDEBUG
-    if (tage->isEnabled()) {
+    // Recomputing complete folded histories is only needed for debugging.
+    if (debug::FoldedHist && tage->isEnabled()) {
         tage->checkFoldedHist(
             tage->usesPathHistory() ? s0PHistory : s0History, tid,
             "speculative update");
     }
-    if (ittage->isEnabled()) {
+    if (debug::FoldedHist && ittage->isEnabled()) {
         ittage->checkFoldedHist(s0PHistory, tid, "speculative update");
     }
-    if (microtage->isEnabled()) {
+    if (debug::FoldedHist && microtage->isEnabled()) {
         microtage->checkFoldedHist(s0PHistory, tid, "speculative update");
     }
-    if (mgsc->isEnabled()) {
+    if (debug::FoldedHist && mgsc->isEnabled()) {
         mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, tid,
                               "speculative update");
     }
@@ -1548,23 +1550,24 @@ DecoupledBPUWithBTB::recoverHistoryForSquash(
     // Perform history consistency checks when not a fast build variant
 #ifndef NDEBUG
     checkHistories(s0History, s0PHistory, tid);
-    if (tage->isEnabled()) {
+    // Recomputing complete folded histories is only needed for debugging.
+    if (debug::FoldedHist && tage->isEnabled()) {
         tage->checkFoldedHist(
             tage->usesPathHistory() ? s0PHistory : s0History, tid,
             squash_type == SQUASH_CTRL ? "control squash" :
             squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
-    if (ittage->isEnabled()) {
+    if (debug::FoldedHist && ittage->isEnabled()) {
         ittage->checkFoldedHist(s0PHistory, tid,
             squash_type == SQUASH_CTRL ? "control squash" :
             squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
-    if (microtage->isEnabled()) {
+    if (debug::FoldedHist && microtage->isEnabled()) {
         microtage->checkFoldedHist(s0PHistory, tid,
             squash_type == SQUASH_CTRL ? "control squash" :
             squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");
     }
-    if (mgsc->isEnabled()) {
+    if (debug::FoldedHist && mgsc->isEnabled()) {
         mgsc->checkFoldedHist(s0History, s0PHistory, s0LHistory, tid,
             squash_type == SQUASH_CTRL ? "control squash" :
             squash_type == SQUASH_OTHER ? "non control squash" : "trap squash");


### PR DESCRIPTION
## Motivation

`FoldedHistBase::fold()` was the hottest self-time function in a full CoreMark host profile (about 6% of sampled cycles). Its runtime callers are consistency checks that recompute every predictor bank from the complete history after each prediction and squash, then compare against the incrementally maintained state.

These checks do not affect prediction state, but they run by default in `gem5.opt` because they are only guarded by `NDEBUG`.

## Change

Gate the runtime `checkFoldedHist()` calls behind the existing `FoldedHist` debug flag. Normal runs skip the complete-history recomputation; `--debug-flags=FoldedHist` restores the checks. Direct unit-test calls to the checking functions are unchanged.

No model parameters, predictor state, metadata layout, or stats are changed.

## Validation

Compared against `xs-dev` at `f63979dc6c` using the default GCC `gem5.opt`, full CoreMark, difftest enabled, and CPU affinity fixed to CPU 35. Five runs per variant were interleaved.

| Host metric | Baseline median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| task-clock | 58.412 s | 54.373 s | 7.43% throughput gain |
| retired instructions | 321.443 B | 264.000 B | -17.87% |

All ten runs exited at tick `473882310` with clean difftest. After excluding host-time fields and the known `decodeEfficiency` presentation difference, all ten complete stats files had the same normalized SHA-256 hash. Key guest results were unchanged: IPC `2.214576`, CPU cycles `1423071`, and simulated instructions `3151499`.

The folded-history unit test also passed all 10 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of speculative prediction and recovery consistency checks.
  * Added optional debug diagnostics for folded-history tracking without affecting normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->