### PR TITLE
cpu-o3: Remove serialization barriers for vsetvli and vsetivli

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -571,7 +571,7 @@ template<typename ElemType>
 class VMaskMergeMicroInst : public VectorArithMicroInst
 {
   private:
-    RegId srcRegIdxArr[NumVecInternalRegs];
+    RegId srcRegIdxArr[NumVecInternalRegs + 1];
     RegId destRegIdxArr[1];
 
   public:
@@ -594,6 +594,8 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
         for (uint8_t i=0; i<_numSrcs; i++) {
             setSrcRegIdx(_numSrcRegs++, RegId(VecRegClass, VecTempReg0 + i));
         }
+        vlsrcIdx = _numSrcRegs;
+        setSrcRegIdx(_numSrcRegs++, VecRenamedVLReg);
     }
 
     Fault execute(ExecContext* xc, Trace::InstRecord* traceData)
@@ -610,7 +612,7 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
 
         // cp the first result and tail
         memcpy(Vd, s, VLENB);
-        for (uint8_t i = 1; i < this->_numSrcRegs; i++) {
+        for (uint8_t i = 1; i < vlsrcIdx; i++) {
             xc->getRegOperand(this, i, &tmp_s);
             s = tmp_s.as<uint8_t>();
             if constexpr (elems_per_vreg < 8) {
@@ -627,7 +629,7 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
         }
         // Fill mask destination tail bits with ones.
         // Mask-producing instructions always treat their tail as agnostic.
-        const uint64_t rVl = xc->readMiscReg(MISCREG_VL);
+        const uint64_t rVl = xc->getRegOperand(this, vlsrcIdx);
         const uint64_t vstart = xc->readMiscReg(MISCREG_VSTART);
 
         // If vstart >= vl, no destination elements, including tail

--- a/src/arch/riscv/isa/vector/base/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/base/vector_conf.isa
@@ -93,8 +93,6 @@ def template VConfExecute {{
     %(class_name)s::execute(ExecContext *xc,
         Trace::InstRecord *traceData) const
     {
-        auto tc = xc->tcBase();
-
         // All vector configuration instructions are illegal when the
         // vector context is disabled. This check must happen before
         // writing vstart, vtype or vl, because those writes may mark
@@ -120,7 +118,8 @@ def template VConfExecute {{
         assert(vtypesrcIdx > 0);
         VTYPE current_vtype = xc->getRegOperand(this, vtypesrcIdx);
 
-        tc->setMiscReg(MISCREG_VSTART, 0);
+        // Defer architectural updates until commit on speculative CPUs.
+        xc->setMiscReg(MISCREG_VSTART, 0);
 
         uint32_t vlen = xc->readMiscReg(MISCREG_VLENB) * 8;
         uint32_t vlmax = getVlmax(requested_vtype, vlen);

--- a/src/arch/riscv/isa/vector/simple/vector_conf.isa
+++ b/src/arch/riscv/isa/vector/simple/vector_conf.isa
@@ -93,8 +93,6 @@ def template VConfExecute {{
     %(class_name)s::execute(ExecContext *xc,
         Trace::InstRecord *traceData) const
     {
-        auto tc = xc->tcBase();
-
         // All vector configuration instructions are illegal when the
         // vector context is disabled. This check must happen before
         // writing vstart, vtype or vl, because those writes may mark
@@ -120,7 +118,8 @@ def template VConfExecute {{
         assert(vtypesrcIdx > 0);
         VTYPE current_vtype = xc->getRegOperand(this, vtypesrcIdx);
 
-        tc->setMiscReg(MISCREG_VSTART, 0);
+        // Defer architectural updates until commit on speculative CPUs.
+        xc->setMiscReg(MISCREG_VSTART, 0);
 
         uint32_t vlen = xc->readMiscReg(MISCREG_VLENB) * 8;
         uint32_t vlmax = getVlmax(requested_vtype, vlen);

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1729,7 +1729,8 @@ Commit::commitInsts()
                                     RiscvISA::MISCREG_VTYPE);
                             tc->getDecoderPtr()->as<RiscvISA::Decoder>().setVtype(new_vtype);
                         }
-                        if (hasExecutedYoungerInst(tid, head_inst->seqNum)) {
+                        if (!vset->vtypeIsImm &&
+                            hasExecutedYoungerInst(tid, head_inst->seqNum)) {
                             DPRINTF(Commit,
                                     "[tid:%i] [sn:%llu] Vector config "
                                     "committed with executed younger "

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -44,6 +44,7 @@
 
 #include "arch/generic/pcstate.hh"
 #include "arch/riscv/insts/fusion.hh"
+#include "arch/riscv/insts/vector.hh"
 #include "base/trace.hh"
 #include "config/the_isa.hh"
 #include "cpu/inst_seq.hh"
@@ -892,13 +893,17 @@ Decode::decodeInsts(ThreadID tid, unsigned max_insts)
         }
 #endif
 
-        if (inst->staticInst->isVectorConfig()) {
+        // Only register-based vtype needs a serialization barrier.
+        if (inst->staticInst->isVectorConfig() &&
+            !static_cast<RiscvISA::VConfOp *>(
+                inst->staticInst.get())->vtypeIsImm) {
             inst->setSerializeBefore();
             inst->setSerializeAfter();
             decode_stalls.push(StallReason::SerializeStall);
             breakDecode = StallReason::SerializeStall;
             DPRINTF(Decode,
-                    "[tid:%i] [sn:%llu] Vector config decoded, set serialize barrier and stop decoding younger "
+                    "[tid:%i] [sn:%llu] vsetvl decoded, set serialize "
+                    "barrier and stop decoding younger "
                     "instructions.\n",
                     tid, inst->seqNum);
             break;

--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -92,6 +92,29 @@ operator==(const BranchHistory &a, const BranchHistory &b)
     return true;
 }
 
+RegVal
+DynInst::read_pending_vstart(RegVal committed_val) const
+{
+    // Serialized CSR writes leave only speculative vset resets to forward.
+    for (auto it = cpu->instList.rbegin(); it != cpu->instList.rend(); ++it) {
+        const auto &inst = *it;
+        if (inst->seqNum >= seqNum || inst->threadNumber != threadNumber ||
+            inst->isSquashed()) {
+            continue;
+        }
+        for (size_t i = 0; i < inst->_destMiscRegIdx.size(); ++i) {
+            if (inst->_destMiscRegIdx[i] == RiscvISA::MISCREG_VSTART) {
+                DPRINTF(RiscvMisc,
+                        "[tid:%i] [sn:%llu] Forward VSTART from [sn:%llu]: "
+                        "%#lx\n", threadNumber, seqNum, inst->seqNum,
+                        inst->_destMiscRegVal[i]);
+                return inst->_destMiscRegVal[i];
+            }
+        }
+    }
+    return committed_val;
+}
+
 DynInst::DynInst(const Arrays &arrays, const StaticInstPtr &static_inst,
         const StaticInstPtr &_macroop, InstSeqNum seq_num, CPU *_cpu)
     : seqNum(seq_num), staticInst(static_inst),

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -53,6 +53,7 @@
 #include <string>
 #include <utility>
 
+#include "arch/riscv/regs/misc.hh"
 #include "base/refcnt.hh"
 #include "base/trace.hh"
 #include "base/types.hh"
@@ -1538,13 +1539,19 @@ class DynInst : public ExecContext, public RefCounted
     Tick RARQueueEntryTick = -1;
     Tick RAWQueueEntryTick = -1;
 
+    RegVal read_pending_vstart(RegVal committed_val) const;
+
     /** Reads a misc. register, including any side-effects the read
      * might have as defined by the architecture.
      */
     RegVal
     readMiscReg(int misc_reg) override
     {
-        return cpu->readMiscReg(misc_reg, threadNumber);
+        RegVal val = cpu->readMiscReg(misc_reg, threadNumber);
+        if (misc_reg == RiscvISA::MISCREG_VSTART && val != 0) {
+            return read_pending_vstart(val);
+        }
+        return val;
     }
 
     /** Sets a misc. register, including any side-effects the write

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1349,17 +1349,24 @@ Fetch::doSquash(PCStateBase &new_pc, const DynInstPtr squashInst, const InstSeqN
 
     // restore vtype
     uint8_t restored_vtype = cpu->readMiscReg(RiscvISA::MISCREG_VTYPE, tid);
+    bool vtype_ready = true;
     for (auto& it : cpu->instList) {
-        if (!it->isSquashed() &&
+        if (it->threadNumber == tid && !it->isSquashed() &&
             it->seqNum <= seqNum &&
             it->staticInst->isVectorConfig()) {
             auto vset = static_cast<RiscvISA::VConfOp*>(it->staticInst.get());
-            if (vset->vtypeIsImm) {
+            vtype_ready = vset->vtypeIsImm;
+            if (vtype_ready) {
                 restored_vtype = vset->earlyVtype;
             }
         }
     }
     decoder[tid]->as<RiscvISA::Decoder>().setVtype(restored_vtype);
+    // Only surviving unresolved vsetvl instructions keep fetch waiting.
+    if (!vtype_ready) {
+        decoder[tid]->as<RiscvISA::Decoder>().clearVtype();
+    }
+    waitForVsetvl[tid] = !vtype_ready;
 
     // align PC to 2 bytes
     // This handles cases where PC might be odd due to speculative execution,
@@ -1565,7 +1572,9 @@ Fetch::initializeTickState()
         bool updated_status = checkSignalsAndUpdate(tid);
         status_change =  status_change || updated_status;
         if (fromCommit->commitInfo[tid].emptyROB) {
-            waitForVsetvl[tid] = false;
+            // A decoded vsetvl may not have reached the ROB yet.
+            waitForVsetvl[tid] =
+                decoder[tid]->as<RiscvISA::Decoder>().stall();
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of RISC-V vector configuration instructions during speculative and out-of-order execution.
  - Corrected recovery and serialization behavior for register-based versus immediate vector configurations.
  - Improved tracking of vector length and vector start state so dependent instructions observe the correct values.
  - Fixed decoder and fetch recovery behavior after squashed vector configuration instructions, including cases where the instruction queue is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->