### PR TITLE
cpu: Remove unused BTB parameters [skip ci]

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -987,8 +987,6 @@ class MBTB(TimedBaseBTBPredictor):
 
     numEntries = Param.Unsigned(8192, "Number of entries in the MBTB")
     tagBits = Param.Unsigned(16, "Number of bits in the tag")
-    instShiftAmt = Param.Unsigned(1, "Amount to shift PC to get inst bits")
-    numThreads = Param.Unsigned(1, "Number of threads")
     numWays = Param.Unsigned(4, "Number of ways per set") # for 2 SRAMs, 4 ways per SRAM
     numDelay = 2
     blockSize = 32  # max 64 byte block, 32 byte aligned
@@ -1002,11 +1000,9 @@ class AheadBTB(TimedBaseBTBPredictor):
 
     numEntries = Param.Unsigned(1024, "Number of entries in the BTB")
     tagBits = Param.Unsigned(24, "Number of bits in the tag")
-    instShiftAmt = Param.Unsigned(1, "Amount to shift PC to get inst bits")
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     numWays = Param.Unsigned(4, "Number of ways per set")
     aheadPipelinedStages = Param.Unsigned(1, "Number of stages ahead pipelined")
-    entryHalfAligned = Param.Bool(False, "Whether the entries are half-aligned")
     blockSize = 64
     numDelay = 0
     usingS3Pred = Param.Bool(True, "Whether using S3 predictor to update AheadBTB")
@@ -1019,7 +1015,6 @@ class UBTB(TimedBaseBTBPredictor):
     numEntries = Param.Unsigned(32, "Number of entries in the uBTB")
     tagBits = Param.Unsigned(22, "Number of bits in the tag")
 
-    aheadPipelinedStages = Param.Unsigned(0, "Number of stages ahead pipelined")
     numDelay = 0
     usingS3Pred = Param.Bool(True, "Whether using S3 predictor to update uBTB")
     # blockSize = 32  not used in uBTB
@@ -1085,7 +1080,6 @@ class MicroTAGE(TimedBaseBTBPredictor):
     cxx_class = 'gem5::branch_prediction::btb_pred::MicroTAGE'
     cxx_header = "cpu/pred/btb/microtage.hh"
 
-    enableSC = Param.Bool(False, "Enable SC or not")
     updateOnRead = Param.Bool(True,"Enable update on read, no need to save tage meta in FTQ")
     usingS3Pred = Param.Bool(False, "Whether using final-stage prediction to teacher-update MicroTAGE")
     # Keep vector parameters consistent with numPredictors to avoid constructor asserts.
@@ -1097,12 +1091,8 @@ class MicroTAGE(TimedBaseBTBPredictor):
 
     histLengths = VectorParam.Unsigned([5,9] ,"the BTB TAGE T0~Tn history length")
     maxHistLen = Param.Unsigned(970,"The length of history passed from DBP")
-    numTablesToAlloc = Param.Unsigned(1,"The number of table to allocated each time")
     numWays = Param.Unsigned(1, "Number of ways per set")
-    baseTableSize = Param.Unsigned(512,"Base table size")
     maxBranchPositions = Param.Unsigned(32,"Maximum branch positions per 64-byte block")
-    useAltOnNaSize = Param.Unsigned(128,"Size of the useAltOnNa table")
-    useAltOnNaWidth = Param.Unsigned(7,"Width of the useAltOnNa table")
     numBanks = Param.Unsigned(4,"Number of banks for bank conflict simulation")
     enableBankConflict = Param.Bool(False,"Enable bank conflict simulation")
     numDelay = 0


### PR DESCRIPTION
## Motivation

Several BTB predictor parameters were exposed through `BranchPredictor.py` but never read by their C++ implementations. Keeping these parameters makes configuration changes appear effective when they cannot affect the model.

## Approach

Remove the unused Python SimObject parameters from MBTB, AheadBTB, UBTB, and MicroTAGE. Parameters that are consumed by C++ remain unchanged.

## Scope

This only narrows the configuration interface. It does not change predictor state, timing, capacity, indexing, update behavior, or statistics.

## Validation

- Confirmed no repository configuration references the removed parameters
- Checked Python syntax with `compile()`
- Regenerated SimObject parameter interfaces
- Built successfully with `scons build/RISCV/gem5.opt --gold-linker -j64`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed several configuration options from branch prediction components, including BTB alignment, threading, pipelining, and MicroTAGE tuning parameters.
  * Existing configurations that reference these options may need to be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->