### PR TITLE
cpu-o3: Implement SMT fetch block policy and round-robin decode sched…

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -458,6 +458,13 @@ def _finish_xiangshan_system(args, test_sys, TestCPUClass, ruby):
     for cpu in test_sys.cpu:
         if args.smt:
             cpu.numThreads = 2
+        # === Block Policy: pass SMT fetch block parameters ===
+        from m5.objects.BaseO3CPU import SMTDecodePolicy
+        cpu.smtDecodePolicy = SMTDecodePolicy(args.smt_decode_policy)
+        from m5.objects.BaseO3CPU import SMTFetchBlockPolicy
+        cpu.smtFetchBlockPolicy = SMTFetchBlockPolicy(args.smt_fetch_block_policy)
+        cpu.smtFetchBlockThreshold = args.smt_fetch_block_threshold
+        cpu.smtBorrowThrottleCycles = args.smt_fetch_throttle_cycles
         cpu.mmu.pma_checker = PMAChecker(
             uncacheable=[AddrRange(0, size=0x80000000)])
         cpu.mmu.functional = args.functional_tlb
@@ -968,6 +975,36 @@ def xiangshan_system_init():
         default=False,
         help="Disable direction TAGE sources in kmhv3 and force MGSC standalone SC prediction",
     )
+
+    parser.add_argument(
+        "--smt-decode-policy",
+        type=str,
+        default="MultiPriority",
+        choices=["ICount", "DelayedICount", "MultiPriority", "RoundRobin"],
+        help="SMT decode select policy: ICount, DelayedICount, MultiPriority, RoundRobin",
+    )
+    parser.add_argument(
+        "--smt-fetch-block-policy",
+        type=str,
+        default="BaseLine",
+        choices=["BaseLine", "BlockPolicy"],
+        help="SMT fetch block policy for long-latency loads: "
+             "Baseline (no blocking) or BlockPolicy (stall fetch on long-latency load)",
+    )
+    parser.add_argument(
+        "--smt-fetch-block-threshold",
+        type=int,
+        default=15,
+        help="Number of consecutive cycles a thread's LQ head must be stalled on a "
+             "long-latency load before IEW signals Fetch to block (T15 from Tullsen & Brown)",
+    )
+    parser.add_argument(
+        "--smt-fetch-throttle-cycles",
+        type=int,
+        default=8,
+        help="Cycles to keep a backend-stalled SMT thread throttled at fetch, 0 means disable throttle",
+    )
+
     parser.add_argument(
         "--solver-problem-ref",
         type=str,

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -50,6 +50,12 @@ from m5.SimObject import *
 class SMTFetchPolicy(ScopedEnum):
     vals = [ 'RoundRobin', 'Branch', 'IQCount', 'LSQCount' ]
 
+class SMTDecodePolicy(ScopedEnum):
+    vals = [ 'ICount', 'DelayedICount', 'MultiPriority', 'RoundRobin' ]
+
+class SMTFetchBlockPolicy(ScopedEnum):
+    vals = [ 'BaseLine', 'BlockPolicy' ]
+
 class SMTQueuePolicy(ScopedEnum):
     vals = [ 'Dynamic', 'Partitioned', 'Threshold', 'DynamicBorrowing' ]
 
@@ -269,8 +275,6 @@ class BaseO3CPU(BaseCPU):
                                           "SMT ROB Sharing Policy")
     smtROBThreshold = Param.Int(100, "SMT ROB Threshold Sharing Parameter")
     smtCommitPolicy = Param.CommitPolicy('RoundRobin', "SMT Commit Policy")
-    smtBorrowThrottleCycles = Param.Unsigned(
-        8, "Cycles to keep a backend-stalled SMT thread throttled at fetch")
     smtBorrowLdstqHighWater = Param.Unsigned(
         0, "Explicit SMT borrowing LSQ high-water threshold; 0 uses percentage")
     smtBorrowLdstqHighWaterPercent = Param.Percent(
@@ -279,6 +283,20 @@ class BaseO3CPU(BaseCPU):
         8, "Cycles to keep an SMT thread marked as a ROB borrowing donor")
     smtBorrowDonorReserveEntries = Param.Unsigned(
         8, "Minimum ROB entries reserved for a borrowing donor to resume")
