### PR TITLE
tests,util: Fall back when distributed runners are busy

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -280,7 +280,7 @@ jobs:
           CONFIG_NAME=$(printf '%s' "$CONFIG_NAME" | tr -c 'A-Za-z0-9._-' '_')
           CONFIG_NAME=${CONFIG_NAME:-config}
           TARGET_DIR="${BENCHMARK_DIR}/${TIMESTAMP}_${COMMIT_SHORT}_${CONFIG_NAME}_run${RUN_NUMBER}"
-          DEFAULT_DISTRIBUTED_SERVERS="node020-node029,node033-node034,node036-node039"
+          DEFAULT_DISTRIBUTED_SERVERS="node003-node008,node020-node029,node033-node034,node036-node039"
           DISTRIBUTED_SERVERS_INPUT="$DISTRIBUTED_SERVERS_RAW"
           DISTRIBUTED_SERVERS=$(echo "$DISTRIBUTED_SERVERS_INPUT" | xargs)
           if [ "$DISTRIBUTED_SERVERS" = "default" ]; then
@@ -390,9 +390,20 @@ jobs:
             } >> "$PERF_ARCHIVE_DIR/metadata.txt"
           fi
 
+          run_local_parallel() {
+            echo "Using local parallel_sim.sh runner"
+            bash "$GEM5_HOME/util/xs_scripts/parallel_sim.sh" "$(realpath "$CONFIG_PATH")" \
+              "$CHECKPOINT_LIST" \
+              "$CHECKPOINT_ROOT_NODE" \
+              spec_all \
+              "$SPECIFIC_BENCHMARKS_INPUT" \
+              "$extra_args"
+          }
+
           distributed_servers="$DISTRIBUTED_SERVERS"
           if [ -n "$distributed_servers" ]; then
             echo "Using distributed gem5 runner on servers: $distributed_servers"
+            distributed_status=0
             python3 "$GEM5_HOME/util/xs_scripts/distributed_sim.py" \
               --servers "$distributed_servers" \
               --jobs-per-server "$DISTRIBUTED_JOBS_PER_SERVER" \
@@ -410,15 +421,16 @@ jobs:
               "$CHECKPOINT_ROOT_NODE" \
               spec_all \
               "$SPECIFIC_BENCHMARKS_INPUT" \
-              "$extra_args"
+              "$extra_args" || distributed_status=$?
+
+            if [ "$distributed_status" -eq 75 ]; then
+              echo "::warning title=Distributed servers unavailable::Falling back to local parallel_sim.sh"
+              run_local_parallel
+            elif [ "$distributed_status" -ne 0 ]; then
+              exit "$distributed_status"
+            fi
           else
-            echo "Using local parallel_sim.sh runner"
-            bash "$GEM5_HOME/util/xs_scripts/parallel_sim.sh" "$(realpath "$CONFIG_PATH")" \
-              "$CHECKPOINT_LIST" \
-              "$CHECKPOINT_ROOT_NODE" \
-              spec_all \
-              "$SPECIFIC_BENCHMARKS_INPUT" \
-              "$extra_args"
+            run_local_parallel
           fi
       - name: Setup gem5_data_proc environment
         run: |

--- a/util/xs_scripts/distributed_sim.py
+++ b/util/xs_scripts/distributed_sim.py
@@ -32,7 +32,12 @@ DEFAULT_MARKER_TIMEOUT_SEC = 30.0
 DEFAULT_LAUNCH_RETRIES = 2
 DEFAULT_LAUNCH_RETRY_DELAY_SEC = 20.0
 DEFAULT_LAUNCH_INTERVAL_SEC = 0.2
+NO_ELIGIBLE_SERVERS_EXIT_CODE = 75
 ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class NoEligibleServersError(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -841,7 +846,7 @@ def filter_servers_by_idle(
             f"{server.name}: {server.idle_probe_error or server.idle_cpus}"
             for server in servers
         )
-        raise RuntimeError(
+        raise NoEligibleServersError(
             f"no servers satisfy --require-idle-cpus={require_idle_cpus}. {details}"
         )
     return selected
@@ -1300,6 +1305,9 @@ def main(argv: list[str]) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main(sys.argv[1:]))
+    except NoEligibleServersError as exc:
+        print(f"distributed_sim.py: error: {exc}", file=sys.stderr)
+        raise SystemExit(NO_ELIGIBLE_SERVERS_EXIT_CODE)
     except Exception as exc:
         print(f"distributed_sim.py: error: {exc}", file=sys.stderr)
         raise SystemExit(1)


### PR DESCRIPTION
## Motivation

Performance CI currently fails immediately when no distributed server has enough idle physical cores, even though the existing single-runner path can still make progress.

## Changes

- add node003-node008 to the default distributed performance pool
- return exit code 75 specifically when no server passes the idle check
- fall back to the existing local parallel_sim.sh path only for that condition
- keep all other distributed runner errors fatal

## Validation

- python3 -m py_compile util/xs_scripts/distributed_sim.py
- parsed gem5-perf-template.yml with PyYAML
- checked the embedded workflow script with bash -n
- verified node003-node008 range expansion
- verified no eligible server exits with 75
- verified an unrelated launcher error still exits with 1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved simulation workflow resilience when no eligible distributed servers are available.
  - Jobs now automatically fall back to local parallel execution in supported server-availability scenarios.
  - Other distributed execution failures continue to report their original failure status.

- **Improvements**
  - Expanded the default distributed server pool to include additional compute nodes.
  - Added clearer handling and reporting for cases where server eligibility filters match no available servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->