### PR TITLE
cpu-o3: Improve the DynamicBorrowing and Threshold sharing for LQ/SQ

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -24,7 +24,9 @@ def setSharedLSQParams(args, system):
         # shared target queue and starve the other thread's frontend.
         cpu.StoreQueueMultiple = 1 # Do not support Virtual-SQ in SMT
         cpu.smtLSQMode = 'Shared'
-        cpu.smtLSQPolicy = 'Dynamic'
+        cpu.smtLSQPolicy = 'DynamicBorrowing'  # for LQ and SQ only
+        cpu.smtRARQPolicy = 'Dynamic'  # RARQ uses pure Dynamic policy
+        cpu.smtRAWQPolicy = 'Dynamic'  # RAWQ uses pure Dynamic policy
         cpu.smtROBPolicy = 'DynamicBorrowing'
         cpu.branchPred.smtFTQMode = 'Shared'
         cpu.branchPred.smtFTQPolicy = 'Partitioned'

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -254,7 +254,13 @@ class BaseO3CPU(BaseCPU):
                                   "SMT LSQ mode: per-thread independent or shared quota")
     smtLSQPolicy    = Param.SMTQueuePolicy('Partitioned',
                                            "SMT shared LSQ allocation policy")
-    smtLSQThreshold = Param.Int(100, "SMT LSQ Threshold Sharing Parameter")
+    smtLQThreshold = Param.Int(108, "SMT LQ Threshold Sharing Parameter")
+    smtSQThreshold = Param.Int(56, "SMT SQ Threshold Sharing Parameter")
+
+    smtRARQPolicy   = Param.SMTQueuePolicy('Dynamic',
+                                           "SMT shared RARQ allocation policy")
+    smtRAWQPolicy   = Param.SMTQueuePolicy('Dynamic',
+                                           "SMT shared RAWQ allocation policy")
     smtIQPolicy    = Param.SMTQueuePolicy('Partitioned',
                                           "SMT IQ Sharing Policy")
     smtIQThreshold = Param.Int(100, "SMT IQ Threshold Sharing Parameter")
@@ -289,6 +295,14 @@ class BaseO3CPU(BaseCPU):
            "marking held after the triggering condition clears")
     smtBorrowBaseReserveEntries = Param.Unsigned(
         80, "Minimum ROB entries reserved for a borrowing base to resume")
+    smtLQBorrowBaseReserveEntries = Param.Unsigned(
+        60, "Minimum LQ entries reserved for a borrowing base thread to resume")
+    smtLQBorrowDonorReserveEntries = Param.Unsigned(
+        6, "Minimum LQ entries reserved for a borrowing donor thread to resume")
+    smtSQBorrowBaseReserveEntries = Param.Unsigned(
+        32, "Minimum SQ entries reserved for a borrowing base thread to resume")
+    smtSQBorrowDonorReserveEntries = Param.Unsigned(
+        4, "Minimum SQ entries reserved for a borrowing donor thread to resume")
 
     branchPred = Param.BranchPredictor(DecoupledBPUWithBTB(),
                                        "Branch Predictor")

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -451,6 +451,18 @@ smtHasBorrowThrottleStall(const TimeStruct::IewComm &info)
 }
 
 inline bool