+
+    smtDecodePolicy = Param.SMTDecodePolicy('MultiPriority',
+        "SMT decode select policy: ICount, DelayedICount, MultiPriority, RoundRobin")
+    smtFetchBlockPolicy = Param.SMTFetchBlockPolicy('BaseLine',
+        "SMT fetch block policy for long-latency loads: "
+        "Baseline (no blocking) or BlockPolicy (stall fetch on long-latency load)")
+    smtFetchBlockThreshold = Param.Unsigned(15,
+        "Number of cycles a load must wait in the LQ before it is considered "
+        "long-latency and triggers fetch blocking (T15 from Tullsen & Brown's paper)")
+    smtFetchDelayedSchedulerDelay = Param.Unsigned(2,
+        "Number of cycles the DelayedICount Policy delayed")
+    smtBorrowThrottleCycles = Param.Unsigned(
+        8, "Cycles to keep a backend-stalled SMT thread throttled at fetch, 0 means disable throttle")
+
     smtPregPolicy = Param.SMTQueuePolicy('Dynamic',
                                          "SMT Preg (physical register) Sharing Policy")
     smtPregFixedBase = Param.Unsigned(0,

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -35,7 +35,8 @@ if env['CONF']['TARGET_ISA'] != 'null':
               'IssuePort', 'IssueQue', 'BaseSelector', 'PAgeSelector', 'Scheduler'])
     SimObject('FuncUnitConfig.py', sim_objects=[])
     SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'], enums=[
-        'SMTFetchPolicy', 'SMTQueuePolicy', 'SMTLSQMode', 'CommitPolicy',
+        'SMTFetchPolicy', 'SMTDecodePolicy', 'SMTFetchBlockPolicy',
+        'SMTQueuePolicy', 'SMTLSQMode', 'CommitPolicy',
         'ROBWalkPolicy', 'ROBCompressPolicy', 'PerfRecord'])
 
     Source('commit.cc')

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -186,6 +186,7 @@ CPU::CPU(const BaseO3CPUParams &params)
     commit.setIEWQueue(&iewTimebuffer);
     commit.setRenameQueue(&renameTimebuffer);
 
+    fetch.setIEWStage(&iew);
     decode.setFetchStage(&fetch);
     commit.setIEWStage(&iew);
     commit.setDecodeStage(&decode);

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -89,6 +89,11 @@ Fetch::IcachePort::IcachePort(Fetch *_fetch, CPU *_cpu) :
 
 Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
     : fetchPolicy(params.smtFetchPolicy),
+      smtDecodePolicy(params.smtDecodePolicy),
+      smtBorrowThrottleHoldCycles(params.smtBorrowThrottleCycles),
+      delayedSchedulerDelay(params.smtFetchDelayedSchedulerDelay),
+      smtFetchBlockPolicy(params.smtFetchBlockPolicy),
+      longLatencyThreshold(params.smtFetchBlockThreshold),
       cpu(_cpu),
       branchPred(nullptr),
       dbpbtb(nullptr),
@@ -143,7 +148,6 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
             std::make_unique<FinishTranslationEvent>(this));
     }
 
-    smtBorrowThrottleHoldCycles = params.smtBorrowThrottleCycles;
     // IEW reports an early redirect before the formal Commit squash reaches
     // Fetch:
     //   T0                 IEW detects a wrong-path condition
@@ -166,6 +170,10 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         redirectPendingCycles[i] = 0;
         lastIcacheStall[i] = 0;
         smtBorrowThrottleCycles[i] = 0;
