### PR TITLE
cpu: Synchronize initial DUT state to difftest reference

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -240,7 +240,6 @@ BaseCPU::BaseCPU(const Params &p, bool is_checker)
             warn("Difftest is enabled with ref so: %s.\n",
                  params().difftest_ref_so.c_str());
 
-            diff_state->proxy->regcpy(&(diff_state->gem5RegFile), REF_TO_DUT);
             diff_state->diff.dynamic_config.ignore_illegal_mem_access = false;
             diff_state->diff.dynamic_config.debug_difftest = false;
             diff_state->proxy->update_config(&diff_state->diff.dynamic_config);
@@ -432,6 +431,78 @@ BaseCPU::startup()
     }
     diffInfo.scalarResults.resize(MaxDestRegisters);
 
+    if (enableDifftest && !_switchedOut) {
+        for (ThreadID tid = 0; tid < numThreads; ++tid) {
+            captureDifftestState(tid);
+        }
+    }
+
+}
+
+void
+BaseCPU::captureDifftestState(ThreadID tid)
+{
+    auto &state = diffAllStates[tid]->gem5RegFile;
+    state = {};
+    readGem5Regs(tid);
+
+    state.mode = readMiscRegNoEffect(RiscvISA::MISCREG_PRV, tid);
+    state.mstatus = readMiscRegNoEffect(RiscvISA::MISCREG_STATUS, tid);
+    state.sstatus = state.mstatus & RiscvISA::NEMU_SSTATUS_RMASK;
+    state.mepc = readMiscRegNoEffect(RiscvISA::MISCREG_MEPC, tid);
+    state.sepc = readMiscRegNoEffect(RiscvISA::MISCREG_SEPC, tid);
+    state.mtval = readMiscRegNoEffect(RiscvISA::MISCREG_MTVAL, tid);
+    state.stval = readMiscRegNoEffect(RiscvISA::MISCREG_STVAL, tid);
+    state.mtvec = readMiscRegNoEffect(RiscvISA::MISCREG_MTVEC, tid);
+    state.stvec = readMiscRegNoEffect(RiscvISA::MISCREG_STVEC, tid);
+    state.mcause = readMiscRegNoEffect(RiscvISA::MISCREG_MCAUSE, tid);
+    state.scause = readMiscRegNoEffect(RiscvISA::MISCREG_SCAUSE, tid);
+    state.satp = readMiscRegNoEffect(RiscvISA::MISCREG_SATP, tid);
+    state.mip = readMiscReg(RiscvISA::MISCREG_IP, tid);
+    state.mie = readMiscReg(RiscvISA::MISCREG_IE, tid);
+    state.mscratch = readMiscRegNoEffect(RiscvISA::MISCREG_MSCRATCH, tid);
+    state.sscratch = readMiscRegNoEffect(RiscvISA::MISCREG_SSCRATCH, tid);
+    state.mideleg = readMiscRegNoEffect(RiscvISA::MISCREG_MIDELEG, tid);
+    state.medeleg = readMiscRegNoEffect(RiscvISA::MISCREG_MEDELEG, tid);
+    state.pc = threadContexts[tid]->pcState().instAddr();
+
+    state.v = readMiscRegNoEffect(RiscvISA::MISCREG_VIRMODE, tid);
+    state.mtval2 = readMiscRegNoEffect(RiscvISA::MISCREG_MTVAL2, tid);
+    state.mtinst = readMiscRegNoEffect(RiscvISA::MISCREG_MTINST, tid);
+    state.hstatus = readMiscRegNoEffect(RiscvISA::MISCREG_HSTATUS, tid);
+    state.hideleg = readMiscReg(RiscvISA::MISCREG_HIDELEG, tid);
+    state.hedeleg = readMiscRegNoEffect(RiscvISA::MISCREG_HEDELEG, tid);
+    state.hcounteren =
+        readMiscRegNoEffect(RiscvISA::MISCREG_HCOUNTEREN, tid);
+    state.htval = readMiscRegNoEffect(RiscvISA::MISCREG_HTVAL, tid);
+    state.htinst = readMiscRegNoEffect(RiscvISA::MISCREG_HTINST, tid);
+    state.hgatp = readMiscRegNoEffect(RiscvISA::MISCREG_HGATP, tid);
+    state.vsstatus = readMiscRegNoEffect(RiscvISA::MISCREG_VSSTATUS, tid);
+    state.vstvec = readMiscRegNoEffect(RiscvISA::MISCREG_VSTVEC, tid);
+    state.vsepc = readMiscRegNoEffect(RiscvISA::MISCREG_VSEPC, tid);
+    state.vscause = readMiscRegNoEffect(RiscvISA::MISCREG_VSCAUSE, tid);
+    state.vstval = readMiscRegNoEffect(RiscvISA::MISCREG_VSTVAL, tid);
+    state.vsatp = readMiscRegNoEffect(RiscvISA::MISCREG_VSATP, tid);
+    state.vsscratch =
+        readMiscRegNoEffect(RiscvISA::MISCREG_VSSCRATCH, tid);
+
+    state.vstart = readMiscRegNoEffect(RiscvISA::MISCREG_VSTART, tid);
+    state.vxsat = readMiscRegNoEffect(RiscvISA::MISCREG_VXSAT, tid);
+    state.vxrm = readMiscRegNoEffect(RiscvISA::MISCREG_VXRM, tid);
+    state.vcsr = readMiscReg(RiscvISA::MISCREG_VCSR, tid);
+    state.vl = readMiscRegNoEffect(RiscvISA::MISCREG_VL, tid);
+    state.vtype = readMiscRegNoEffect(RiscvISA::MISCREG_VTYPE, tid);
+    state.vlenb = readMiscReg(RiscvISA::MISCREG_VLENB, tid);
+
+    state.fcsr =
+        (readMiscRegNoEffect(RiscvISA::MISCREG_FFLAGS, tid) &
+         RiscvISA::FFLAGS_MASK) |
+        ((readMiscRegNoEffect(RiscvISA::MISCREG_FRM, tid) &
+          RiscvISA::FRM_MASK) << RiscvISA::FRM_OFFSET);
+
+    DPRINTF(Diff,
+            "Captured initial DUT state for tid %d: pc %#lx, mstatus %#lx\n",
+            tid, state.pc, state.mstatus);
 }
 
 void