+smtHasBorrowThrottleLQStall(const TimeStruct::IewComm &info)
+{
+    return smtCanDonateRobHeadroom(info.lqHeadStallReason);
+}
+
+inline bool
+smtHasBorrowThrottleSQStall(const TimeStruct::IewComm &info)
+{
+    return smtCanDonateRobHeadroom(info.sqHeadStallReason);
+}
+
+inline bool
 smtHasMemoryPressure(const TimeStruct::IewComm &info,
                      unsigned ldstqHighWater = 0)
 {

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -1927,6 +1927,34 @@ IEW::tick()
 
     scheduler->tick();
     ldstQueue.tick();
+    
+    // Update LSQ borrowing donor status for LQ and SQ
+    // A thread becomes a donor if it has no buffered rename instructions and is stalled
+    // Use hold cycles to avoid frequent donor state transitions
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        bool has_buffered_rename = !fixedbuffer[tid].empty();
+        
+        // For LQ: determine if thread should be a donor
+        bool lq_donor = false;
+        lq_donor = smtHasBorrowThrottleLQStall(toFetch->iewInfo[tid]);
+        if (lq_donor) {
+            ldstQueue.setLQBorrowingDonor(tid, true);
+        } else {
+            ldstQueue.setLQBorrowingDonor(tid, false);
+        }
+        
+        // For SQ: determine if thread should be a donor
+        bool sq_donor = false;
+        sq_donor = smtHasBorrowThrottleSQStall(toFetch->iewInfo[tid]);
+        if (sq_donor) {
+            ldstQueue.setSQBorrowingDonor(tid, true);
+        } else {
+            ldstQueue.setSQBorrowingDonor(tid, false);
+        }
+    }
+    
+    // Add borrowing state hold cycle for LSQ
+    ldstQueue.addBorrowingStateHoldCycle();
 
     // dispatch
     moveInstsToBuffer();

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -497,7 +497,14 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       staleTranslationWaitTxnId(0),
       lsqMode(params.smtLSQMode),
       lsqPolicy(params.smtLSQPolicy),
-      smtLSQThreshold(params.smtLSQThreshold),
+      rarqPolicy(params.smtRARQPolicy),
+      rawqPolicy(params.smtRAWQPolicy),
+      smtLQThreshold(params.smtLQThreshold),
+      smtSQThreshold(params.smtSQThreshold),
+      lqBorrowBaseReserveEntries(params.smtLQBorrowBaseReserveEntries),
+      lqBorrowDonorReserveEntries(params.smtLQBorrowDonorReserveEntries),
+      sqBorrowBaseReserveEntries(params.smtSQBorrowBaseReserveEntries),
+      sqBorrowDonorReserveEntries(params.smtSQBorrowDonorReserveEntries),
       stats(nullptr, params.numThreads),
       LQEntries(params.LQEntries),
       physicalSQEntries(params.SQEntries),
@@ -511,6 +518,13 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       numThreads(params.numThreads)
 {
     assert(numThreads > 0 && numThreads <= MaxThreads);
+    // Initialize LSQ borrowing state for LQ and SQ separately
+    for (ThreadID tid = 0; tid < MaxThreads; ++tid) {
+        lqBorrowingDonor[tid] = false;
+        sqBorrowingDonor[tid] = false;
+        lqBorrowingStateHoldCycle[tid] = 0;
+        sqBorrowingStateHoldCycle[tid] = 0;
+    }
     panic_if(physicalSQEntries == 0,
              "SQEntries must be greater than zero\n");
     panic_if(storeQueueMultiple == 0 || !isPowerOf2(storeQueueMultiple),
@@ -574,20 +588,28 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
                 LQEntries, SQEntries, RARQEntries, RAWQEntries);
     } else if (lsqMode == SMTLSQMode::Shared) {
         panic_if(lsqPolicy == SMTQueuePolicy::Threshold &&
-                 smtLSQThreshold == 0,
-                 "SMT LSQ threshold must be non-zero in shared threshold mode");
+                 (smtLQThreshold == 0 || smtSQThreshold == 0),
+                 "SMT LQ/SQ thresholds must be non-zero in shared threshold mode");
 