+        threadFetchBlocked[i] = false;
+        blockStateHoldCycles[i] = 0;
+        longLatencyStallCycles[i] = 0;
+        lastLoadHeadSeqNum[i] = UINT64_MAX;
     }
     smtLdstqHighWater = params.smtBorrowLdstqHighWater;
     if (smtLdstqHighWater == 0) {
@@ -364,7 +372,15 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
     ADD_STAT(traceMetaCleanupSquashEntries, statistics::units::Count::get(),
              "Total entries erased by squash/rollback cleanups"),
     ADD_STAT(traceMetaCleanupCommitCalls, statistics::units::Count::get(),
-             "Number of times cleanup was called on successful commit")
+             "Number of times cleanup was called on successful commit"),
+    ADD_STAT(fetchBlockState, statistics::units::Count::get(),
+             "Block policy thread state combination per cycle "
+             "(0=both unblocked, 1=tid0 blocked, 2=tid1 blocked, 3=both blocked)"),
+    ADD_STAT(fetchThrottleState, statistics::units::Count::get(),
+             "Decode policy thread state combination per cycle, Th means "
+             "uncandidated or throttled. (0=both not Th, 1=tid0 Th, 2=tid1 Th, 3=both Th)"),
+    ADD_STAT(fetchBlockHoldCycle, statistics::units::Count::get(),
+             "Per-thread block/unblock state holding cycle distribution")
 {
         icacheStallCycles
             .prereq(icacheStallCycles);
@@ -469,7 +485,32 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .prereq(traceMetaCleanupSquashEntries);
         traceMetaCleanupCommitCalls
             .prereq(traceMetaCleanupCommitCalls);
+        fetchBlockState
+            .init(1 << cpu->numThreads)
+            .flags(statistics::total);
+        fetchBlockState.subname(0, "BothUnBlocked");
+        fetchBlockState.subname(1, "Tid0Blocked");
+        fetchBlockState.subname(2, "Tid1Blocked");
+        fetchBlockState.subname(3, "BothBlocked");
+        fetchThrottleState
+            .init(1 << cpu->numThreads)
+            .flags(statistics::total);
+        fetchThrottleState.subname(0, "BothUnThrottled");
+        fetchThrottleState.subname(1, "Tid0Throttled");
+        fetchThrottleState.subname(2, "Tid1Throttled");
+        fetchThrottleState.subname(3, "BothThrottled");
+        fetchBlockHoldCycle
+            .init(2, 0, 999, 100)
+            .flags(statistics::pdf);
+        fetchBlockHoldCycle.subname(0, "Unblocked");
+        fetchBlockHoldCycle.subname(1, "Blocked");
 }
+
+void
+Fetch::setIEWStage(IEW *iew_stage) {
+    iewStage = iew_stage;
+}
+
 void
 Fetch::setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer)
 {
@@ -499,22 +540,23 @@ Fetch::initDecodeScheduler()
     }
     DPRINTF(Fetch, "Initialized SMT Decode Scheduler: 1\n");
     
