### PR TITLE
mem-cache: Preserve L2 request source across buffering

### DIFF
--- a/src/mem/cache/xs_l2/L2CacheSlice.cc
+++ b/src/mem/cache/xs_l2/L2CacheSlice.cc
@@ -181,6 +181,7 @@ L2CacheSlice::cpuSidePortRecvTimingReq(PacketPtr pkt)
 
     // Then the request is from L1 MSHR(ReadEx/ReadShare etc.) or L2 PF,
     // we can buffer it
+    TaskSource source = is_prefetch ? TaskSource::L2PF : TaskSource::L1MSHR;
     if (inner_cache_blocked || !requestBuffer.empty()) {
         // If the Wrapper is waiting for inner cache's retry or some pending requestes
         // are in the buffer, we cannot forward it directly to inner cache
@@ -189,14 +190,13 @@ L2CacheSlice::cpuSidePortRecvTimingReq(PacketPtr pkt)
             pending_l1_retry = true;
             return false;
         }
-        requestBuffer.push(pkt);
+        requestBuffer.push(pkt, source);
         DPRINTF(L2CacheSlice, "Request buffered, buffer size: %d\n", requestBuffer.size());
         return true;
     }
     // If the Wrapper is not waiting for inner cache's retry and
     // there is no pending request in the buffer,
     // we can try to forward it directly to inner cache
-    TaskSource source = is_prefetch ? TaskSource::L2PF : TaskSource::L1MSHR;
     if (!innerCpuPortSendTimingReq(pkt, source)) {
         inner_cache_blocked = true;
         DPRINTF(L2CacheSlice, "Inner cache busy, try buffering request and blocking\n");
@@ -205,7 +205,7 @@ L2CacheSlice::cpuSidePortRecvTimingReq(PacketPtr pkt)
             pending_l1_retry = true;
             return false;
         }
-        requestBuffer.push(pkt);
+        requestBuffer.push(pkt, source);
         DPRINTF(L2CacheSlice, "Request buffered, buffer size: %d\n", requestBuffer.size());
         return true;
     }
@@ -245,9 +245,9 @@ L2CacheSlice::trySendFromBuffer()
     DPRINTF(L2CacheSlice, "Attempting to send delayed request from buffer, buffer size: %d\n",
             requestBuffer.size());
 
-    PacketPtr pkt = requestBuffer.front();
+    const RequestBuffer::Entry entry = requestBuffer.front();
 
-    if (!innerCpuPortSendTimingReq(pkt, TaskSource::L1MSHR)) {
+    if (!innerCpuPortSendTimingReq(entry.pkt, entry.source)) {
         DPRINTF(L2CacheSlice, "Send delayed request failed, blocking again\n");
         inner_cache_blocked = true;
     } else {

--- a/src/mem/cache/xs_l2/L2MainPipe.hh
+++ b/src/mem/cache/xs_l2/L2MainPipe.hh
@@ -8,25 +8,13 @@
 #include "base/types.hh"
 #include "mem/cache/xs_l2/CacheWrapper.hh"
 #include "mem/cache/xs_l2/PipelineResources.hh"
+#include "mem/cache/xs_l2/TaskSource.hh"
 #include "mem/packet.hh"
 
 namespace gem5
 {
 
 class L2CacheSlice;
-
-// For task source
-// Indicate the source of the task that is being processed by the pipeline.
-enum TaskSource
-{
-    NoWhere,
-    L1MSHR,
-    L1WQ,
-    L2PF,
-    L3Snoop,
-    L2MSHRGrant,
-    L2MSHRRelease,
-};
 
 class L2MainPipe
 {

--- a/src/mem/cache/xs_l2/RequestBuffer.cc
+++ b/src/mem/cache/xs_l2/RequestBuffer.cc
@@ -29,10 +29,10 @@ RequestBuffer::size() const
 }
 
 void
-RequestBuffer::push(PacketPtr pkt)
+RequestBuffer::push(PacketPtr pkt, TaskSource source)
 {
     fatal_if(isFull(), "RequestBuffer is full");
-    buffer.push_back(pkt);
+    buffer.push_back({pkt, source});
 }
 
 void
@@ -42,8 +42,8 @@ RequestBuffer::pop()
     buffer.pop_front();
 }
 
-PacketPtr
-RequestBuffer::front()
+RequestBuffer::Entry
+RequestBuffer::front() const
 {
     fatal_if(empty(), "RequestBuffer is empty");
     return buffer.front();

--- a/src/mem/cache/xs_l2/RequestBuffer.hh
+++ b/src/mem/cache/xs_l2/RequestBuffer.hh
@@ -3,6 +3,7 @@
 
 #include <deque>
 
+#include "mem/cache/xs_l2/TaskSource.hh"
 #include "mem/packet.hh"
 
 namespace gem5
@@ -11,18 +12,24 @@ namespace gem5
 class RequestBuffer
 {
   public:
+    struct Entry
+    {
+        PacketPtr pkt;
+        TaskSource source;
+    };
+
     explicit RequestBuffer(unsigned size);
 
     bool isFull() const;
     bool empty() const;
     unsigned size() const;
-    void push(PacketPtr pkt);
+    void push(PacketPtr pkt, TaskSource source);
     void pop();
-    PacketPtr front();
+    Entry front() const;
 
   private:
     const unsigned _size;
-    std::deque<PacketPtr> buffer;
+    std::deque<Entry> buffer;
 };
 
 } // namespace gem5

--- a/src/mem/cache/xs_l2/TaskSource.hh
+++ b/src/mem/cache/xs_l2/TaskSource.hh
@@ -1,0 +1,21 @@
+#ifndef __MEM_CACHE_XS_L2_TASK_SOURCE_HH__
+#define __MEM_CACHE_XS_L2_TASK_SOURCE_HH__
+
+namespace gem5
+{
+
+// Indicate the source of a task processed by the L2 pipeline.
+enum TaskSource
+{
+    NoWhere,
+    L1MSHR,
+    L1WQ,
+    L2PF,
+    L3Snoop,
+    L2MSHRGrant,
+    L2MSHRRelease,
+};
+
+} // namespace gem5
+
+#endif // __MEM_CACHE_XS_L2_TASK_SOURCE_HH__


### PR DESCRIPTION
## Motivation

L2 slice request buffering currently stores only `PacketPtr`. A request's source is classified on receipt (`L1MSHR` for demand or `L2PF` for hardware prefetch), but buffered requests are replayed unconditionally as `L1MSHR`.

This changes the request's pipeline resource, arbitration, and same-set blocking semantics whenever an L2 prefetch is delayed by backpressure.

## Change

- Store `PacketPtr` and `TaskSource` together in each RequestBuffer entry.
- Preserve the source at both enqueue sites.
- Replay buffered requests with their original source.
- Move the shared `TaskSource` enum to a small standalone header.

FIFO order, buffer capacity, scheduling, and pipeline policy are unchanged.

## Validation

- Built `build/RISCV/gem5.opt` with `scons build/RISCV/gem5.opt --gold-linker -j32`.
- The PR intentionally contains production code only; no test sources or CI configuration are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved L2 cache request handling by preserving each request’s originating task source while buffered.
  * Ensured buffered requests are forwarded using their recorded source rather than a default source.

* **Refactor**
  * Consolidated task-source definitions for more consistent internal cache request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->