### PR TITLE
cpu-o3: Add optional registered IQ enqueue timing

### DIFF
--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -64,6 +64,8 @@ def setKmhV3Params(args, system):
         # scheduler
         cpu.scheduler = KMHV3Scheduler()
         cpu.scheduler.disableAllRegArb()
+        for iq in cpu.scheduler.IQs:
+            iq.deferNewEnqueueSelection = True
         cpu.scheduler.enableMainRdpOpt = False
         cpu.scheduler.intRegfileBanks = 1
         # intiq0

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -64,8 +64,6 @@ def setKmhV3Params(args, system):
         # scheduler
         cpu.scheduler = KMHV3Scheduler()
         cpu.scheduler.disableAllRegArb()
-        for iq in cpu.scheduler.IQs:
-            iq.deferNewEnqueueSelection = True
         cpu.scheduler.enableMainRdpOpt = False
         cpu.scheduler.intRegfileBanks = 1
         # intiq0

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -64,6 +64,8 @@ def setKmhV3Params(args, system):
         # scheduler
         cpu.scheduler = KMHV3Scheduler()
         cpu.scheduler.disableAllRegArb()
+        for iq in cpu.scheduler.IQs:
+            iq.deferNewEnqueueSelection = not args.smt
         cpu.scheduler.enableMainRdpOpt = False
         cpu.scheduler.intRegfileBanks = 1
         # intiq0

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -84,9 +84,6 @@ class IssueQue(SimObject):
     size = Param.Int(16, "")
     inports = Param.Int(2, "")
     scheduleToExecDelay = Param.Cycles(2, "")
-    deferNewEnqueueSelection = Param.Bool(
-        False, "Delay selection of newly enqueued instructions until the next cycle"
-    )
     vectorSplitUnits = Param.Unsigned(
         2, "Number of independent vector load/store split units per direction")
     oports = VectorParam.IssuePort("")

--- a/src/cpu/o3/FuncScheduler.py
+++ b/src/cpu/o3/FuncScheduler.py
@@ -84,6 +84,9 @@ class IssueQue(SimObject):
     size = Param.Int(16, "")
     inports = Param.Int(2, "")
     scheduleToExecDelay = Param.Cycles(2, "")
+    deferNewEnqueueSelection = Param.Bool(
+        False, "Delay selection of newly enqueued instructions until the next cycle"
+    )
     vectorSplitUnits = Param.Unsigned(
         2, "Number of independent vector load/store split units per direction")
     oports = VectorParam.IssuePort("")

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -197,6 +197,7 @@ IssueQue::IssueQue(const IssueQueParams& params)
       outports(params.oports.size()),
       iqsize(params.size),
       scheduleToExecDelay(params.scheduleToExecDelay),
+      deferNewEnqueueSelection(params.deferNewEnqueueSelection),
       iqname(params.name),
       vectorSplitUnits(params.vectorSplitUnits),
       nextVectorLoadSplitUnit(0),
@@ -210,6 +211,10 @@ IssueQue::IssueQue(const IssueQueParams& params)
 {
     panic_if(vectorSplitUnits == 0,
              "%s: vectorSplitUnits must be greater than 0\n", iqname);
+
+    if (deferNewEnqueueSelection) {
+        enqueuedThisCycle.reserve(inports);
+    }
 
     toIssue = inflightIssues.getWire(0);
     toFu = inflightIssues.getWire(-scheduleToExecDelay);
@@ -989,6 +994,16 @@ IssueQue::selectInst()
                 continue;
             }
 
+            // Registered entries cannot participate in their enqueue cycle.
+            if (deferNewEnqueueSelection &&
+                std::find(enqueuedThisCycle.begin(), enqueuedThisCycle.end(),
+                          inst->seqNum) != enqueuedThisCycle.end()) {
+                DPRINTF(Schedule, "[sn:%llu] defer selection after enqueue\n",
+                        inst->seqNum);
+                ++it;
+                continue;
+            }
+
             uint32_t lat = scheduler->getCorrectedOpLat(inst);
             uint64_t busy_bit = (lat > 63 ? -1 : (1llu << lat));
             if (!(portBusy[pi] & busy_bit)) {
@@ -1086,6 +1101,7 @@ IssueQue::tick()
         iqstats->insertDist[instNumInsert]++;
     }
     instNumInsert = 0;
+    enqueuedThisCycle.clear();
 
     scheduleInst();
     processVectorReadyQ();
@@ -1117,6 +1133,9 @@ IssueQue::insert(const DynInstPtr& inst)
     (*instNumClassify[inst->opClass()])++;
     instNum++;
     instNumInsert++;
+    if (deferNewEnqueueSelection) {
+        enqueuedThisCycle.push_back(inst->seqNum);
+    }
 
     cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueQue);
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -197,6 +197,7 @@ IssueQue::IssueQue(const IssueQueParams& params)
       outports(params.oports.size()),
       iqsize(params.size),
       scheduleToExecDelay(params.scheduleToExecDelay),
