### PR TITLE
configs: set L3 as 32MB in kmhv3

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -202,6 +202,7 @@ if __name__ == '__m5_main__':
     # If user didn't specify bp_type, set default based on ideal_kmhv3
     args.bp_type = 'DecoupledBPUWithBTB'
     args.l2_size = '2MB'
+    args.l3_size = '32MB'
     args.kmh_align = True   # align prefetcher in RTL, spec06 decrease 1 score
     args.cdp_use_dynamic_degree = False
     args.cdp_accuracy_threshold = 0.05


### PR DESCRIPTION
Change-Id: Ie232c5ae1f9c7fbe883cab2897cb8fc9d166ce5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example configuration now uses a default 32 MB L3 cache size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->