### PR TITLE
cpu-o3: Add SMT fetch block and flush policies

### DIFF
--- a/configs/common/xiangshan.py
+++ b/configs/common/xiangshan.py
@@ -983,13 +983,21 @@ def xiangshan_system_init():
         choices=["ICount", "DelayedICount", "MultiPriority", "RoundRobin"],
         help="SMT decode select policy: ICount, DelayedICount, MultiPriority, RoundRobin",
     )
+    # BlockStallPolicy: block is an ADDITIONAL throttle source (OR with base throttle)
+    # BlockThrottlePolicy: block REPLACES base throttle, becoming the sole throttle driver
+    # FlushFromLoadPolicy: squash all instructions after the long-latency load
+    # FlushFromUsePolicy: squash from first consumer of load result (or ROB tail if none)
     parser.add_argument(
         "--smt-fetch-block-policy",
         type=str,
         default="BaseLine",
-        choices=["BaseLine", "BlockPolicy"],
-        help="SMT fetch block policy for long-latency loads: "
-             "Baseline (no blocking) or BlockPolicy (stall fetch on long-latency load)",
+        choices=["BaseLine", "BlockStallPolicy", "BlockThrottlePolicy",
+                 "FlushFromLoadPolicy", "FlushFromUsePolicy"],
+        help="SMT fetch block/flush policy for long-latency loads: "
+             "BaseLine (no blocking), BlockStallPolicy (block + base throttle), "
+             "BlockThrottlePolicy (block drives throttle), "
+             "FlushFromLoadPolicy (squash after load), "
+             "FlushFromUsePolicy (squash from first consumer)",
     )
     parser.add_argument(
         "--smt-fetch-block-threshold",

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -54,7 +54,29 @@ class SMTDecodePolicy(ScopedEnum):
     vals = [ 'ICount', 'DelayedICount', 'MultiPriority', 'RoundRobin' ]
 
 class SMTFetchBlockPolicy(ScopedEnum):
-    vals = [ 'BaseLine', 'BlockPolicy' ]
+    # BaseLine:
+    #   No blocking or flushing. Normal multi-priority scheduling.
+    #
+    # BlockStallPolicy (Stall):
+    #   When a thread is blocked by a long-latency load, it is directly marked as
+    #   throttled (stalled). This acts as an ADDITIONAL throttle source on top of the
+    #   base throttle (ROB/IQ full, memory pressure). The two are OR'd together.
+    #
+    # BlockThrottlePolicy (Throttle):
+    #   The block signal REPLACES the base throttle entirely. throttle_now is driven
+    #   solely by threadFetchBlocked[tid]. The block state continuously refreshes the
+    #   smtBorrowThrottleCycles hold counter, keeping the thread throttled.
+    #
+    # FlushFromLoadPolicy (Flush V1):
+    #   Squash ALL instructions after the long-latency load (including pipeline in-flight).
+    #   Same throttle behavior as BlockThrottlePolicy, plus resource reclamation via squash.
+    #
+    # FlushFromUsePolicy (Flush V2):
+    #   Squash from the first consumer of the load's result. If no consumer exists in the
+    #   ROB, squash from ROB tail (preserving independent instructions). Same throttle
+    #   behavior as BlockThrottlePolicy.
+    vals = [ 'BaseLine', 'BlockStallPolicy', 'BlockThrottlePolicy',
+             'FlushFromLoadPolicy', 'FlushFromUsePolicy' ]
 
 class SMTQueuePolicy(ScopedEnum):
     vals = [ 'Dynamic', 'Partitioned', 'Threshold', 'DynamicBorrowing' ]
@@ -321,8 +343,7 @@ class BaseO3CPU(BaseCPU):
     smtDecodePolicy = Param.SMTDecodePolicy('MultiPriority',
         "SMT decode select policy: ICount, DelayedICount, MultiPriority, RoundRobin")
     smtFetchBlockPolicy = Param.SMTFetchBlockPolicy('BaseLine',
-        "SMT fetch block policy for long-latency loads: "
-        "Baseline (no blocking) or BlockPolicy (stall fetch on long-latency load)")
+        "SMT fetch block policy for long-latency loads")
     smtFetchBlockThreshold = Param.Unsigned(15,
         "Number of cycles a load must wait in the LQ before it is considered "
         "long-latency and triggers fetch blocking (T15 from Tullsen & Brown's paper)")

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -127,6 +127,7 @@ enum class SquashCause
     Trap,
     ThreadContext,
     SquashAfter,
+    LongLatencyFlush,
 };
 
 inline StallReason
@@ -200,6 +201,7 @@ struct IEWStruct
     bool includeSquashInst[MaxThreads];
 
     bool valuePredictionError[MaxThreads];
+    bool longLatencyFlush[MaxThreads];
 };
 
 struct IssueStruct

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -333,6 +333,8 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
                "Number of squash due to TC"),
       ADD_STAT(squashDueToSquashAfter, statistics::units::Count::get(),
                "Number of squash due to squash after"),
