### PR TITLE
cpu-pred: Align RAS capacity with RTL

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1031,8 +1031,8 @@ class BTBRAS(TimedBaseBTBPredictor):
     cxx_header = 'cpu/pred/btb/ras.hh'
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
-    numEntries = Param.Unsigned(32, "Number of entries in the RAS")
-    ctrWidth = Param.Unsigned(8, "Width of the counter")
+    numEntries = Param.Unsigned(16, "Number of entries in the RAS")
+    ctrWidth = Param.Unsigned(3, "Width of the counter")
     numInflightEntries = Param.Unsigned(384, "Number of inflight entries")
     numDelay = 2
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1033,7 +1033,7 @@ class BTBRAS(TimedBaseBTBPredictor):
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     numEntries = Param.Unsigned(16, "Number of entries in the RAS")
     ctrWidth = Param.Unsigned(3, "Width of the counter")
-    numInflightEntries = Param.Unsigned(384, "Number of inflight entries")
+    numInflightEntries = Param.Unsigned(32, "Number of inflight entries")
     numDelay = 2
 
 class BTBuRAS(TimedBaseBTBPredictor):

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -1,5 +1,7 @@
 #include "cpu/pred/btb/ras.hh"
 
+#include <algorithm>
+
 // Additional conditional includes based on build mode
 #ifdef UNIT_TEST
     #include "cpu/pred/btb/test/test_dprintf.hh"
