### PR TITLE
misc: Add GEM5 RTL performance alignment skill

### DIFF
--- a/.agents/skills/gem5-rtl-performance-alignment/SKILL.md
+++ b/.agents/skills/gem5-rtl-performance-alignment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: gem5-rtl-performance-alignment
+description: 对齐 GEM5 与 XiangShan RTL 同一 benchmark/slice 的性能差异。适用于后 20M 计数器、权重贡献、lifetime trace/inter-gap 和代码归因；默认逐轮确认，只有用户显式开启 autonomous-iterate 才自动修改和重跑 GEM5。
+---
+
+# GEM5 / RTL 性能对齐
+
+## 不变量
+
+- 默认比较总 40M committed instructions 的后 20M：GEM5 取第二个 stats block，RTL 必须证明 warmup reset 或做 40M-20M 差分。
+- 先匹配共同 slice 并输出全部 slice 的带权 cycle gap，再做计数器和 trace 初筛。
+- 计数器优先用 `gem5_data_proc`；lifetime DB 优先用 `ClockAnalysis.py` 做 inter-gap/BB 聚合。
+- 已有结果分析不推断 commit、checkpoint 或输入；重跑时 commit 必须由用户提供。
+- 所有产物写入 `<ARTIFACT_ROOT>/<CASE_ID>/`，不写 source worktree。
+
+## 配置权威来源
+
+workflow 只负责组合输入和调用运行器；重跑时按下面的源码入口解析实际配置，不依赖旧版 workflow 中的 `case` 分支：
+
+```text
+GEM5 benchmark/checkpoint: util/xs_scripts/perf_benchmarks.py
+GEM5 reference SO:         util/nemu_ref/resolve.py + lock.json
+RTL checkpoint mapping:    .github/workflows/perf-template.yml
+RTL CI runner:             /nfs/home/share/ci-workloads/env-scripts/perf_trigger/main.py
+RTL build:                 scripts/xiangshan.py 或用户确认的 make emu 命令
+```
+
+GEM5 的 `cluster_config` 用于评分/集群配置，不等同于 checkpoint 列表或 checkpoint source JSON。RTL workflow 可能将 reference SO 复制到 slice 结果目录后再运行，必须同时记录源文件和运行副本。
+
+## 默认：分析已有结果
+
+用户提供 GEM5 结果目录、RTL 结果目录、artifact 根目录和 case id。按顺序执行：
+
+1. 读取 [analysis-rules](references/analysis-rules.md)，按精确的 benchmark/point 匹配共同 slice，忽略 RTL 多出的 slice。
+2. 用 `parse_gem5_stats.py` 与 `parse_rtl_results.py` 验证每个共同 slice 的后 20M window。
+3. 用 `emit_slice_gap_contribution.py` 输出完整 `reports/slice_gap_contribution.csv` 和 `slice_gap_summary.json`；按 `weight * (GEM5_cycles - RTL_cycles)` 排序，保留正贡献、负贡献和 excluded。
+4. 用 `gem5_data_proc` 做 counter 初筛，并记录映射、分母和最大的正/负差异。
+5. 检查 lifetime DB；双方 DB 都可读且覆盖后 20M 时，读取 [trace-and-inter-gap](references/trace-and-inter-gap.md)，对 GEM5 使用 `ClockAnalysis.py`。
+
+先读 weighted summary；只有定位具体 slice、counter、PC 或事件时才打开完整 CSV/TXT/DB。
+
+## 重跑与 A/B
+
+默认 `manual` 模式：先给出单变量方案并等待用户确认。读取 [rerun-commands](references/rerun-commands.md) 前，用户必须提供两侧 commit/worktree 和目标 slice；其中定义的 preflight evidence 必须完整。
+
+显式 `MODE=autonomous-iterate` 才开启自动模式，默认关闭。读取 [iteration-rules](references/iteration-rules.md)：冻结一份 RTL baseline（已有合格 DB 直接复用，否则最多运行一次 RTL primary-slice trace），之后只在隔离 GEM5 candidate worktree 中自动执行“单变量修改 → 编译 → 40M/20M 重跑 → lifetime/inter-gap → 与冻结 RTL 比较”。不修改或重复运行 RTL，不自动 commit/push/PR/远程 CI。
+
+两种模式都必须比较 post-warmup IPC/cycles、相关 counters、关键 inter-gap/commit-gap、weighted cycle gap 和 correctness；结论区分 `Confirmed`、`Supported hypothesis`、`Unresolved`。
+
+## 按需参考
+
+- [analysis-rules](references/analysis-rules.md)：窗口、slice、权重、counter 与可比性。
+- [trace-and-inter-gap](references/trace-and-inter-gap.md)：DB 检查、`ClockAnalysis.py` 和 trace 缺失处理。
+- [rerun-commands](references/rerun-commands.md)：profile/checkpoint preflight、GEM5/RTL 命令。
+- [iteration-rules](references/iteration-rules.md)：自动模式预算、RTL 冻结和停机条件。

--- a/.agents/skills/gem5-rtl-performance-alignment/agents/openai.yaml
+++ b/.agents/skills/gem5-rtl-performance-alignment/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GEM5 / RTL Performance Alignment"
+  short_description: "Trace and close GEM5-to-RTL performance gaps"
+  default_prompt: "Use $gem5-rtl-performance-alignment to compare these GEM5 and RTL results; keep manual mode unless I explicitly request autonomous GEM5-only iteration."