+      ADD_STAT(squashDueToLongLatencyFlush, statistics::units::Count::get(),
+               "Number of squash due to long-latency flush policy"),
       ADD_STAT(totalSquash, statistics::units::Count::get(),
                "Total number of squash"),
       ADD_STAT(ROBFull, statistics::units::Count::get(),
@@ -457,9 +459,13 @@ Commit::CommitStats::CommitStats(CPU *cpu, Commit *commit)
         .init(cpu->numThreads)
         .flags(total);
 
+    squashDueToLongLatencyFlush
+        .init(cpu->numThreads)
+        .flags(total);
+
     totalSquash = squashDueToBranch + squashDueToOrderViolation + \
         squashDueToValuePrediction + squashDueToTrap + squashDueToTC + \
-        squashDueToSquashAfter;
+        squashDueToSquashAfter + squashDueToLongLatencyFlush;
 
     ROBFull
         .init(cpu->numThreads)
@@ -1162,8 +1168,10 @@ Commit::commit()
         // Squashed sequence number must be older than youngest valid
         // instruction in the ROB. This prevents squashes from younger
         // instructions overriding squashes from older instructions.
-        DPRINTF(Commit, "fromIEW->squash %d, commitStatus %d, fromIEW->squashedSeqNum %d, youngestSeqNum %d\n",
-            fromIEW->squash[tid], commitStatus[tid], fromIEW->squashedSeqNum[tid], youngestSeqNum[tid]);
+        DPRINTF(Commit, "fromIEW->squash %d, commitStatus %d, fromIEW->squashedSeqNum %d, "
+                "includeSquashInst %d, youngestSeqNum %d\n",
+                fromIEW->squash[tid], commitStatus[tid], fromIEW->squashedSeqNum[tid],
+                fromIEW->includeSquashInst[tid], youngestSeqNum[tid]);
         if (fromIEW->squash[tid] &&
             commitStatus[tid] != TrapPending &&
             fromIEW->squashedSeqNum[tid] <= youngestSeqNum[tid]) {
@@ -1183,6 +1191,12 @@ Commit::commit()
                     tid, fromIEW->squashedSeqNum[tid]);
                 stats.squashDueToValuePrediction[tid]++;
                 curSquashCause[tid] = SquashCause::ValuePrediction;
+            } else if (fromIEW->longLatencyFlush[tid]) {
+                DPRINTF(Commit,
+                    "[tid:%i] Squashing due to long-latency flush [sn:%llu]\n",
+                    tid, fromIEW->squashedSeqNum[tid]);
+                stats.squashDueToLongLatencyFlush[tid]++;
+                curSquashCause[tid] = SquashCause::LongLatencyFlush;
             } else {
                 DPRINTF(Commit,
                     "[tid:%i] Squashing due to order violation [sn:%llu]\n",
@@ -2412,7 +2426,17 @@ Commit::squashInflightAndUpdateVersion(ThreadID tid)
         inst->setSquashed();
     }
 
-    fixedbuffer[tid].clear();
+    // Selectively remove only instructions younger than squash boundary
+    {
+        InstSeqNum squash_seq = toIEW->commitInfo[tid].doneSeqNum;
+        for (auto it = fixedbuffer[tid].begin(); it != fixedbuffer[tid].end(); ) {
+            if ((*it)->seqNum > squash_seq) {
+                it = fixedbuffer[tid].erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 
     localSquashVer[tid].update(localSquashVer[tid].nextVersion());
     toIEW->commitInfo[tid].squashVersion = localSquashVer[tid];

--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -679,6 +679,7 @@ class Commit
         statistics::Vector squashDueToTrap;
         statistics::Vector squashDueToTC;
         statistics::Vector squashDueToSquashAfter;
+        statistics::Vector squashDueToLongLatencyFlush;
         statistics::Formula totalSquash;
 
         statistics::Vector ROBFull;

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -401,7 +401,17 @@ Decode::squash(ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] Squashing.\n",tid);
 
-    fixedbuffer[tid].clear();
+    // Selectively remove only instructions younger than squash boundary
+    {
+        InstSeqNum squash_seq = fromCommit->commitInfo[tid].doneSeqNum;
+        for (auto it = fixedbuffer[tid].begin(); it != fixedbuffer[tid].end(); ) {
+            if ((*it)->seqNum > squash_seq) {
+                it = fixedbuffer[tid].erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
     squashBranchHistory(tid, fromCommit->commitInfo[tid].doneSeqNum, false);
 
     // Clear per-thread stallBuffer for the squashed thread

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1642,17 +1642,6 @@ Fetch::selectUnstalledThread()
         candidate[tid] = true;
         throttled[tid] = false;
 
-        // === Flush Policy: initiate flush after asymmetric check passes ===
-        if (isFlushFromPolicy() && block_active &&
-            threadFetchBlocked[tid] && !flushFromInitiated[tid]) {
-            InstSeqNum loadSeqNum = iewStage->ldstQueue.getLoadHeadSeqNum(tid);
-            DynInstPtr loadInst = iewStage->findRobInst(tid, loadSeqNum);
-            if (loadInst && loadInst->isLoad()) {
-                bool fromUse = (smtFetchBlockPolicy == SMTFetchBlockPolicy::FlushFromUsePolicy);
-                flushFromInitiateFlush(loadInst, tid, fromUse);
-            }
-        }
-
         // update throttle status
         //
         // Policy differences:
@@ -1693,6 +1682,15 @@ Fetch::selectUnstalledThread()
 
         // thread can not candidate has lowest priv, should not be chosen
         if (stallSig->blockFetch[tid] || fetchQueue[tid].empty()) {
+            smtBorrowThrottleCycles[tid] = 0;
+            lsqCounter->setCounter(tid, UINT64_MAX);
+            iqCounter->setCounter(tid, UINT64_MAX);
+            robCounter->setCounter(tid, UINT64_MAX);
+            candidate[tid] = false;
+            continue;
+        }
+        // flush policy: should not pipedown insts
+        if (isFlushFromPolicy() && block_active && threadFetchBlocked[tid]) {
             smtBorrowThrottleCycles[tid] = 0;
             lsqCounter->setCounter(tid, UINT64_MAX);
             iqCounter->setCounter(tid, UINT64_MAX);
@@ -1780,6 +1778,17 @@ Fetch::sendInstructionsToDecode()
             //break;
         }else{
             fetchStats.smtdecodeStalls[i]++; 
+        }
+
+        // === Flush Policy: initiate flush after asymmetric check passes ===
+        if (isFlushFromPolicy() && isBlockPolicyActive() &&
+            threadFetchBlocked[i] && !flushFromInitiated[i]) {
+            InstSeqNum loadSeqNum = iewStage->ldstQueue.getLoadHeadSeqNum(i);
+            DynInstPtr loadInst = iewStage->findRobInst(i, loadSeqNum);
+            if (loadInst && loadInst->isLoad()) {
+                bool fromUse = (smtFetchBlockPolicy == SMTFetchBlockPolicy::FlushFromUsePolicy);
+                flushFromInitiateFlush(loadInst, i, fromUse);
+            }
         }
     }
 
@@ -1985,12 +1994,16 @@ Fetch::findFirstUse(const DynInstPtr &loadInst, ThreadID tid)
 
     auto& instList = iewStage->getRobInstList(tid);
     bool foundLoad = false;
+    DynInstPtr lastNonControl = loadInst;  // fallback: load itself
     for (auto it = instList.begin(); it != instList.end(); ++it) {
         if (!foundLoad) {
             if ((*it)->seqNum == loadInst->seqNum) foundLoad = true;
             continue;
         }
         const auto &candidate = *it;
+        if (!candidate->isControl()) {
+            lastNonControl = candidate;
+        }
         for (int s = 0; s < candidate->numSrcRegs(); s++) {
             PhysRegIdPtr srcReg = candidate->renamedSrcIdx(s);
             if (srcReg) {
@@ -2001,7 +2014,14 @@ Fetch::findFirstUse(const DynInstPtr &loadInst, ThreadID tid)
                                 "[sn:%llu] reads phys reg %u from load [sn:%llu]\n",
                                 tid, candidate->pcState().instAddr(),
                                 candidate->seqNum, srcFlat, loadInst->seqNum);
-                        return candidate;
+                        // Avoid selecting a control instruction as squash boundary
+                        // to prevent predictor state corruption at commit.
+                        if (candidate->isControl()) {
+                            DPRINTF(Fetch, "[tid:%i] FlushFromUse: first use is control, "
+                                    "falling back to last non-control before it\n", tid);
+                        }
+                        assert(foundLoad);
+                        return lastNonControl;
                     }
                 }
             }
@@ -2009,6 +2029,7 @@ Fetch::findFirstUse(const DynInstPtr &loadInst, ThreadID tid)
     }
     DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer found for load [sn:%llu], "
             "no consumer, will squash from ROB tail\n", tid, loadInst->seqNum);
+    assert(foundLoad);
     return nullptr;
 }
 
@@ -2029,25 +2050,45 @@ Fetch::flushFromInitiateFlush(const DynInstPtr &loadInst, ThreadID tid, bool fro
         // FlushFromUse: try to find first consumer and flush from there
         squashFromInst = findFirstUse(loadInst, tid);
         if (squashFromInst) {
-            includeSquashInst = true;
-            DPRINTF(Fetch, "[tid:%i] FlushFromUse: load PC=%#x [sn:%llu], "
-                    "squash from first-use PC=%#x [sn:%llu]\n",
-                    tid, loadInst->pcState().instAddr(), loadInst->seqNum,
-                    squashFromInst->pcState().instAddr(), squashFromInst->seqNum);
+            if (squashFromInst == loadInst) {
+                squashFromInst = loadInst;
+                includeSquashInst = false;  // do not include the load itself
+                DPRINTF(Fetch, "[tid:%i] FlushFromUse: load PC=%#x [sn:%llu], "
+                        "squash all after load\n",
+                        tid, loadInst->pcState().instAddr(), loadInst->seqNum);
+            } else {
+                includeSquashInst = true;
+                DPRINTF(Fetch, "[tid:%i] FlushFromUse: load PC=%#x [sn:%llu], "
+                        "squash from first-use PC=%#x [sn:%llu]\n",
+                        tid, loadInst->pcState().instAddr(), loadInst->seqNum,
+                        squashFromInst->pcState().instAddr(), squashFromInst->seqNum);
+            }
             fetchStats.flushFromFirstUseFound++;
         } else {
-            DynInstPtr robTail = iewStage->readRobTailInst(tid);
-            if (!robTail || robTail->seqNum == loadInst->seqNum) {
+            // Find the last non-control instruction in ROB (after load)
+            // to avoid predictor state corruption when preserving a branch.
+            DynInstPtr safeTail = nullptr;
+            auto& instList2 = iewStage->getRobInstList(tid);
+            for (auto it = instList2.rbegin(); it != instList2.rend(); ++it) {
+                if ((*it)->seqNum <= loadInst->seqNum) break;
+                if (!(*it)->isControl()) {
+                    safeTail = *it;
+                    break;
+                }
+            }
+            if (!safeTail) {
+                // All instructions after load are control, or ROB only has load
                 squashFromInst = loadInst;
                 includeSquashInst = false;
-                DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer, ROB only has load, "
-                        "fallback squash from load [sn:%llu]\n", tid, loadInst->seqNum);
+                DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer, no non-control "
+                        "inst after load, fallback squash from load [sn:%llu]\n",
+                        tid, loadInst->seqNum);
             } else {
-                squashFromInst = robTail;
+                squashFromInst = safeTail;
                 includeSquashInst = false;
                 DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer, "
-                        "squash from ROB tail [sn:%llu] next (preserve ROB)\n",
-                        tid, robTail->seqNum);
+                        "squash from non-control [sn:%llu] next (preserve ROB)\n",
+                        tid, safeTail->seqNum);
             }
             fetchStats.flushFromFirstUseNoConsumer++;
         }

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -184,6 +184,7 @@ Fetch::Fetch(CPU *_cpu, const BaseO3CPUParams &params)
         blockStateHoldCycles[i] = 0;
         longLatencyStallCycles[i] = 0;
         lastLoadHeadSeqNum[i] = UINT64_MAX;