@@ -1728,10 +1799,16 @@ BaseCPU::difftestStep(ThreadID tid, InstSeqNum seq)
 
     if (fence_should_diff || amo_should_diff || is_sc || other_should_diff || lr_should_diff) {
         should_diff = true;
-        if (!diffAllStates->hasCommit && diffInfo.pc->instAddr() == 0x80000000u) {
+        if (!diffAllStates->hasCommit) {
+            // The snapshot was captured before the DUT retired this
+            // instruction, so both DUT and REF execute it exactly once.
+            fatal_if(diffAllStates->gem5RegFile.pc !=
+                         diffInfo.pc->instAddr(),
+                     "Difftest initial state PC %#lx does not match first "
+                     "committed instruction PC %#lx for tid %d",
+                     diffAllStates->gem5RegFile.pc,
+                     diffInfo.pc->instAddr(), tid);
             diffAllStates->hasCommit = true;
-            readGem5Regs(tid);
-            diffAllStates->gem5RegFile.pc = diffInfo.pc->instAddr();
             if (noHypeMode) {
                 auto start = pmemStart + pmemSize * difftestHartId(tid);
                 diffAllStates->proxy->memcpy(0x80000000u, start, pmemSize, DUT_TO_REF);

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -219,7 +219,6 @@ BaseCPU::BaseCPU(const Params &p, bool is_checker)
             diffAllStates[tid] = std::make_shared<DiffAllStates>();
             auto diff_state = diffAllStates[tid];
             diff_state->diff.nemu_reg = &(diff_state->referenceRegFile);
-            diff_state->diff.nemu_this_pc = 0x80000000u;
             diff_state->diff.cpu_id = difftestHartId(tid);
             warn("difftest hart id set to %d for tid %d\n",
                  diff_state->diff.cpu_id, tid);
@@ -1808,6 +1807,8 @@ BaseCPU::difftestStep(ThreadID tid, InstSeqNum seq)
                      "committed instruction PC %#lx for tid %d",
                      diffAllStates->gem5RegFile.pc,
                      diffInfo.pc->instAddr(), tid);
+            diffAllStates->diff.nemu_this_pc =
+                diffAllStates->gem5RegFile.pc;
             diffAllStates->hasCommit = true;
             if (noHypeMode) {
                 auto start = pmemStart + pmemSize * difftestHartId(tid);

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -128,11 +128,12 @@ class CPUProgressEvent : public Event
 
 struct DiffAllStates
 {
-    riscv64_CPU_regfile gem5RegFile;
-    riscv64_CPU_regfile referenceRegFile;
-    DiffState diff;
-    RefProxy *proxy;
+    riscv64_CPU_regfile gem5RegFile{};
+    riscv64_CPU_regfile referenceRegFile{};
+    DiffState diff{};
+    RefProxy *proxy{nullptr};
 
+    // Mirrors RTL difftest's first-commit reference initialization state.
     bool hasCommit{false};
 };
 
@@ -721,6 +722,12 @@ class BaseCPU : public ClockedObject
     {
         panic("difftest:readGem5Regs() is not implemented\n");
     }
+
+    /**
+     * Capture the DUT state from which the reference executes its first
+     * instruction. This must run before the DUT retires any instruction.
+     */
+    void captureDifftestState(ThreadID tid);
 
     void csrDiffMessage(uint64_t gem5_val, uint64_t ref_val, int error_num, uint64_t &error_reg, InstSeqNum seq,
                         std::string error_csr_name,int &diff_at);

--- a/src/cpu/difftest.hh
+++ b/src/cpu/difftest.hh
@@ -79,6 +79,9 @@ struct riscv64_CPU_regfile
     uint64_t vxsat, vxrm, vcsr;
     uint64_t vl, vtype, vlenb;
 
+    // Optional in NEMU, but enabled by riscv64-gem5-ref_defconfig.
+    uint64_t fcsr;
+
 
     uint64_t& operator[](int x) {
         assert(x<64);

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -527,6 +527,8 @@ BaseSimpleCPU::readGem5Regs(ThreadID tid)
             threadContexts[tid]->getReg(RegId(IntRegClass, i));
         diffAllStates->gem5RegFile[i + 32] =
             threadContexts[tid]->getReg(RegId(FloatRegClass, i));
+        threadContexts[tid]->getReg(
+            RegId(VecRegClass, i), &diffAllStates->gem5RegFile.vr[i]);
     }
 }
 


### PR DESCRIPTION
## Background

This change fixes a long-standing ambiguity at the difftest initialization boundary.

`mstatus.FS` describes the current floating-point context state (`Off`, `Initial`, `Clean`, or `Dirty`); it is not a capability bit. The RISC-V privileged specification defines the meaning and state transitions of this field, but two implementations are not required to select the same legal reset encoding. In practice, the pinned NEMU ref-so used by our CI starts with `FS=Off`, while a newer NEMU build starts with `FS=Initial`. GEM5 and NEMU can therefore both have legal initial states and still fail their first strict `mstatus` comparison.

This is not specific to `FS`: any independently selected architectural reset value can create the same class of failure. The difftest invariant should be:

1. choose the DUT's architectural state as the common initial state;
2. initialize REF from that state once, before REF executes the first instruction;
3. execute each instruction exactly once on DUT and REF;
4. compare the resulting architectural states strictly.

Accordingly, this PR does **not** force `FS` to zero, mask `FS` from comparison, or relax CSR checking. It establishes a shared initial state and retains strict checking afterward.

RISC-V reference: [Extension Context Status in `mstatus`](https://docs.riscv.org/reference/isa/priv/machine.html#extension-context-status-in-mstatus-register).

## Reference design: XiangShan RTL difftest

The XiangShan RTL difftest framework already follows this model. Its [`FirstInstrCommitChecker`](https://github.com/OpenXiangShan/difftest/blob/master/src/test/csrc/difftest/checkers/instructions.cpp#L20-L41) handles the first committed instruction by:

- copying DUT memory to REF;
- calling `regcpy(..., FIRST_INST_ADDRESS)` to initialize REF from the DUT-provided register state;
- then entering the normal step-and-compare flow.

The corresponding [`RefProxy::regcpy`](https://github.com/OpenXiangShan/difftest/blob/master/src/test/csrc/difftest/refproxy.cpp) transfers the complete architectural state exposed by the difftest interface, including integer, floating-point, vector, CSR, hypervisor CSR, vector CSR, and FCSR state.

The important contract is temporal: the state copied to REF is the DUT state **before the first instruction**, rather than state reread after that instruction has committed.

## Previous GEM5 behavior

GEM5 previously initialized difftest in two stages:

1. During CPU construction, `REF_TO_DUT` copied NEMU's reset state into the host-side `gem5RegFile` buffer.
2. At the first comparable commit, GEM5 reread only GPR/FPR/vector registers from its committed state and sent the whole buffer back with `DUT_TO_REF`.

This caused two independent problems.

### 1. REF reset values leaked into the common state

CSR fields that were not overwritten at the first commit, including `mstatus.FS`, remained values originally read from NEMU. Changing NEMU's reset policy could therefore change GEM5 difftest behavior even though GEM5 itself had not changed.

### 2. The first instruction could be executed from the wrong state

`difftestStep()` runs after GEM5 has committed the current instruction. Rereading the committed register map at that point obtains the post-instruction state `S1`, not the pre-instruction state `S0`. If REF is initialized with `S1` and then asked to execute the same instruction, the sequence becomes:

```text
GEM5: S0 --instruction--> S1
REF:  S1 --instruction--> S2
compare S1 with S2
```

Many common first instructions overwrite their destination and can hide this issue. A state-dependent instruction such as `addi t0, t0, 1` exposes it immediately.

The old path also depended on a hard-coded `PC == 0x80000000` condition, which tied initialization to one boot address rather than to the actual first comparable commit.

## New synchronization flow

This PR aligns GEM5 with the RTL difftest contract:

```text
CPU startup, after initial/restored state is installed:
    capture complete DUT state S0

first comparable commit of instruction I:
    GEM5 has executed I: S0 -> S1
    copy memory and captured S0 to REF
    execute I once on REF: S0 -> R1
    compare S1 with R1
```

Concretely, the change:

- captures GPR, FPR, vector registers, privilege mode, PC, CSR, hypervisor CSR, vector CSR, and FCSR state in `BaseCPU::startup()`, before any instruction retires;
- initializes REF from that saved snapshot at the first comparable commit;
- removes the constructor-time `REF_TO_DUT` seed and the post-commit register reread;
- removes the hard-coded `0x80000000` initialization gate;
- verifies that the captured initial PC matches the first committed instruction PC, so a stale or incorrectly timed snapshot fails explicitly instead of silently synchronizing the wrong state;
- adds initial vector-state capture for SimpleCPU;
- includes the `fcsr` field enabled by NEMU's normal `riscv64-gem5-ref_defconfig` and zero-initializes difftest state storage.

## Scope and review notes

- The behavioral change is limited to the `enableDifftest` path.
- GEM5's architectural reset values are unchanged.
- NEMU's reset values and execution semantics are unchanged.
- `mstatus`, including `FS`, remains part of strict difftest comparison after the one-time initialization.
- Checkpoint/restorer state is treated the same way as boot state: the restored DUT state is the source of truth for the initial REF snapshot.
- The first-PC assertion is intentional. If software or a restore path changes architectural state between `startup()` and the first comparable commit, that path needs an explicit recapture point rather than silently using a mismatched snapshot.

## Validation

### Build and style

- `git diff --check`
- `scons build/RISCV/gem5.opt --gold-linker -j64`

### Targeted first-instruction regression

Used a raw image whose first instruction is `c.addi t0, t0, 1`, followed by repeated increments. This specifically detects copying post-commit state to REF.

- pinned CI reference with `mstatus.FS=Off`: passed 10 commits;
- NEMU master `39d120ce` built with `riscv64-gem5-ref_defconfig`, with `mstatus.FS=Initial`: passed 10 commits;
- debug trace confirmed startup captured `pc=0x80000000, mstatus=0xa00000000` from GEM5 and that both models produced `t0=1`, then `2`, then `3` after the same instructions.

### Longer smoke test

- CoreMark raw image with the `FS=Initial` NEMU reference: passed 10,000 committed instructions under difftest.

Temporary NEMU reference SHA-256 used for the `FS=Initial` checks:

```text
1553e6c71592c4eec2784b8cc04c9c3491f9ea8a8987a5c66d4db535356f895a
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved RISC-V differential testing initialization with comprehensive CPU state capture, including integer, floating-point, vector, control/status, hypervisor, privilege, and PC state.
  * Added validation that the initial PC matches the first committed instruction.
  * Extended vector register snapshot support for SimpleCPU.

* **Bug Fixes**
  * Improved first-instruction synchronization between the DUT and reference model.
  * Reduced reliance on reset CSR values during initial synchronization.

* **Maintenance**
  * Improved initialization of differential-testing state and removed hard-coded initial PC setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
