### PR TITLE
cpu-o3: Deduplicate scheduler regcache updates

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1866,8 +1866,10 @@ void
 Scheduler::useRfRdPort(const DynInstPtr& inst, const PhysRegIdPtr& regid, int typePortId, int pri)
 {
     if (regid->is(IntRegClass)) {
-        if (regCache.contains(regid->flatIndex())) {
-            regCache.get(regid->flatIndex());
+        // get() both reports presence and performs the same most-recently-used
+        // bump the original contains()+get() pair relied on, so folding the two
+        // lookups into one is bit-identical while dropping a redundant map find.
+        if (regCache.get(regid->flatIndex())) {
             return;
         }
     }

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -1796,8 +1796,15 @@ Scheduler::specWakeUpFromVP(const DynInstPtr& inst)
 {
     DPRINTF(Schedule, "[sn:%llu] VP speculative wakeup dependents\n", inst->seqNum);
     // Wake consumers already in IQ via speculative wakeup (preserves subDepGraph)
+    // Populate the regcache once for the whole fan-out; the per-queue
+    // wakeUpDependents() below would otherwise repeat the same idempotent
+    // insert. wakeUpDependents(speculative=true) skips the insert entirely for
+    // a canceled producer, so mirror that guard here.
+    if (!inst->canceled()) {
+        cacheProducerRegs(inst);
+    }
     for (auto to : issueQues) {
-        to->wakeUpDependents(inst, true);  // speculative=true -> depgraph preserved
+        to->wakeUpDependents(inst, true, /*cacheProducer=*/false);  // speculative=true -> depgraph preserved
     }
     // Set earlyScoreboard + bypassScoreboard (but NOT scoreboard) so that
     // future consumers entering IQ via insert() will:
@@ -1822,11 +1829,17 @@ Scheduler::specWakeUpFromLoadPipe(const DynInstPtr& inst)
 {
     assert(inst->isLoad());
     auto from_issue_queue = inst->issueQue;
+    // Insert the load's destinations into the regcache once instead of once per
+    // woken queue; wakeUpDependents(speculative=true) skips the insert for a
+    // canceled producer, so mirror that guard.
+    if (!inst->canceled()) {
+        cacheProducerRegs(inst);
+    }
     for (auto to : wakeMatrix[from_issue_queue->getId()]) {
 
         DPRINTF(Schedule, "[sn:%llu] %s create wakeupEvent to %s at loadpipe, no delay\n", inst->seqNum,
                 from_issue_queue->getName(), to->getName());
-        to->wakeUpDependents(inst, true);
+        to->wakeUpDependents(inst, true, /*cacheProducer=*/false);
 
         for (int i = 0; i < inst->numDestRegs(); i++) {
             PhysRegIdPtr dst = inst->renamedDestIdx(i);

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -861,7 +861,7 @@ IssueQue::markMemDepDone(const DynInstPtr& inst)
 }
 
 void
-IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative)
+IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative, bool cacheProducer)
 {
     if (speculative && inst->canceled()) [[unlikely]] {
         return;
@@ -871,7 +871,9 @@ IssueQue::wakeUpDependents(const DynInstPtr& inst, bool speculative)
         if (dst->isFixedMapping() || dst->getNumPinnedWritesToComplete() != 1) [[unlikely]] {
             continue;
         }
-        scheduler->regCache.insert(dst->flatIndex(), {});
+        if (cacheProducer) {
+            scheduler->regCache.insert(dst->flatIndex(), {});
+        }
         DPRINTF(Schedule, "was %s woken by p%lu [sn:%llu]\n", speculative ? "spec" : "wb", dst->flatIndex(),
                 inst->seqNum);
         auto& depgraph = subDepGraph[dst->flatIndex()];
@@ -1996,6 +1998,18 @@ Scheduler::loadCancel(const DynInstPtr& inst)
 }
 
 void
+Scheduler::cacheProducerRegs(const DynInstPtr& inst)
+{
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        PhysRegIdPtr dst = inst->renamedDestIdx(i);
+        if (dst->isFixedMapping() || dst->getNumPinnedWritesToComplete() != 1) [[unlikely]] {
+            continue;
+        }
+        regCache.insert(dst->flatIndex(), {});
+    }
+}
+
+void
 Scheduler::writebackWakeup(const DynInstPtr& inst)
 {
     DPRINTF(Schedule, "[sn:%llu] was writeback\n", inst->seqNum);
@@ -2008,8 +2022,13 @@ Scheduler::writebackWakeup(const DynInstPtr& inst)
         }
         scoreboard[dst->flatIndex()] = true;
     }
+    // Insert this producer's destinations into the regcache once. Each
+    // wakeUpDependents() below would otherwise repeat the same idempotent
+    // insert for every issue queue; the regcache is shared scheduler state and
+    // no wakeUpDependents() reads it, so the final state is bit-identical.
+    cacheProducerRegs(inst);
     for (auto it : issueQues) {
-        it->wakeUpDependents(inst, false);
+        it->wakeUpDependents(inst, false, /*cacheProducer=*/false);
     }
 }
 

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -248,7 +248,8 @@ class IssueQue : public SimObject
     void scheduleVectorReadyQEvent();
     void releaseVectorDelayedReadyQ();
     void issueToFu();
-    void wakeUpDependents(const DynInstPtr& inst, bool speculative);
+    void wakeUpDependents(const DynInstPtr& inst, bool speculative,
+                          bool cacheProducer = true);
     void selectInst();
     void scheduleInst();
     void addIfReady(const DynInstPtr& inst);
@@ -429,6 +430,12 @@ class Scheduler : public SimObject
 
     void writebackWakeup(const DynInstPtr& inst);
     void bypassWriteback(const DynInstPtr& inst);
+
+    // Populate the integer regcache for a producer's destination registers.
+    // wakeUpDependents() performs the same idempotent inserts inline; this lets
+    // callers that fan a single producer out to every issue queue do the insert
+    // once instead of once per queue.
+    void cacheProducerRegs(const DynInstPtr& inst);
 
     uint32_t getOpLatency(const DynInstPtr& inst);
     uint32_t getCorrectedOpLat(const DynInstPtr& inst);


### PR DESCRIPTION
## Motivation

The scheduler's 28-entry integer read-port regcache is shared across issue queues. A producer wakeup fans out to several queues, and the old path inserted the same destination registers once per queue even though the insert is idempotent. Read-port probing also performed `contains()` followed by `get()`, doing two cache lookups for a hit.

## Approach

This PR keeps three reviewable commits that:

1. Populate producer destinations once before normal writeback fan-out.
2. Do the same for VP and load-pipe speculative fan-out.
3. Replace `contains()+get()` with one `get()` that both reports the hit and preserves the MRU bump.

`wakeUpDependents()` still performs the original insert by default, so deferred/single-queue callers retain their behavior. Deduplication is used only where one producer is synchronously fanned out and no intervening path reads the regcache. The speculative canceled-producer guard mirrors the original early return.

Modeling scope:

- External behavior: preserve regcache membership and LRU order, scoreboard updates, wakeup timing, and read-port decisions.
- State/resources: keep the existing 28-entry regcache and policy; add no modeled resource or persistent state.
- Parameters/stats: no new parameter, default, debug flag, or statistic.
- Granularity/complexity: producer insertion changes from once per destination per woken queue to once per destination per synchronous fan-out; a read-port hit changes from two LRU-cache lookups to one.
- Accuracy boundary: this PR does not merge deferred speculative events across ticks; their default per-event insertion path remains intact.

The optimizations were originally authored by Easton Man on the `perf-host-sim-speed` branch; the three original commit authorships are retained.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j32` on node102.
- Three interleaved CoreMark A/B pairs on node102 CPU 4, fixed `gem5.opt`, identical KMHv3 config/checkpoint/reference and 10 guest iterations:

| Pair | Baseline task-clock | Candidate task-clock | Throughput gain | Retired instructions |
| --- | ---: | ---: | ---: | ---: |
| 1 | 30.444 s | 29.774 s | +2.25% | -0.67% |
| 2 | 29.871 s | 30.600 s | -2.38% | -0.71% |
| 3 | 29.982 s | 29.698 s | +0.96% | -0.71% |

The node had one visibly noisy wall-clock pair; median pairwise throughput gain is **+0.96%**. Retired instructions consistently fell by **0.67%-0.71%**, and retired branches by about **1.2%**. All six runs exited at guest tick `473882310` with the same CoreMark completion output.

The third-pair stats were identical after filtering host-only fields and the existing invalid `decodeEfficiency` derived formula.

This reports fixed `gem5.opt` host-speed results. PGO/fast was not retrained for this candidate, and local RVV regression was not run; the normal CI regression can cover those paths.

This touches different scheduler paths from #1090 and #1091 and has no direct diff overlap with their optimized loops.