+        flushFromInitiated[i] = false;
     }
     smtLdstqHighWater = params.smtBorrowLdstqHighWater;
     if (smtLdstqHighWater == 0) {
@@ -394,7 +395,13 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
              "Decode policy thread state combination per cycle, Th means "
              "uncandidated or throttled. (0=both not Th, 1=tid0 Th, 2=tid1 Th, 3=both Th)"),
     ADD_STAT(fetchBlockHoldCycle, statistics::units::Count::get(),
-             "Per-thread block/unblock state holding cycle distribution")
+             "Per-thread block/unblock state holding cycle distribution"),
+    ADD_STAT(flushForFlushPolicy, statistics::units::Count::get(),
+             "Number of long-latency load flush events per thread"),
+    ADD_STAT(flushFromFirstUseFound, statistics::units::Count::get(),
+             "FlushFromUse: first-use consumer found, squash initiated"),
+    ADD_STAT(flushFromFirstUseNoConsumer, statistics::units::Count::get(),
+             "FlushFromUse: no consumer found, squash from ROB tail")
 {
         icacheStallCycles
             .prereq(icacheStallCycles);
@@ -524,6 +531,13 @@ Fetch::FetchStatGroup::FetchStatGroup(CPU *cpu, Fetch *fetch)
             .flags(statistics::pdf);
         fetchBlockHoldCycle.subname(0, "Unblocked");
         fetchBlockHoldCycle.subname(1, "Blocked");
+        flushForFlushPolicy
+            .init(cpu->numThreads)
+            .flags(statistics::total);
+        flushForFlushPolicy
+            .prereq(flushForFlushPolicy);
+        flushFromFirstUseNoConsumer
+            .prereq(flushFromFirstUseNoConsumer);
 }
 
 void
