### PR TITLE
cpu-o3: Skip empty dependency slots on issue-queue squash

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -334,6 +334,9 @@ void
 IssueQue::resetDepGraph(int numPhysRegs)
 {
     subDepGraph.resize(numPhysRegs);
+    depIdxActive.assign(numPhysRegs, false);
+    activeDepIdx.clear();
+    activeDepIdx.reserve(numPhysRegs);
 }
 
 bool
@@ -1117,7 +1120,12 @@ IssueQue::insert(const DynInstPtr& inst)
                     inst->markSrcRegReady(i);
                 }
                 DPRINTF(Schedule, "[sn:%llu] src p%d add to depGraph\n", inst->seqNum, src->flatIndex());
-                subDepGraph[src->flatIndex()].push_back({i, inst});
+                const auto depIdx = src->flatIndex();
+                if (!depIdxActive[depIdx]) {
+                    depIdxActive[depIdx] = true;
+                    activeDepIdx.push_back(depIdx);
+                }
+                subDepGraph[depIdx].push_back({i, inst});
                 addToDepGraph = true;
             }
         }
@@ -1238,8 +1246,13 @@ IssueQue::doSquash(SquashInfo squashInfo)
         }
     }
 
-    // clear in depGraph
-    for (auto& entrys : subDepGraph) {
+    // clear in depGraph: visit only registered (possibly non-empty) indices and
+    // drop any that end up empty. Order across indices does not matter here since
+    // this loop only erases squashed consumers and never reorders survivors.
+    size_t writeIdx = 0;
+    for (size_t readIdx = 0; readIdx < activeDepIdx.size(); ++readIdx) {
+        const uint32_t depIdx = activeDepIdx[readIdx];
+        auto& entrys = subDepGraph[depIdx];
         for (auto it = entrys.begin(); it != entrys.end();) {
             if ((*it).second->isSquashed() && ((*it).second->threadNumber == squashInfo.squashTid)) {
                 it = entrys.erase(it);
@@ -1247,7 +1260,13 @@ IssueQue::doSquash(SquashInfo squashInfo)
                 it++;
             }
         }
+        if (entrys.empty()) {
+            depIdxActive[depIdx] = false;
+        } else {
+            activeDepIdx[writeIdx++] = depIdx;
+        }
     }
+    activeDepIdx.resize(writeIdx);
 
     scheduleVectorReadyQEvent();
 }

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -180,6 +180,18 @@ class IssueQue : public SimObject
     // srcIdx : inst
     std::vector<std::vector<std::pair<uint8_t, DynInstPtr>>> subDepGraph;
 
+    // Sparse index of subDepGraph entries that may be non-empty. subDepGraph is
+    // sized to the total physical register count (int+float+vec+vec-elem, a few
+    // thousand entries) but only a handful hold waiting consumers at any time.
+    // doSquash walks this list instead of the full vector so a per-squash scan
+    // is proportional to the working set, not the register file size. Invariant:
+    // depIdxActive[idx] == (idx present in activeDepIdx); every non-empty
+    // subDepGraph vector is registered here. Empty-but-registered entries are
+    // pruned lazily during doSquash, so skipping unregistered indices is
+    // bit-identical (their erase loop would find nothing).
+    std::vector<uint32_t> activeDepIdx;
+    std::vector<bool> depIdxActive;
+
     struct VectorSplitUnitState
     {
         std::queue<DynInstPtr> splitQ;


### PR DESCRIPTION
## Motivation

Each issue queue owns a dependency graph sized to the total physical register count, including vector-element expansion. `IssueQue::doSquash()` scanned every slot on every squash even though only a small working set normally contains waiting consumers.

## Approach

- Maintain a compact vector of dependency-graph indices that may be non-empty.
- Register an index when `IssueQue::insert()` adds its first waiting consumer.
- On squash, visit only registered indices and compact away those that become empty.

Normal wakeup can clear a slot without immediately removing its registration. This is intentionally conservative: it may cause one later empty visit, but every non-empty slot remains registered. Dependency entries, per-slot order, and squash filtering are unchanged.

Modeling scope:

- External behavior: no guest-visible timing or policy change.
- State/resources: one `uint32_t` sparse-index vector plus one bit per physical-register slot for each issue queue; no modeled hardware resource.
- Parameters/stats: no new parameter, default, debug flag, or statistic.
- Complexity: squash dependency cleanup changes from `O(total physical-register slots + consumers)` to `O(recently active slots + consumers)`; insertion adds one bitmap check.
- Accuracy boundary: all dependency-graph insertion remains centralized in `IssueQue::insert()`; normal wakeup is allowed to leave an empty slot registered, never a non-empty slot unregistered.

The optimization was originally authored by Easton Man on the `perf-host-sim-speed` branch; commit authorship is retained.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j32` on node102.
- Three interleaved CoreMark A/B pairs on node102 CPU 4, fixed `gem5.opt`, identical KMHv3 config/checkpoint/reference and 10 guest iterations:

| Pair | Baseline task-clock | Candidate task-clock | Throughput gain | Retired instructions |
| --- | ---: | ---: | ---: | ---: |
| 1 | 30.567 s | 30.281 s | +0.95% | -1.09% |
| 2 | 30.323 s | 30.217 s | +0.35% | -1.11% |
| 3 | 30.216 s | 29.965 s | +0.84% | -1.13% |

Median pairwise throughput gain: **+0.84%**; median retired-instruction reduction: **-1.11%**. All six runs exited at guest tick `473882310` with the same CoreMark completion output.

After filtering host-only fields, the third-pair stats had one textual difference in the existing derived `decodeEfficiency` formula (`-0` versus `inf`); its inputs were identical (`decodedInsts=3911505`, `numCycles=1423071`), and all other guest stats matched.

This reports fixed `gem5.opt` host-speed results. PGO/fast was not retrained for this candidate, and local RVV regression was not run; the normal CI regression can cover those paths.

This is independent of #1090: #1090 reduces commit-list scans and empty vector bookkeeping, while this PR maintains a sparse index for dependency cleanup during squash.
