### PR TITLE
misc: Add jensen-yan as a repository code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jueshiwenli @happy-lx
+* @jueshiwenli @happy-lx @jensen-yan


### PR DESCRIPTION
## Motivation

Add @jensen-yan as a code owner to reflect broad review responsibilities across CI, frontend, SMT, external partner contributions, and miscellaneous maintenance.

## Changes

- Add @jensen-yan to the existing repository-wide `*` rule.
- Preserve @jueshiwenli and @happy-lx as existing owners.
- Use repository-wide coverage because these responsibilities span paths; CODEOWNERS cannot select owners based on PR authorship.

## Scope and permissions

This updates code-owner review routing and applicable owner-approval rules only. It does not grant repository access or change branch protection.

## Validation

- `git diff --check` passed.
- Verified the diff changes only one line in `.github/CODEOWNERS`.
- No runtime tests required for this ownership-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments to include an additional code owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->