### PR TITLE
configs: Default SMT pre-dispatch to 2 x 4

### DIFF
--- a/configs/example/smt_idealkmhv3.py
+++ b/configs/example/smt_idealkmhv3.py
@@ -41,12 +41,11 @@ def setDualFrontendProbeParams(system):
         cpu.branchPred.smtNumPredictingThreads = 2
         cpu.smtNumFetchTargetThreads = 2
         cpu.smtNumPreDispatchThreads = 2
-        # Keep the dual-thread pre-dispatch probe closer to an RTL-oriented
-        # 10-wide implementation: each thread can contribute up to five
-        # instructions per cycle. Wider upper-bound probes can override both
-        # widths from the command line.
-        cpu.decodeWidth = 5
-        cpu.renameWidth = 5
+        # Match the single-thread baseline's aggregate 8-wide decode/rename
+        # bandwidth: each thread can contribute up to four instructions per
+        # cycle. Wider probes can override both widths from the command line.
+        cpu.decodeWidth = 4
+        cpu.renameWidth = 4
         cpu.icache.tag_load_read_ports = 4
 
         # Keep early-predictor training on the existing resolve/commit path.


### PR DESCRIPTION
## Motivation and change

The default SMT configuration admits up to 10 instructions per cycle (2 x 5) through decode/rename, while the single-thread baseline admits 8. Set the per-thread decode and rename caps to 4 so the aggregate admission bandwidth matches the baseline. Dual-thread admission remains enabled; issue, execution, retirement, and queue capacities are unchanged. Wider probes remain available through parameter overrides.

## Validation

- `git diff --check` and the repository style check on modified lines passed.
- Python compilation and direct configuration-function evaluation confirmed `decodeWidth=4`, `renameWidth=4`, and `smtNumPreDispatchThreads=2`.
- Preliminary [0.3c experiment](https://github.com/OpenXiangShan/GEM5/actions/runs/34100809094): 140/148 completed slices, compared with the identical subset from [the 2 x 5 weekly run](https://github.com/OpenXiangShan/GEM5/actions/runs/33793885374), both on `fe20fb50db`. Reweighted with `gem5_data_proc --slice gcc12`: SPECint -3.56%, SPECfp -1.59%, overall -2.44%. These are partial results: lbm is absent and several other benchmarks have missing slices.

The branch starts from the weekly commit to isolate the width change in the forthcoming distributed 1.0c comparison. It does not include the subsequent BPU refactor #1122. No full local rebuild or new simulation was run for this configuration-only edit; the earlier experiment exercised the same width overrides.

Distributed 1.0c follow-up: [run 34112840967](https://github.com/OpenXiangShan/GEM5/actions/runs/34112840967), dispatched against tested commit `e9226da8d9d48b5824dcbba4e90a22ece4ee5e9a` with `gcc12-spec06-smt-1.0c`, `distributed_servers=default`, and 32 jobs per server. The workflow is dispatched from `xs-dev`; its workflow head SHA is distinct from the tested commit. Run created and queued; results pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dual-frontend probe configuration to use a decode and rename width of 4 instructions per thread instead of 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->