--- a/.agents/skills/gem5-rtl-performance-alignment/references/analysis-rules.md
+++ b/.agents/skills/gem5-rtl-performance-alignment/references/analysis-rules.md
@@ -1,0 +1,43 @@
+# 分析规则
+
+## Window
+
+正式口径是总 40M、warmup 前 20M、measurement 后 20M。
+
+- GEM5 必须恰有两个 stats block，只取第二段：`IPC = committedInsts / numCycles`。
+- RTL 的 `clock_cycle`/`commitInstr` 可能是 reset 后值或累计值。没有日志、源码或 20M/40M 边界证据时，不参与精确比较。
+
+```bash
+python3 "<SKILL_DIR>/scripts/parse_gem5_stats.py" "<GEM5_RESULT>/stats.txt" \
+  --output "<ARTIFACT_ROOT>/<CASE_ID>/counters/gem5/measurement.json"
+python3 "<SKILL_DIR>/scripts/parse_rtl_results.py" "<RTL_RESULT>" \
+  --window-semantics reset-after-warmup \
+  --output "<ARTIFACT_ROOT>/<CASE_ID>/counters/rtl/measurement.json"
+```
+
+累计 RTL counter 只能使用显式的 `cumulative-at-boundaries` 差分；不要把两个 GEM5 stats block 相加或平均。
+
+## Slice 与权重
+
+从 GEM5 的 `stats.txt` 和 RTL 的结果/日志目录列出 slice。以 `<benchmark>_<point>` 精确匹配；RTL 目录名最后一段是数值时，它是 weight。RTL 多出的 slice 忽略；任何一侧重复、名字无法解析或缺失 weight 的 slice 记录为 excluded，不猜测匹配关系。
+
+为每个共同 slice 建立一条最小 JSON record：`identity`、`benchmark`、`slice`、`weight`、`weight_source`、GEM5/RTL measurement JSON，以及两侧 window-valid flag。对合格 slice：
+
+```text
+extra_cycles = GEM5_cycles - RTL_cycles
+weighted_extra_cycles = weight * extra_cycles
+```
+
+将 records 交给 `emit_slice_gap_contribution.py`。按 `weighted_extra_cycles` 降序输出全部共同 slice，保留正/负贡献和 excluded；summary 给出净 gap、absolute gap、coverage 与 excluded 原因。不要平均 per-slice IPC。
+
+## Counter 初筛
+
+复用用户指定或环境中明确找到的 `gem5_data_proc`，优先检查 `basic`、`intel_topdown`、`branch` 及适用的 local targets。它用于发现 frontend、speculation、backend、memory、IQ/FU、replay、cache 等方向的症状，不能替代 RTL window 证明，也不能单独证明硬件结构有问题。
+
+保留完整 normalized 表；按相同分母的 `RTL - GEM5` 和绝对差异排序，只报告 top 正差、top 负差、最大绝对差和缺失项。每个条目记录原始名称、公式/分母、window status 和 mapping quality：`exact`、`derived`、`approximate` 或 `unavailable`。
+
+## 结论等级
+
+- `Confirmed`：counter、trace 和代码语义在同一事件边界上相互支持。
+- `Supported hypothesis`：证据方向一致，但事件映射或 window 仍有近似部分。
+- `Unresolved`：缺少等价事件、窗口或运行证据。

--- a/.agents/skills/gem5-rtl-performance-alignment/references/iteration-rules.md
+++ b/.agents/skills/gem5-rtl-performance-alignment/references/iteration-rules.md
@@ -1,0 +1,49 @@
+# 迭代规则
+
+本文件只适用于显式 `MODE=autonomous-iterate`；默认模式仍需逐轮确认。
+
+## 启动与预算
+
+用户一次性提供两侧 commit/worktree、已有 GEM5/RTL result、`ARTIFACT_ROOT` 和 `CASE_ID`。不猜 commit；开始前必须记录唯一 profile、共同 checkpoint realpath、两侧 reference SO 路径和后 20M window evidence。
+
+默认预算，可在启动时增大前三项：
+
+```text
+MAX_ITERATIONS=8
+MAX_CANDIDATE_SLICES_PER_ITERATION=4
+MAX_NEW_GEM5_RERUNS_PER_ITERATION=4
+MAX_RTL_TRACE_RERUNS=1       # 硬上限
+MAX_RTL_TRACE_SLICES=1       # primary slice only
+```
+
+## 冻结 RTL
+
+优先复用已有且已证明覆盖后 20M 的 RTL lifetime DB，并记录其 commit、worktree、checkpoint、reference SO hash、schema 和 window evidence。若没有合格 DB，最多运行一次 RTL primary-slice trace；记录任务状态和产物，完成后检查并冻结。之后不修改、不重复运行 RTL，不增加 RTL slice。
+
+## GEM5-only 循环
+
+每轮从用户提供的 GEM5 commit 创建隔离 candidate worktree，只应用一个由 counter + trace + 代码支持的行为改动：
+
+```text
+记录 hypothesis 和预测
+→ 编译 GEM5
+→ 对不超过预算的 slice 跑 40M/20M
+→ 保存后 20M stats、counter、lifetime DB 和 inter-gap report
+→ 与同一 RTL baseline 比较
+→ accepted / rejected / inconclusive
+```
+
+不得改变 checkpoint、输入、reference SO、40M/20M、cache/DRAM、difftest 或停止条件来制造收敛；不得自动 commit、push、PR、远程 CI 或清理共享结果。
+
+`accepted` 必须同时满足：关键 gap/热点贡献向 RTL 收敛、相关 counter 按预测变化、总体 IPC 或 weighted gap 收敛且 correctness 正常。只有 IPC 变化而 counter/gap 不变时标记 `inconclusive`。
+
+## 停止条件
+
+立即停止并报告 `reports/iteration_summary.json`：
+
+- profile、checkpoint、SO、commit、window 或 RTL baseline 不可验证；
+- 需要第二次 RTL trace、RTL 改动/配置改动或更换 slice/input；
+- GEM5 candidate 无法隔离，或 build/run/difftest 失败；
+- 需要非单变量改动、额外 instrumentation 或改变比较合同；
+- 达到预算，或连续两轮没有收敛且没有更强的新假设；
+- 需要任何外部提交、推送、PR、远程 CI 或共享目录操作。

