### PR TITLE
cpu-o3: Fix folded history updates for large shifts

### DIFF
--- a/src/cpu/pred/btb/folded_hist.cc
+++ b/src/cpu/pred/btb/folded_hist.cc
@@ -121,19 +121,31 @@ DirectionFoldedHist::update(const boost::dynamic_bitset<> &ghr, int shamt, bool 
     }
     // Case 3: When folded length < history length
     else {
+        assert(shamt <= maxShamt);
         // Step 1: Handle the bits that would be lost in shift
         for (int i = 0; i < shamt; i++) {
             // XOR the highest bits from GHR with corresponding positions in folded history
             temp ^= (ghr[posHighestBitsInGhr[i]] << posHighestBitsInOldFoldedHist[i]);
         }
 
-        // Step 2: Perform the shift
-        temp <<= shamt;
+        if (shamt > foldedLen) {
+            // A shift wider than the folded history can wrap the retained
+            // bits more than once. Rotate by the effective shift instead of
+            // using the single-wrap fast path below.
+            const auto rotate = shamt % foldedLen;
+            if (rotate != 0) {
+                temp = ((temp << rotate) |
+                        (temp >> (foldedLen - rotate))) & foldedMask;
+            }
+        } else {
+            // Step 2: Perform the shift
+            temp <<= shamt;
 
-        // Step 3: Copy the XORed bits back to lower positions
-        for (int i = 0; i < shamt; i++) {
-            uint64_t highBit = (temp >> (foldedLen + i)) & 1;
-            temp |= (highBit << i);
+            // Step 3: Copy the XORed bits back to lower positions
+            for (int i = 0; i < shamt; i++) {
+                uint64_t highBit = (temp >> (foldedLen + i)) & 1;
+                temp |= (highBit << i);
+            }
         }
 
         // Step 4: Add new branch outcome

--- a/src/cpu/pred/btb/test/folded_hist.test.cc
+++ b/src/cpu/pred/btb/test/folded_hist.test.cc
@@ -1,7 +1,38 @@
 #include <gtest/gtest.h>
+
+#include <array>
+
 #include "cpu/pred/btb/folded_hist.hh"
 
 using namespace gem5::branch_prediction::btb_pred;
+
+namespace
+{
+
+uint64_t
+foldReference(const boost::dynamic_bitset<> &history, unsigned histLen,
+              unsigned foldedLen)
+{
+    uint64_t folded = 0;
+    for (unsigned i = 0; i < histLen; ++i) {
+        folded ^= static_cast<uint64_t>(history[i]) << (i % foldedLen);
+    }
+    return folded;
+}
+
+void
+initializeHistory(DirectionFoldedHist &folded,
+                  boost::dynamic_bitset<> &history, uint64_t value)
+{
+    for (int bit = history.size() - 1; bit >= 0; --bit) {
+        const bool taken = (value >> bit) & 1;
+        folded.update(history, 1, taken);
+        history <<= 1;
+        history[0] = taken;
+    }
+}
+
+}  // anonymous namespace
 
 class FoldedHistTest : public ::testing::Test {
 protected:
@@ -308,6 +339,45 @@ TEST_F(FoldedHistTest, MaxShift) {
     
     // Test shift amount less than maxShamt
     EXPECT_NO_THROW(hist.update(ghr, 1, true));
+}
+
+TEST_F(FoldedHistTest, ShiftWiderThanFoldedHistory) {
+    DirectionFoldedHist folded(16, 7, 16);
+    boost::dynamic_bitset<> history(16, 0);
+    initializeHistory(folded, history, 0x0051);
+
+    folded.update(history, 8, true);
+    history <<= 8;
+    history[0] = true;
+
+    EXPECT_EQ(history.to_ulong(), 0x5101);
+    EXPECT_EQ(folded.get(), 0x22);
+    EXPECT_EQ(folded.get(), foldReference(history, 16, 7));
+}
+
+TEST_F(FoldedHistTest, LargeShiftsMatchReferenceFold) {
+    constexpr std::array<uint64_t, 7> patterns = {
+        0x0000, 0x0001, 0x0051, 0x1234, 0x8001, 0xaaaa, 0xffff
+    };
+    constexpr std::array<int, 6> shifts = {7, 8, 9, 13, 14, 15};
+
+    for (const auto pattern : patterns) {
+        for (const auto shamt : shifts) {
+            for (const bool taken : {false, true}) {
+                DirectionFoldedHist folded(16, 7, 16);
+                boost::dynamic_bitset<> history(16, 0);
+                initializeHistory(folded, history, pattern);
+
+                folded.update(history, shamt, taken);
+                history <<= shamt;
+                history[0] = taken;
+
+                EXPECT_EQ(folded.get(), foldReference(history, 16, 7))
+                    << "pattern=" << pattern << " shamt=" << shamt
+                    << " taken=" << taken;
+            }
+        }
+    }
 }
 
 TEST_F(FoldedHistTest, BoundaryConditions) {


### PR DESCRIPTION
## Motivation

DirectionFoldedHist used a single-wrap update after shifting the folded value. That is correct only when shamt is no wider than foldedLen.

In the SMT MGSC configuration, table partitioning reduces a 16-bit G-history fold from 8 bits to 7 bits, while one prediction update can still contain 8 conditional branches. The resulting H=16, F=7, shamt=8 update makes the incremental fold diverge from a full recomputation. gem5.opt then aborts in FoldedHistBase::check; gem5.fast silently uses the wrong MGSC index.

## Change

- Remove outgoing history bits as before.
- For shamt > foldedLen, rotate the retained folded value by shamt modulo foldedLen before inserting the newest outcome.
- Keep the existing common shamt <= foldedLen path unchanged.
- Add an exact H=16, F=7, shamt=8 regression and oracle-based coverage for several large shifts and history patterns.

The edge path is O(shamt) with O(1) extra state and performs no dynamic allocation or full-history refold.

## Validation

- util/style.py -m
- scons build/RISCV/gem5.opt --gold-linker -j64
- folded_hist.test.opt: 12/12 passed
- mgsc.test.opt: 14/14 passed
- Pre-fix SMT gobmk reproductions:
  - gobmk_13x13_6366 aborted at tick 3,680,325,657, expected 0x0, actual 0x1
  - gobmk_trevorc_2978 aborted at tick 2,457,182,025, expected 0x43, actual 0x42
- With this change:
  - gobmk_13x13_6366 reached the configured 3,800,000,000 tick limit
  - gobmk_trevorc_2978 reached the configured 2,700,000,000 tick limit

Both post-fix runs used gem5.opt with the SMT ideal KMHv3 configuration and difftest enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folded-history updates for shift amounts larger than the folded-history length.
  * Ensured retained history bits are rotated correctly during large shifts.

* **Tests**
  * Added coverage for large-shift scenarios.
  * Added validation against reference folded-history calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->