-        if (lsqPolicy == SMTQueuePolicy::Dynamic ||
-            lsqPolicy == SMTQueuePolicy::DynamicBorrowing) {
-            DPRINTF(LSQ, "LSQ mode set to Shared/Dynamic: %u LQ and %u SQ "
-                    "entries are shared across active SMT threads, along "
-                    "with %u RARQ and %u RAWQ entries\n",
-                    LQEntries, SQEntries, RARQEntries, RAWQEntries);
+        // Print LQ/SQ policy
+        if (lsqPolicy == SMTQueuePolicy::Dynamic) {
+            DPRINTF(LSQ, "LSQ mode set to Shared: LQ/SQ use Dynamic policy, "
+                    "RARQ uses %s policy, RAWQ uses %s policy\n",
+                    SMTQueuePolicyStrings[static_cast<int>(rarqPolicy)],
+                    SMTQueuePolicyStrings[static_cast<int>(rawqPolicy)]);
+        } else if (lsqPolicy == SMTQueuePolicy::DynamicBorrowing) {
+            DPRINTF(LSQ, "LSQ mode set to Shared: LQ/SQ use DynamicBorrowing policy, "
+                    "RARQ uses %s policy, RAWQ uses %s policy\n",
+                    SMTQueuePolicyStrings[static_cast<int>(rarqPolicy)],
+                    SMTQueuePolicyStrings[static_cast<int>(rawqPolicy)]);
         } else if (lsqPolicy == SMTQueuePolicy::Partitioned) {
-            DPRINTF(LSQ, "LSQ mode set to Shared/Partitioned\n");
+            DPRINTF(LSQ, "LSQ mode set to Shared: LQ/SQ use Partitioned policy, "
+                    "RARQ uses %s policy, RAWQ uses %s policy\n",
+                    SMTQueuePolicyStrings[static_cast<int>(rarqPolicy)],
+                    SMTQueuePolicyStrings[static_cast<int>(rawqPolicy)]);
         } else if (lsqPolicy == SMTQueuePolicy::Threshold) {
-            DPRINTF(LSQ, "LSQ mode set to Shared/Threshold: threshold=%u\n",
-                    smtLSQThreshold);
+            DPRINTF(LSQ, "LSQ mode set to Shared/Threshold: LQ threshold=%u, SQ threshold=%u\n",
+                    smtLQThreshold, smtSQThreshold);
         } else {
             panic("Invalid LSQ sharing policy. Options are: Dynamic, "
                         "Partitioned, Threshold, DynamicBorrowing");
@@ -686,6 +708,11 @@ LSQ::takeOverFrom()
 
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         thread[tid].takeOverFrom();
+        // Reset LSQ borrowing state
+        lqBorrowingDonor[tid] = false;
+        sqBorrowingDonor[tid] = false;
+        lqBorrowingStateHoldCycle[tid] = 0;
+        sqBorrowingStateHoldCycle[tid] = 0;
     }
 }
 
@@ -2137,48 +2164,194 @@ LSQ::activeLSQThreads() const
     return activeThreads->size();
 }
 
+/** Queue type enum for sharedLSQAllocation */
+enum class LSQQueueType
+{
+    LQ,
+    SQ,
+    RARQ,
+    RAWQ
+};
+
 unsigned