@@ -24,8 +26,10 @@ namespace btb_pred {
               numInflightEntries(numInflightEntries),
               maxCtr((1 << ctrWidth) - 1),
               numThreads(1),
-              threadStates(numThreads)
+              threadStates(numThreads),
+              rasStats()
         {
+            assert(numInflightEntries >= 2);
             for (auto &state : threadStates) {
                 initThreadState(state);
             }
@@ -42,6 +46,7 @@ namespace btb_pred {
           threadStates(numThreads),
           rasStats(this)
     {
+        assert(numInflightEntries >= 2);
         for (auto &state : threadStates) {
             initThreadState(state);
         }
@@ -52,8 +57,7 @@ void
 BTBRAS::initThreadState(ThreadRASState &state)
 {
     state.TOSW = 0;
-    state.TOSR = 0;
-    inflightPtrDec(state.TOSR);
+    state.TOSR = -1;
     state.BOS = 0;
     state.ssp = 0;
     state.nsp = 0;
@@ -149,6 +153,13 @@ BTBRAS::specUpdateState(FullBTBPrediction &pred)
     auto takenEntry = pred.getTakenEntry();
     DPRINTFR(RAS, "Do specUpdate for PC %lx pred target %lx ", pred.bbStart, pred.returnTarget);
 
+    if ((takenEntry.isCall || takenEntry.isReturn) &&
+        inflightNearOverflow(state)) {
+        rasStats.SpecUpdatesBlockedNearOverflow++;
+        DPRINTF(RAS, "Block speculative RAS update near inflight overflow\n");
+        return;
+    }
+
     // RISC-V JALR PopAndPush has both flags set; pop first to retain the new return address.
     if (takenEntry.isReturn) {
         // do pop
@@ -167,7 +178,9 @@ BTBRAS::specUpdateState(FullBTBPrediction &pred)
     
     if (takenEntry.isCall || takenEntry.isReturn)
         printStack("after specUpdateState", tid);
-    DPRINTFR(RAS, "meta TOSR %d TOSW %d\n", state.meta->TOSR, state.meta->TOSW);
+    DPRINTFR(RAS, "meta TOSR %lld TOSW %lld\n",
+             static_cast<long long>(state.meta->TOSR),
+             static_cast<long long>(state.meta->TOSW));
 }
 
 void
@@ -183,8 +196,19 @@ BTBRAS::recoverState(const FetchTarget &entry)
     }*/
     // recover sp and tos first
     auto meta_ptr = std::static_pointer_cast<RASMeta>(entry.predMetas[getComponentIdx()]);
-    DPRINTF(RAS, "recover called, meta TOSR %d TOSW %d ssp %d sctr %u entry PC %lx end PC %lx\n",
-        meta_ptr->TOSR, meta_ptr->TOSW, meta_ptr->ssp, meta_ptr->sctr, entry.startPC, entry.predEndPC);
+    DPRINTF(RAS, "recover called, meta TOSR %lld TOSW %lld ssp %d sctr %u entry PC %lx end PC %lx\n",
+        static_cast<long long>(meta_ptr->TOSR),
+        static_cast<long long>(meta_ptr->TOSW), meta_ptr->ssp,
+        meta_ptr->sctr, entry.startPC, entry.predEndPC);
+
+    // RTL only accepts a redirect near overflow when it rolls the speculative
+    // write pointer back. This prevents a redirect on the current queue head
+    // from consuming the final ring entry.
+    if (inflightNearOverflow(state) && meta_ptr->TOSW >= state.TOSW) {
+        rasStats.RedirectsBlockedNearOverflow++;
+        DPRINTF(RAS, "Block RAS redirect recovery near inflight overflow\n");
+        return;
+    }
 
     state.TOSR = meta_ptr->TOSR;
     state.TOSW = meta_ptr->TOSW;
@@ -238,11 +262,12 @@ BTBRAS::update(const FetchTarget &entry)
             pop_stack(tid);
         }
         if (takenEntry.isCall) {
-            DPRINTF(RAS, "real update call BTB hit %d meta TOSR %d TOSW %d\n entry PC %lx",
-                entry.isHit, meta_ptr->TOSR, meta_ptr->TOSW, entry.startPC);
+            DPRINTF(RAS, "real update call BTB hit %d meta TOSR %lld TOSW %lld\n entry PC %lx",
+                entry.isHit, static_cast<long long>(meta_ptr->TOSR),
+                static_cast<long long>(meta_ptr->TOSW), entry.startPC);
             Addr retAddr = takenEntry.pc + takenEntry.size;
             push_stack(tid, retAddr);
-            state.BOS = inflightPtrPlus1(meta_ptr->TOSW);
+            state.BOS = std::max(state.BOS, meta_ptr->TOSW + 1);
         }
     }
     if (takenEntry.isCall || takenEntry.isReturn) {
@@ -288,9 +313,10 @@ BTBRAS::push(ThreadID tid, Addr retAddr)
     t.data.retAddr = retAddr;
     t.data.ctr = state.sctr;
     t.nos = state.TOSR;
-    state.inflightStack[state.TOSW] = t;
+    state.inflightStack[inflightIndex(state.TOSW)] = t;
     state.TOSR = state.TOSW;
-    inflightPtrInc(state.TOSW);
+    state.TOSW++;
+    recordInflightDepth(state);
 }
 
 void
@@ -319,8 +345,10 @@ BTBRAS::pop(ThreadID tid)
     rasStats.Pops++;
     // pop may need to deal with committed stack
     if (inflightInRange(state, state.TOSR)) {
-        DPRINTF(RAS, "Select from inflight, addr %lx\n", state.inflightStack[state.TOSR].data.retAddr);
-        state.TOSR = state.inflightStack[state.TOSR].nos;
+        const auto top_idx = inflightIndex(state.TOSR);
+        DPRINTF(RAS, "Select from inflight, addr %lx\n",
+                state.inflightStack[top_idx].data.retAddr);
+        state.TOSR = state.inflightStack[top_idx].nos;
         if (state.sctr > 0) {
             state.sctr--;
         } else {
@@ -361,39 +389,42 @@ BTBRAS::ptrDec(int &ptr)
     }
 }
 
-void
-BTBRAS::inflightPtrInc(int &ptr)
+unsigned
+BTBRAS::inflightIndex(int64_t ptr) const
 {
-    ptr = (ptr + 1) % numInflightEntries;
+    assert(ptr >= 0);
+    return ptr % numInflightEntries;
 }
 
-void
-BTBRAS::inflightPtrDec(int &ptr)
+uint64_t
+BTBRAS::inflightOccupancy(const ThreadRASState &state) const
 {
-    if (ptr > 0) {
-        ptr--;
-    } else {
-        assert(ptr == 0);
-        ptr = numInflightEntries - 1;
-    }
-}
-
-int
-BTBRAS::inflightPtrPlus1(int ptr) {
-    return (ptr + 1) % numInflightEntries;
+    assert(state.TOSW >= state.BOS);
+    return state.TOSW - state.BOS;
 }
 
 bool
-BTBRAS::inflightInRange(const ThreadRASState &state, int ptr)
+BTBRAS::inflightNearOverflow(const ThreadRASState &state) const
 {
-    if (state.TOSW > state.BOS) {
-        return ptr >= state.BOS && ptr < state.TOSW;
-    } else if (state.TOSW < state.BOS) {
-        return ptr < state.TOSW || ptr >= state.BOS;
-    } else {
-        // empty inflight queue
-        return false;
-    }
+    return inflightOccupancy(state) > numInflightEntries - 2;
+}
+
+bool
+BTBRAS::inflightInRange(const ThreadRASState &state, int64_t ptr) const
+{
+    return ptr >= state.BOS && ptr < state.TOSW;
+}
+
+void
+BTBRAS::recordInflightDepth(const ThreadRASState &state)
+{
+    const auto depth = inflightOccupancy(state);
+#ifdef UNIT_TEST
+    rasStats.MaxInflightDepth = std::max(rasStats.MaxInflightDepth, depth);
+#else
+    rasStats.MaxInflightDepth =
+        std::max(rasStats.MaxInflightDepth.value(), static_cast<double>(depth));
+#endif
 }
 
 BTBRAS::RASEssential
@@ -404,7 +435,7 @@ BTBRAS::getTop(ThreadID tid)
     if (inflightInRange(state, state.TOSR)) {
         // result come from inflight queue
         DPRINTF(RAS, "Select from inflight, addr %lx\n",
-                state.inflightStack[state.TOSR].data.retAddr);
+                state.inflightStack[inflightIndex(state.TOSR)].data.retAddr);
         // additional check: if nos is out of bound, check if commit stack top == inflight[nos]
         /*
         if (!inflightInRange(state, state.inflightStack[state.TOSR].nos)) {
@@ -421,7 +452,7 @@ BTBRAS::getTop(ThreadID tid)
             }
         }*/
 
-        return state.inflightStack[state.TOSR].data;
+        return state.inflightStack[inflightIndex(state.TOSR)].data;
     } else {
         // result come from commit queue
         DPRINTF(RAS, "Select from stack, addr %lx\n", state.stack[state.ssp].data.retAddr);
@@ -437,12 +468,13 @@ BTBRAS::getTop_meta(ThreadID tid) {
     if (inflightInRange(state, state.TOSR)) {
         // result come from inflight queue
         DPRINTF(RAS, "Select from inflight, addr %lx\n",
-                state.inflightStack[state.TOSR].data.retAddr);
+                state.inflightStack[inflightIndex(state.TOSR)].data.retAddr);
         state.meta->ssp = state.ssp;
         state.meta->sctr = state.sctr;
         state.meta->TOSR = state.TOSR;
         state.meta->TOSW = state.TOSW;
-        state.meta->target = state.inflightStack[state.TOSR].data.retAddr;
+        state.meta->target =
+            state.inflightStack[inflightIndex(state.TOSR)].data.retAddr;
 
         // additional check: if nos is out of bound, check if commit stack top == inflight[nos]
         /*
@@ -460,7 +492,7 @@ BTBRAS::getTop_meta(ThreadID tid) {
             }
         }*/
 
-        return state.inflightStack[state.TOSR].data;
+        return state.inflightStack[inflightIndex(state.TOSR)].data;
     } else {
         // result come from commit queue
         state.meta->ssp = state.ssp;
@@ -513,7 +545,15 @@ BTBRAS::RASStats::RASStats(statistics::Group *parent):
     ADD_STAT(CorrectWithSctr, statistics::units::Count::get(),"number of RAS correct predictions when sctr > 0"),
 
     ADD_STAT(Pushes, statistics::units::Count::get(),"number of RAS pushes"),
-    ADD_STAT(Pops, statistics::units::Count::get(),"number of RAS pops")
+    ADD_STAT(Pops, statistics::units::Count::get(),"number of RAS pops"),
+    ADD_STAT(SpecUpdatesBlockedNearOverflow,
+             statistics::units::Count::get(),
+             "number of speculative RAS updates blocked near queue overflow"),
+    ADD_STAT(RedirectsBlockedNearOverflow,
+             statistics::units::Count::get(),
+             "number of RAS redirect recoveries blocked near queue overflow"),
+    ADD_STAT(MaxInflightDepth, statistics::units::Count::get(),
+             "maximum number of occupied speculative RAS entries")
 
 {}
 

--- a/src/cpu/pred/btb/ras.cc
+++ b/src/cpu/pred/btb/ras.cc
@@ -267,8 +267,17 @@ BTBRAS::update(const FetchTarget &entry)
                 static_cast<long long>(meta_ptr->TOSW), entry.startPC);
             Addr retAddr = takenEntry.pc + takenEntry.size;
             push_stack(tid, retAddr);
-            state.BOS = std::max(state.BOS, meta_ptr->TOSW + 1);
         }
+    }
+
+    // Match the RTL inference-queue retirement window. A committed push stays
+    // available as the oldest speculative entry because younger entries may
+    // still name it as their parent. Other commits may reclaim all but one
+    // predecessor once their prediction metadata has moved far enough ahead.
+    if (entry.exeTaken && takenEntry.isCall) {
+        state.BOS = std::max(state.BOS, meta_ptr->TOSW);
+    } else if (meta_ptr->TOSW - state.BOS > 2) {
+        state.BOS = std::max(state.BOS, meta_ptr->TOSW - 1);
     }
     if (takenEntry.isCall || takenEntry.isReturn) {
         printStack("after update(commit)", tid);

--- a/src/cpu/pred/btb/ras.hh
+++ b/src/cpu/pred/btb/ras.hh
@@ -1,6 +1,8 @@
 #ifndef __CPU_PRED_BTB_RAS_HH__
 #define __CPU_PRED_BTB_RAS_HH__
 
+#include <cstdint>
+
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/btb/common.hh"
@@ -70,15 +72,15 @@ namespace btb_pred {
         typedef struct RASInflightEntry
         {
             RASEssential data;
-            int nos; // parent node pointer
+            int64_t nos; // Logical parent node pointer
         }RASInflightEntry;
 
         typedef struct RASMeta {
             int ssp;
             int sctr;
             // RASEntry tos; // top of stack
-            int TOSR;
-            int TOSW;
+            int64_t TOSR;
+            int64_t TOSW;
             bool willPush;
             Addr target;
             // RASInflightEntry inflight; // inflight top of stack
@@ -108,9 +110,9 @@ namespace btb_pred {
     private:
         struct ThreadRASState
         {
-            int TOSW = 0; // inflight pointer to the write top of stack
-            int TOSR = 0; // inflight pointer to the read top of stack
-            int BOS = 0;  // inflight pointer to the bottom of stack
+            int64_t TOSW = 0; // Logical next-write pointer
+            int64_t TOSR = -1; // Logical top-of-stack read pointer
+            int64_t BOS = 0;  // Logical oldest valid pointer
             int ssp = 0;  // speculative stack pointer
             int nsp = 0;  // committed stack pointer
             int sctr = 0;
@@ -133,13 +135,15 @@ namespace btb_pred {
 
         void ptrDec(int &ptr);
 
-        void inflightPtrInc(int &ptr);
-        
-        void inflightPtrDec(int &ptr);
+        unsigned inflightIndex(int64_t ptr) const;
 
-        bool inflightInRange(const ThreadRASState &state, int ptr);
+        uint64_t inflightOccupancy(const ThreadRASState &state) const;
 
-        int inflightPtrPlus1(int ptr);
+        bool inflightNearOverflow(const ThreadRASState &state) const;
+
+        bool inflightInRange(const ThreadRASState &state, int64_t ptr) const;
+
+        void recordInflightDepth(const ThreadRASState &state);
 
         void checkCorrectness(ThreadID tid);
 
@@ -163,17 +167,18 @@ namespace btb_pred {
             }
             DPRINTFR(RAS, "non-volatile stack:\n");
             for (int i = 0; i < numInflightEntries; i++) {
-                DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %d", i,
+                DPRINTFR(RAS, "entry [%d] retAddr %#lx, ctr %u nos %lld", i,
                          state.inflightStack[i].data.retAddr,
                          state.inflightStack[i].data.ctr,
-                         state.inflightStack[i].nos);
-                if (state.TOSW == i) {
+                         static_cast<long long>(state.inflightStack[i].nos));
+                if (inflightIndex(state.TOSW) == i) {
                     DPRINTFR(RAS, " <-- TOSW");
                 }
-                if (state.TOSR == i) {
+                if (inflightInRange(state, state.TOSR) &&
+                    inflightIndex(state.TOSR) == i) {
                     DPRINTFR(RAS, " <-- TOSR");
                 }
-                if (state.BOS == i) {
+                if (inflightIndex(state.BOS) == i) {
                     DPRINTFR(RAS, " <-- BOS");
                 }
                 DPRINTFR(RAS, "\n");
@@ -229,6 +234,9 @@ namespace btb_pred {
 
         Scalar Pushes;
         Scalar Pops;
+        Scalar SpecUpdatesBlockedNearOverflow;
+        Scalar RedirectsBlockedNearOverflow;
+        Scalar MaxInflightDepth;
 
 #ifndef UNIT_TEST
         RASStats(statistics::Group* parent);

--- a/src/cpu/pred/btb/test/ras_pop_push.test.cc
+++ b/src/cpu/pred/btb/test/ras_pop_push.test.cc
@@ -140,6 +140,60 @@ TEST_F(RASPopPushTest, BlocksSpecUpdatesNearInflightOverflow) {
     check_return_target(0x6000, 0x3004);
 }
 
+TEST_F(RASPopPushTest, RetainsCommittedPushAtInflightBottom) {
+    reset_ras(4);
+
+    // RTL keeps the committed push itself at BOS because younger speculative
+    // entries can still name it as their parent.
+    spec_and_commit_call(0x1000, 0x2000);
+
+    check_return_target(0x2000, 0x1004);
+    auto second_call = create_prediction(0x2000, 0x3000, true, false);
+    ras->specUpdateState(second_call);
+
+    check_return_target(0x3000, 0x2004);
+    auto third_call = create_prediction(0x3000, 0x4000, true, false);
+    ras->specUpdateState(third_call);
+
+    // Occupancy is now three in a four-entry ring, so the RTL near-overflow
+    // policy blocks another speculative update.
+    check_return_target(0x4000, 0x3004);
+    auto blocked_call = create_prediction(0x4000, 0x5000, true, false);
+    ras->specUpdateState(blocked_call);
+    check_return_target(0x5000, 0x3004);
+}
+
+TEST_F(RASPopPushTest, ReclaimsInflightPredecessorsAtCommit) {
+    reset_ras(4);
+
+    for (int i = 0; i < 3; ++i) {
+        const Addr call_pc = 0x1000 + i * 4;
+        check_return_target(call_pc,
+            i == 0 ? 0x80000000L : call_pc);
+        auto call = create_prediction(call_pc, 0x2000 + i * 4,
+                                      true, false);
+        ras->specUpdateState(call);
+    }
+
+    check_return_target(0x3000, 0x100c);
+    auto committed_meta = ras->getPredictionMeta();
+
+    auto blocked_call = create_prediction(0x3000, 0x4000, true, false);
+    ras->specUpdateState(blocked_call);
+    check_return_target(0x4000, 0x100c);
+
+    // A later non-call commit moves BOS to one entry before its TOSW, which
+    // preserves the parent link while reclaiming older queue entries.
+    auto neutral_commit = create_stream(0x3000, 0, false, false,
+                                        committed_meta);
+    neutral_commit.exeTaken = false;
+    ras->update(neutral_commit);
+
+    auto resumed_call = create_prediction(0x4000, 0x5000, true, false);
+    ras->specUpdateState(resumed_call);
+    check_return_target(0x5000, 0x4004);
+}
+
 } // namespace test
 } // namespace btb_pred
 } // namespace branch_prediction

--- a/src/cpu/pred/btb/test/ras_pop_push.test.cc
+++ b/src/cpu/pred/btb/test/ras_pop_push.test.cc
@@ -72,6 +72,11 @@ class RASPopPushTest : public ::testing::Test
         ras->update(create_stream(pc, target, true, false, meta));
     }
 
+    void reset_ras(unsigned inflight_entries) {
+        ras = std::make_unique<BTBRAS>(16, 3, inflight_entries);
+        check_return_target(0, 0x80000000L);
+    }
+
     std::unique_ptr<BTBRAS> ras;
 };
 
@@ -94,6 +99,45 @@ TEST_F(RASPopPushTest, CallReturnPopsBeforePushingInAllPaths) {
 
     ras->update(create_stream(0x3000, 0x2004, true, true, popPushMeta));
     check_return_target(0x2004, 0x3004);
+}
+
+TEST_F(RASPopPushTest, BlocksSpecUpdatesNearInflightOverflow) {
+    reset_ras(32);
+
+    std::shared_ptr<void> recovery_meta;
+    for (int i = 0; i < 31; ++i) {
+        const Addr call_pc = 0x1000 + i * 4;
+        check_return_target(call_pc,
+            i == 0 ? 0x80000000L : call_pc);
+        if (i == 20) {
+            recovery_meta = ras->getPredictionMeta();
+        }
+        auto call = create_prediction(call_pc, 0x4000 + i * 4,
+                                      true, false);
+        ras->specUpdateState(call);
+    }
+
+    // The 32nd call and a following return are ignored while 31 entries are
+    // occupied, matching the RTL near-overflow policy.
+    check_return_target(0x2000, 0x107c);
+    auto blocked_call = create_prediction(0x2000, 0x5000, true, false);
+    ras->specUpdateState(blocked_call);
+    check_return_target(0x5000, 0x107c);
+
+    auto blocked_return = create_prediction(0x5000, 0x107c, false, true);
+    ras->specUpdateState(blocked_return);
+    check_return_target(0x107c, 0x107c);
+
+    // Rolling back to an older prediction frees speculative entries and
+    // allows updates to resume.
+    auto recovery = create_stream(0x1050, 0, false, false, recovery_meta);
+    recovery.exeTaken = false;
+    ras->recoverState(recovery);
+    check_return_target(0x1050, 0x1050);
+
+    auto resumed_call = create_prediction(0x3000, 0x6000, true, false);
+    ras->specUpdateState(resumed_call);
+    check_return_target(0x6000, 0x3004);
 }
 
 } // namespace test


### PR DESCRIPTION
## Motivation

The BTB RAS model was substantially larger than the XiangShan RTL:

| Resource | Previous model | RTL / this PR |
| --- | ---: | ---: |
| Committed stack | 32 | 16 |
| Same-return counter width | 8 | 3 |
| Speculative queue | 384 | 32 |

This made return prediction capacity optimistic and made the speculative queue effectively unbounded for normal workloads.

## What changed

- Align the committed RAS stack and saturation counter with RTL defaults.
- Model the 32-entry speculative queue as a fixed ring addressed by monotonic logical pointers.
- Block speculative call/return updates near queue overflow, while allowing redirect rollback to release entries.
- Align the `BOS` retirement window with RTL: retain a committed push while younger entries may still reference it, and reclaim older predecessors on later commits.
- Preserve pop-before-push ordering for RISC-V `PopAndPush` JALR behavior.
- Add counters for blocked speculative updates, blocked redirects, and maximum inflight depth.

The model preserves the externally visible queue-capacity and recovery behavior with O(1) update paths. It does not reproduce RTL register/bypass timing cycle by cycle.

## Validation

- `scons build/RISCV/cpu/pred/btb/test/ras_pop_push.test.opt --unit-test -j64`
- `build/RISCV/cpu/pred/btb/test/ras_pop_push.test.opt`: 4/4 tests passed
- `scons build/RISCV/gem5.opt --gold-linker -j1`
- 100K-instruction CoreMark smoke with difftest: passed; 0 wrong / 207 correct RAS predictions
- `git diff --check`: passed

The unit tests cover pop-before-push ordering, near-overflow admission, committed-push retention at `BOS`, and predecessor reclamation at commit.

## Performance result

Candidate: [`28574e3e1d`](https://github.com/OpenXiangShan/GEM5/commit/28574e3e1dae20fd73f0a2449542b43b58ef2f26), `spec06-rva23-novec-gcc16-0.3c`  
Baseline: direct parent [`f63979dc6c`](https://github.com/OpenXiangShan/GEM5/commit/f63979dc6ccc57fc214e1e380750ab29e2c73b0b), same workload/profile and matching configuration  
Completeness: 145/145 slices and 0 aborts in every run

| Configuration | Suite | Baseline | Candidate | Change |
| --- | --- | ---: | ---: | ---: |
| `idealkmhv3` | SPECint | 22.54560 | 22.54934 | +0.0166% |
| `idealkmhv3` | SPECfp | 23.85671 | 23.84359 | -0.0550% |
| `idealkmhv3` | Overall | 23.30518 | 23.29926 | -0.0254% |
| `kmhv3` | SPECint | 20.54399 | 20.54052 | -0.0169% |
| `kmhv3` | SPECfp | 22.33778 | 22.33664 | -0.0051% |
| `kmhv3` | Overall | 21.57727 | 21.57512 | -0.0100% |

Runs:

- `idealkmhv3`: [baseline](https://github.com/OpenXiangShan/GEM5/actions/runs/33047849037), [candidate](https://github.com/OpenXiangShan/GEM5/actions/runs/33138651018)
- `kmhv3`: [baseline](https://github.com/OpenXiangShan/GEM5/actions/runs/33047849136), [candidate](https://github.com/OpenXiangShan/GEM5/actions/runs/33138653433)

### Benchmark breakdown

- `idealkmhv3`: the largest regressions are `dealII` (-0.980%), `gobmk` (-0.315%), and `xalancbmk` (-0.058%); the largest improvements are `gcc` (+0.313%) and `sjeng` (+0.233%).
- `kmhv3`: the largest regressions are `gobmk` (-0.265%), `xalancbmk` (-0.174%), and `povray` (-0.155%); the largest improvements are `sjeng` (+0.173%), `dealII` (+0.073%), and `gcc` (+0.063%).

### RAS counter evidence

| Configuration | RAS miss rate | Wrong predictions | `MispredWithSctr` | Queue blocking |
| --- | ---: | ---: | ---: | ---: |
| `idealkmhv3` baseline | 0.4435% | 85,239 | 11,319 | N/A |
| `idealkmhv3` candidate | 0.4938% | 94,904 | 11,353 | 305 events in 7 slices |
| `kmhv3` baseline | 0.3372% | 64,814 | 6,996 | N/A |
| `kmhv3` candidate | 0.3920% | 75,334 | 7,231 | 280 events in 10 slices |

Both candidate configurations reached a maximum speculative depth of 31. No redirect recovery was blocked. The increased return miss rate is therefore primarily attributable to the smaller committed capacity, while the 32-entry speculative queue limit is rarely exercised. Despite the expected return-miss increase, the overall score changes remain below 0.03%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved return-address prediction stability when speculative activity approaches capacity.
  * Preserved committed return-address state more reliably during rollbacks and commits.
  * Prevented overflow-related errors in deep speculative execution.

* **Performance**
  * Reduced default predictor resource usage while maintaining safe inflight-entry handling.

* **Tests**
  * Added coverage for near-capacity speculation, rollback recovery, committed stack entries, and inflight predecessor reclamation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->