### PR TITLE
arch-riscv: Fix L2 TLB removal stats size

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -3266,13 +3266,13 @@ TLB::TlbStats::TlbStats(statistics::Group *parent)
                readAccesses + writeAccesses)
 {
     l2tlbRemove
-        .init(L_L2sp3 + 1)
+        .init(L_L2SUM)
         .flags(gem5::statistics::total);
     l2tlbUsedRemove
-        .init(L_L2sp3 + 1)
+        .init(L_L2SUM)
         .flags(gem5::statistics::total);
     l2tlbUnusedRemove
-        .init(L_L2sp3 + 1)
+        .init(L_L2SUM)
         .flags(gem5::statistics::total);
     l1CompressPotentialPagesPerBlock
         .init(l2tlbLineSize + 1)


### PR DESCRIPTION
## Motivation

The full SPEC17 run [34309235322](https://github.com/OpenXiangShan/GEM5/actions/runs/34309235322) aborted only on `557.xz_rate_refrate_00_cld.tar-160-6`, point `16910` (weight `0.0109951%`), with:

```
panic condition !(index < size()) occurred: l2tlbRemove
```

## Root cause

The L2 TLB removal path uses page-type values `1..7` (`L_L2L3` through `L_L2sp1`) as statistics vector indexes. The three removal vectors were initialized with `L_L2sp3 + 1`, giving only six entries (`0..5`). Removing an `sp2` or `sp1` entry therefore indexed past the vector.

## Change

Initialize `l2tlbRemove`, `l2tlbUsedRemove`, and `l2tlbUnusedRemove` with `L_L2SUM`, covering every valid page-type index while preserving the existing one-based indexing. This changes only statistics storage; L2 TLB lookup, replacement, and removal behavior are unchanged.

## Validation

- `scons build/RISCV/gem5.opt --gold-linker -j64`
- Re-ran the exact failing GCC16 RVA23 SPEC17 checkpoint with `idealkmhv3.py` and the r2 RVA23 NEMU reference.
- Completed normally at tick `10452992544` with two statistics blocks (about 20M warmup + 20M measured instructions).
- `system.cpu.mmu.l2_shared.l2tlbRemove::7 = 1`, confirming the formerly out-of-range access is now recorded.
- No panic or difftest failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initialization of L2 TLB removal statistics to use the appropriate histogram range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->