-LSQ::sharedLSQAllocation(unsigned entries) const
+LSQ::sharedLSQAllocation(unsigned entries, LSQQueueType queueType) const
 {
     const unsigned active_threads = std::max(1U, activeLSQThreads());
 
-    switch (lsqPolicy) {
+    // Select policy based on queue type
+    SMTQueuePolicy policy;
+    switch (queueType) {
+      case LSQQueueType::LQ:
+      case LSQQueueType::SQ:
+        policy = lsqPolicy;
+        break;
+      case LSQQueueType::RARQ:
+        policy = rarqPolicy;
+        break;
+      case LSQQueueType::RAWQ:
+        policy = rawqPolicy;
+        break;
+      default:
+        panic("Invalid LSQ queue type");
+    }
+
+    switch (policy) {
       case SMTQueuePolicy::Dynamic:
       case SMTQueuePolicy::DynamicBorrowing:
         return entries;
       case SMTQueuePolicy::Partitioned:
         return entries / active_threads;
       case SMTQueuePolicy::Threshold:
-        return active_threads == 1 ? entries :
-            std::min(entries, smtLSQThreshold);
+        // Use separate thresholds for LQ and SQ
+        if (queueType == LSQQueueType::LQ) {
+            return active_threads == 1 ? entries :
+                std::min(entries, smtLQThreshold);
+        } else if (queueType == LSQQueueType::SQ) {
+            return active_threads == 1 ? entries :
+                std::min(entries, smtSQThreshold);
+        } else {
+            // RARQ/RAWQ should not use Threshold policy through lsqPolicy
+            panic("Threshold policy for RARQ/RAWQ requires separate threshold parameters");
+        }
       default:
         panic("Invalid LSQ sharing policy. Options are: Dynamic, "
               "Partitioned, Threshold, DynamicBorrowing");
     }
 }
 
+bool
+LSQ::canBorrowLQ(ThreadID tid) const
+{
+    return lsqPolicy == SMTQueuePolicy::DynamicBorrowing &&
+           tid < numThreads;
+}
+
+bool
+LSQ::canBorrowSQ(ThreadID tid) const
+{
+    return lsqPolicy == SMTQueuePolicy::DynamicBorrowing &&
+           tid < numThreads;
+}
+
+unsigned
+LSQ::borrowingLimitLQ(ThreadID tid) const
+{
+    if (tid >= numThreads) {
+        return 0;
+    }
+
+    if (!canBorrowLQ(tid)) {
+        return logicalMaxLoadEntries(tid);
+    }
+
+    const unsigned active_threads = std::max(1U, activeLSQThreads());
+    const unsigned base = lqBorrowBaseReserveEntries;
+    const unsigned donor_resume_quota =
+        std::min(base, lqBorrowDonorReserveEntries);
+
+    unsigned reserved = 0;
+    for (ThreadID other = 0; other < numThreads; ++other) {
+        if (other == tid) {
+            continue;
+        }
+
+        const unsigned reserve =
+            lqBorrowingDonor[other] ? donor_resume_quota : base;
+        const unsigned used = thread[other].numLoads();
+        reserved += std::max(reserve, used);
+    }
+
+    if (reserved >= LQEntries) {
+        return 0;
+    }
+
+    return LQEntries - reserved;
+}
+
+unsigned
+LSQ::borrowingLimitSQ(ThreadID tid) const
+{
+    if (tid >= numThreads) {
+        return 0;
+    }
+
+    if (!canBorrowSQ(tid)) {
+        return logicalMaxStoreEntries(tid);
+    }
+
+    const unsigned active_threads = std::max(1U, activeLSQThreads());
+    const unsigned base = sqBorrowBaseReserveEntries;
+    const unsigned donor_resume_quota =
+        std::min(base, sqBorrowDonorReserveEntries);
+
+    unsigned reserved = 0;
+    for (ThreadID other = 0; other < numThreads; ++other) {
+        if (other == tid) {
+            continue;
+        }
+
+        const unsigned reserve =
+            sqBorrowingDonor[other] ? donor_resume_quota : base;
+        const unsigned used = thread[other].numStores();
+        reserved += std::max(reserve, used);
+    }
+
+    if (reserved >= SQEntries) {
+        return 0;
+    }
+
+    return SQEntries - reserved;
+}
+
+void
+LSQ::setLQBorrowingDonor(ThreadID tid, bool donor)
+{
+    if (lqBorrowingDonor[tid] != donor) {
+        lqBorrowingDonor[tid] = donor;
+        lqBorrowingStateHoldCycle[tid] = 0;
+    }
+}
+
+void
+LSQ::setSQBorrowingDonor(ThreadID tid, bool donor)
+{
+    if (sqBorrowingDonor[tid] != donor) {
+        sqBorrowingDonor[tid] = donor;
+        sqBorrowingStateHoldCycle[tid] = 0;
+    }
+}
+
+void
+LSQ::addBorrowingStateHoldCycle()
+{
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        lqBorrowingStateHoldCycle[tid]++;
+        sqBorrowingStateHoldCycle[tid]++;
+    }
+}
+
 unsigned
 LSQ::logicalMaxLoadEntries(ThreadID tid) const
 {
-    return sharedLSQMode() ? sharedLSQAllocation(LQEntries) : LQEntries;
+    return sharedLSQMode() ? sharedLSQAllocation(LQEntries, LSQQueueType::LQ) : LQEntries;
 }
 
 unsigned
 LSQ::logicalMaxStoreEntries(ThreadID tid) const
 {
-    return sharedLSQMode() ? sharedLSQAllocation(SQEntries) : SQEntries;
+    return sharedLSQMode() ? sharedLSQAllocation(SQEntries, LSQQueueType::SQ) : SQEntries;
 }
 
 unsigned
 LSQ::logicalMaxRAREntries(ThreadID tid) const
 {
-    return sharedLSQMode() ? sharedLSQAllocation(RARQEntries) : RARQEntries;
+    return sharedLSQMode() ? sharedLSQAllocation(RARQEntries, LSQQueueType::RARQ) : RARQEntries;
 }
 
 unsigned
 LSQ::logicalMaxRAWEntries(ThreadID tid) const
 {
-    return sharedLSQMode() ? sharedLSQAllocation(RAWQEntries) : RAWQEntries;
+    return sharedLSQMode() ? sharedLSQAllocation(RAWQEntries, LSQQueueType::RAWQ) : RAWQEntries;
 }
 
 unsigned
