### PR TITLE
cpu-o3: Stop single-thread issue-queue scans at commit prefix

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -482,11 +482,18 @@ IssueQue::nextVectorSplitReleaseTick() const
 void
 IssueQue::eraseVectorSplitBlocker(InstSeqNum seq_num)
 {
+    // Erasing from an empty set is a no-op; skip the hash lookup entirely so
+    // scalar workloads (no vector splits in flight) pay nothing per commit or
+    // squash.
     for (auto& unit : vectorLoadSplitStates) {
-        unit.blockingSeqs.erase(seq_num);
+        if (!unit.blockingSeqs.empty()) {
+            unit.blockingSeqs.erase(seq_num);
+        }
     }
     for (auto& unit : vectorStoreSplitStates) {
-        unit.blockingSeqs.erase(seq_num);
+        if (!unit.blockingSeqs.empty()) {
+            unit.blockingSeqs.erase(seq_num);
+        }
     }
 }
 
@@ -1181,22 +1188,36 @@ IssueQue::popReadyVectorInst()
 void
 IssueQue::doCommit(const InstSeqNum seqNum, ThreadID tid)
 {
+    // With a single thread, instList is filled in global dispatch order, so its
+    // seqNums increase monotonically and every committed instruction
+    // (inst->seqNum <= seqNum) forms a front prefix: stop at the first younger
+    // entry instead of walking to the tail. Under SMT the shared per-IQ instList
+    // interleaves threads against one global seqNum counter, so it is not
+    // per-thread monotonic (a thread stalled before dispatch appends older
+    // seqNums after another thread's newer ones); fall back to the full filtered
+    // walk there. Only touch the vector-ready set when it actually holds entries
+    // (empty on scalar workloads).
+    const bool monotonic = cpu->numThreads == 1;
     for (auto it = instList.begin(); it != instList.end();) {
         const auto &inst = *it;
-        if (inst->threadNumber == tid && inst->seqNum <= seqNum) {
+        if (inst->seqNum > seqNum) {
+            if (monotonic) {
+                break;
+            }
+            ++it;
+            continue;
+        }
+        if (inst->threadNumber == tid) {
             assert(inst->isIssued());
-            vectorReadyQSeqs.erase(inst->seqNum);
+            if (!vectorReadyQSeqs.empty()) {
+                vectorReadyQSeqs.erase(inst->seqNum);
+            }
             eraseVectorSplitBlocker(inst->seqNum);
             it = instList.erase(it);
         } else {
             ++it;
         }
     }
-    // while (!instList.empty() && instList.front()->seqNum <= seqNum) {
-    //     assert(instList.front()->isIssued());
-    //     vectorReadyQSeqs.erase(instList.front()->seqNum);
-    //     instList.pop_front();
-    // }
 }
 
 void


### PR DESCRIPTION
## Motivation

`IssueQue::doCommit()` walks the complete issue-queue instruction list on every commit, even though a single-thread list is appended in dispatch order and retired entries always form a front prefix. Profiling also showed scalar workloads repeatedly performing empty hash-set erases for vector-ready/split bookkeeping.

## Approach

- Stop a single-thread commit scan at the first instruction newer than the commit sequence number.
- Preserve the original full, thread-filtered scan for SMT because cross-thread dispatch can break sequence-number ordering in the shared list.
- Skip vector-ready and vector-split erases when their sets are empty.

This keeps the existing `std::list` and set state, introduces no parameter or modeled resource, and removes the same entries in the same order. Single-thread commit scanning changes from walking the full resident list to walking only the committed prefix; SMT complexity is unchanged.

The optimization was originally authored by Easton Man on the `perf-host-sim-speed` branch; commit authorship is retained.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Three interleaved CoreMark A/B pairs on node102 CPU 4, fixed `gem5.opt`, identical KMHv3 config/checkpoint/reference and 10 guest iterations:

| Pair | Baseline task-clock | Candidate task-clock | Throughput gain | Retired instructions |
| --- | ---: | ---: | ---: | ---: |
| 1 | 30.337 s | 29.825 s | +1.72% | -0.39% |
| 2 | 30.093 s | 29.614 s | +1.62% | -0.38% |
| 3 | 30.351 s | 29.813 s | +1.80% | -0.43% |

Median pairwise throughput gain: **+1.72%**. All six runs exited at guest tick `473882310` with the same CoreMark completion output. A full stats diff on the preserved third A/B pair was empty after filtering host-time/rate fields.

This reports fixed `gem5.opt` host-speed results. PGO/fast was not retrained for this candidate, and local RVV regression was not run; the normal CI regression can cover those paths.

This is independent of #1087: both touch `issue_queue.cc`, but #1087 skips idle vector-ready processing, while this PR reduces commit-list scans and empty bookkeeping lookups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved instruction commit processing for single-thread execution.
  * Reduced unnecessary work when handling vector-ready instructions and empty blocker sets.

* **Reliability**
  * Improved instruction sequencing while preserving correct behavior during simultaneous multithreading (SMT).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->