### PR TITLE
cpu-o3: Align FP divide resources and timing with XiangShan RTL

### DIFF
--- a/configs/common/FUScheduler.py
+++ b/configs/common/FUScheduler.py
@@ -243,16 +243,14 @@ class KMHV3Scheduler(Scheduler):
     __fpIQs = [
         IssueQue(name='fpIQ0', inports=2, size=18, oports=[
             IssuePort(fu=[FP_ALU(), FP_MISC(), FP_MAC()],
-                      rp=[FpRD(0,0), FpRD(1, 0), FpRD(2,0)]),
-            IssuePort(fu=[FP_SLOW()],
-                      rp=[FpRD(2,1), FpRD(5,1)])
+                      rp=[FpRD(0,0), FpRD(1, 0), FpRD(2,0)])
         ]),
         IssueQue(name='fpIQ1', inports=2, size=18, oports=[
-            IssuePort(fu=[FP_ALU(), FP_MAC()],
+            IssuePort(fu=[FP_ALU(), FP_MAC(), FP_SLOW()],
                       rp=[FpRD(3,0), FpRD(4,0), FpRD(5,0)])
         ]),
         IssueQue(name='fpIQ2', inports=2, size=18, oports=[
-            IssuePort(fu=[FP_ALU(), FP_MAC()],
+            IssuePort(fu=[FP_ALU(), FP_MAC(), FP_SLOW()],
                       rp=[FpRD(6,0), FpRD(7,0), FpRD(8,0)])
         ]),
         IssueQue(name='fpIQ3', inports=2, size=18, oports=[

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -87,7 +87,9 @@ class IntMult(FUDesc):
     opList = [ OpDesc(opClass='IntMult', opLat=3) ]
 
 class FP_SLOW(FUDesc):
-    opList = [ OpDesc(opClass='FloatDiv', opLat=14),
+    # XiangShan's scalar divider accepts one operation at a time and keeps
+    # the FEX divider token busy until the result is bypassed.
+    opList = [ OpDesc(opClass='FloatDiv', opLat=14, pipelined=False),
                OpDesc(opClass='FloatSqrt', opLat=17)]
 
 class FP_ALU(FUDesc):

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1211,6 +1211,18 @@ CPU::getReg(VirtRegId virt_reg)
     return regFile.getReg(virt_reg);
 }
 
+RegVal
+CPU::peekReg(PhysRegIdPtr phys_reg) const
+{
+    return regFile.getReg(phys_reg);
+}
+
+RegVal
+CPU::peekReg(VirtRegId virt_reg) const
+{
+    return regFile.getReg(virt_reg);
+}
+
 void
 CPU::getReg(PhysRegIdPtr phys_reg, void *val)
 {

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -345,6 +345,9 @@ class CPU : public BaseCPU
 
     RegVal getReg(PhysRegIdPtr phys_reg);
     RegVal getReg(VirtRegId phys_reg);
+    /** Read a physical register without charging the architectural RF-read statistic. */
+    RegVal peekReg(PhysRegIdPtr phys_reg) const;
+    RegVal peekReg(VirtRegId virt_reg) const;
     void getReg(PhysRegIdPtr phys_reg, void *val);
     void getReg(VirtRegId phys_reg, void *val);
     void *getWritableReg(PhysRegIdPtr phys_reg);

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -539,6 +539,14 @@ class DynInst : public ExecContext, public RefCounted
     int issueportid = -1;
     int iqtag = -1;
 
+    // Cached semantic latency for a dynamic floating-point divide.  The
+    // value is computed after the renamed source operands are available and
+    // reused by issue-port arbitration, execution, and wakeup scheduling.
+    mutable int fdivLatency = -1;
+
+    int getFdivLatency() const { return fdivLatency; }
+    void setFdivLatency(int latency) const { fdivLatency = latency; }
+
   public:
     /** Records changes to result? */
     void recordResult(bool f) { instFlags[RecordResult] = f; }

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -2069,6 +2069,76 @@ uint32_t
 Scheduler::getOpLatency(const DynInstPtr& inst)
 {
     if (inst->opClass() == FloatDivOp) [[unlikely]] {
+        if (inst->staticInst->operWid() == 64) {
+            const int cached = inst->getFdivLatency();
+            if (cached >= 0) {
+                return cached;
+            }
+
+            // Speculative wakeup can make an instruction selectable before a
+            // producer has placed its value in the physical register file.
+            // Do not classify stale data; use the normal path until both
+            // source registers are architecturally available, then cache the
+            // semantic result for all subsequent timing decisions.
+            for (int i = 0; i < inst->numSrcRegs(); ++i) {
+                const auto src = inst->renamedSrcIdx(i);
+                if (!src->isFixedMapping() &&
+                    !bypassScoreboard[src->flatIndex()]) {
+                    return 12;
+                }
+            }
+
+            // Read the renamed physical registers so an out-of-order
+            // producer is observed at the same point as normal execution.
+            const uint64_t opa = cpu->peekReg(inst->renamedSrcIdx(0));
+            const uint64_t opb = cpu->peekReg(inst->renamedSrcIdx(1));
+            const uint64_t opaExp = (opa >> 52) & 0x7ff;
+            const uint64_t opbExp = (opb >> 52) & 0x7ff;
+            const uint64_t opaFrac = opa & ((uint64_t(1) << 52) - 1);
+            const uint64_t opbFrac = opb & ((uint64_t(1) << 52) - 1);
+
+            const bool opaZero = opaExp == 0 && opaFrac == 0;
+            const bool opbZero = opbExp == 0 && opbFrac == 0;
+            const bool opaInf = opaExp == 0x7ff && opaFrac == 0;
+            const bool opbInf = opbExp == 0x7ff && opbFrac == 0;
+            const bool opaNan = opaExp == 0x7ff && opaFrac != 0;
+            const bool opbNan = opbExp == 0x7ff && opbFrac != 0;
+
+            // This is the same early-finish partition used by the RTL:
+            // NaN, invalid (Inf/Inf or 0/0), Inf result, or exact zero.
+            const bool invalid = (opaInf && opbInf) ||
+                                 (opaZero && opbZero);
+            const bool earlyFinish = opaNan || opbNan || invalid ||
+                                     opaInf || opbZero || opaZero || opbInf;
+
+            uint32_t latency = 12;
+            if (earlyFinish || (!opbInf && !opbZero && opbFrac == 0)) {
+                latency = 4;
+            } else if (opaExp == 0 || opbExp == 0) {
+                latency = 13;
+            } else {
+                // For normal finite operands, the quotient exponent is
+                // determined by the unbiased exponent difference and the
+                // significand comparison.  An exponent below -1022 means
+                // the RTL takes its extra denormal post-processing cycle.
+                const uint64_t opaSig = (uint64_t(1) << 52) | opaFrac;
+                const uint64_t opbSig = (uint64_t(1) << 52) | opbFrac;
+                int quotientExp = static_cast<int>(opaExp) - 1023 -
+                                   (static_cast<int>(opbExp) - 1023);
+                if (opaSig < opbSig) {
+                    --quotientExp;
+                }
+                if (quotientExp < -1022) {
+                    latency = 13;
+                }
+            }
+            inst->setFdivLatency(latency);
+            DPRINTF(Schedule,
+                    "[sn:%llu] semantic fdiv latency opLat=%u "
+                    "(AtFU->bypass=%u), opa=%#lx opb=%#lx\n",
+                    inst->seqNum, latency, latency - 1, opa, opb);
+            return latency;
+        }
         if (inst->staticInst->operWid() == 32) {
             return 11;
         }


### PR DESCRIPTION
# Motivation

The XiangShan RTL has two independent non-pipelined scalar FP divider instances in FEX1 and FEX2. The previous GEM5 configuration exposed only one FP_SLOW divider, which serialized independent fdiv.d instructions and caused large performance distortion on FDiv-intensive workloads.

The RTL divider also has operand-dependent completion paths, while GEM5 used a single fixed latency for all scalar FP divides.

## Changes

- Map FP_SLOW to fpIQ1 and fpIQ2, matching the two RTL divider units.
- Mark FloatDiv as non-pipelined so each divider remains occupied until result bypass/writeback.
- Model operand-dependent latency for 64-bit floating-point division across special-value, power-of-two, normal finite, and subnormal-related paths.
- Keep scheduling and completion timing consistent for each dynamic divide.

## Validation

Build:

    scons build/RISCV/gem5.opt --gold-linker -j64

40M-instruction checkpoint runs:

| Slice | Baseline GEM5 IPC | Updated GEM5 IPC | RTL IPC | Baseline vs RTL | Updated vs RTL |
|---|---:|---:|---:|---:|---:|
| leslie3d_62308 | 4.776399 | 3.139892 | 3.342665 | +42.89% | -6.07% |
| leslie3d_18494 | 4.472812 | 3.054794 | 3.144603 | +42.24% | -2.86% |

Baseline GEM5 IPC is calculated from the normal m5out/stats.txt results collected before this change. Each GEM5 IPC combines the two 20M-instruction statistics sections, so both GEM5 columns use the same 40M-instruction scope as the RTL results. This change reduces the GEM5-to-RTL gap from more than 42% above RTL to within 6.07% and 2.86% below RTL for the two slices.

## Scope

This is a behavior-level model of divider resource count and main operand-dependent completion paths. RTL outValidAhead3Cycle speculative wakeup is not enabled in GEM5 because the current model does not provide a corresponding early result-data bypass path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved simulation accuracy for 64-bit floating-point division by accounting for operand-dependent execution latency.
  - Updated floating-point division scheduling to reflect non-pipelined divider behavior and result availability.
  - Consolidated floating-point execution resources to better represent how division operations are handled across scheduler ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->