--- a/.agents/skills/gem5-rtl-performance-alignment/references/rerun-commands.md
+++ b/.agents/skills/gem5-rtl-performance-alignment/references/rerun-commands.md
@@ -1,0 +1,94 @@
+# 重跑命令
+
+仅在 manual 模式获得用户确认，或显式开启 `MODE=autonomous-iterate` 后读取。本文件只描述输入解析和固定命令；自动迭代预算/停机条件见 [iteration-rules](iteration-rules.md)。
+
+## 输入与 preflight
+
+重跑需要用户提供：
+
+```text
+GEM5_COMMIT=<sha>
+RTL_COMMIT=<sha>
+GEM5_WORKTREE=<path>
+RTL_WORKTREE=<path>
+GEM5_RESULT=<existing GEM5 result>
+SLICE=<benchmark_point[_weight]>
+```
+
+自动模式另外需要 `RTL_RESULT`、`ARTIFACT_ROOT` 和 `CASE_ID`。不从目录名、日志或当前 HEAD 猜 commit。profile 只从两个目标 workflow 和已有 GEM5 result 的直接 metadata/父目录证据读取：
+
+```text
+<GEM5_WORKTREE>/.github/workflows/gem5-perf-template.yml
+<RTL_WORKTREE>/.github/workflows/perf-template.yml
+```
+
+当前主线的配置解析入口如下：
+
+```text
+GEM5 benchmark/checkpoint: <GEM5_WORKTREE>/util/xs_scripts/perf_benchmarks.py
+GEM5 reference SO:         <GEM5_WORKTREE>/util/nemu_ref/resolve.py + lock.json
+RTL checkpoint mapping:    <RTL_WORKTREE>/.github/workflows/perf-template.yml
+RTL CI runner:              /nfs/home/share/ci-workloads/env-scripts/perf_trigger/main.py
+```
+
+对 GEM5，使用 `perf_benchmarks.py <benchmark_type> --github-output <file>` 解析 `checkpoint_list`、`checkpoint_root`、`config_path` 关联的 profile 和评分配置。`checkpoint_list` 是 checkpoint 列表；`cluster_config` 只用于评分/集群配置，不能作为 checkpoint source JSON。对 reference SO，使用 `util/nemu_ref/resolve.py <variant>`，并从 `lock.json` 记录 release、variant、实际路径和 hash。不要假设 SO 固定位于 `ready-to-run/`。
+
+对 RTL，从 `perf-template.yml` 的同名 benchmark 配置取得 `CKPT_HOME` 和 `CKPT_JSON_PATH`，再按 checkpoint JSON/list 选择目标 slice。CI 的实际调度入口是共享环境中的 `perf_trigger/main.py`；workflow 通常会把 reference SO 复制到 `$SPEC_DIR/riscv64-nemu-interpreter-so`，运行时使用该副本，因此 preflight 要同时记录源 SO 和运行副本。
+
+执行以下核验，并把选中的 profile、checkpoint、SO 和证据写入 `<ARTIFACT_ROOT>/<CASE_ID>/manifest/preflight.md`：
+
+```bash
+test "$(git -C "<GEM5_WORKTREE>" rev-parse HEAD)" = "$(git -C "<GEM5_WORKTREE>" rev-parse --verify "<GEM5_COMMIT>^{commit}")"
+test "$(git -C "<RTL_WORKTREE>" rev-parse HEAD)" = "$(git -C "<RTL_WORKTREE>" rev-parse --verify "<RTL_COMMIT>^{commit}")"
+readlink -f "<GEM5_CHECKPOINT>"
+readlink -f "<RTL_CHECKPOINT>"
+test "$(readlink -f "<GEM5_CHECKPOINT>")" = "$(readlink -f "<RTL_CHECKPOINT>")"
+test -r "<GEM5_REF_SO>"
+test -r "<RTL_REF_SO_SOURCE>"
+test -r "<RTL_REF_SO_RUN_COPY>"
+sha256sum "<GEM5_REF_SO>" "<RTL_REF_SO_SOURCE>" "<RTL_REF_SO_RUN_COPY>"
+```
+
+`GEM5_COMMIT` 和 `RTL_COMMIT` 必须由用户提供；结果 `metadata.txt` 中的 commit 只能作为交叉核验，不能在缺失时猜测。若 profile、checkpoint、reference SO variant 或 realpath/hash 不能唯一确定，停止并要求用户补充信息。只有全部核验通过才可运行。
+
+CI-compatible 全量运行可使用 workflow 调用的 `parallel_sim.sh` 或 `distributed_sim.py`；单 slice 对齐验证可以直接调用下面的 `gem5.opt`/RTL emu 命令，但必须把解析出的参数写入 manifest。
+
+## GEM5
+
+```bash
+cd "<GEM5_CANDIDATE_WORKTREE>"
+scons build/RISCV/gem5.opt --gold-linker -j64
+```
+
+```bash
+GCBV_REF_SO="<GEM5_REF_SO>" \
+"<GEM5_CANDIDATE_WORKTREE>/build/RISCV/gem5.opt" \
+  --outdir="<ARTIFACT_ROOT>/<CASE_ID>/trace-full/gem5/<SLICE>" \
+  "<GEM5_CANDIDATE_WORKTREE>/configs/example/kmhv3.py" \
+  --generic-rv-cpt="<CHECKPOINT>" \
+  -I 40000000 --warmup-insts-no-switch=20000000 \
+  --enable-arch-db --arch-db-dump-lifetime \
+  --arch-db-file="<ARTIFACT_ROOT>/<CASE_ID>/trace-full/gem5/<SLICE>/trace.db"
+```
+
+`.zstd` 不加 `--raw-cpt`；raw `.bin` 才添加。每轮保留 command、stats、DB、退出状态和 measurement 检查。reference SO 应使用 `nemu_ref/resolve.py` 解析出的实际文件，而不是固定路径。
+
+## RTL baseline（最多一次）
+
+```bash
+cd "<RTL_WORKTREE>"
+make emu EMU_THREADS=8 WITH_DRAMSIM3=1 WITH_CONSTANTIN=1 WITH_CHISELDB=1 -j16
+```
+
+```bash
+"<RTL_WORKTREE>/build/emu" \
+  -i "<CHECKPOINT>" \
+  --diff "<RTL_REF_SO_RUN_COPY>" \
+  -W 20000000 -I 40000000 --dump-db \
+  --db-path "<ARTIFACT_ROOT>/<CASE_ID>/trace-full/rtl-baseline/<SLICE>/trace.db" \
+  --dump-select-db "<LIFETIME_TABLES>" \
+  > "<ARTIFACT_ROOT>/<CASE_ID>/logs/rtl_<SLICE>.stdout" \
+  2> "<ARTIFACT_ROOT>/<CASE_ID>/logs/rtl_<SLICE>.stderr"
+```
+
+`make emu` 是当前本地 trace 构建入口；`<LIFETIME_TABLES>` 必须由当前 emu help、源码或 schema 确认。RTL 任务可能运行数小时：记录 PID/job、命令、日志和预期 DB 后交还控制权，不持续轮询。自动模式只有在缺少合格 baseline 时允许执行这一次 RTL 运行，之后只重跑 GEM5。