@@ -1622,17 +1636,62 @@ Fetch::selectUnstalledThread()
     bool throttled[MaxThreads];
 
     // update smtBorrowThrottleCycles and check whether has candidate
+    const bool block_active = isBlockPolicyActive();
+
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
         candidate[tid] = true;
         throttled[tid] = false;
-        const bool throttle_now =
-            smtHasBorrowThrottleStall(fromIEW->iewInfo[tid]) ||
-            smtHasMemoryPressure(fromIEW->iewInfo[tid], smtLdstqHighWater);
-        if (throttle_now) {
-            smtBorrowThrottleCycles[tid] = smtBorrowThrottleHoldCycles;
-        } else if (smtBorrowThrottleCycles[tid] > 0) {
-            --smtBorrowThrottleCycles[tid];
+
+        // === Flush Policy: initiate flush after asymmetric check passes ===
+        if (isFlushFromPolicy() && block_active &&
+            threadFetchBlocked[tid] && !flushFromInitiated[tid]) {
+            InstSeqNum loadSeqNum = iewStage->ldstQueue.getLoadHeadSeqNum(tid);
+            DynInstPtr loadInst = iewStage->findRobInst(tid, loadSeqNum);
+            if (loadInst && loadInst->isLoad()) {
+                bool fromUse = (smtFetchBlockPolicy == SMTFetchBlockPolicy::FlushFromUsePolicy);
+                flushFromInitiateFlush(loadInst, tid, fromUse);
+            }
         }
+
+        // update throttle status
+        //
+        // Policy differences:
+        //   BlockStallPolicy (Hold):
+        //     - throttle_now uses BASE throttle (ROB/IQ full, memory pressure)
+        //     - block is an ADDITIONAL throttle source: when isBlockPolicyActive()
+        //       and thread is blocked, throttled[tid] is set directly (OR with base)
+        //   BlockThrottlePolicy (Drive):
+        //     - throttle_now = threadFetchBlocked[tid] (block REPLACES base throttle)
+        //     - the block signal continuously refreshes smtBorrowThrottleCycles hold counter
+        //   FlushFromLoadPolicy / FlushFromUsePolicy:
+        //     - same throttle behavior as BlockThrottlePolicy (block drives throttle)
+        //     - additionally initiates a squash to free pipeline resources
+        {
+            bool throttle_now = false;
+            if (smtFetchBlockPolicy == SMTFetchBlockPolicy::BlockThrottlePolicy) {
+                // BlockThrottlePolicy completely replaces base throttle policy
+                throttle_now = threadFetchBlocked[tid];
+            } else {
+                // base throttle policy
+                throttle_now =
+                    smtHasBorrowThrottleStall(fromIEW->iewInfo[tid]) ||
+                    smtHasMemoryPressure(fromIEW->iewInfo[tid], smtLdstqHighWater);
+            }
+            if (throttle_now) {
+                smtBorrowThrottleCycles[tid] = smtBorrowThrottleHoldCycles;
+            } else if (smtBorrowThrottleCycles[tid] > 0) {
+                --smtBorrowThrottleCycles[tid];
+            }
+            // BlockStallPolicy and Flush*Policy will directly set throttled[tid]
+            if ((smtFetchBlockPolicy == SMTFetchBlockPolicy::BlockStallPolicy ||
+                 isFlushFromPolicy()) &&
+                block_active && threadFetchBlocked[tid]) {
+                throttled[tid] = true;
+            }
+            throttled[tid] |= smtBorrowThrottleCycles[tid] > 0;
+        }
+
+        // thread can not candidate has lowest priv, should not be chosen
         if (stallSig->blockFetch[tid] || fetchQueue[tid].empty()) {
             smtBorrowThrottleCycles[tid] = 0;
             lsqCounter->setCounter(tid, UINT64_MAX);
@@ -1649,21 +1708,12 @@ Fetch::selectUnstalledThread()
             lsqCounter->setCounter(tid, fromIEW->iewInfo[tid].ldstqCount);
             iqCounter->setCounter(tid, fromIEW->iewInfo[tid].iqCount);
             robCounter->setCounter(tid, fromIEW->iewInfo[tid].robCount);
-            if (isBlockPolicyActive() && threadFetchBlocked[tid]) {
-                // === Block Policy: skip blocked thread when policy is active ===
-                throttled[tid] = true;
+            if (throttled[tid]) {
                 lsqCounter->setCounter(tid, UINT64_MAX - 1);
                 iqCounter->setCounter(tid, UINT64_MAX - 1);
                 robCounter->setCounter(tid, UINT64_MAX - 1);
             } else {
-                if (smtBorrowThrottleCycles[tid] > 0) {
-                    throttled[tid] = true;
-                    lsqCounter->setCounter(tid, UINT64_MAX - 1);
-                    iqCounter->setCounter(tid, UINT64_MAX - 1);
-                    robCounter->setCounter(tid, UINT64_MAX - 1);
-                } else {
-                    has_unthrottled_candidate = true;
-                }
+                has_unthrottled_candidate = true;
             }
             DPRINTF(Fetch,
                     "[tid:%i] block=%u mem_pressure=%u hold=%u throttled=%u lsq=%u iq=%u rob=%u\n",
@@ -1696,7 +1746,10 @@ Fetch::selectUnstalledThread()
 bool
 Fetch::isBlockPolicyActive() const
 {
-    if (smtFetchBlockPolicy != SMTFetchBlockPolicy::BlockPolicy) {
+    if (smtFetchBlockPolicy != SMTFetchBlockPolicy::BlockStallPolicy &&
+        smtFetchBlockPolicy != SMTFetchBlockPolicy::BlockThrottlePolicy &&
+        smtFetchBlockPolicy != SMTFetchBlockPolicy::FlushFromLoadPolicy &&
+        smtFetchBlockPolicy != SMTFetchBlockPolicy::FlushFromUsePolicy) {
         return false;
     }
     int blocked_count = 0;
@@ -1910,57 +1963,157 @@ Fetch::checkSignalsAndUpdate(ThreadID tid)
 }
 
 
+
+bool
+Fetch::isFlushFromPolicy() const
+{
+    return smtFetchBlockPolicy == SMTFetchBlockPolicy::FlushFromLoadPolicy ||
+           smtFetchBlockPolicy == SMTFetchBlockPolicy::FlushFromUsePolicy;
+}
+
+DynInstPtr
+Fetch::findFirstUse(const DynInstPtr &loadInst, ThreadID tid)
+{
+    if (loadInst->numDestRegs() == 0) return nullptr;
+
+    std::vector<RegIndex> destPhysRegs;
+    for (int d = 0; d < loadInst->numDestRegs(); d++) {
+        PhysRegIdPtr r = loadInst->renamedDestIdx(d);
+        if (r) destPhysRegs.push_back(r->flatIndex());
+    }
+    if (destPhysRegs.empty()) return nullptr;
+
+    auto& instList = iewStage->getRobInstList(tid);
+    bool foundLoad = false;
+    for (auto it = instList.begin(); it != instList.end(); ++it) {
+        if (!foundLoad) {
+            if ((*it)->seqNum == loadInst->seqNum) foundLoad = true;
+            continue;
+        }
+        const auto &candidate = *it;
+        for (int s = 0; s < candidate->numSrcRegs(); s++) {
+            PhysRegIdPtr srcReg = candidate->renamedSrcIdx(s);
+            if (srcReg) {
+                RegIndex srcFlat = srcReg->flatIndex();
+                for (RegIndex destFlat : destPhysRegs) {
+                    if (srcFlat == destFlat) {
+                        DPRINTF(Fetch, "[tid:%i] FlushFromUse: first use PC=%#x "
+                                "[sn:%llu] reads phys reg %u from load [sn:%llu]\n",
+                                tid, candidate->pcState().instAddr(),
+                                candidate->seqNum, srcFlat, loadInst->seqNum);
+                        return candidate;
+                    }
+                }
+            }
+        }
+    }
+    DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer found for load [sn:%llu], "
+            "no consumer, will squash from ROB tail\n", tid, loadInst->seqNum);
+    return nullptr;
+}
+
+void
+Fetch::flushFromInitiateFlush(const DynInstPtr &loadInst, ThreadID tid, bool fromUse)
+{
+    DynInstPtr squashFromInst = nullptr;
+    bool includeSquashInst = true;
+
+    if (!fromUse) {
+        // FlushFromLoad: squash all instructions after the load (including pipeline in-flight)
+        squashFromInst = loadInst;
+        includeSquashInst = false;  // do not include the load itself
+        DPRINTF(Fetch, "[tid:%i] FlushFromLoad: load PC=%#x [sn:%llu], "
+                "squash all after load\n",
+                tid, loadInst->pcState().instAddr(), loadInst->seqNum);
+    } else {
+        // FlushFromUse: try to find first consumer and flush from there
+        squashFromInst = findFirstUse(loadInst, tid);
+        if (squashFromInst) {
+            includeSquashInst = true;
+            DPRINTF(Fetch, "[tid:%i] FlushFromUse: load PC=%#x [sn:%llu], "
+                    "squash from first-use PC=%#x [sn:%llu]\n",
+                    tid, loadInst->pcState().instAddr(), loadInst->seqNum,
+                    squashFromInst->pcState().instAddr(), squashFromInst->seqNum);
+            fetchStats.flushFromFirstUseFound++;
+        } else {
+            DynInstPtr robTail = iewStage->readRobTailInst(tid);
+            if (!robTail || robTail->seqNum == loadInst->seqNum) {
+                squashFromInst = loadInst;
+                includeSquashInst = false;
+                DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer, ROB only has load, "
+                        "fallback squash from load [sn:%llu]\n", tid, loadInst->seqNum);
+            } else {
+                squashFromInst = robTail;
+                includeSquashInst = false;
+                DPRINTF(Fetch, "[tid:%i] FlushFromUse: no consumer, "
+                        "squash from ROB tail [sn:%llu] next (preserve ROB)\n",
+                        tid, robTail->seqNum);
+            }
+            fetchStats.flushFromFirstUseNoConsumer++;
+        }
+    }
+
+    flushFromInitiated[tid] = true;
+    fetchStats.flushForFlushPolicy[tid]++;
+
+    iewStage->squashDueToLongLatencyLoad(loadInst, squashFromInst, tid,
+                                          includeSquashInst);
+}
+
 void
 Fetch::checkLongLatencyLoads()
 {
-    if (smtFetchBlockPolicy == SMTFetchBlockPolicy::BlockPolicy) {
-        for (ThreadID tid = 0; tid < numThreads; ++tid) {
-            blockStateHoldCycles[tid]++;
+    if (smtFetchBlockPolicy == SMTFetchBlockPolicy::BaseLine) {
+        return;
+    }
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        blockStateHoldCycles[tid]++;
 
-            // Get LQ head stall reason for this thread
-            StallReason lqReason = iewStage->ldstQueue.lqEmpty(tid)
-                ? StallReason::NoStall
-                : iewStage->checkLsqStall(tid, true);
+        // Get LQ head stall reason for this thread
+        StallReason lqReason = iewStage->ldstQueue.lqEmpty(tid)
+            ? StallReason::NoStall
+            : iewStage->checkLsqStall(tid, true);
 
-            // Check if LQ head is stuck on a long-latency load
-            bool is_long_latency =
-                (lqReason == StallReason::LoadL2Bound ||
-                lqReason == StallReason::LoadL3Bound ||
-                lqReason == StallReason::LoadMemBound);
+        // Check if LQ head is stuck on a long-latency load
+        bool is_long_latency =
+            (lqReason == StallReason::LoadL2Bound ||
+            lqReason == StallReason::LoadL3Bound ||
+            lqReason == StallReason::LoadMemBound);
 
-            if (is_long_latency) {
-                InstSeqNum newLoadHead = iewStage->ldstQueue.getLoadHeadSeqNum(tid);
-                if (newLoadHead == lastLoadHeadSeqNum[tid]) {
-                    if (!threadFetchBlocked[tid] &&
-                        longLatencyStallCycles[tid] >= longLatencyThreshold) {
-                        threadFetchBlocked[tid] = true;
-                        fetchStats.fetchBlockHoldCycle[0].sample(blockStateHoldCycles[tid]);
-                        blockStateHoldCycles[tid] = 0;
-                        DPRINTF(Fetch, "[tid:%i] Long-latency load detected: "
-                            "LQ head stalled for %llu cycles (reason=%d)\n",
-                            tid, longLatencyStallCycles[tid], (int)lqReason);
-                    }
-                    longLatencyStallCycles[tid]++;
-                } else {
-                    if (threadFetchBlocked[tid]) {
-                        threadFetchBlocked[tid] = false;
-                        fetchStats.fetchBlockHoldCycle[1].sample(blockStateHoldCycles[tid]);
-                        blockStateHoldCycles[tid] = 0;
-                        DPRINTF(Fetch, "[tid:%i] Long-latency load Done\n", tid);
-                    }
-                    longLatencyStallCycles[tid] = 0;
-                    lastLoadHeadSeqNum[tid] = newLoadHead;
+        if (is_long_latency) {
+            InstSeqNum newLoadHead = iewStage->ldstQueue.getLoadHeadSeqNum(tid);
+            if (newLoadHead == lastLoadHeadSeqNum[tid]) {
+                if (!threadFetchBlocked[tid] &&
+                    longLatencyStallCycles[tid] >= longLatencyThreshold) {
+                    threadFetchBlocked[tid] = true;
+                    fetchStats.fetchBlockHoldCycle[0].sample(blockStateHoldCycles[tid]);
+                    blockStateHoldCycles[tid] = 0;
+                    DPRINTF(Fetch, "[tid:%i] Long-latency load detected: "
+                        "LQ head stalled for %llu cycles (reason=%d)\n",
+                        tid, longLatencyStallCycles[tid], (int)lqReason);
                 }
+                longLatencyStallCycles[tid]++;
             } else {
                 if (threadFetchBlocked[tid]) {
                     threadFetchBlocked[tid] = false;
+                    flushFromInitiated[tid] = false;
                     fetchStats.fetchBlockHoldCycle[1].sample(blockStateHoldCycles[tid]);
                     blockStateHoldCycles[tid] = 0;
                     DPRINTF(Fetch, "[tid:%i] Long-latency load Done\n", tid);
                 }
                 longLatencyStallCycles[tid] = 0;
-                lastLoadHeadSeqNum[tid] = UINT64_MAX;
+                lastLoadHeadSeqNum[tid] = newLoadHead;
             }
+        } else {
+            if (threadFetchBlocked[tid]) {
+                threadFetchBlocked[tid] = false;
+                flushFromInitiated[tid] = false;
+                fetchStats.fetchBlockHoldCycle[1].sample(blockStateHoldCycles[tid]);
+                blockStateHoldCycles[tid] = 0;
+                DPRINTF(Fetch, "[tid:%i] Long-latency load Done\n", tid);
+            }
+            longLatencyStallCycles[tid] = 0;
+            lastLoadHeadSeqNum[tid] = UINT64_MAX;
         }
     }
     int blockState = 0;

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -252,6 +252,14 @@ class Fetch
     /** Block Policy: per-thread state tracking for statistics */
     uint64_t blockStateHoldCycles[MaxThreads];
 
+    // === FlushFrom Policy state ===
+    bool flushFromInitiated[MaxThreads];
+
+    // FlushFrom Policy methods
+    bool isFlushFromPolicy() const;
+    DynInstPtr findFirstUse(const DynInstPtr &loadInst, ThreadID tid);
+    void flushFromInitiateFlush(const DynInstPtr &loadInst, ThreadID tid, bool fromUse);
+
     /** List that has the threads organized by priority. */
     std::list<ThreadID> priorityList;
 
@@ -1211,6 +1219,11 @@ class Fetch
         statistics::Vector fetchBlockState;
         statistics::Vector fetchThrottleState;
         statistics::VectorDistribution fetchBlockHoldCycle;  // [0]=Unblocked [1]=Blocked
+
+        // === FlushFrom Policy statistics ===
+        statistics::Vector flushForFlushPolicy;
+        statistics::Scalar flushFromFirstUseFound;
+        statistics::Scalar flushFromFirstUseNoConsumer;
     } fetchStats;
 
     SquashVersion localSquashVer[MaxThreads];

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -599,7 +599,17 @@ IEW::squash(ThreadID tid)
     ldstQueue.squash(fromCommit->commitInfo[tid].doneSeqNum, tid);
     updatedQueues = true;
 
-    fixedbuffer[tid].clear();
+    // Selectively remove only instructions younger than squash boundary
+    {
+        InstSeqNum squash_seq = fromCommit->commitInfo[tid].doneSeqNum;
+        for (auto it = fixedbuffer[tid].begin(); it != fixedbuffer[tid].end(); ) {
+            if ((*it)->seqNum > squash_seq) {
+                it = fixedbuffer[tid].erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 
     stallSig->blockRename[tid] = true;
 
@@ -727,6 +737,74 @@ IEW::squashDueToValuePrediction(const DynInstPtr &inst, ThreadID tid)
     }
 
     cpu->getDecode()->squashBranchHistory(tid, inst->seqNum, true);
+
+    stallSig->blockRename[tid] = true;
+}
+
+
+std::list<DynInstPtr>&
+IEW::getRobInstList(ThreadID tid)
+{
+    return rob->getInstList(tid);
+}
+
+DynInstPtr
+IEW::readRobTailInst(ThreadID tid)
+{
+    return rob->readTailInst(tid);
+}
+
+DynInstPtr
+IEW::findRobInst(ThreadID tid, InstSeqNum seqNum)
+{
+    return rob->findInst(tid, seqNum);
+}
+
+void
+IEW::squashDueToLongLatencyLoad(const DynInstPtr &loadInst,
+                                const DynInstPtr &squashFromInst,
+                                ThreadID tid,
+                                bool includeSquashInst)
+{
+    recordThreadSquash(tid);
+
+    DPRINTF(IEW, "[tid:%i] Long-latency flush: load [sn:%llu], "
+            "squash from [sn:%llu], includeSquashInst=%d\n",
+            tid, loadInst->seqNum, squashFromInst->seqNum,
+            (int)includeSquashInst);
+
+    if (!toCommit->squash[tid] || squashFromInst->seqNum < toCommit->squashedSeqNum[tid] ||
+        (squashFromInst->seqNum == toCommit->squashedSeqNum[tid] && includeSquashInst)) {
+        toFetch->iewInfo[tid].redirectPending = true;
+        toCommit->squash[tid] = true;
+        toCommit->squashedSeqNum[tid] = squashFromInst->seqNum;
+        toCommit->squashedTargetId[tid] = squashFromInst->getFtqId();
+        toCommit->squashedLoopIter[tid] = squashFromInst->getLoopIteration();
+        set(toCommit->pc[tid], squashFromInst->pcState());
+        if (!includeSquashInst) {
+            // squashFromInst itself is NOT squashed
+            if (squashFromInst->isControl() && !(squashFromInst->isExecuted())) {
+                // Control instruction: use predicted PC from frontend
+                set(toCommit->pc[tid], squashFromInst->readPredTarg());
+            } else {
+                // Non-control instruction: sequential next PC
+                squashFromInst->staticInst->advancePC(*toCommit->pc[tid]);
+            }
+        }
+        toCommit->mispredictInst[tid] = NULL;
+        toCommit->branchTaken[tid] = false;
+        toCommit->valuePredictionError[tid] = false;
+        toCommit->includeSquashInst[tid] = includeSquashInst;
+        toCommit->longLatencyFlush[tid] = true;
+        wroteToTimeBuffer = true;
+
+        DPRINTF(DecoupleBP,
+                "long-latency flush (pc=%#lx) set target id "
+                "to %lu, loop iter to %u\n",
+                toCommit->pc[tid]->instAddr(),
+                toCommit->squashedTargetId[tid],
+                toCommit->squashedLoopIter[tid]);
+    }
 
     stallSig->blockRename[tid] = true;
 }

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -773,8 +773,19 @@ IEW::squashDueToLongLatencyLoad(const DynInstPtr &loadInst,
             tid, loadInst->seqNum, squashFromInst->seqNum,
             (int)includeSquashInst);
 
+    // Long-latency flush is a non-essential, lowest-priority squash.
+    // It proceeds when ANY of the following holds:
+    //   (a) No other squash is pending;
+    //   (b) This flush has an older boundary than the existing squash;
+    //   (c) Same boundary as the existing squash, but the existing squash does
+    //       NOT include the boundary instruction (!toCommit->includeSquashInst).
+    //       In this case the flush is strictly more aggressive and can override.
+    // Conversely, if an existing squash already includes the boundary instruction
+    // (e.g., branch mispredict or mem-order violation), it has higher priority
+    // and this flush must yield.
     if (!toCommit->squash[tid] || squashFromInst->seqNum < toCommit->squashedSeqNum[tid] ||
-        (squashFromInst->seqNum == toCommit->squashedSeqNum[tid] && includeSquashInst)) {
+        (squashFromInst->seqNum == toCommit->squashedSeqNum[tid] &&
+         includeSquashInst && !toCommit->includeSquashInst[tid])) {
         toFetch->iewInfo[tid].redirectPending = true;
         toCommit->squash[tid] = true;
         toCommit->squashedSeqNum[tid] = squashFromInst->seqNum;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -642,6 +642,19 @@ class IEW
     StallReason checkLsqStall(ThreadID tid, bool isLoad) {
       return checkLSQStall(tid, isLoad);
     }
+
+    /** Sends commit proper information for a squash due to a long-latency
+     * load detected by the fetch stage's flush policy.
+     */
+    void squashDueToLongLatencyLoad(const DynInstPtr &loadInst,
+                                    const DynInstPtr &squashFromInst,
+                                    ThreadID tid,
+                                    bool includeSquashInst);
+
+    /** ROB access wrappers for Fetch's FlushFrom policy. */
+    std::list<DynInstPtr>& getRobInstList(ThreadID tid);
+    DynInstPtr readRobTailInst(ThreadID tid);
+    DynInstPtr findRobInst(ThreadID tid, InstSeqNum seqNum);
 };
 
 } // namespace o3

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -385,7 +385,14 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
     DPRINTF(Rename, "[tid:%i] [squash sn:%llu] Squashing instructions.\n",
         tid,squash_seq_num);
 
-    fixedbuffer[tid].clear();
+    // Selectively remove only instructions younger than squash boundary
+    for (auto it = fixedbuffer[tid].begin(); it != fixedbuffer[tid].end(); ) {
+        if ((*it)->seqNum > squash_seq_num) {
+            it = fixedbuffer[tid].erase(it);
+        } else {
+            ++it;
+        }
+    }
 
     doSquash(squash_seq_num, tid);
 }


### PR DESCRIPTION
## Summary

This PR extends SMT handling for long-latency loads from a single fetch-blocking mode into separate stall, throttle, and selective-flush policies. It allows experiments to deprioritize a blocked thread, drive fetch throttling from the block state, or reclaim younger pipeline work while keeping `BaseLine` as the default behavior.

## Policy behavior

| Policy | Behavior |
| --- | --- |
| `BaseLine` | Keeps the existing resource-pressure-based fetch throttling and does not block or flush on long-latency loads. |
| `BlockStallPolicy` | Adds asymmetric long-latency-load blocking to the existing backend-stall and memory-pressure throttling. |
| `BlockThrottlePolicy` | Uses the long-latency block state to drive the fetch throttle hold counter instead of the base throttle condition. |
| `FlushFromLoadPolicy` | Preserves the blocked load, squashes younger instructions, and restarts after the load. The current implementation retains base resource-pressure throttling and adds asymmetric block-based deprioritization. |
| `FlushFromUsePolicy` | Squashes from the first younger direct ROB consumer of the load result. If no consumer is present, it preserves the ROB through its tail and flushes only younger in-flight work. The current implementation retains base resource-pressure throttling and adds asymmetric block-based deprioritization. |

A thread enters the blocked state after the LQ-head instruction is classified as L2-, L3-, or memory-bound and remains in that state for the configured number of cycles. Asymmetric block/flush handling is enabled only when at least one configured thread is blocked and another is unblocked.

## Implementation

- Extend `SMTFetchBlockPolicy` and the XiangShan command-line option with the new policy choices.
- Detect persistent long-latency LQ-head stalls and track per-thread block and flush state in Fetch.
- Locate the first direct consumer through renamed physical-register dependencies for `FlushFromUsePolicy`.
- Add an IEW-to-Commit long-latency squash path with restart-PC and inclusive/exclusive squash-boundary handling.
- Add `LongLatencyFlush` squash accounting and fetch-side flush statistics.
- Preserve fixed-buffer entries at or before the squash boundary in Decode, Rename, IEW, and Commit so selective flushes retain older work.

## Compatibility

`BlockPolicy` is replaced by `BlockStallPolicy`; existing command lines or configuration files using `BlockPolicy` must migrate to the new name. `BaseLine` remains the default. The fixed-buffer cleanup change is part of the generic squash paths and therefore also applies outside the new flush policies.

## Performance Results

Evaluated on SPEC2006 SMT dual-thread configurations (thread 0 = INT, thread 1 = INT), using weighted speedup as the metric. Baseline: `BaseLine` with `--smt-decode-policy MultiPriority`, `--smt-fetch-block-threshold 15`, `--smt-fetch-throttle-cycles 8` (score = 24.828).

### Best Configurations per Policy (all with `--smt-decode-policy RoundRobin`)

| `--smt-fetch-block-policy` | `--smt-fetch-throttle-cycles` | `--smt-fetch-block-threshold` | Score | Speedup |
| --- | --- | --- | --- | --- |
| `BaseLine` | 15 | 1 | 24.916 | +0.35% |
| `BlockStallPolicy` | 4 | 0 | 24.930 | +0.41% |
| `BlockThrottlePolicy` | 4 | 1 | 24.930 | +0.41% |
| `FlushFromLoadPolicy` | 64 | 4 | 24.964 | +0.55% |
| `FlushFromUsePolicy` | 256 | 16 | 24.966 | +0.55% |

### Key Observations

- **RoundRobin** alone provides a modest +0.3% improvement over MultiPriority baseline.
- **Block + RoundRobin** (both Stall and Throttle variants) achieves up to +0.4%, with the block mechanism deprioritizing the stalled thread and RoundRobin ensuring fair scheduling.
- **Flush + RoundRobin** achieves the best results at +0.5%, with the squash mechanism reclaiming pipeline resources (ROB/IQ/rename registers) from the stalled thread.
- **Parameter sensitivity**: Flush policies show higher sensitivity to `--smt-fetch-throttle-cycles` and `--smt-fetch-block-threshold`. `FlushFromUsePolicy` optimal config requires `--smt-fetch-throttle-cycles 256` (much higher than other policies), indicating that the flush mechanism benefits from longer throttle hold periods to amortize the squash cost.
- **FlushFromLoadPolicy vs FlushFromUsePolicy**: Both achieve similar peak performance (+0.55%). `FlushFromUsePolicy` preserves more independent instructions in the ROB (squashing from first consumer rather than from the load), but requires more careful parameter tuning.

### Statistical Insights

The `fetchBlockState` statistics confirm the asymmetric blocking behavior:

- Under `BlockStallPolicy`, `BothUnblocked` drops by ~16-24% (relative to baseline) while `Tid0Blocked`, `Tid1Blocked`, and `BothBlocked` states appear, confirming the detection mechanism is active.
- `fetchBlockHoldCycle::Blocked::mean` ranges from ~20 cycles (`--smt-fetch-throttle-cycles 0`) to ~104 cycles (`--smt-fetch-throttle-cycles 15`), consistent with the configured throttle hold parameters.
- Under `FlushFromUsePolicy` with `--smt-fetch-throttle-cycles 256`, the blocked hold cycle mean reaches ~509 cycles, reflecting the longer throttle period needed for the flush to be effective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded SMT fetch-blocking options with distinct stall, throttle, and flush-from-load/use policies.
  - Added long-latency load handling with consumer detection, throttling, and targeted pipeline flushing.
  - Added statistics for long-latency-load-triggered flushes and their outcomes.

- **Bug Fixes**
  - Pipeline squashes now preserve instructions at or before the squash boundary instead of clearing entire buffers.
  - Improved squash tracking and reporting for long-latency events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->