+      deferNewEnqueueSelection(params.deferNewEnqueueSelection),
       iqname(params.name),
       vectorSplitUnits(params.vectorSplitUnits),
       nextVectorLoadSplitUnit(0),
@@ -211,7 +212,9 @@ IssueQue::IssueQue(const IssueQueParams& params)
     panic_if(vectorSplitUnits == 0,
              "%s: vectorSplitUnits must be greater than 0\n", iqname);
 
-    enqueuedThisCycle.reserve(inports);
+    if (deferNewEnqueueSelection) {
+        enqueuedThisCycle.reserve(inports);
+    }
 
     toIssue = inflightIssues.getWire(0);
     toFu = inflightIssues.getWire(-scheduleToExecDelay);
@@ -993,7 +996,8 @@ IssueQue::selectInst()
 
             // The dispatch input becomes selectable only after the enqueue
             // register boundary. Resident entries keep their wakeup timing.
-            if (std::find(enqueuedThisCycle.begin(), enqueuedThisCycle.end(),
+            if (deferNewEnqueueSelection &&
+                std::find(enqueuedThisCycle.begin(), enqueuedThisCycle.end(),
                           inst->seqNum) != enqueuedThisCycle.end()) {
                 DPRINTF(Schedule, "[sn:%llu] defer selection after enqueue\n",
                         inst->seqNum);
@@ -1130,7 +1134,9 @@ IssueQue::insert(const DynInstPtr& inst)
     (*instNumClassify[inst->opClass()])++;
     instNum++;
     instNumInsert++;
-    enqueuedThisCycle.push_back(inst->seqNum);
+    if (deferNewEnqueueSelection) {
+        enqueuedThisCycle.push_back(inst->seqNum);
+    }
 
     cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueQue);
 

--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -197,7 +197,6 @@ IssueQue::IssueQue(const IssueQueParams& params)
       outports(params.oports.size()),
       iqsize(params.size),
       scheduleToExecDelay(params.scheduleToExecDelay),
-      deferNewEnqueueSelection(params.deferNewEnqueueSelection),
       iqname(params.name),
       vectorSplitUnits(params.vectorSplitUnits),
       nextVectorLoadSplitUnit(0),
@@ -212,9 +211,7 @@ IssueQue::IssueQue(const IssueQueParams& params)
     panic_if(vectorSplitUnits == 0,
              "%s: vectorSplitUnits must be greater than 0\n", iqname);
 
-    if (deferNewEnqueueSelection) {
-        enqueuedThisCycle.reserve(inports);
-    }
+    enqueuedThisCycle.reserve(inports);
 
     toIssue = inflightIssues.getWire(0);
     toFu = inflightIssues.getWire(-scheduleToExecDelay);
@@ -994,9 +991,9 @@ IssueQue::selectInst()
                 continue;
             }
 
-            // Registered entries cannot participate in their enqueue cycle.
-            if (deferNewEnqueueSelection &&
-                std::find(enqueuedThisCycle.begin(), enqueuedThisCycle.end(),
+            // The dispatch input becomes selectable only after the enqueue
+            // register boundary. Resident entries keep their wakeup timing.
+            if (std::find(enqueuedThisCycle.begin(), enqueuedThisCycle.end(),
                           inst->seqNum) != enqueuedThisCycle.end()) {
                 DPRINTF(Schedule, "[sn:%llu] defer selection after enqueue\n",
                         inst->seqNum);
@@ -1133,9 +1130,7 @@ IssueQue::insert(const DynInstPtr& inst)
     (*instNumClassify[inst->opClass()])++;
     instNum++;
     instNumInsert++;
-    if (deferNewEnqueueSelection) {
-        enqueuedThisCycle.push_back(inst->seqNum);
-    }
+    enqueuedThisCycle.push_back(inst->seqNum);
 
     cpu->perfCCT->updateInstPos(inst->seqNum, PerfRecord::AtIssueQue);
 

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -115,6 +115,7 @@ class IssueQue : public SimObject
     const int iqsize;
     const int replayQsize = 32;
     const int scheduleToExecDelay;
+    const bool deferNewEnqueueSelection;
     const std::string iqname;
     std::vector<std::bitset<Num_OpClasses>> portFuDescs;
     std::vector<FUDesc*> fuDescs;
@@ -155,6 +156,8 @@ class IssueQue : public SimObject
 
     std::list<DynInstPtr> instList;
     uint64_t instNumInsert = 0;
+    // Bounded by this IQ's enqueue bandwidth; cleared before dispatch each tick.
+    std::vector<InstSeqNum> enqueuedThisCycle;
 
     std::vector<uint8_t*> instNumClassify;
     uint64_t instNum = 0;

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -115,7 +115,6 @@ class IssueQue : public SimObject
     const int iqsize;
     const int replayQsize = 32;
     const int scheduleToExecDelay;
-    const bool deferNewEnqueueSelection;
     const std::string iqname;
     std::vector<std::bitset<Num_OpClasses>> portFuDescs;
     std::vector<FUDesc*> fuDescs;

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -115,6 +115,7 @@ class IssueQue : public SimObject
     const int iqsize;
     const int replayQsize = 32;
     const int scheduleToExecDelay;
+    const bool deferNewEnqueueSelection;
     const std::string iqname;
     std::vector<std::bitset<Num_OpClasses>> portFuDescs;
     std::vector<FUDesc*> fuDescs;


### PR DESCRIPTION
A source-ready instruction currently can be selected in the same cycle gem5 dispatches it into an IQ. XiangShan's dispatch-to-selection path crosses an enqueue register first: the input becomes a valid `EnqEntry` in the following cycle. RTL designers confirmed that the former same-cycle optimization was removed for timing closure.

Add `IssueQue.deferNewEnqueueSelection` (default `false`) to model the registered enqueue boundary while retaining the same-cycle fast path for ideal/SMT studies. Enable it only in single-thread `configs/example/kmhv3.py`; `kmhv3.py --smt`, `idealkmhv3.py`, and `smt_idealkmhv3.py` leave it disabled. RTL designers may revisit the fast path, so keeping both timing contracts allows a controlled comparison.

When enabled, each IQ tracks the sequence numbers inserted this cycle and skips them during selection until the next tick. No separate RTL-style EnqEntry structure is needed. Users can override the setting with `--param 'system.cpu[0].scheduler.IQs[:].deferNewEnqueueSelection=True'` (or `False`).

RTL/CCT interpretation for an already-ready instruction without contention:

| Cycle | RTL behavior |
| --- | --- |
| T | Dispatch presents `io.enq`; `AtIssueQue` is recorded on `enq.valid`, before registered entry visibility. This marker alone does not establish `enq.fire` under backpressure. |
| T+1 | The registered `EnqEntry` is valid and can participate in selection directly; transfer to an `OthersEntry` is not a prerequisite for issue. |
| T+2 | The selected instruction crosses `deqDelay` and reaches DataPath `s0`, where register-read arbitration occurs and `AtIssueArb` is recorded. |

Thus the minimum CCT input-to-read-arbitration interval changes from 1 to 2 cycles. This is not a blanket extra cycle after every wakeup: existing resident instructions retain their original wakeup/select rules. FU latency, queue capacity, replay, redirect handling, and EnqEntry-to-OthersEntry migration are not reimplemented. The bounded per-IQ sequence-number list has O(enqueue bandwidth) lookup, at most 5 entries for KMHV3.

Validation against `daf5e33fc7` (#1122 merged):

- Final configurable revision: optimized build, style/diff checks, and CoreMark difftest pass for kmhv3, kmhv3 --smt, idealkmhv3, and smt_idealkmhv3. All 18 IQ flags are true only for single-thread kmhv3. kmhv3 reproduces the prior enabled-rule counters; ideal and smt_ideal reproduce pre-change baseline non-host counters (excluding the existing unstable decodeEfficiency derived statistic). CCT minimum input-to-arbitration is 2 cycles for kmhv3 and 1 for ideal.
- The enabled kmhv3 timing rule was validated with optimized builds, difftest, CoreMark, and CCT (minimum IQ input-to-arbitration interval 1 → 2 cycles).
- [Performance run 34202021021](https://github.com/OpenXiangShan/GEM5/actions/runs/34202021021) tested `87ddf3996c`; its single-thread kmhv3 behavior matches this enabled setting. All 145 selected GCC16 0.3c slices completed. SPECint/GHz: 21.2338 → 21.0524 (-0.854%); astar: 29.5619 → 29.1900 (-1.26%). This is a timing correction, not a speedup claim.
- [The performance comment](https://github.com/OpenXiangShan/GEM5/pull/1127#issuecomment-5583746138) includes matched RTL `421ad2da183` data: astar's positive score gap decreases from 8.05% to 6.69%. This does not establish uniform alignment across all benchmarks.

No full-suite performance rerun of the configurable revision or RVV regression is claimed. The run above must not be interpreted as evidence that ideal/SMT defaults are enabled. Dispatch Queue and redirect/flush changes remain independent.

No additional performance CI was dispatched for this revision, as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Newly enqueued instructions are no longer eligible for selection during the same cycle they enter the issue queue.
  * This behavior now applies consistently rather than being controlled by an option.
  * Eligibility is reevaluated on the following cycle, preserving the existing queue and dispatch flow while preventing same-cycle selection of newly inserted instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->