### PR TITLE
misc: Reduce performance archive retention to 100 runs

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -370,11 +370,11 @@ jobs:
             cp "$GITHUB_WORKSPACE/score.txt" "$TARGET_DIR/"
           fi
           
-          # Auto cleanup: keep only last 200 runs for this benchmark type
-          if [ -d "$BENCHMARK_DIR" ] && [ $(ls -1 "$BENCHMARK_DIR" 2>/dev/null | wc -l) -gt 200 ]; then
-            echo "Cleaning up old performance data, keeping last 200 runs"
+          # Auto cleanup: keep only last 100 runs for this benchmark type
+          if [ -d "$BENCHMARK_DIR" ] && [ $(ls -1 "$BENCHMARK_DIR" 2>/dev/null | wc -l) -gt 100 ]; then
+            echo "Cleaning up old performance data, keeping last 100 runs"
             # Use absolute paths to avoid accidental deletion if cd fails
-            ls -1t "$BENCHMARK_DIR" | tail -n +201 | while read -r old_run; do
+            ls -1t "$BENCHMARK_DIR" | tail -n +101 | while read -r old_run; do
               if [ -n "$old_run" ] && [ -d "$BENCHMARK_DIR/$old_run" ]; then
                 rm -rf "$BENCHMARK_DIR/$old_run"
                 echo "Deleted: $BENCHMARK_DIR/$old_run"


### PR DESCRIPTION
Performance CI retains up to 200 NFS archives per benchmark type, allowing historical simulation outputs to accumulate across profiles. Reduce this limit to 100: when a benchmark directory exceeds 100 entries, the existing cleanup keeps its 100 most recently modified entries and removes older run directories.

This changes only the retention threshold and its log messages. Cleanup still runs when that benchmark type executes; inactive profile directories are not proactively cleaned. Archive naming and GitHub artifact retention are unchanged.

Validation: repository pre-commit style check, `git diff --cached --check`, and `bash -n` on the cleanup block passed; verified the threshold is `-gt 100` and deletion starts at entry 101. No live archive deletion was performed for validation.
