### PR TITLE
tests,util: prepend config type to artifact name

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           ref: ${{ inputs.pr_sha || github.sha }}
           persist-credentials: false
-      
+
       - name: Set benchmark configuration
         id: config
         run: |
@@ -87,7 +87,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-smt-0.3c")
@@ -95,7 +94,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/spec06_0.3c.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-smt-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage dual-context SMT spec06 checkpoints, 148 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-smt-1.0c")
@@ -103,7 +101,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-smt-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage dual-context SMT spec06 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-smt-int-1.0c")
@@ -111,7 +108,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/xuyan/spec06_gcc12.2.0_rv64gcb_base_intFppOff_for_qemu_dual_core_disable_timer_QEMU_archgroup_2024-11-11-15-46/checkpoint-0-0-0" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/spec06_1c_int.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-smt-int-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage dual-context SMT SPEC06 int checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-0.8c")
@@ -119,7 +115,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-0.8c" >> $GITHUB_OUTPUT
               echo "comment=run 80% coverage spec06 checkpoints, 500+ checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc12-spec06-1.0c")
@@ -127,7 +122,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/jiaxiaoyu/simpoint_checkpoint_zstd_format/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc12-spec06-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage spec06 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "spec06-rva23-novec-gcc16-0.3c")
@@ -135,7 +129,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_cov0.3.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-rva23-novec-gcc16-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage gcc16 rva23-novec SPEC06 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "spec06-rva23-novec-gcc16-1.0c")
@@ -143,7 +136,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_all.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-rva23-novec-gcc16-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage gcc16 rva23-novec SPEC06 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec06-0.3c")
@@ -151,7 +143,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/json/checkpoints_cov0.3.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc15-spec06-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run legacy 30% coverage gcc15 SPEC06 checkpoints from spec06_gcc15_rv64gcb_base_260604" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec06-1.0c")
@@ -159,7 +150,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/json/checkpoints_all.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc15-spec06-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run legacy 100% coverage gcc15 SPEC06 checkpoints from spec06_gcc15_rv64gcb_base_260604" >> $GITHUB_OUTPUT
               ;;
             "h-spec06-0.5c")
@@ -167,7 +157,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/gem5_ci/spec06_cpts/h_spec06/checkpoint-0-0-0" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/h_spec06/h_spec06_0.5c_h_profile_insts.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-h-spec06-0.5c" >> $GITHUB_OUTPUT
               echo "comment=run 50% coverage H SPEC06 checkpoints with FS0 NEMU, GCPT restore, DRAMsim3 and 40M maxinsts" >> $GITHUB_OUTPUT
               ;;
             "h-spec06-1.0c")
@@ -175,7 +164,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/gem5_ci/spec06_cpts/h_spec06/checkpoint-0-0-0" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec06_cpts/h_spec06/h_spec06_1.0c_h_profile_insts.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-h-spec06-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage H SPEC06 checkpoints with FS0 NEMU, GCPT restore, DRAMsim3 and 40M maxinsts" >> $GITHUB_OUTPUT
               ;;
             "spec17-1.0c")
@@ -183,7 +171,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/yanyue/spec17_cpts/checkpoint-0-0-0/" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci-17.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/yanyue/spec17_cpts/checkpoint-0-0-0/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec17-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage spec17 checkpoints" >> $GITHUB_OUTPUT
               ;;
             "spec06-rvv-1.0c")
@@ -191,7 +178,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/xutongqiao/GEM5-CI/spec06_gcc15_rv64gcbv_O3_lto_base_nemu_single_core_NEMU_archgroup_2024-10-12-16-05/checkpoint06_rv64gcbv/" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/xutongqiao/GEM5-CI/spec06_gcc15_rv64gcbv_O3_lto_base_nemu_single_core_NEMU_archgroup_2024-10-12-16-05/checkpoint06_rv64gcbv/cluster-0-0.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06-1.0c-with-rvv-extension" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage spec06 rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
             "spec06int-rvv-0.8c")
@@ -199,7 +185,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/xutongqiao/GEM5-CI/spec06_gcc15_rv64gcbv_O3_lto_base_nemu_single_core_NEMU_archgroup_2024-10-12-16-05/checkpoint06_rv64gcbv/" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/xutongqiao/GEM5-CI/spec06_gcc15_rv64gcbv_O3_lto_base_nemu_single_core_NEMU_archgroup_2024-10-12-16-05/checkpoint06_rv64gcbv/cluster_0.8c_int.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-spec06int-0.8c-with-rvv-extension" >> $GITHUB_OUTPUT
               echo "comment=run 80% coverage spec06 int rvv checkpoints" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec26-0.3c")
@@ -207,7 +192,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_rate_gcc15_rv64gcb_260718/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/checkpoints_cov0.3.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc15-spec26-0.3c" >> $GITHUB_OUTPUT
               echo "comment=run 30% coverage SPEC CPU2026 checkpoints plus 722.palm_r/201821 regression" >> $GITHUB_OUTPUT
               ;;
             "gcc15-spec26-1.0c")
@@ -215,7 +199,6 @@ jobs:
               echo "checkpoint_root_node=/nfs/home/share/checkpoints_profiles/spec26_rate_gcc15_rv64gcb_260718/checkpoint" >> $GITHUB_OUTPUT
               echo "score_script=gem5-score-ci-26.sh" >> $GITHUB_OUTPUT
               echo "cluster_config=/nfs/home/share/gem5_ci/spec26_cpts/rv64gcb_260718/checkpoints_all.json" >> $GITHUB_OUTPUT
-              echo "artifact_name=performance-score-gcc15-spec26-1.0c" >> $GITHUB_OUTPUT
               echo "comment=run 100% coverage SPEC CPU2026 checkpoints" >> $GITHUB_OUTPUT
               ;;
             *)
@@ -232,6 +215,22 @@ jobs:
             echo "profile_restorer=$H_RESTORER" >> "$GITHUB_OUTPUT"
             echo "profile_extra_args=--enable-h-gcpt --restore-rvh-cpt --gcpt-restorer=$H_RESTORER --difftest-ref-so=$H_REF_SO --maxinsts=40000000 --dramsim3-ini=$H_DRAM_INI" >> "$GITHUB_OUTPUT"
           fi
+
+          case "${{ inputs.config_path }}" in
+            */kmhv3.py|*/kmhv2.py)
+              artifact_name_prefix="score"
+              ;;
+            */idealkmhv3.py)
+              artifact_name_prefix="score-ideal"
+              ;;
+            */smt_idealkmhv3.py)
+              artifact_name_prefix="score-smt-ideal"
+              ;;
+            *)
+              artifact_name_prefix="score-unknown"
+              ;;
+          esac
+          echo "artifact_name=${artifact_name_prefix}-${{ inputs.benchmark_type }}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/build-dramsim
       - name: Build GEM5 fast
@@ -522,8 +521,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.config.outputs.artifact_name }}${{ steps.config.outputs.pf_artifact_suffix }}
+          name: ${{ steps.config.outputs.artifact_name }}
           path: score.txt
           if-no-files-found: warn
           retention-days: 30
-      


### PR DESCRIPTION
So other scripts like https://github.com/OpenXiangShan/XiangShan-Dashboard and https://github.com/jensen-yan/GEM5-Perf-Dashboard can identify them in an easier way.

Change-Id: Ia935f5d62ee49e9a95f2fed9dd085ed889a633db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized performance artifact naming based on benchmark configuration and type.
  * Improved artifact naming for score, ideal-score, SMT ideal-score, and unknown configurations.
  * Simplified uploaded artifact labels for more consistent identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->