@@ -2188,6 +2361,21 @@ LSQ::logicalFreeLoadEntries(ThreadID tid) const
         static_cast<int>(logicalMaxLoadEntries(tid)) - thread[tid].numLoads());
     if (!sharedLSQMode()) {
         return thread_free;
+    }
+
+    // For DynamicBorrowing policy, use borrowing limit
+    if (lsqPolicy == SMTQueuePolicy::DynamicBorrowing) {
+        const unsigned limit = borrowingLimitLQ(tid);
+        const unsigned used = thread[tid].numLoads();
+        if (limit <= used) {
+            return 0;
+        }
+        const unsigned borrow_free = limit - used;
+        // Also ensure we don't exceed shared free space
+        const unsigned shared_used = numLoads();
+        const unsigned shared_free = std::max(
+            0, static_cast<int>(LQEntries) - static_cast<int>(shared_used));
+        return std::min(borrow_free, shared_free);
     }
 
     const unsigned shared_used = numLoads();
@@ -2203,6 +2391,21 @@ LSQ::logicalFreeStoreEntries(ThreadID tid) const
         static_cast<int>(logicalMaxStoreEntries(tid)) - thread[tid].numStores());
     if (!sharedLSQMode()) {
         return thread_free;
+    }
+
+    // For DynamicBorrowing policy, use borrowing limit
+    if (lsqPolicy == SMTQueuePolicy::DynamicBorrowing) {
+        const unsigned limit = borrowingLimitSQ(tid);
+        const unsigned used = thread[tid].numStores();
+        if (limit <= used) {
+            return 0;
+        }
+        const unsigned borrow_free = limit - used;
+        // Also ensure we don't exceed shared free space
+        const unsigned shared_used = numStores();
+        const unsigned shared_free = std::max(
+            0, static_cast<int>(SQEntries) - static_cast<int>(shared_used));
+        return std::min(borrow_free, shared_free);
     }
 
     const unsigned shared_used = numStores();

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -1278,7 +1278,38 @@ class LSQ
 
     bool sharedLSQMode() const;
     unsigned activeLSQThreads() const;
-    unsigned sharedLSQAllocation(unsigned entries) const;
+
+    /** Returns whether the thread may borrow unused LQ/SQ capacity. */
+    bool canBorrowLQ(ThreadID tid) const;
+    bool canBorrowSQ(ThreadID tid) const;
+
+    /** Returns the borrowing limit for LQ entries. */
+    unsigned borrowingLimitLQ(ThreadID tid) const;
+
+    /** Returns the borrowing limit for SQ entries. */
+    unsigned borrowingLimitSQ(ThreadID tid) const;
+
+    /** Sets whether the thread may donate unused LQ/SQ capacity this cycle. */
+    void setLQBorrowingDonor(ThreadID tid, bool donor);
+    void setSQBorrowingDonor(ThreadID tid, bool donor);
+    
+    /** Returns whether the thread is currently an LQ/SQ borrowing donor. */
+    bool isLQBorrowingDonor(ThreadID tid) const { return lqBorrowingDonor[tid]; }
+    bool isSQBorrowingDonor(ThreadID tid) const { return sqBorrowingDonor[tid]; }
+    
+    /** Add cycle count for borrowing state holding cycle stats */
+    void addBorrowingStateHoldCycle();
+
+    /** Queue type for sharedLSQAllocation */
+    enum class LSQQueueType
+    {
+        LQ,
+        SQ,
+        RARQ,
+        RAWQ
+    };
+
+    unsigned sharedLSQAllocation(unsigned entries, LSQQueueType queueType) const;
     unsigned logicalMaxLoadEntries(ThreadID tid) const;
     unsigned logicalMaxStoreEntries(ThreadID tid) const;
     unsigned logicalFreeLoadEntries(ThreadID tid) const;
@@ -1487,11 +1518,44 @@ class LSQ
     /** The LSQ policy for SMT mode. */
     SMTLSQMode lsqMode;
 