-    if (smtDecodePolicy == "icount") {
+    if (smtDecodePolicy == SMTDecodePolicy::ICount) {
         // Use ROB as default counter for icount
         decodeScheduler = new ICountScheduler(numThreads, robCounter);
     }
-    else if (smtDecodePolicy == "delayed") {
+    else if (smtDecodePolicy == SMTDecodePolicy::DelayedICount) {
         decodeScheduler = new DelayedICountScheduler(numThreads, robCounter, delayedSchedulerDelay);
     }
-    else if (smtDecodePolicy == "multi_priority") {
+    else if (smtDecodePolicy == SMTDecodePolicy::MultiPriority) {
         decodeScheduler = new MultiPrioritySched(numThreads, {lsqCounter, iqCounter, robCounter});
     }
-    else {
-        // Default: round-robin like (use delayed with thread cycling)
-        decodeScheduler = new DelayedICountScheduler(numThreads, robCounter, numThreads);
+    else if (smtDecodePolicy == SMTDecodePolicy::RoundRobin) {
+        decodeScheduler = new RoundRobinScheduler(numThreads, robCounter);
+    } else {
+        panic("undifined smtDecodePolicy:%d\n", (int)smtDecodePolicy);
     }
 
-    DPRINTF(Fetch, "Initialized SMT Decode Scheduler: %s\n", smtDecodePolicy.c_str());
+    DPRINTF(Fetch, "Initialized SMT Decode Scheduler: %d\n", (int)smtDecodePolicy);
 }
 
 void
@@ -1484,6 +1526,9 @@ Fetch::initializeTickState()
         }
     }
 
+    // === Block Policy: consume IEW long-latency signals ===
+    checkLongLatencyLoads();
+
     // Check signal updates for all active threads
     while (threads != end) {
         ThreadID tid = *threads++;
@@ -1553,19 +1598,13 @@ Fetch::selectUnstalledThread()
     ThreadID selected = InvalidThreadID;
     bool has_candidate = false;
     bool has_unthrottled_candidate = false;
+    bool candidate[MaxThreads];
+    bool throttled[MaxThreads];
 
+    // update smtBorrowThrottleCycles and check whether has candidate
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        const bool candidate = !stallSig->blockFetch[tid] &&
-                               !fetchQueue[tid].empty();
-        if (!candidate) {
-            smtBorrowThrottleCycles[tid] = 0;
-            lsqCounter->setCounter(tid, UINT64_MAX);
-            iqCounter->setCounter(tid, UINT64_MAX);
-            robCounter->setCounter(tid, UINT64_MAX);
-            continue;
-        }
-        has_candidate = true;
-
+        candidate[tid] = true;
+        throttled[tid] = false;
         const bool throttle_now =
             smtHasBorrowThrottleStall(fromIEW->iewInfo[tid]) ||
             smtHasMemoryPressure(fromIEW->iewInfo[tid], smtLdstqHighWater);
@@ -1574,44 +1613,84 @@ Fetch::selectUnstalledThread()
         } else if (smtBorrowThrottleCycles[tid] > 0) {
             --smtBorrowThrottleCycles[tid];
         }
-
-        const bool throttled = smtBorrowThrottleCycles[tid] > 0;
-        if (!throttled) {
-            has_unthrottled_candidate = true;
+        if (stallSig->blockFetch[tid] || fetchQueue[tid].empty()) {
+            smtBorrowThrottleCycles[tid] = 0;
+            lsqCounter->setCounter(tid, UINT64_MAX);
+            iqCounter->setCounter(tid, UINT64_MAX);
+            robCounter->setCounter(tid, UINT64_MAX);
+            candidate[tid] = false;
+            continue;
         }
-
-        lsqCounter->setCounter(
-            tid, throttled ? UINT64_MAX : fromIEW->iewInfo[tid].ldstqCount);
-        iqCounter->setCounter(
-            tid, throttled ? UINT64_MAX : fromIEW->iewInfo[tid].iqCount);
-        robCounter->setCounter(
-            tid, throttled ? UINT64_MAX : fromIEW->iewInfo[tid].robCount);
-
-        DPRINTF(Fetch,
-                "[tid:%i] lsq=%u iq=%u rob=%u throttled=%u mem_pressure=%u hold=%u\n",
-                tid, fromIEW->iewInfo[tid].ldstqCount,
-                fromIEW->iewInfo[tid].iqCount, fromIEW->iewInfo[tid].robCount,
-                throttled,
-                smtHasMemoryPressure(fromIEW->iewInfo[tid], smtLdstqHighWater),
-                smtBorrowThrottleCycles[tid]);
+        has_candidate = true;
     }
-
-    if (has_candidate && !has_unthrottled_candidate) {
+    if (has_candidate) {
         for (ThreadID tid = 0; tid < numThreads; ++tid) {
-            if (stallSig->blockFetch[tid] || fetchQueue[tid].empty()) {
-                continue;
-            }
+            if (!candidate[tid]) continue;
             lsqCounter->setCounter(tid, fromIEW->iewInfo[tid].ldstqCount);
             iqCounter->setCounter(tid, fromIEW->iewInfo[tid].iqCount);
             robCounter->setCounter(tid, fromIEW->iewInfo[tid].robCount);
+            if (isBlockPolicyActive() && threadFetchBlocked[tid]) {
+                // === Block Policy: skip blocked thread when policy is active ===
+                throttled[tid] = true;
+                lsqCounter->setCounter(tid, UINT64_MAX - 1);
+                iqCounter->setCounter(tid, UINT64_MAX - 1);
+                robCounter->setCounter(tid, UINT64_MAX - 1);
+            } else {
+                if (smtBorrowThrottleCycles[tid] > 0) {
+                    throttled[tid] = true;
+                    lsqCounter->setCounter(tid, UINT64_MAX - 1);
+                    iqCounter->setCounter(tid, UINT64_MAX - 1);
+                    robCounter->setCounter(tid, UINT64_MAX - 1);
+                } else {
+                    has_unthrottled_candidate = true;
+                }
+            }
+            DPRINTF(Fetch,
+                    "[tid:%i] block=%u mem_pressure=%u hold=%u throttled=%u lsq=%u iq=%u rob=%u\n",
+                    tid, threadFetchBlocked[tid],
+                    smtHasMemoryPressure(fromIEW->iewInfo[tid], smtLdstqHighWater),
+                    smtBorrowThrottleCycles[tid], throttled[tid], fromIEW->iewInfo[tid].ldstqCount,
+                    fromIEW->iewInfo[tid].iqCount, fromIEW->iewInfo[tid].robCount);
         }
-    }
-
-    if (has_candidate) {
+        // while both threads are throttled, select policy as both threads are not throttle
+        if (!has_unthrottled_candidate) {
+            for (ThreadID tid = 0; tid < numThreads; ++tid) {
+                if (!candidate[tid]) continue;
+                lsqCounter->setCounter(tid, fromIEW->iewInfo[tid].ldstqCount);
+                iqCounter->setCounter(tid, fromIEW->iewInfo[tid].iqCount);
+                robCounter->setCounter(tid, fromIEW->iewInfo[tid].robCount);
+            }
+        }
+        int throttleState = 0;
+        for (ThreadID tid = numThreads - 1; tid >= 0; tid--) {
+            throttleState = (throttleState << 1) + (int)(!candidate[tid] || throttled[tid]);
+        }
+        fetchStats.fetchThrottleState[throttleState]++;
         selected = decodeScheduler->getThread();
+    } else {
+        DPRINTF(Fetch, "No candidate thread at this tick!\n");
+    }
+    return selected;
+}
+
+bool
+Fetch::isBlockPolicyActive() const
+{
+    if (smtFetchBlockPolicy != SMTFetchBlockPolicy::BlockPolicy) {
+        return false;
+    }
+    int blocked_count = 0;
+    int unblocked_count = 0;
+
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        if (threadFetchBlocked[tid])
+            blocked_count++;
+        else
+            unblocked_count++;
     }
 
-    return selected;
+    // Only active when both blocked and unblocked candidates exist
+    return (blocked_count > 0 && unblocked_count > 0);
 }
 
 void