--- a/.agents/skills/gem5-rtl-performance-alignment/references/trace-and-inter-gap.md
+++ b/.agents/skills/gem5-rtl-performance-alignment/references/trace-and-inter-gap.md
@@ -1,0 +1,32 @@
+# lifetime trace 与 inter-gap
+
+只有 DB 可读、schema 可识别、含 PC/instruction 与 cycle/order 字段，并能证明覆盖后 20M 时，才做严格指令级比较。先用 SQLite 检查两侧 DB：
+
+```bash
+sqlite3 "<GEM5_TRACE_DB>" '.tables'
+sqlite3 "<GEM5_TRACE_DB>" '.schema'
+sqlite3 "<RTL_TRACE_DB>" '.tables'
+sqlite3 "<RTL_TRACE_DB>" '.schema'
+```
+
+不要假定表名、字段名或 trace 已自动排除 warmup；保存原始/保留行数、过滤条件和 window evidence。缺少 window、身份或等价事件时，结论只能是 `Unresolved`。
+
+## GEM5 inter-gap
+
+确认 schema 兼容后运行：
+
+```bash
+python3 "<GEM5_WORKTREE>/util/ClockAnalysis.py" \
+  "<GEM5_TRACE_DB>" -p 333 -P gem5 --tool bbl --inter-gap \
+  > "<ARTIFACT_ROOT>/<CASE_ID>/inter-gap/gem5/inter_gap.txt"
+```
+
+从输出中按 `Count * Total commit time` 排序，记录 top basic block 的 occurrence、平均 commit cycles、估算累计影响、first PC 和 jumped-from；具体 opcode/依赖链再回看完整文本。`Total commit time` 是 block 平均值，累计值只是估算。
+
+## RTL 与事件归因
+
+RTL 不直接套用 GEM5 参数；先根据实际 schema 确认表/字段映射，再使用等价 SQL/脚本或兼容的 ClockAnalysis 入口。围绕下列边界比较：dispatch/rename、IQ enter、operand-ready、issue、execution start/complete、bypass/wakeup、writeback、commit、replay/squash。按 PC/opcode/BB/function 聚合 count、分位数、额外 gap 和累计贡献，并与 counter 症状交叉检查。
+
+## 缺失 trace
+
+`manual` 模式先报告缺失项并等待重跑确认。`autonomous-iterate` 仅可按 [rerun-commands](rerun-commands.md) 生成一次 RTL baseline；完成后只重跑 GEM5。RTL DB 不合格、需要第二份 RTL trace、修改 RTL instrumentation 或无法证明后 20M 时，立即停止并请求用户决定。

