### PR TITLE
cpu: Store folded-history snapshots as values

### DIFF
--- a/src/cpu/pred/btb/btb_mgsc.cc
+++ b/src/cpu/pred/btb/btb_mgsc.cc
@@ -35,6 +35,26 @@ namespace branch_prediction
 namespace btb_pred
 {
 
+namespace
+{
+
+// Snapshot a folded-history vector as raw folded values. Prediction and tag
+// lookups read the values directly and recovery restores them through
+// recoverValue(), so the metadata only needs the folded value and not the full
+// object with its per-shift position tables.
+template <typename Src>
+void
+snapshotFoldedValues(const Src &src, std::vector<uint64_t> &dst)
+{
+    dst.resize(src.size());
+    for (size_t i = 0; i < src.size(); ++i) {
+        dst[i] = src[i].get();
+    }
+}
+
+}  // namespace
+
+
 #ifdef UNIT_TEST
 namespace test
 {
@@ -605,13 +625,22 @@ BTBMGSC::putPCHistory(Addr stream_start, const boost::dynamic_bitset<> &history,
         return;  // Just return if MGSC is disabled
     }
 
-    // Clear old prediction metadata and save current history state
+    // Clear old prediction metadata and save current history state. Only the
+    // folded values are stored (see MgscMeta); recovery restores them via
+    // recoverValue().
     threadMeta[tid] = std::make_shared<MgscMeta>();
-    threadMeta[tid]->indexBwFoldedHist = state.indexBwFoldedHist;
-    threadMeta[tid]->indexLFoldedHist = state.indexLFoldedHist;
-    threadMeta[tid]->indexIFoldedHist = state.indexIFoldedHist;
-    threadMeta[tid]->indexGFoldedHist = state.indexGFoldedHist;
-    threadMeta[tid]->indexPFoldedHist = state.indexPFoldedHist;
+    snapshotFoldedValues(state.indexBwFoldedHist, threadMeta[tid]->indexBwFoldedHist);
+    snapshotFoldedValues(state.indexIFoldedHist, threadMeta[tid]->indexIFoldedHist);
+    snapshotFoldedValues(state.indexGFoldedHist, threadMeta[tid]->indexGFoldedHist);
+    snapshotFoldedValues(state.indexPFoldedHist, threadMeta[tid]->indexPFoldedHist);
+    {
+        const auto &src = state.indexLFoldedHist;
+        auto &dst = threadMeta[tid]->indexLFoldedHist;
+        dst.resize(src.size());
+        for (size_t k = 0; k < src.size(); ++k) {
+            snapshotFoldedValues(src[k], dst[k]);
+        }
+    }
 
     for (int s = getDelay(); s < stagePreds.size(); s++) {
         // TODO: only lookup once for one btb entry in different stages
@@ -646,11 +675,18 @@ BTBMGSC::refreshPredictionMeta(Addr startAddr,
     auto &state = historyState(pred.tid);
     threadMeta[pred.tid] = std::make_shared<MgscMeta>();
     auto &meta = threadMeta[pred.tid];
-    meta->indexBwFoldedHist = state.indexBwFoldedHist;
-    meta->indexLFoldedHist = state.indexLFoldedHist;
-    meta->indexIFoldedHist = state.indexIFoldedHist;
-    meta->indexGFoldedHist = state.indexGFoldedHist;
-    meta->indexPFoldedHist = state.indexPFoldedHist;
+    snapshotFoldedValues(state.indexBwFoldedHist, meta->indexBwFoldedHist);
+    snapshotFoldedValues(state.indexIFoldedHist, meta->indexIFoldedHist);
+    snapshotFoldedValues(state.indexGFoldedHist, meta->indexGFoldedHist);
+    snapshotFoldedValues(state.indexPFoldedHist, meta->indexPFoldedHist);
+    {
+        const auto &src = state.indexLFoldedHist;
+        auto &dst = meta->indexLFoldedHist;
+        dst.resize(src.size());
+        for (size_t k = 0; k < src.size(); ++k) {
+            snapshotFoldedValues(src[k], dst[k]);
+        }
+    }
 
     for (const auto &btb_entry : pred.btbEntries) {
         if (!(btb_entry.isCond && btb_entry.valid)) {
@@ -1299,7 +1335,7 @@ BTBMGSC::recoverHist(const boost::dynamic_bitset<> &history, const FetchTarget &
     auto &state = historyState(entry.tid);
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < gTableNum; i++) {
-        state.indexGFoldedHist[i].recover(predMeta->indexGFoldedHist[i]);
+        state.indexGFoldedHist[i].recoverValue(predMeta->indexGFoldedHist[i]);
     }
     doUpdateHist(history, shamt, cond_taken, state.indexGFoldedHist);
 }
@@ -1328,7 +1364,7 @@ BTBMGSC::recoverPHist(const boost::dynamic_bitset<> &history,
     auto &state = historyState(entry.tid);
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < pTableNum; i++) {
-        state.indexPFoldedHist[i].recover(predMeta->indexPFoldedHist[i]);
+        state.indexPFoldedHist[i].recoverValue(predMeta->indexPFoldedHist[i]);
     }
     doUpdateHist(history, update.shamt, update.taken, state.indexPFoldedHist,
                  update.pc, update.target);
@@ -1356,7 +1392,7 @@ BTBMGSC::recoverBwHist(const boost::dynamic_bitset<> &history, const FetchTarget
     auto &state = historyState(entry.tid);
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < bwTableNum; i++) {
-        state.indexBwFoldedHist[i].recover(predMeta->indexBwFoldedHist[i]);
+        state.indexBwFoldedHist[i].recoverValue(predMeta->indexBwFoldedHist[i]);
     }
     doUpdateHist(history, shamt, cond_taken, state.indexBwFoldedHist);
 }
@@ -1383,7 +1419,7 @@ BTBMGSC::recoverIHist(const FetchTarget &entry, int shamt, bool cond_taken)
     auto &state = historyState(entry.tid);
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < iTableNum; i++) {
-        state.indexIFoldedHist[i].recover(predMeta->indexIFoldedHist[i]);
+        state.indexIFoldedHist[i].recoverValue(predMeta->indexIFoldedHist[i]);
     }
     // IMLI uses counter only, pass empty bitset (not used by ImliFoldedHist::update)
     boost::dynamic_bitset<> dummy;
@@ -1414,7 +1450,7 @@ BTBMGSC::recoverLHist(const std::vector<boost::dynamic_bitset<>> &history, const
     std::shared_ptr<MgscMeta> predMeta = std::static_pointer_cast<MgscMeta>(entry.predMetas[getComponentIdx()]);
     for (unsigned int k = 0; k < numEntriesFirstLocalHistories; ++k) {
         for (int i = 0; i < lTableNum; i++) {
-            state.indexLFoldedHist[k][i].recover(predMeta->indexLFoldedHist[k][i]);
+            state.indexLFoldedHist[k][i].recoverValue(predMeta->indexLFoldedHist[k][i]);
         }
     }
     const Addr localHistoryIndex =

--- a/src/cpu/pred/btb/btb_mgsc.hh
+++ b/src/cpu/pred/btb/btb_mgsc.hh
@@ -592,15 +592,19 @@ class BTBMGSC : public TimedBaseBTBPredictor
     typedef struct MgscMeta
     {
         std::unordered_map<Addr, MgscPrediction> preds;
-        std::vector<GlobalBwFoldedHist> indexBwFoldedHist;
-        std::vector<std::vector<LocalFoldedHist>> indexLFoldedHist;
-        std::vector<ImliFoldedHist> indexIFoldedHist;
-        std::vector<GlobalFoldedHist> indexGFoldedHist;
-        std::vector<PathFoldedHist> indexPFoldedHist;
-        MgscMeta(std::unordered_map<Addr, MgscPrediction> preds, std::vector<GlobalBwFoldedHist> indexBwFoldedHist,
-                 std::vector<std::vector<LocalFoldedHist>> indexLFoldedHist,
-                 std::vector<ImliFoldedHist> indexIFoldedHist, std::vector<GlobalFoldedHist> indexGFoldedHist,
-                 std::vector<PathFoldedHist> indexPFoldedHist)
+        // Folded-history snapshots stored as raw values (get()) rather than the
+        // full FoldedHistBase objects. These are only consumed during recovery
+        // (via recoverValue()), so the folded value is all that is needed; this
+        // avoids copying the large position tables on every prediction.
+        std::vector<uint64_t> indexBwFoldedHist;
+        std::vector<std::vector<uint64_t>> indexLFoldedHist;
+        std::vector<uint64_t> indexIFoldedHist;
+        std::vector<uint64_t> indexGFoldedHist;
+        std::vector<uint64_t> indexPFoldedHist;
+        MgscMeta(std::unordered_map<Addr, MgscPrediction> preds, std::vector<uint64_t> indexBwFoldedHist,
+                 std::vector<std::vector<uint64_t>> indexLFoldedHist,
+                 std::vector<uint64_t> indexIFoldedHist, std::vector<uint64_t> indexGFoldedHist,
+                 std::vector<uint64_t> indexPFoldedHist)
             : preds(preds),
               indexBwFoldedHist(indexBwFoldedHist),
               indexLFoldedHist(indexLFoldedHist),

--- a/src/cpu/pred/btb/btb_tage.cc
+++ b/src/cpu/pred/btb/btb_tage.cc
@@ -31,6 +31,26 @@ namespace btb_pred{
 namespace
 {
 
+// Snapshot a folded-history vector as raw folded values. Prediction and tag
+// lookups read the values directly and recovery restores them through
+// recoverValue(), so the metadata only needs the folded value and not the full
+// object with its per-shift position tables.
+template <typename Src>
+void
+snapshotFoldedValues(const Src &src, std::vector<uint64_t> &dst)
+{
+    dst.resize(src.size());
+    for (size_t i = 0; i < src.size(); ++i) {
+        dst[i] = src[i].get();
+    }
+}
+
+}  // namespace
+
+
+namespace
+{
+
 #ifndef UNIT_TEST
 inline uint64_t
 mixTraceHash(uint64_t value)
@@ -56,13 +76,18 @@ hashBitset(const boost::dynamic_bitset<> &bits)
     return seed;
 }
 
+// Hash a vector of folded-history values snapshotted via get(). The history
+// type is taken from a parallel vector of live folded-history objects (the type
+// is a per-table constant), so the result is identical to hashing the original
+// TageFoldedHist objects directly.
 uint64_t
-hashFoldedHistVec(const std::vector<TageFoldedHist> &folded)
+hashFoldedHistVec(const std::vector<uint64_t> &values,
+                  const std::vector<TageFoldedHist> &typeSrc)
 {
-    uint64_t seed = mixTraceHash(folded.size());
-    for (size_t i = 0; i < folded.size(); ++i) {
-        uint64_t value = folded[i].get();
-        value ^= static_cast<uint64_t>(folded[i].getHistoryType()) << 56;
+    uint64_t seed = mixTraceHash(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+        uint64_t value = values[i];
+        value ^= static_cast<uint64_t>(typeSrc[i].getHistoryType()) << 56;
         seed ^= mixTraceHash(value + static_cast<uint64_t>(i) * 0x9e3779b97f4a7c15ULL +
                              (seed << 6) + (seed >> 2));
     }
@@ -321,11 +346,11 @@ BTBTAGE::generateSinglePrediction(const BTBEntry &btb_entry,
         // Calculate index and tag: use snapshot if provided, otherwise use current folded history
         // Tag includes position XOR (like RTL: tag = tempTag ^ cfiPosition)
         Addr index = predMeta ? getTageIndex(
-            startPC, i, predMeta->indexFoldedHist[i].get(), asidHash, tid)
+            startPC, i, predMeta->indexFoldedHist[i], asidHash, tid)
                               : getTageIndex(
             startPC, i, state.indexFoldedHist[i].get(), asidHash, tid);
         Addr tag = predMeta ? getTageTag(startPC, i,
-                            predMeta->tagFoldedHist[i].get(), predMeta->altTagFoldedHist[i].get(),
+                            predMeta->tagFoldedHist[i], predMeta->altTagFoldedHist[i],
                             position, asidHash)
                         : getTageTag(startPC, i, state.tagFoldedHist[i].get(),
                                      state.altTagFoldedHist[i].get(), position, asidHash);
@@ -511,9 +536,9 @@ BTBTAGE::putPCHistory(Addr startPC, const bitset &history, std::vector<FullBTBPr
 
     // Clear old prediction metadata and save current history state
     threadMeta[tid] = std::make_shared<TageMeta>();
-    threadMeta[tid]->tagFoldedHist = state.tagFoldedHist;
-    threadMeta[tid]->altTagFoldedHist = state.altTagFoldedHist;
-    threadMeta[tid]->indexFoldedHist = state.indexFoldedHist;
+    snapshotFoldedValues(state.tagFoldedHist, threadMeta[tid]->tagFoldedHist);
+    snapshotFoldedValues(state.altTagFoldedHist, threadMeta[tid]->altTagFoldedHist);
+    snapshotFoldedValues(state.indexFoldedHist, threadMeta[tid]->indexFoldedHist);
     threadMeta[tid]->history = history;
 
     for (int s = getDelay(); s < stagePreds.size(); s++) {
@@ -542,9 +567,9 @@ BTBTAGE::refreshPredictionMeta(Addr startPC,
     auto &state = historyState(pred.tid);
     threadMeta[pred.tid] = std::make_shared<TageMeta>();
     auto &meta = threadMeta[pred.tid];
-    meta->tagFoldedHist = state.tagFoldedHist;
-    meta->altTagFoldedHist = state.altTagFoldedHist;
-    meta->indexFoldedHist = state.indexFoldedHist;
+    snapshotFoldedValues(state.tagFoldedHist, meta->tagFoldedHist);
+    snapshotFoldedValues(state.altTagFoldedHist, meta->altTagFoldedHist);
+    snapshotFoldedValues(state.indexFoldedHist, meta->indexFoldedHist);
     meta->history = history;
 
     pred.tageInfoForMgscs.clear();
@@ -801,9 +826,9 @@ BTBTAGE::handleNewEntryAllocation(const Addr &startPC,
 
     for (unsigned ti = start_table; ti < numPredictors; ++ti) {
         Addr newIndex = getTageIndex(
-            startPC, ti, meta->indexFoldedHist[ti].get(), asidHash, tid);
+            startPC, ti, meta->indexFoldedHist[ti], asidHash, tid);
         Addr newTag = getTageTag(startPC, ti,
-            meta->tagFoldedHist[ti].get(), meta->altTagFoldedHist[ti].get(), position, asidHash);
+            meta->tagFoldedHist[ti], meta->altTagFoldedHist[ti], position, asidHash);
 
         auto &set = tageTable[ti][newIndex];
 
@@ -1030,12 +1055,13 @@ BTBTAGE::update(const FetchTarget &stream) {
             auto alt_info = trace_pred.altInfo;
             const uint64_t history_hash = hashBitset(predMeta->history);
             const uint64_t phistory_hash = hashBitset(stream.phistory);
+            const auto &dbState = historyState(stream.tid);
             const uint64_t index_folded_hist_hash =
-                hashFoldedHistVec(predMeta->indexFoldedHist);
+                hashFoldedHistVec(predMeta->indexFoldedHist, dbState.indexFoldedHist);
             const uint64_t tag_folded_hist_hash =
-                hashFoldedHistVec(predMeta->tagFoldedHist);
+                hashFoldedHistVec(predMeta->tagFoldedHist, dbState.tagFoldedHist);
             const uint64_t alt_tag_folded_hist_hash =
-                hashFoldedHistVec(predMeta->altTagFoldedHist);
+                hashFoldedHistVec(predMeta->altTagFoldedHist, dbState.altTagFoldedHist);
             t.set(startAddr, btb_entry.pc, main_info.way,
                 main_info.found, main_info.entry.counter, main_info.entry.useful,
                 main_info.table, main_info.index, main_info.entry.tag,
@@ -1047,7 +1073,7 @@ BTBTAGE::update(const FetchTarget &stream) {
                 allocInfo.victimCounter, allocInfo.victimUseful,
                 allocInfo.victimPC,
                 history_str, phistory_str,
-                predMeta->indexFoldedHist[main_info.table].get(),
+                predMeta->indexFoldedHist[main_info.table],
                 trace_pred.useAltIdx, trace_pred.useAltCtr,
                 trace_pred.hitTableMask, trace_pred.finalProviderTable,
                 trace_pred.finalProviderIsAlt, history_hash, phistory_hash,
@@ -1295,9 +1321,9 @@ BTBTAGE::recoverFoldedHist(const FetchTarget &entry)
     auto predMeta =
         std::static_pointer_cast<TageMeta>(entry.predMetas[getComponentIdx()]);
     for (int i = 0; i < numPredictors; i++) {
-        threadHistory[entry.tid].tagFoldedHist[i].recover(predMeta->tagFoldedHist[i]);
-        threadHistory[entry.tid].altTagFoldedHist[i].recover(predMeta->altTagFoldedHist[i]);
-        threadHistory[entry.tid].indexFoldedHist[i].recover(predMeta->indexFoldedHist[i]);
+        threadHistory[entry.tid].tagFoldedHist[i].recoverValue(predMeta->tagFoldedHist[i]);
+        threadHistory[entry.tid].altTagFoldedHist[i].recoverValue(predMeta->altTagFoldedHist[i]);
+        threadHistory[entry.tid].indexFoldedHist[i].recoverValue(predMeta->indexFoldedHist[i]);
     }
 }
 

--- a/src/cpu/pred/btb/btb_tage.hh
+++ b/src/cpu/pred/btb/btb_tage.hh
@@ -452,9 +452,14 @@ public:
     typedef struct TageMeta
     {
         std::unordered_map<Addr, TagePrediction> preds;
-        std::vector<TageFoldedHist> tagFoldedHist;
-        std::vector<TageFoldedHist> altTagFoldedHist;
-        std::vector<TageFoldedHist> indexFoldedHist;
+        // Folded-history snapshots stored as raw values (get()) rather than the
+        // full FoldedHistBase objects. Recovery restores them via recoverValue()
+        // and prediction/tag lookups read the value directly, so only the folded
+        // value is needed. This avoids copying the large position tables inside
+        // each FoldedHistBase on every prediction.
+        std::vector<uint64_t> tagFoldedHist;
+        std::vector<uint64_t> altTagFoldedHist;
+        std::vector<uint64_t> indexFoldedHist;
         bitset history;     // for viewing
         TageMeta() {}
     } TageMeta;

--- a/src/cpu/pred/btb/folded_hist.hh
+++ b/src/cpu/pred/btb/folded_hist.hh
@@ -122,6 +122,16 @@ class FoldedHistBase
     void recover(const FoldedHistBase &other);
 
     /**
+     * Recover the folded history directly from a previously snapshotted value.
+     * Equivalent to recover() when the snapshot was taken with get(): both set
+     * only _folded (the config fields are invariant for a given table). Used so
+     * that recovery metadata can store just the folded value instead of the
+     * full object.
+     * @param value The folded history value captured earlier via get()
+     */
+    void recoverValue(uint64_t value) { _folded = value; }
+
+    /**
      * Verify that the folded history is consistent with the global history
      * @param ghr Global history register to check against
      */
@@ -188,6 +198,16 @@ class TageFoldedHist
     void update(const boost::dynamic_bitset<> &history, int shamt, bool taken,
                 Addr pc = 0, Addr target = 0);
     void recover(const TageFoldedHist &other);
+    // Recover directly from a value snapshotted via get(); sets only the active
+    // sub-history's folded value, matching recover() for the active type.
+    void recoverValue(uint64_t value)
+    {
+        if (isPathBased()) {
+            pathHist.recoverValue(value);
+        } else {
+            directionHist.recoverValue(value);
+        }
+    }
     void check(const boost::dynamic_bitset<> &history) const;
     HistoryType getHistoryType() const { return historyType; }
     bool isPathBased() const { return historyType == HistoryType::PATH; }

--- a/src/cpu/pred/btb/test/btb_tage.test.cc
+++ b/src/cpu/pred/btb/test/btb_tage.test.cc
@@ -482,7 +482,7 @@ int findTableWithEntry(BTBTAGE* tage, Addr startPC, Addr branchPC) {
     auto meta = std::static_pointer_cast<BTBTAGE::TageMeta>(tage->getPredictionMeta());
     // use meta to find the table, predicted info
     for (int t = 0; t < tage->numPredictors; t++) {
-        Addr index = tage->getTageIndex(startPC, t, meta->indexFoldedHist[t].get());
+        Addr index = tage->getTageIndex(startPC, t, meta->indexFoldedHist[t]);
         for (unsigned way = 0; way < tage->numWays[t]; way++) {
             auto &entry = tage->tageTable[t][index][way];
             if (entry.valid && entry.pc == branchPC) {


### PR DESCRIPTION
## Motivation

`perf` on a fixed `gem5.opt` CoreMark run showed repeated folded-history metadata copies in the host hot path. TAGE and MGSC metadata copied full folded-history objects, including their per-shift position tables, although later lookup and recovery only consume the folded value.

## Approach

- Store TAGE and MGSC folded-history snapshots as `uint64_t` values.
- Add `recoverValue()` to restore only the folded value while retaining the live table configuration.
- Preserve the existing full guest history snapshot and database-trace hashes.
- Update the BTBTAGE unit test for the value metadata type.

No predictor parameter, table organization, guest-visible timing, or stats definition changes. The changed prediction/recovery path is present in both opt and fast builds; it is not a debug-only/NDEBUG path.

## Validation

Baseline: `f63979dc6c` (#1067), node102 CPU 4, `gem5.opt`, `configs/example/kmhv3.py`, raw CoreMark (10 iterations), difftest enabled.

- Guest exit tick: `473882310` for baseline and candidate in every run.
- Normalized `stats.txt`: no differences after filtering host-time fields.
- Preliminary interleaved screening: two stable adjacent pairs improved task-clock by 1.69% and 1.59%.
- Final single-commit adjacent pair: 30.471 s -> 29.745 s (+2.44%); retired instructions 319,906,979,297 -> 319,044,893,004 (-0.27%).
- `tage.test.debug`: 28/28 passed.
- `mgsc.test.debug`: 14/14 passed.
- `folded_hist.test.debug`: 10/10 passed.

PGO-fast and RVV full regressions were not run locally; CI can cover those paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced overhead during branch prediction by storing compact history snapshots instead of copying full history structures.
  * Improved prediction-state recovery using lightweight value restoration.
* **Bug Fixes**
  * Improved consistency when restoring prediction histories across TAGE and MGSC components.
* **Tests**
  * Updated branch prediction tests to reflect the revised history-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->