@@ -1653,7 +1732,7 @@ Fetch::sendInstructionsToDecode()
         return;
     }
 
-    ThreadID tid =selectUnstalledThread();
+    ThreadID tid = selectUnstalledThread();
 
     if(tid == -1)
     {
@@ -1790,6 +1869,67 @@ Fetch::checkSignalsAndUpdate(ThreadID tid)
     // If we've reached this point, we have not gotten any signals that
     // cause fetch to change its status.  Fetch remains the same as before.
     return false;
+}
+
+
+void
+Fetch::checkLongLatencyLoads()
+{
+    if (smtFetchBlockPolicy == SMTFetchBlockPolicy::BlockPolicy) {
+        for (ThreadID tid = 0; tid < numThreads; ++tid) {
+            blockStateHoldCycles[tid]++;
+
+            // Get LQ head stall reason for this thread
+            StallReason lqReason = iewStage->ldstQueue.lqEmpty(tid)
+                ? StallReason::NoStall
+                : iewStage->checkLsqStall(tid, true);
+
+            // Check if LQ head is stuck on a long-latency load
+            bool is_long_latency =
+                (lqReason == StallReason::LoadL2Bound ||
+                lqReason == StallReason::LoadL3Bound ||
+                lqReason == StallReason::LoadMemBound);
+
+            if (is_long_latency) {
+                InstSeqNum newLoadHead = iewStage->ldstQueue.getLoadHeadSeqNum(tid);
+                if (newLoadHead == lastLoadHeadSeqNum[tid]) {
+                    if (!threadFetchBlocked[tid] &&
+                        longLatencyStallCycles[tid] >= longLatencyThreshold) {
+                        threadFetchBlocked[tid] = true;
+                        fetchStats.fetchBlockHoldCycle[0].sample(blockStateHoldCycles[tid]);
+                        blockStateHoldCycles[tid] = 0;
+                        DPRINTF(Fetch, "[tid:%i] Long-latency load detected: "
+                            "LQ head stalled for %llu cycles (reason=%d)\n",
+                            tid, longLatencyStallCycles[tid], (int)lqReason);
+                    }
+                    longLatencyStallCycles[tid]++;
+                } else {
+                    if (threadFetchBlocked[tid]) {
+                        threadFetchBlocked[tid] = false;
+                        fetchStats.fetchBlockHoldCycle[1].sample(blockStateHoldCycles[tid]);
+                        blockStateHoldCycles[tid] = 0;
+                        DPRINTF(Fetch, "[tid:%i] Long-latency load Done\n", tid);
+                    }
+                    longLatencyStallCycles[tid] = 0;
+                    lastLoadHeadSeqNum[tid] = newLoadHead;
+                }
+            } else {
+                if (threadFetchBlocked[tid]) {
+                    threadFetchBlocked[tid] = false;
+                    fetchStats.fetchBlockHoldCycle[1].sample(blockStateHoldCycles[tid]);
+                    blockStateHoldCycles[tid] = 0;
+                    DPRINTF(Fetch, "[tid:%i] Long-latency load Done\n", tid);
+                }
+                longLatencyStallCycles[tid] = 0;
+                lastLoadHeadSeqNum[tid] = UINT64_MAX;
+            }
+        }
+    }
+    int blockState = 0;
+    for (ThreadID tid = numThreads - 1; tid >= 0; tid--) {
+        blockState = (blockState << 1) + (int)(threadFetchBlocked[tid]);
+    }
+    fetchStats.fetchBlockState[blockState]++;
 }
 
 void

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -54,19 +54,22 @@
 #include "config/the_isa.hh"
 #include "cpu/o3/comm.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/o3/iew.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/smt_sched.hh"
 #include "cpu/pc_event.hh"
 #include "cpu/pred/bpred_unit.hh"
 #include "cpu/pred/btb/decoupled_bpred.hh"
 #include "cpu/timebuf.hh"
 #include "cpu/translation.hh"
 #include "cpu/valuepred/valuepred_unit.hh"