--- a/.agents/skills/gem5-rtl-performance-alignment/scripts/emit_slice_gap_contribution.py
+++ b/.agents/skills/gem5-rtl-performance-alignment/scripts/emit_slice_gap_contribution.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Compute a compact, complete GEM5/RTL slice gap contribution report."""
+
+import argparse
+import csv
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def load(path: Path) -> Any:
+    with path.open(encoding="utf-8") as source:
+        return json.load(source)
+
+
+def records_from(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("slices"), list):
+        return payload["slices"]
+    raise ValueError("input must be a JSON list or an object with a 'slices' list")
+
+
+def read_measurement(value: Any) -> Dict[str, Any]:
+    if isinstance(value, str):
+        value = load(Path(value))
+    if not isinstance(value, dict):
+        return {}
+    measurement = value.get("measurement")
+    return measurement if isinstance(measurement, dict) else value
+
+
+def numeric(mapping: Dict[str, Any], *names: str) -> Optional[float]:
+    for name in names:
+        value = mapping.get(name)
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return float(value)
+    return None
+
+
+def identity(record: Dict[str, Any]) -> str:
+    if record.get("identity"):
+        return str(record["identity"])
+    benchmark = record.get("benchmark", "unknown")
+    slice_id = record.get("slice", record.get("slice_id", "unknown"))
+    return f"{benchmark}:{slice_id}"
+
+
+def make_row(record: Dict[str, Any]) -> Dict[str, Any]:
+    row: Dict[str, Any] = {
+        "identity": identity(record),
+        "benchmark": record.get("benchmark"),
+        "slice": record.get("slice", record.get("slice_id")),
+        "weight": numeric(record, "weight"),
+        "weight_source": record.get("weight_source", "unavailable"),
+        "status": "included",
+        "exclusion_reason": "",
+    }
+    gem5 = read_measurement(record.get("gem5"))
+    rtl = read_measurement(record.get("rtl"))
+    row.update(
+        {
+            "gem5_committed_insts": numeric(gem5, "committed_insts", "committedInsts"),
+            "gem5_cycles": numeric(gem5, "num_cycles", "cycles", "clock_cycle"),
+            "gem5_ipc": numeric(gem5, "computed_ipc", "ipc"),
+            "rtl_committed_insts": numeric(rtl, "committed_insts", "commitInstr"),
+            "rtl_cycles": numeric(rtl, "num_cycles", "cycles", "clock_cycle"),
+            "rtl_ipc": numeric(rtl, "computed_ipc", "ipc"),
+        }
+    )
+    if isinstance(record.get("weight"), (int, float)):
+        row["weight"] = float(record["weight"])
+    valid_flags = [record.get("gem5_valid", True), record.get("rtl_valid", True)]
+    if isinstance(record.get("gem5"), dict) and "valid_for_default_40m_20m_contract" in record["gem5"]:
+        valid_flags.append(record["gem5"]["valid_for_default_40m_20m_contract"])
+    if isinstance(record.get("rtl"), dict) and "window_valid_for_comparison" in record["rtl"]:
+        valid_flags.append(record["rtl"]["window_valid_for_comparison"])
+    missing = []
+    if row["weight"] is None:
+        missing.append("weight")
+    if row["gem5_cycles"] is None:
+        missing.append("GEM5 cycles")
+    if row["rtl_cycles"] is None:
+        missing.append("RTL cycles")
+    if not all(flag is True for flag in valid_flags):
+        missing.append("measurement window")
+    if missing:
+        row["status"] = "excluded"
+        row["exclusion_reason"] = "; ".join(missing)
+        return row
+    row["extra_cycles"] = row["gem5_cycles"] - row["rtl_cycles"]
+    row["weighted_extra_cycles"] = row["weight"] * row["extra_cycles"]
+    return row
+
+
+def write_csv(rows: Iterable[Dict[str, Any]], path: Path) -> None:
+    fields = [
+        "rank", "identity", "benchmark", "slice", "weight", "weight_source",
+        "gem5_committed_insts", "gem5_cycles", "gem5_ipc", "rtl_committed_insts",
+        "rtl_cycles", "rtl_ipc", "extra_cycles", "weighted_extra_cycles",
+        "signed_contribution_pct", "absolute_contribution_pct", "status", "exclusion_reason",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows({field: row.get(field, "") for field in fields} for row in rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit complete weighted GEM5/RTL slice-gap contribution CSV and summary JSON."
+    )
+    parser.add_argument("input", type=Path, help="normalized JSON list; see analysis-rules.md")
+    parser.add_argument("--output-csv", type=Path, required=True)
+    parser.add_argument("--output-summary", type=Path, required=True)
+    parser.add_argument(
+        "--unstable-ratio",
+        type=float,
+        default=0.01,
+        help="mark signed percentages unstable when abs(net)/abs(total) is below this ratio",
+    )
+    args = parser.parse_args()
+    if not args.input.is_file():
+        parser.error(f"not a readable input: {args.input}")
+    if args.unstable_ratio < 0:
+        parser.error("--unstable-ratio must be non-negative")
+    try:
+        rows = [make_row(record) for record in records_from(load(args.input))]
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    included = [row for row in rows if row["status"] == "included"]
+    included.sort(key=lambda row: row["weighted_extra_cycles"], reverse=True)
+    net = sum(row["weighted_extra_cycles"] for row in included)
+    absolute = sum(abs(row["weighted_extra_cycles"]) for row in included)
+    unstable = absolute == 0 or abs(net) / absolute < args.unstable_ratio
+    for rank, row in enumerate(included, start=1):
+        row["rank"] = rank
+        row["signed_contribution_pct"] = "unstable" if unstable else 100.0 * row["weighted_extra_cycles"] / net
+        row["absolute_contribution_pct"] = (
+            None
+            if absolute == 0
+            else 100.0 * abs(row["weighted_extra_cycles"]) / absolute
+        )
+    excluded = [row for row in rows if row["status"] == "excluded"]
+    for row in excluded:
+        row["rank"] = ""
+    ordered = included + excluded
+    write_csv(ordered, args.output_csv)
+    summary = {
+        "input": str(args.input.resolve()),
+        "output_csv": str(args.output_csv.resolve()),
+        "common_slice_count": len(rows),
+        "included_slice_count": len(included),
+        "excluded_slice_count": len(excluded),
+        "net_weighted_cycle_gap": net,
+        "absolute_weighted_cycle_gap": absolute,
+        "signed_percentages": "unstable" if unstable else "defined",
+        "unstable_ratio_threshold": args.unstable_ratio,
+        "weight_coverage": (
+            sum(row["weight"] for row in included)
+            / sum(row["weight"] for row in rows if row["weight"] is not None)
+            if any(row["weight"] is not None for row in rows)
+            else None
+        ),
+        "excluded_reasons": {
+            reason: sum(1 for row in excluded if row["exclusion_reason"] == reason)
+            for reason in sorted({row["exclusion_reason"] for row in excluded})
+        },
+        "positive_contribution_top": [row["identity"] for row in included if row["weighted_extra_cycles"] > 0][:10],
+        "negative_contribution_top": [
+            row["identity"]
+            for row in sorted(included, key=lambda row: row["weighted_extra_cycles"])
+            if row["weighted_extra_cycles"] < 0
+        ][:10],
+    }
+    args.output_summary.parent.mkdir(parents=True, exist_ok=True)
+    args.output_summary.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output_csv)
+    print(args.output_summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/gem5-rtl-performance-alignment/scripts/parse_gem5_stats.py
+++ b/.agents/skills/gem5-rtl-performance-alignment/scripts/parse_gem5_stats.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Extract only the measurement (second) statistics block from GEM5 stats."""
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+BEGIN = "---------- Begin Simulation Statistics ----------"
+END = "---------- End Simulation Statistics"
+NUMBER = re.compile(
+    r"^\s*(?P<name>\S+)\s+(?P<value>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?|nan|inf|-inf)\b"
+)
+
+
+def parse_number(value: str) -> Any:
+    lower = value.lower()
+    if lower in {"nan", "inf", "-inf"}:
+        return lower
+    number = float(value)
+    return int(number) if number.is_integer() else number
+
+
+def parse_blocks(path: Path) -> List[Dict[str, Any]]:
+    blocks: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    with path.open(encoding="utf-8", errors="replace") as stats_file:
+        for line_number, line in enumerate(stats_file, start=1):
+            if line.startswith(BEGIN):
+                if current is not None:
+                    current["warnings"].append("new begin marker before end marker")
+                    current["end_line"] = line_number - 1
+                    blocks.append(current)
+                current = {
+                    "start_line": line_number,
+                    "end_line": None,
+                    "stats": {},
+                    "warnings": [],
+                }
+                continue
+            if current is None:
+                continue
+            if line.startswith(END):
+                current["end_line"] = line_number
+                blocks.append(current)
+                current = None
+                continue
+            match = NUMBER.match(line)
+            if match is not None:
+                current["stats"][match.group("name")] = parse_number(
+                    match.group("value")
+                )
+    if current is not None:
+        current["warnings"].append("unterminated statistics block")
+        blocks.append(current)
+    return blocks
+
+
+def first_value(stats: Dict[str, Any], names: List[str]) -> Optional[Any]:
+    for name in names:
+        if name in stats:
+            return stats[name]
+    for name in names:
+        matches = sorted(key for key in stats if key.endswith(name))
+        if matches:
+            return stats[matches[0]]
+    return None
+
+
+def make_measurement(
+    block: Dict[str, Any], expected_insts: int, tolerance: float
+) -> Dict[str, Any]:
+    stats = block["stats"]
+    committed = first_value(
+        stats,
+        [
+            "system.cpu.committedInsts",
+            "system.cpu.committedInsts::total",
+            "committedInsts",
+        ],
+    )
+    cycles = first_value(
+        stats,
+        ["system.cpu.numCycles", "system.cpu.numCycles::total", "numCycles"],
+    )
+    reported_ipc = first_value(
+        stats,
+        ["system.cpu.ipc", "system.cpu.totalIpc", "ipc", "totalIpc"],
+    )
+    ipc = None
+    if isinstance(committed, (int, float)) and isinstance(cycles, (int, float)) and cycles > 0:
+        ipc = committed / cycles
+
+    warnings: List[str] = []
+    length_ok = False
+    if isinstance(committed, (int, float)):
+        length_ok = abs(committed - expected_insts) <= expected_insts * tolerance
+        if not length_ok:
+            warnings.append(
+                f"committed instructions {committed} are not within {tolerance:.1%} "
+                f"of expected measurement length {expected_insts}"
+            )
+    else:
+        warnings.append("measurement block has no recognized committedInsts counter")
+    if not isinstance(cycles, (int, float)) or cycles <= 0:
+        warnings.append("measurement block has no positive recognized numCycles counter")
+    if ipc is not None and isinstance(reported_ipc, (int, float)):
+        if not math.isclose(ipc, reported_ipc, rel_tol=5e-5, abs_tol=5e-8):
+            warnings.append(
+                f"computed IPC {ipc:.9g} differs from reported IPC {reported_ipc:.9g}"
+            )
+    return {
+        "block_index_zero_based": 1,
+        "block_role": "second-statistics-block-post-warmup-measurement",
+        "start_line": block["start_line"],
+        "end_line": block["end_line"],
+        "committed_insts": committed,
+        "num_cycles": cycles,
+        "computed_ipc": ipc,
+        "reported_ipc": reported_ipc,
+        "expected_measurement_insts": expected_insts,
+        "measurement_length_ok": length_ok,
+        "warnings": block["warnings"] + warnings,
+    }
+
+
+def emit(payload: Dict[str, Any], output: Optional[Path]) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        print(text, end="")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract GEM5's second stats block as the post-warmup measurement; "
+            "never combines statistics blocks."
+        )
+    )
+    parser.add_argument("stats_file", type=Path, help="path to GEM5 stats.txt")
+    parser.add_argument("--output", type=Path, help="optional JSON output path")
+    parser.add_argument(
+        "--expected-measurement-insts",
+        type=int,
+        default=20_000_000,
+        help="expected committed instructions in block 2 (default: 20M)",
+    )
+    parser.add_argument(
+        "--inst-tolerance",
+        type=float,
+        default=0.02,
+        help="allowed relative instruction-count difference (default: 0.02)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="return nonzero when the normal two-block / post-warmup contract fails",
+    )
+    args = parser.parse_args()
+
+    if args.expected_measurement_insts <= 0 or not 0 <= args.inst_tolerance < 1:
+        parser.error("expected measurement instructions must be positive and tolerance in [0, 1)")
+    if not args.stats_file.is_file():
+        parser.error(f"not a readable file: {args.stats_file}")
+
+    blocks = parse_blocks(args.stats_file)
+    block_summaries = [
+        {
+            "index_zero_based": index,
+            "start_line": block["start_line"],
+            "end_line": block["end_line"],
+            "recognized_committed_insts": first_value(
+                block["stats"], ["system.cpu.committedInsts", "committedInsts"]
+            ),
+            "recognized_num_cycles": first_value(
+                block["stats"], ["system.cpu.numCycles", "numCycles"]
+            ),
+            "warnings": block["warnings"],
+        }
+        for index, block in enumerate(blocks)
+    ]
+    measurement = (
+        make_measurement(blocks[1], args.expected_measurement_insts, args.inst_tolerance)
+        if len(blocks) >= 2
+        else None
+    )
+    warnings: List[str] = []
+    if len(blocks) != 2:
+        warnings.append(
+            f"expected exactly two statistics blocks (warmup + measurement), found {len(blocks)}"
+        )
+    if measurement is None:
+        warnings.append("second statistics block is unavailable")
+    elif not measurement["measurement_length_ok"]:
+        warnings.append("second statistics block does not match expected measurement length")
+    valid = len(blocks) == 2 and measurement is not None and measurement["measurement_length_ok"]
+    payload = {
+        "input": str(args.stats_file.resolve()),
+        "comparison_window": "post-warmup measurement only (second stats block)",
+        "stats_block_count": len(blocks),
+        "blocks": block_summaries,
+        "measurement": measurement,
+        "valid_for_default_40m_20m_contract": valid,
+        "warnings": warnings,
+    }
+    emit(payload, args.output)
+    if args.strict and not valid:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/gem5-rtl-performance-alignment/scripts/parse_rtl_results.py
+++ b/.agents/skills/gem5-rtl-performance-alignment/scripts/parse_rtl_results.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Extract RTL PERF samples without assuming their warmup/reset semantics."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+PERF = re.compile(
+    r"^\[PERF\s*\]\[time=\s*(?P<time>\d+)\]\s*"
+    r"(?P<unit>.*?):\s*(?P<counter>[^,]+),\s*(?P<value>[-+]?\d+(?:\.\d+)?)\s*$"
+)
+DEFAULT_LOG_NAMES = (
+    "simulator_err.txt",
+    "simulator_out.txt",
+    "run.log",
+    "stdout.log",
+    "stderr.log",
+)
+
+
+def is_rtl_log_name(name: str) -> bool:
+    return name in DEFAULT_LOG_NAMES or any(name.endswith(f"_{suffix}") for suffix in DEFAULT_LOG_NAMES)
+
+
+def number(value: str) -> Any:
+    parsed = float(value)
+    return int(parsed) if parsed.is_integer() else parsed
+
+
+def candidate_logs(source: Path) -> List[Path]:
+    if source.is_file():
+        return [source]
+    if not source.is_dir():
+        raise FileNotFoundError(source)
+    logs = [
+        path
+        for path in source.iterdir()
+        if path.is_file() and is_rtl_log_name(path.name)
+    ]
+    if logs:
+        return logs
+    return sorted(
+        path
+        for path in source.iterdir()
+        if path.is_file() and path.suffix.lower() in {".log", ".out", ".err", ".txt"}
+    )
+
+
+def read_samples(paths: Iterable[Path]) -> Tuple[List[Dict[str, Any]], List[str]]:
+    samples: List[Dict[str, Any]] = []
+    warnings: List[str] = []
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as error:
+            warnings.append(f"could not read {path}: {error}")
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            match = PERF.match(line)
+            if match is None:
+                continue
+            samples.append(
+                {
+                    "source": str(path.resolve()),
+                    "line": line_number,
+                    "time": int(match.group("time")),
+                    "unit": match.group("unit"),
+                    "counter": match.group("counter").strip(),
+                    "value": number(match.group("value")),
+                }
+            )
+    return samples, warnings
+
+
+def matching(samples: List[Dict[str, Any]], counter_name: str) -> List[Dict[str, Any]]:
+    exact = [sample for sample in samples if sample["counter"] == counter_name]
+    if exact:
+        return exact
+    return [sample for sample in samples if sample["counter"].endswith(counter_name)]
+
+
+def at_occurrence(
+    samples: List[Dict[str, Any]], occurrence: int, label: str, warnings: List[str]
+) -> Optional[Dict[str, Any]]:
+    if not samples:
+        warnings.append(f"no PERF samples found for {label}")
+        return None
+    try:
+        return samples[occurrence]
+    except IndexError:
+        warnings.append(
+            f"{label} occurrence {occurrence} is out of range for {len(samples)} samples"
+        )
+        return None
+
+
+def parse_weight(source: Path, explicit_weight: Optional[float]) -> Dict[str, Any]:
+    if explicit_weight is not None:
+        return {"value": explicit_weight, "source": "--weight"}
+    name = source.name
+    match = re.match(r"^.+_\d{3,}_(?P<weight>[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)$", name)
+    if match is None:
+        return {"value": None, "source": "unavailable"}
+    value = float(match.group("weight"))
+    return {"value": value, "source": "directory-basename-final-token"}
+
+
+def emit(payload: Dict[str, Any], output: Optional[Path]) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        print(text, end="")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract XiangShan RTL PERF samples. The default 'unknown' window "
+            "does not claim that a counter is post-warmup."
+        )
+    )
+    parser.add_argument("source", type=Path, help="RTL result directory or PERF log")
+    parser.add_argument("--output", type=Path, help="optional JSON output path")
+    parser.add_argument(
+        "--window-semantics",
+        choices=["unknown", "reset-after-warmup", "cumulative-at-boundaries"],
+        default="unknown",
+        help="proven counter-window semantics; default does not calculate measurement IPC",
+    )
+    parser.add_argument("--commit-counter", default="commitInstr")
+    parser.add_argument("--cycle-counter", default="clock_cycle")
+    parser.add_argument(
+        "--measurement-commit-occurrence",
+        type=int,
+        default=-1,
+        help="0-based sample occurrence after a verified reset (default: last)",
+    )
+    parser.add_argument(
+        "--measurement-cycle-occurrence",
+        type=int,
+        default=-1,
+        help="0-based sample occurrence after a verified reset (default: last)",
+    )
+    parser.add_argument("--warmup-commit-occurrence", type=int)
+    parser.add_argument("--warmup-cycle-occurrence", type=int)
+    parser.add_argument("--weight", type=float, help="explicit RTL slice weight")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="return nonzero unless a valid post-warmup IPC can be computed",
+    )
+    args = parser.parse_args()
+
+    try:
+        logs = candidate_logs(args.source)
+    except FileNotFoundError:
+        parser.error(f"not a readable file or directory: {args.source}")
+    samples, warnings = read_samples(logs)
+    commit_samples = matching(samples, args.commit_counter)
+    cycle_samples = matching(samples, args.cycle_counter)
+    measurement = None
+    window_valid = False
+    if args.window_semantics == "reset-after-warmup":
+        commit = at_occurrence(
+            commit_samples, args.measurement_commit_occurrence, "measurement commit", warnings
+        )
+        cycles = at_occurrence(
+            cycle_samples, args.measurement_cycle_occurrence, "measurement cycle", warnings
+        )
+        if commit and cycles and cycles["value"] > 0:
+            measurement = {
+                "committed_insts": commit["value"],
+                "num_cycles": cycles["value"],
+                "computed_ipc": commit["value"] / cycles["value"],
+                "counter_window": "values after verified warmup reset",
+                "commit_sample": commit,
+                "cycle_sample": cycles,
+            }
+            window_valid = True
+    elif args.window_semantics == "cumulative-at-boundaries":
+        required = [
+            args.warmup_commit_occurrence,
+            args.measurement_commit_occurrence,
+            args.warmup_cycle_occurrence,
+            args.measurement_cycle_occurrence,
+        ]
+        if any(value is None for value in required):
+            warnings.append(
+                "cumulative-at-boundaries requires all warmup and measurement occurrence indices"
+            )
+        else:
+            warmup_commit = at_occurrence(
+                commit_samples, args.warmup_commit_occurrence, "warmup commit", warnings
+            )
+            measurement_commit = at_occurrence(
+                commit_samples, args.measurement_commit_occurrence, "measurement commit", warnings
+            )
+            warmup_cycles = at_occurrence(
+                cycle_samples, args.warmup_cycle_occurrence, "warmup cycle", warnings
+            )
+            measurement_cycles = at_occurrence(
+                cycle_samples, args.measurement_cycle_occurrence, "measurement cycle", warnings
+            )
+            if all((warmup_commit, measurement_commit, warmup_cycles, measurement_cycles)):
+                committed = measurement_commit["value"] - warmup_commit["value"]
+                cycles = measurement_cycles["value"] - warmup_cycles["value"]
+                if committed >= 0 and cycles > 0:
+                    measurement = {
+                        "committed_insts": committed,
+                        "num_cycles": cycles,
+                        "computed_ipc": committed / cycles,
+                        "counter_window": "measurement boundary minus warmup boundary",
+                        "warmup_commit_sample": warmup_commit,
+                        "measurement_commit_sample": measurement_commit,
+                        "warmup_cycle_sample": warmup_cycles,
+                        "measurement_cycle_sample": measurement_cycles,
+                    }
+                    window_valid = True
+                else:
+                    warnings.append("counter differences are not a positive measurement window")
+    else:
+        warnings.append(
+            "window semantics are unknown; PERF samples are diagnostic only, not comparable"
+        )
+
+    root_for_weight = args.source if args.source.is_dir() else args.source.parent
+    payload = {
+        "input": str(args.source.resolve()),
+        "perf_logs": [str(path.resolve()) for path in logs],
+        "window_semantics": args.window_semantics,
+        "window_valid_for_comparison": window_valid,
+        "commit_counter": args.commit_counter,
+        "cycle_counter": args.cycle_counter,
+        "commit_samples": commit_samples,
+        "cycle_samples": cycle_samples,
+        "measurement": measurement,
+        "weight": parse_weight(root_for_weight, args.weight),
+        "all_perf_sample_count": len(samples),
+        "warnings": warnings,
+    }
+    emit(payload, args.output)
+    if args.strict and not window_valid:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

