### PR TITLE
cpu-o3: Rename vector split eligibility helper

### DIFF
--- a/src/cpu/o3/issue_queue.cc
+++ b/src/cpu/o3/issue_queue.cc
@@ -379,15 +379,9 @@ IssueQue::addToFu(const DynInstPtr& inst)
 }
 
 bool
-IssueQue::isVectorMemInst(const DynInstPtr& inst) const
+IssueQue::isVectorNonContinuousMemInst(const DynInstPtr& inst) const
 {
-    return inst && inst->isVector() && inst->isMemRef() && !inst->isSquashed();
-}
-
-bool
-IssueQue::needsVectorMemSplit(const DynInstPtr& inst) const
-{
-    return isVectorMemInst(inst) &&
+    return inst && inst->isVector() && inst->isMemRef() && !inst->isSquashed() &&
            inst->opClass() != enums::VectorUnitStrideLoad;
 }
 
@@ -431,7 +425,7 @@ IssueQue::nextVectorSplitUnitFor(VectorSplitKind kind)
 bool
 IssueQue::isBlockingVectorSplitInst(const DynInstPtr& inst) const
 {
-    return needsVectorMemSplit(inst);
+    return isVectorNonContinuousMemInst(inst);
 }
 
 bool
@@ -530,7 +524,7 @@ IssueQue::scheduleVectorReadyQEvent()
 void
 IssueQue::enqueueVectorMemDelay(const DynInstPtr& inst, bool replay)
 {
-    if (!isVectorMemInst(inst) || (!replay && inst->canceled())) {
+    if (!isVectorNonContinuousMemInst(inst) || (!replay && inst->canceled())) {
         return;
     }
 
@@ -825,7 +819,7 @@ IssueQue::retryMem(const DynInstPtr& inst)
             DynInst::LoadPipeSource::ReplayQueue);
     }
     DPRINTF(Schedule, "retry %s [sn:%llu]\n", enums::OpClassStrings[inst->opClass()], inst->seqNum);
-    if (needsVectorMemSplit(inst)) {
+    if (isVectorNonContinuousMemInst(inst)) {
         enqueueVectorMemDelay(inst, true);
         return;
     }
@@ -945,7 +939,7 @@ IssueQue::addIfReady(const DynInstPtr& inst)
         DPRINTF(Schedule, "[sn:%llu] add to readyInstsQue\n", inst->seqNum);
         inst->clearCancel();
         if (!inst->inReadyQ()) {
-            if (needsVectorMemSplit(inst)) {
+            if (isVectorNonContinuousMemInst(inst)) {
                 enqueueVectorMemDelay(inst, false);
             } else {
                 READYQ_PUSH(inst);

--- a/src/cpu/o3/issue_queue.hh
+++ b/src/cpu/o3/issue_queue.hh
@@ -229,8 +229,7 @@ class IssueQue : public SimObject
     void replay(const DynInstPtr& inst);
     void addToFu(const DynInstPtr& inst);
     bool checkScoreboard(const DynInstPtr& inst);
-    bool isVectorMemInst(const DynInstPtr& inst) const;
-    bool needsVectorMemSplit(const DynInstPtr& inst) const;
+    bool isVectorNonContinuousMemInst(const DynInstPtr& inst) const;
     VectorSplitKind vectorSplitKind(const DynInstPtr& inst) const;
     const char* vectorSplitKindName(VectorSplitKind kind) const;
     bool isBlockingVectorSplitInst(const DynInstPtr& inst) const;


### PR DESCRIPTION
Rename isVectorMemInst to isVectorNonContinuousMemInst and consolidate the needsVectorMemSplit predicate into it. Update all call sites and related documentation without changing split behavior.

Change-Id: Iae1f1ccdc1fdb3d510ae3713a47bafaa6b34dff2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vector memory operations in the issue queue.
  * Unit-stride vector loads now follow the appropriate scheduling path instead of entering the vector delay/ready queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->