+#include "enums/SMTDecodePolicy.hh"
+#include "enums/SMTFetchBlockPolicy.hh"
 #include "enums/SMTFetchPolicy.hh"
 #include "mem/packet.hh"
 #include "mem/port.hh"
 #include "sim/eventq.hh"
 #include "sim/probe/probe.hh"
-#include "cpu/o3/smt_sched.hh"
 
 namespace gem5
 {
@@ -227,6 +230,25 @@ class Fetch
     /** Fetch policy. */
     SMTFetchPolicy fetchPolicy;
 
+    /**  Decode Policy: baseline fetch blocking policy */
+    SMTDecodePolicy smtDecodePolicy;
+    unsigned smtBorrowThrottleCycles[MaxThreads];
+    unsigned smtBorrowThrottleHoldCycles;
+    unsigned smtLdstqHighWater;
+    int delayedSchedulerDelay; // only for DelayedICcountPolicy
+
+    /**  Block Policy: long-latency load fetch blocking */
+    SMTFetchBlockPolicy smtFetchBlockPolicy;
+    void checkLongLatencyLoads();
+    bool isBlockPolicyActive() const;
+    unsigned longLatencyThreshold;
+    InstSeqNum lastLoadHeadSeqNum[MaxThreads];
+    uint64_t longLatencyStallCycles[MaxThreads];
+    bool threadFetchBlocked[MaxThreads];
+
+    /** Block Policy: per-thread state tracking for statistics */
+    uint64_t blockStateHoldCycles[MaxThreads];
+
     /** List that has the threads organized by priority. */
     std::list<ThreadID> priorityList;
 
@@ -243,14 +265,6 @@ class Fetch
     InstsCounter* iqCounter;
     InstsCounter* robCounter;
 
-    unsigned smtBorrowThrottleCycles[MaxThreads];
-    unsigned smtBorrowThrottleHoldCycles;
-    unsigned smtLdstqHighWater;
-
-    // Configuration parameters
-    std::string smtDecodePolicy ="multi_priority";
-    int delayedSchedulerDelay;
-
   public:
     /** Fetch constructor. */
     Fetch(CPU *_cpu, const BaseO3CPUParams &params);
@@ -262,6 +276,9 @@ class Fetch
 
     /** Registers probes. */
     void regProbePoints();
+
+    /** Sets ptr to iew. */
+    void setIEWStage(IEW *iew_stage);
 
     /** Sets the main backwards communication time buffer pointer. */
     void setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer);
@@ -605,6 +622,8 @@ class Fetch
   private:
     /** Pointer to the O3CPU. */
     CPU *cpu;
+
+    IEW *iewStage;
 
     /** Time buffer interface. */
     TimeBuffer<TimeStruct> *timeBuffer;
@@ -1180,6 +1199,11 @@ class Fetch
         statistics::Scalar traceMetaCleanupSquashEntries;
         /** Number of times cleanup was called on successful commit. */
         statistics::Scalar traceMetaCleanupCommitCalls;
+
+        // === Block Policy statistics ===
+        statistics::Vector fetchBlockState;
+        statistics::Vector fetchThrottleState;
+        statistics::VectorDistribution fetchBlockHoldCycle;  // [0]=Unblocked [1]=Blocked
     } fetchStats;
 
     SquashVersion localSquashVer[MaxThreads];

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -626,6 +626,9 @@ class IEW
 
     void setRob(ROB *rob);
 