Provide a reusable workflow for analyzing GEM5 and XiangShan RTL performance gaps with a consistent post-warmup measurement contract.

## Changes

- Add `gem5-rtl-performance-alignment` skill under `.codex/skills/`.
- Define the 40M total / post-warmup 20M comparison contract, common-slice matching, weighted cycle-gap contribution, and counter mapping requirements.
- Reuse `gem5_data_proc` for counter triage and add compact counter-delta summaries.
- Add lifetime trace inspection and `ClockAnalysis.py` inter-gap guidance with compact basic-block summaries.
- Add reproducible rerun input resolution for workflow profiles, checkpoints, and reference SO provenance.
- Add an opt-in `autonomous-iterate` mode that freezes one RTL trace baseline and iterates only GEM5 candidate changes. The mode is disabled by default.

## Scope

This change adds skill documentation and helper scripts only. It does not modify GEM5 performance-model behavior, XiangShan RTL, benchmark configurations, or CI workflows.

## Validation

- `util/style.py -m` on the modified Python helper scripts
- `quick_validate.py .codex/skills/gem5-rtl-performance-alignment`
- `git diff --check`

No GEM5 or RTL performance workload was launched for this skill-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured workflow for comparing GEM5 and RTL performance over consistent benchmark windows.
  * Added validation for measurement ranges, checkpoints, profiles, and result compatibility before analysis.
  * Added tools to parse performance statistics and logs, calculate IPC, and identify major cycle-gap contributors.
  * Added CSV and JSON reports with coverage, exclusions, contribution rankings, and confidence classifications.

* **Documentation**
  * Added guidance for trace comparisons, reruns, analysis rules, and controlled GEM5-only iteration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->