-    /** The LSQ allocation policy used in shared mode. */
+    /** The LSQ allocation policy used in shared mode for LQ and SQ. */
     SMTQueuePolicy lsqPolicy;
 
-    /** The per-thread threshold used in shared threshold mode. */
-    unsigned smtLSQThreshold;
+    /** The RARQ allocation policy used in shared mode. */
+    SMTQueuePolicy rarqPolicy;
+
+    /** The RAWQ allocation policy used in shared mode. */
+    SMTQueuePolicy rawqPolicy;
+
+    /** The LQ threshold used in shared mode for Threshold policy. */
+    const unsigned smtLQThreshold;
+
+    /** The SQ threshold used in shared mode for Threshold policy. */
+    const unsigned smtSQThreshold;
+
+    /** Minimum LQ entries reserved for a borrowing base thread to resume. */
+    const unsigned lqBorrowBaseReserveEntries;
+
+    /** Minimum LQ entries reserved for a borrowing donor thread to resume. */
+    const unsigned lqBorrowDonorReserveEntries;
+
+    /** Minimum SQ entries reserved for a borrowing base thread to resume. */
+    const unsigned sqBorrowBaseReserveEntries;
+
+    /** Minimum SQ entries reserved for a borrowing donor thread to resume. */
+    const unsigned sqBorrowDonorReserveEntries;
+
+    /** Whether a thread may donate unused LQ capacity this cycle. */
+    bool lqBorrowingDonor[MaxThreads];
+
+    /** Whether a thread may donate unused SQ capacity this cycle. */
+    bool sqBorrowingDonor[MaxThreads];
+    
+    /** Cycle count for LQ borrowing state holding */
+    unsigned lqBorrowingStateHoldCycle[MaxThreads];
+    
+    /** Cycle count for SQ borrowing state holding */
+    unsigned sqBorrowingStateHoldCycle[MaxThreads];
 
     struct LSQStats : public statistics::Group
     {


### PR DESCRIPTION
### Motivation
We currently configure the LQ/SQ with a Dynamic sharing policy, where DynamicBorrowing behaves identically to Dynamic, allowing a single thread in SMT mode to fully utilize all available resources. However, the backpressure from lsqFull is reflected at the dispatch stage. As a result, if thread 0 is memory-intensive and thread 1 is compute-intensive, thread 1 may still be backpressured at dispatch due to LQ/SQ resource exhaustion caused by thread 0, even though thread 1 issues few load/store instructions. To improve overall SMT performance, we propose imposing a per-thread limit on LQ/SQ resource usage, thereby preventing any single thread from monopolizing the LSQ and improving resource fairness and system-wide throughput.

### Changes
1. The sharing strategies adopted by LQ/SQ and RARQ/RAWQ can be isolated and configured as different strategies
2. Improve the logic of DynamicBorrowing and Threshold under lsq, and support configurable parameters

### Environment
- Branch: xs-dev
- Base commit:（tests,util: Exclude RTL nodes from distributed defaults（00ba529c44584f2d247b30f1f0276806deca5e6b））
- Test: SPEC06 1167 SimPoint checkpoints

### Results（SPEC06 INT）
| Config               | score/GHz       | vs Dynamic |
|----------------------|-----------------|------------|
| Dynamic (baseline)   | 24.93041641     | ---        |
| Threshold            | 25.05286892     | 0.49%      |
| DynamicBorrowing     | 25.13229086     | 0.81%      |

- Threshold（smtLQThreshold = 108  smtSQThreshold = 56）
- DynamicBorrowing（smtLQBorrowBaseReserveEntries = 60 smtLQBorrowDonorReserveEntries = 6 ，smtSQBorrowBaseReserveEntries = 32 smtSQBorrowDonorReserveEntries = 4）
#### Highlights（DynamicBorrowing）
sjeng：+4.22%
mcf：+2.31%
gobmk：1.33%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent load-queue, store-queue, read-after-read, and read-after-write sharing policies.
  * Added configurable load/store queue thresholds and borrowing reserve capacities.
  * Enabled dynamic queue-entry borrowing between SMT threads.
  * Added automatic donor selection and temporary borrowing-state hold cycles.
  * Updated example configuration with the new SMT queue policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->