### PR TITLE
misc: Support custom checkpoint profiles in manual perf runs

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -16,6 +16,16 @@ on:
         required: true
         type: string
         description: "Benchmark type registered in util/xs_scripts/perf_benchmarks.py"
+      checkpoint_path:
+        required: false
+        type: string
+        default: ""
+        description: "Custom profile or checkpoint directory."
+      json_path:
+        required: false
+        type: string
+        default: ""
+        description: "Custom weights JSON; empty discovers the full-coverage JSON."
       specific_benchmarks:
         required: false
         type: string
@@ -78,11 +88,16 @@ jobs:
         id: config
         env:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
+          CHECKPOINT_PATH_INPUT: ${{ inputs.checkpoint_path }}
+          JSON_PATH_INPUT: ${{ inputs.json_path }}
           GCBV_REF_INPUT: ${{ inputs.gcbv_ref_so }}
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
         run: |
           python3 util/xs_scripts/perf_benchmarks.py \
             "$BENCHMARK_TYPE" \
+            --checkpoint-path "$CHECKPOINT_PATH_INPUT" \
+            --json-path "$JSON_PATH_INPUT" \
+            --output-dir "$GITHUB_WORKSPACE/.perf-inputs" \
             --github-output "$GITHUB_OUTPUT"
 
           if [[ "$BENCHMARK_TYPE" == h-spec06-* ]]; then