+    StallReason checkLsqStall(ThreadID tid, bool isLoad) {
+      return checkLSQStall(tid, isLoad);
+    }
 };
 
 } // namespace o3

--- a/src/cpu/o3/smt_sched.hh
+++ b/src/cpu/o3/smt_sched.hh
@@ -89,6 +89,15 @@ class DelayedICountScheduler : public ICountScheduler
         ThreadID selectedTid = timebuffer.front();
         timebuffer.pop_front();
         timebuffer.push_back(ICountScheduler::getThread());
+        // check whether candidate
+        for (uint64_t i = 0; i < numThreads; i++) {
+            ThreadID tid = (selectedTid + i) % numThreads;
+            uint64_t count = counter->getCounter(tid);
+            if (count < UINT64_MAX) {
+                selectedTid = tid;
+                break;
+            }
+        }
         return selectedTid;
     }
 };
@@ -128,6 +137,33 @@ class MultiPrioritySched : public SMTScheduler
         return selectedTid;
     }
 };
+
+class RoundRobinScheduler : public SMTScheduler
+{
+    // count of inst based smt shceduler
+  protected:
+    InstsCounter* counter;
+    uint64_t selectedTimes = 0;
+
+  public:
+    RoundRobinScheduler(int numThreads, InstsCounter* counter) : SMTScheduler(numThreads), counter(counter) {}
+
+    ThreadID getThread() override
+    {
+        ThreadID selectedTid = 0;
+        for (uint64_t i = 0; i < numThreads; i++) {
+            ThreadID tid = (selectedTimes + i) % numThreads;
+            uint64_t count = counter->getCounter(tid);
+            if (count < UINT64_MAX - 1) {
+                selectedTid = tid;
+                break;
+            }
+        }
+        selectedTimes++;
+        return selectedTid;
+    }
+};
+
 
 }}
 #endif


### PR DESCRIPTION
## Summary
This PR adds SMT fetch/decode scheduling improvements to the O3 CPU,
including a new long-latency-load fetch block policy and a real
round-robin decode scheduler.

## Changes
1. **Fix uninitialized `delayedSchedulerDelay`**
   - Promote `delayedSchedulerDelay` from a local variable to a class
     member with default value `2`.
   - Full parameterization is left for future work.

2. **Type-safe decode policy selection**
   - Replace the string-based `smtDecodePolicy` with the new
     `SMTDecodePolicy` SimObject enum (`ICount`, `DelayedICount`,
     `MultiPriority`, `RoundRobin`).
   - Update `Fetch::initDecodeScheduler()` to compare enum values.

3. **Round-robin decode scheduler**
   - Implement `RoundRobinScheduler` in `src/cpu/o3/smt_sched.hh`.
   - Hook it into `Fetch::initDecodeScheduler()`.

4. **Refactor `Fetch::selectUnstalledThread()`**
   - Rewrite candidate/throttle tracking with explicit `candidate[]` and
     `throttled[]` arrays for clarity.
   - Preserve the existing all-throttled fallback logic.
   - Record per-cycle throttle state in `fetchThrottleState`.

5. **Tullsen & Brown BlockPolicy for long-latency loads**
   - Add `SMTFetchBlockPolicy` enum (`BaseLine` / `BlockPolicy`).
   - Detect LQ-head stalls due to L2/L3/memory-bound loads and block the
     stalled thread's fetch when `BlockPolicy` is enabled.
   - Default is `BaseLine` (off), preserving existing behavior.
   - Add `isBlockPolicyActive()` and `checkLongLatencyLoads()`.

6. **New CLI options and statistics**
   - New flags in `configs/common/xiangshan.py`:
     `--smt-decode-policy`, `--smt-fetch-block-policy`,
     `--smt-fetch-block-threshold`, `--smt-fetch-throttle-cycles`.
   - New stats:
     - `fetchBlockState`: per-cycle blocked-thread combination.
     - `fetchThrottleState`: per-cycle throttled-thread combination.
     - `fetchBlockHoldCycle`: blocked/unblocked hold-time distribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SMT decode scheduling, including round-robin scheduling.
  * Added SMT fetch-blocking policies to manage long-latency load stalls.
  * Added configurable fetch-block thresholds, delayed scheduling, and throttle cycles, including support for disabling throttling.
  * Added statistics for fetch blocking, throttling, and block duration.
* **Configuration**
  * Xiangshan CPU setups now provide command-line options for SMT scheduling and fetch-blocking controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->