### PR TITLE
arch-riscv: implement Zawrs wrs.nto and wrs.sto instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2453,6 +2453,33 @@ decode QUADRANT {
                             return std::make_shared<BreakpointFault>(
                                 xc->pcState());
                         }}, IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                        0xd: decode RS1 {
+                            0x0: decode RD {
+                                0x0: wrs_nto({{
+                                    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                                    HSTATUS hstatus = xc->readMiscReg(MISCREG_HSTATUS);
+                                    int v = xc->readMiscReg(MISCREG_VIRMODE);
+                                    auto pm = (PrivilegeMode)xc->readMiscReg(
+                                        MISCREG_PRV);
+                                    if ( pm != PRV_M && status.tw == 1){
+                                        return std::make_shared<IllegalInstFault>(
+                                                    "wrs.nto not in machine mode with TW enabled",
+                                                    machInst);
+                                    }
+                                    if ( v && status.tw == 0 && hstatus.vtw == 1){
+                                        return std::make_shared<HVFault>();
+                                    }
+                                    // don't do anything for now in other cases
+                                }}, No_OpClass);
+                            }
+                        }
+                        0x1d: decode RS1 {
+                            0x0: decode RD {
+                                0x0: wrs_sto({{
+                                    // don't do anything for now in any cases
+                                }}, No_OpClass);
+                            }
+                        }
                     }
                     0x8: decode RS2 {
                         0x2: sret({{


### PR DESCRIPTION
Add the Zawrs wrs.nto and wrs.sto to the SYSTEM (funct3=0) decode so they no longer fall through to the Unknown instruction path.

The decoder had no case for these encodings, so executing wrs.nto (0x00d00073) raised an UnknownInstFault and trapped, diverging from NEMU (CONFIG_RV_ZAWRS treats wrs as a wait hint). This
  caused difftest failures on workloads that use wrs, e.g. the wrs.nto reached in an S-mode handler of the SPEC checkpoint image.

The implementation mirrors the existing wfi handling: raise IllegalInstFault in non-M mode when mstatus.TW is set (matching NEMU riscv64_priv_wrs_nto), otherwise treat as a no-op and advance
  PC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for decoding the RISC-V `wrs.nto` and `wrs.sto` system instructions.
  - Added required privilege and virtualization checks for `wrs.nto`, including illegal-instruction and virtual-instruction fault handling where applicable.
  - `wrs.sto` now executes as a no-op, while permitted `wrs.nto` executions complete without side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->