@@ -131,9 +146,12 @@ jobs:
         id: archive
         env:
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
-          BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
+          BENCHMARK_TYPE_INPUT: ${{ steps.config.outputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_ARGS_INPUT: ${{ inputs.extra_args }}
+          CHECKPOINT_LIST_INPUT: ${{ steps.config.outputs.checkpoint_list }}
+          CHECKPOINT_ROOT_INPUT: ${{ steps.config.outputs.checkpoint_root_node }}
+          CLUSTER_CONFIG_INPUT: ${{ steps.config.outputs.cluster_config }}
           DISTRIBUTED_SERVERS_RAW: ${{ inputs.distributed_servers }}
           DISTRIBUTED_JOBS_PER_SERVER_RAW: ${{ inputs.distributed_jobs_per_server }}
         run: |
@@ -156,6 +174,8 @@ jobs:
           DISTRIBUTED_IDLE_PROBE_MODE="physical"
 
           mkdir -p "$TARGET_DIR"
+          cp "$CHECKPOINT_LIST_INPUT" "$TARGET_DIR/checkpoints.lst"
+          cp "$CLUSTER_CONFIG_INPUT" "$TARGET_DIR/cluster.json"
 
           {
             echo "benchmark_dir=$BENCHMARK_DIR"
@@ -177,6 +197,9 @@ jobs:
           echo "config_name: $CONFIG_NAME" >> "$TARGET_DIR/metadata.txt"
           echo "run_number: $RUN_NUMBER" >> "$TARGET_DIR/metadata.txt"
           echo "benchmark_type: $BENCHMARK_TYPE_INPUT" >> "$TARGET_DIR/metadata.txt"
+          echo "checkpoint_root: $CHECKPOINT_ROOT_INPUT" >> "$TARGET_DIR/metadata.txt"
+          echo "checkpoint_list: $CHECKPOINT_LIST_INPUT" >> "$TARGET_DIR/metadata.txt"
+          echo "cluster_config: $CLUSTER_CONFIG_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "specific_benchmarks: $SPECIFIC_BENCHMARKS_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers_input: $DISTRIBUTED_SERVERS_INPUT" >> "$TARGET_DIR/metadata.txt"
           echo "distributed_servers: $DISTRIBUTED_SERVERS" >> "$TARGET_DIR/metadata.txt"
@@ -207,10 +230,10 @@ jobs:
           GEM5_BUILD_TYPE: fast
           PERF_ARCHIVE_DIR: ${{ steps.archive.outputs.target_dir }}
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
-          BENCHMARK_TYPE_INPUT: ${{ inputs.benchmark_type }}
+          BENCHMARK_TYPE_INPUT: ${{ steps.config.outputs.benchmark_type }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_GEM5_ARGS_RAW: ${{ inputs.extra_args }}
-          CHECKPOINT_LIST: ${{ steps.config.outputs.checkpoint_list }}
+          CHECKPOINT_LIST: ${{ steps.archive.outputs.target_dir }}/checkpoints.lst
           CHECKPOINT_ROOT_NODE: ${{ steps.config.outputs.checkpoint_root_node }}
           DISTRIBUTED_SERVERS: ${{ steps.archive.outputs.distributed_servers }}
           DISTRIBUTED_JOBS_PER_SERVER: ${{ inputs.distributed_jobs_per_server }}
@@ -321,7 +344,7 @@ jobs:
           export GEM5_HOME=$GITHUB_WORKSPACE
 
           cd $GITHUB_WORKSPACE/gem5_data_proc
-          CLUSTER_CONFIG="${{ steps.config.outputs.cluster_config }}"
+          CLUSTER_CONFIG="$PERF_ARCHIVE_DIR/cluster.json"
           if [[ "$CLUSTER_CONFIG" != /* ]]; then
             CLUSTER_CONFIG="$GEM5_HOME/$CLUSTER_CONFIG"
           fi

--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -147,6 +147,7 @@ jobs:
         env:
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
           BENCHMARK_TYPE_INPUT: ${{ steps.config.outputs.benchmark_type }}
+          ARCHIVE_SUBDIR_INPUT: ${{ steps.config.outputs.archive_subdir }}
           SPECIFIC_BENCHMARKS_INPUT: ${{ inputs.specific_benchmarks }}
           EXTRA_ARGS_INPUT: ${{ inputs.extra_args }}
           CHECKPOINT_LIST_INPUT: ${{ steps.config.outputs.checkpoint_list }}
@@ -156,7 +157,7 @@ jobs:
           DISTRIBUTED_JOBS_PER_SERVER_RAW: ${{ inputs.distributed_jobs_per_server }}
         run: |
           ARCHIVE_ROOT="/nfs/home/share/gem5_ci/performance_data"
-          BENCHMARK_DIR="${ARCHIVE_ROOT}/${BENCHMARK_TYPE_INPUT}"
+          BENCHMARK_DIR="${ARCHIVE_ROOT}/${ARCHIVE_SUBDIR_INPUT}"
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           RUN_NUMBER="${{ github.run_number }}"

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -38,6 +38,20 @@ on:
           - spec06int-rvv-0.8c
           - gcc15-spec26-0.3c
           - gcc15-spec26-1.0c
+          - custom
+          - custom-spec06
+          - custom-spec17
+          - custom-spec26
+      checkpoint_path:
+        description: 'Custom profile/checkpoint directory (custom auto-detects SPEC06/17/26 from path; all JSON points run by default)'
+        required: false
+        type: string
+        default: ''
+      json_path:
+        description: 'Custom weights JSON (empty: discover checkpoints_all.json or cluster-0-0.json in the profile)'
+        required: false
+        type: string
+        default: ''
       specific_benchmarks:
         description: 'Specific benchmarks to run (comma-separated, eg. "mcf,gcc"), leave empty to run all'
         required: false
@@ -96,6 +110,8 @@ jobs:
     with:
       config_path: ${{ needs.setup.outputs.config_path }}
       benchmark_type: ${{ github.event.inputs.benchmark_type }}
+      checkpoint_path: ${{ github.event.inputs.checkpoint_path }}
+      json_path: ${{ github.event.inputs.json_path }}
       specific_benchmarks: ${{ github.event.inputs.specific_benchmarks }}
       extra_args: ${{ github.event.inputs.extra_args }}
       gcbv_ref_so: ${{ github.event.inputs.gcbv_ref_so }}

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, startsWith(github.event.inputs.benchmark_type, 'custom') && github.event.inputs.checkpoint_path && format('{0} [{1}]', github.event.inputs.benchmark_type, github.event.inputs.checkpoint_path) || github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.extra_args || 'no-extra-args') }}
+run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5} [{6}]', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, startsWith(github.event.inputs.benchmark_type, 'custom') && github.event.inputs.checkpoint_path && format('{0} [{1}]', github.event.inputs.benchmark_type, github.event.inputs.checkpoint_path) || github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.extra_args || 'no-extra-args', github.event.inputs.distributed_servers && 'distributed' || 'local') }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-perf.yml
+++ b/.github/workflows/manual-perf.yml
@@ -1,5 +1,5 @@
 name: Manual Performance Test
-run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.extra_args || 'no-extra-args') }}
+run-name: ${{ format('{0} - {1} - {2}{3} - {4} - {5}', github.event.inputs.note || 'Manual Performance Test', github.event.inputs.configuration, startsWith(github.event.inputs.benchmark_type, 'custom') && github.event.inputs.checkpoint_path && format('{0} [{1}]', github.event.inputs.benchmark_type, github.event.inputs.checkpoint_path) || github.event.inputs.benchmark_type, github.event.inputs.specific_benchmarks && format(' ({0})', github.event.inputs.specific_benchmarks) || '', github.event.inputs.branch || github.ref_name, github.event.inputs.extra_args || 'no-extra-args') }}
 
 on:
   workflow_dispatch:

--- a/docs/tools/others/shared-perf-benchmark-config.md
+++ b/docs/tools/others/shared-perf-benchmark-config.md
@@ -82,3 +82,45 @@ python3 -m py_compile \
 
 提交前应确认性能模板调用共享 resolver、solver 不再包含 NFS 切片路径、GitHub output
 schema 保持兼容，以及 solver 的 SMT/H-profile 限制没有因共享 catalog 而放宽。
+
+## 手动运行新的切片 profile
+
+在 `manual-perf.yml` 的 Run workflow 中填写：
+
+- `benchmark_type`: `custom`，从输入路径名中的 `spec06`、`spec17`、`spec26`
+  识别计分类型；路径没有这些标记或包含多个类型时，显式选择
+  `custom-spec06`、`custom-spec17`、`custom-spec26`。
+- `checkpoint_path`: profile 根目录，或直接填写 `checkpoint` / `checkpoint-0-0-0`
+  目录。runner 必须能读取该路径；分布式运行时所有节点都必须可见。
+- `json_path`: 通常留空。自动查找切片目录内的 `checkpoints_all.json`、
+  `cluster-0-0.json`，以及上一级的 `json/checkpoints_all.json`、
+  `cluster-0-0.json`。缺失或存在多个候选时，必须明确填写对应权重 JSON 的绝对路径。
+
+例如 `checkpoint_path` 填写：
+
+```text
+/nfs/home/share/checkpoints_profiles/spec17_rate_gcc16_rva23_novec_260904
+```
+
+选择 `custom` 即可自动使用 SPEC17 计分脚本。这里的默认 **1c 是完整切片覆盖率**，
+与运行单核还是 SMT 无关；程序按 JSON 的全部 `workload/point` 生成列表，
+支持每个点目录下唯一一个 `.gz` 或 `.zstd` 镜像，不依赖旧 CI 的列表或权重。
+若显式指定部分覆盖 JSON，运行范围也随之缩小；`specific_benchmarks` 仍可进一步筛选。
+JSON 必须包含每个 workload 的 `insts` 和 `points` 权重。
+
+NEMU 沿用现有统一 REF 选择逻辑。单核使用普通 configuration；双 hart 切片需显式
+选择 `smt_idealkmhv3.py`，不能仅凭 SPEC 类型推断核数。
+
+本地只检查目录和配置，不启动 GEM5：
+
+```bash
+python3 util/xs_scripts/perf_benchmarks.py custom \
+  --checkpoint-path /nfs/home/share/checkpoints_profiles/spec17_rate_gcc16_rva23_novec_260904 \
+  --output-dir /tmp/gem5-custom-perf
+```
+
+预检在 CI 构建前执行；缺镜像或歧义会直接报错。归档目录使用
+`custom-specXX-<路径与JSON内容摘要>`，避免混入内建 profile 的 baseline。
+归档保存实际运行列表 `checkpoints.lst`、权重 `cluster.json` 和源路径 metadata；
+同一 SPEC 类型的不同 profile 仍需显式匹配后再做性能比较。
+此入口只扩展手动性能 CI，不扩展 solver 的可选类型。

--- a/docs/tools/others/shared-perf-benchmark-config.md
+++ b/docs/tools/others/shared-perf-benchmark-config.md
@@ -120,7 +120,9 @@ python3 util/xs_scripts/perf_benchmarks.py custom \
 ```
 
 预检在 CI 构建前执行；缺镜像或歧义会直接报错。归档目录使用
-`custom-specXX-<路径与JSON内容摘要>`，避免混入内建 profile 的 baseline。
+`custom/<profile目录名>/<时间_SHA_配置_run编号>`，内建类型仍使用原路径。
+路径与 JSON 内容摘要保留在 metadata 的 `benchmark_type` 中，用于区分同名
+profile 或权重更新；目录名相同不代表结果可以直接作为 baseline 比较。
 归档保存实际运行列表 `checkpoints.lst`、权重 `cluster.json` 和源路径 metadata；
 同一 SPEC 类型的不同 profile 仍需显式匹配后再做性能比较。
 此入口只扩展手动性能 CI，不扩展 solver 的可选类型。

--- a/tests/pyunit/util/pyunit_perf_benchmarks_check.py
+++ b/tests/pyunit/util/pyunit_perf_benchmarks_check.py
@@ -1,0 +1,116 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "util/xs_scripts/perf_benchmarks.py"
+)
+SPEC = importlib.util.spec_from_file_location("perf_benchmarks", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class CustomBenchmarkTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.base = Path(self.temp.name)
+        self.profile = self.base / "spec17_example"
+        self.root = self.profile / "checkpoint"
+        image_dir = self.root / "gcc_input" / "42"
+        image_dir.mkdir(parents=True)
+        self.image = image_dir / "test.zstd"
+        self.image.touch()
+        self.cluster = self.profile / "json" / "checkpoints_all.json"
+        self.cluster.parent.mkdir()
+        self.cluster.write_text(
+            json.dumps(
+                {"gcc_input": {"insts": "123456", "points": {"42": "1.0"}}}
+            )
+        )
+
+    def resolve(self, kind="custom", root=None, cluster=""):
+        return MODULE.resolve_custom_benchmark(
+            kind, str(root or self.profile), str(cluster), self.base / "output"
+        )
+
+    def test_profile_and_checkpoint_root(self):
+        config = self.resolve()
+        self.assertEqual(config, self.resolve(root=self.root))
+        self.assertEqual(config.score_script, "gem5-score-ci-17.sh")
+        self.assertEqual(
+            Path(config.checkpoint_list).read_text(),
+            "gcc_input_42 gcc_input/42 0 0 20 20\n",
+        )
+
+    def test_explicit_suite_and_json(self):
+        for suite, script in [
+            ("06", "gem5-score-ci.sh"),
+            ("17", "gem5-score-ci-17.sh"),
+            ("26", "gem5-score-ci-26.sh"),
+        ]:
+            config = self.resolve(f"custom-spec{suite}", cluster=self.cluster)
+            self.assertEqual(config.score_script, script)
+
+    def test_legacy_layout(self):
+        legacy = self.profile / "checkpoint-0-0-0"
+        self.root.rename(legacy)
+        self.cluster.rename(legacy / "cluster-0-0.json")
+        self.assertEqual(self.resolve().checkpoint_root, str(legacy))
+
+    def test_missing_or_ambiguous_image(self):
+        self.image.unlink()
+        with self.assertRaisesRegex(
+            ValueError, "expected one checkpoint image"
+        ):
+            self.resolve()
+        self.image.touch()
+        self.image.with_suffix(".gz").touch()
+        with self.assertRaisesRegex(
+            ValueError, "expected one checkpoint image"
+        ):
+            self.resolve()
+
+    def test_no_implicit_weights_fallback(self):
+        self.cluster.unlink()
+        with self.assertRaisesRegex(ValueError, "full-coverage JSON"):
+            self.resolve()
+
+    def test_ambiguous_json_requires_override(self):
+        (self.root / "cluster-0-0.json").write_text(self.cluster.read_text())
+        with self.assertRaisesRegex(ValueError, "full-coverage JSON"):
+            self.resolve()
+        self.resolve(cluster=self.cluster)
+
+    def test_unknown_suite_requires_override(self):
+        renamed = self.base / "new_profile"
+        self.profile.rename(renamed)
+        with self.assertRaisesRegex(ValueError, "cannot infer SPEC suite"):
+            self.resolve(root=renamed)
+        self.resolve("custom-spec17", root=renamed)
+
+    def test_invalid_metadata(self):
+        for profile in [
+            {},
+            {"gcc_input": {"insts": 1, "points": {}}},
+            {"gcc_input": {"insts": 0, "points": {"42": 1}}},
+            {"gcc_input": {"insts": 1, "points": {"42": "nan"}}},
+        ]:
+            self.cluster.write_text(json.dumps(profile))
+            with self.assertRaises(ValueError):
+                self.resolve()
+
+    def test_registered_profiles_unchanged(self):
+        for name in MODULE.benchmark_types():
+            config = MODULE.resolve_benchmark(name)
+            self.assertEqual(config.benchmark_type, name)
+            self.assertEqual(config.github_outputs()["benchmark_type"], name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pyunit/util/pyunit_perf_benchmarks_check.py
+++ b/tests/pyunit/util/pyunit_perf_benchmarks_check.py
@@ -41,6 +41,9 @@ class CustomBenchmarkTest(unittest.TestCase):
 
     def test_profile_and_checkpoint_root(self):
         config = self.resolve()
+        self.assertEqual(
+            config.github_outputs()["archive_subdir"], "custom/spec17_example"
+        )
         self.assertEqual(config, self.resolve(root=self.root))
         self.assertEqual(config.score_script, "gem5-score-ci-17.sh")
         self.assertEqual(
@@ -109,6 +112,7 @@ class CustomBenchmarkTest(unittest.TestCase):
         for name in MODULE.benchmark_types():
             config = MODULE.resolve_benchmark(name)
             self.assertEqual(config.benchmark_type, name)
+            self.assertEqual(config.github_outputs()["archive_subdir"], name)
             self.assertEqual(config.github_outputs()["benchmark_type"], name)
 
 

--- a/util/xs_scripts/perf_benchmarks.py
+++ b/util/xs_scripts/perf_benchmarks.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
+import math
+import re
 from pathlib import Path
 
 
@@ -34,6 +37,7 @@ class BenchmarkConfig:
 
     def github_outputs(self) -> dict[str, str]:
         return {
+            "benchmark_type": self.benchmark_type,
             "checkpoint_list": self.checkpoint_list,
             "checkpoint_root_node": self.checkpoint_root,
             "score_script": self.score_script,
@@ -109,18 +113,14 @@ _BENCHMARKS = _index_benchmarks(
             checkpoint_list="/nfs/home/share/gem5_ci/spec06_cpts/gcc16_rva23_novec/spec06_0.3c.lst",
             checkpoint_root="/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/checkpoint",
             cluster_config="/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_cov0.3.json",
-            comment=(
-                "run 30% coverage gcc16 rva23-novec SPEC06 checkpoints"
-            ),
+            comment=("run 30% coverage gcc16 rva23-novec SPEC06 checkpoints"),
         ),
         BenchmarkConfig(
             benchmark_type="spec06-rva23-novec-gcc16-1.0c",
             checkpoint_list="/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/checkpoint/checkpoint.lst",
             checkpoint_root="/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/checkpoint",
             cluster_config="/nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_all.json",
-            comment=(
-                "run 100% coverage gcc16 rva23-novec SPEC06 checkpoints"
-            ),
+            comment=("run 100% coverage gcc16 rva23-novec SPEC06 checkpoints"),
         ),
         BenchmarkConfig(
             benchmark_type="h-spec06-0.5c",
@@ -211,6 +211,125 @@ def resolve_benchmark(benchmark_type: str) -> BenchmarkConfig:
         ) from None
 
 
+def resolve_custom_benchmark(
+    benchmark_type: str,
+    checkpoint_path: str,
+    json_path: str,
+    output_dir: str | Path,
+) -> BenchmarkConfig:
+    """Resolve a profile and materialize its complete point list for both runners."""
+    if not checkpoint_path or not Path(checkpoint_path).is_absolute():
+        raise ValueError(
+            "custom checkpoint_path must be an absolute directory"
+        )
+    supplied_root = Path(checkpoint_path).resolve()
+    if not supplied_root.is_dir():
+        raise ValueError(
+            f"checkpoint directory does not exist: {supplied_root}"
+        )
+    roots = [
+        supplied_root / name for name in ("checkpoint", "checkpoint-0-0-0")
+    ]
+    roots = [root for root in roots if root.is_dir()]
+    if len(roots) > 1:
+        raise ValueError(
+            "multiple checkpoint directories; specify one explicitly"
+        )
+    root = roots[0] if roots else supplied_root
+    if benchmark_type == "custom":
+        suites = set(
+            re.findall(r"spec(06|17|26)(?=[^0-9]|$)", checkpoint_path.lower())
+        )
+        if len(suites) != 1:
+            raise ValueError(
+                "cannot infer SPEC suite; select custom-spec06/17/26"
+            )
+        suite = suites.pop()
+    else:
+        suite = benchmark_type.removeprefix("custom-spec")
+        if suite not in ("06", "17", "26"):
+            raise ValueError(
+                f"unsupported custom benchmark type: {benchmark_type}"
+            )
+    if json_path:
+        cluster = Path(json_path)
+        if not cluster.is_absolute():
+            raise ValueError("json_path must be absolute")
+    else:
+        candidates = [
+            root / "checkpoints_all.json",
+            root / "cluster-0-0.json",
+            root.parent / "json" / "checkpoints_all.json",
+            root.parent / "cluster-0-0.json",
+        ]
+        candidates = list(
+            dict.fromkeys(p.resolve() for p in candidates if p.is_file())
+        )
+        if len(candidates) != 1:
+            raise ValueError(
+                "expected one full-coverage JSON; specify json_path explicitly"
+            )
+        cluster = candidates[0]
+    cluster = cluster.resolve()
+    with cluster.open(encoding="utf-8") as source:
+        profile = json.load(source)
+    if not isinstance(profile, dict) or not profile:
+        raise ValueError("checkpoint JSON must be a nonempty workload mapping")
+    rows = []
+    for workload, entry in sorted(profile.items()):
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", workload) or workload in (
+            ".",
+            "..",
+        ):
+            raise ValueError(f"invalid workload name: {workload!r}")
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("points"), dict)
+            or not entry["points"]
+        ):
+            raise ValueError(f"missing points for {workload}")
+        insts = float(entry.get("insts", 0))
+        if not math.isfinite(insts) or insts <= 0:
+            raise ValueError(f"invalid instruction count for {workload}")
+        for point, weight in sorted(entry["points"].items()):
+            if not re.fullmatch(r"[0-9]+", point):
+                raise ValueError(f"invalid checkpoint point: {point!r}")
+            weight = float(weight)
+            if not math.isfinite(weight) or weight < 0:
+                raise ValueError(f"invalid weight for {workload}/{point}")
+            directory = root / workload / point
+            images = [
+                p
+                for p in directory.glob("*")
+                if p.is_file() and p.suffix in (".gz", ".zstd")
+            ]
+            if len(images) != 1:
+                raise ValueError(
+                    f"expected one checkpoint image in {directory}, got {len(images)}"
+                )
+            rows.append(f"{workload}_{point} {workload}/{point} 0 0 20 20\n")
+    identity = hashlib.sha256(
+        (str(root) + "\n" + str(cluster)).encode() + cluster.read_bytes()
+    ).hexdigest()[:12]
+    resolved_type = f"custom-spec{suite}-{identity}"
+    destination = Path(output_dir).resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    checkpoint_list = destination / f"{resolved_type}.lst"
+    checkpoint_list.write_text("".join(rows), encoding="utf-8")
+    return BenchmarkConfig(
+        benchmark_type=resolved_type,
+        checkpoint_list=str(checkpoint_list),
+        checkpoint_root=str(root),
+        cluster_config=str(cluster),
+        score_script=(
+            "gem5-score-ci.sh"
+            if suite == "06"
+            else f"gem5-score-ci-{suite}.sh"
+        ),
+        comment=f"custom SPEC{suite}: all {len(rows)} points from {cluster}",
+    )
+
+
 def write_github_outputs(
     config: BenchmarkConfig, output_path: str | Path
 ) -> None:
@@ -232,12 +351,31 @@ def main() -> int:
         "--github-output",
         help="Append step outputs to this GitHub Actions output file.",
     )
+    parser.add_argument("--checkpoint-path", default="")
+    parser.add_argument("--json-path", default="")
+    parser.add_argument("--output-dir", default=".")
     args = parser.parse_args()
 
     try:
-        config = resolve_benchmark(args.benchmark_type)
-    except KeyError as error:
-        parser.error(error.args[0])
+        if args.benchmark_type == "custom" or args.benchmark_type.startswith(
+            "custom-spec"
+        ):
+            config = resolve_custom_benchmark(
+                args.benchmark_type,
+                args.checkpoint_path,
+                args.json_path,
+                args.output_dir,
+            )
+        else:
+            if args.checkpoint_path or args.json_path:
+                raise ValueError(
+                    "checkpoint_path/json_path require a custom benchmark type"
+                )
+            config = resolve_benchmark(args.benchmark_type)
+    except (KeyError, ValueError, OSError, TypeError) as error:
+        parser.error(
+            error.args[0] if isinstance(error, KeyError) else str(error)
+        )
 
     if args.github_output:
         write_github_outputs(config, args.github_output)

--- a/util/xs_scripts/perf_benchmarks.py
+++ b/util/xs_scripts/perf_benchmarks.py
@@ -24,10 +24,12 @@ class BenchmarkConfig:
     cluster_config: str
     comment: str
     score_script: str = "gem5-score-ci.sh"
+    archive_subdir: str = ""
 
     def as_dict(self) -> dict[str, str]:
         return {
             "benchmark_type": self.benchmark_type,
+            "archive_subdir": self.archive_subdir or self.benchmark_type,
             "checkpoint_list": self.checkpoint_list,
             "checkpoint_root": self.checkpoint_root,
             "cluster_config": self.cluster_config,
@@ -38,6 +40,7 @@ class BenchmarkConfig:
     def github_outputs(self) -> dict[str, str]:
         return {
             "benchmark_type": self.benchmark_type,
+            "archive_subdir": self.archive_subdir or self.benchmark_type,
             "checkpoint_list": self.checkpoint_list,
             "checkpoint_root_node": self.checkpoint_root,
             "score_script": self.score_script,
@@ -312,12 +315,20 @@ def resolve_custom_benchmark(
         (str(root) + "\n" + str(cluster)).encode() + cluster.read_bytes()
     ).hexdigest()[:12]
     resolved_type = f"custom-spec{suite}-{identity}"
+    profile_root = (
+        root.parent
+        if root.name in ("checkpoint", "checkpoint-0-0-0")
+        else root
+    )
+    profile_name = re.sub(r"[^A-Za-z0-9_.-]", "_", profile_root.name)
+    profile_name = profile_name.strip(".") or "profile"
     destination = Path(output_dir).resolve()
     destination.mkdir(parents=True, exist_ok=True)
     checkpoint_list = destination / f"{resolved_type}.lst"
     checkpoint_list.write_text("".join(rows), encoding="utf-8")
     return BenchmarkConfig(
         benchmark_type=resolved_type,
+        archive_subdir=f"custom/{profile_name}",
         checkpoint_list=str(checkpoint_list),
         checkpoint_root=str(root),
         cluster_config=str(cluster),


### PR DESCRIPTION
New checkpoint profiles currently need a catalog edit before manual performance CI can run and score them. Add `custom` plus explicit SPEC06/17/26 choices, with `checkpoint_path` and optional `json_path`, so a profile can be evaluated directly at full coverage.

The resolver discovers standard and legacy layouts, generates the run list from the selected weights JSON, and rejects missing or ambiguous images before building. SPEC detection selects the score script. Both local and distributed execution reuse the existing runners and pinned NEMU selection, including SMT. Archives retain the actual list and JSON and use a profile-specific identifier to keep custom data separate from built-in baselines.

Validation:
- 9 custom-profile tests and the existing solver evaluator test passed.
- Python formatting, YAML parsing, embedded shell syntax, workflow input wiring, and `git diff --check` passed.
- Read-only preflight passed on real SPEC06 (1094 points), SPEC17 (1783), SPEC26 (1397), legacy SPEC17 (714), and the 260817 two-hart SPEC06 profile (1154).
- End-to-end distributed performance runs are pending; directory checks do not establish simulation or scoring success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for manually running custom SPEC06, SPEC17, and SPEC26 performance benchmarks.
  - Added optional checkpoint and workload-configuration inputs, with automatic discovery and suite detection.
  - Archived benchmark results now include checkpoint and cluster configuration details.

- **Bug Fixes**
  - Improved validation and error reporting for missing, ambiguous, or invalid benchmark profiles.

- **Documentation**
  - Added guidance for custom profiles, image formats, prechecks, CI behavior, and archived outputs.

- **Tests**
  - Added coverage for custom benchmark resolution and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->