### PR TITLE
mem: Add CHIron CCHI fabric with pluggable L2/home endpoints

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -277,6 +277,17 @@ Export('base_dir')
 # the ext directory should be on the #includes path
 main.Append(CPPPATH=[Dir('ext')])
 
+# vendored sqlite3 amalgamation headers (arch_db needs sqlite3.h; used when
+# the system doesn't ship libsqlite3-dev, version-matched to libsqlite3-0)
+main.Append(CPPPATH=[Dir('ext/sqlite3/include')])
+# unversioned .so symlink for -lsqlite3 (libsqlite3-dev normally provides it)
+main.Append(LIBPATH=[Dir('ext/sqlite3/lib')])
+
+# vendored boost headers (o3 uses boost::circular_buffer; used when the
+# system doesn't ship libboost-dev). -isystem so gem5's -Wundef/-Werror do
+# not fire inside boost's preprocessor machinery.
+main.Append(CCFLAGS=['-isystem', Dir('ext/boost/include').abspath])
+
 # Add shared top-level headers
 main.Prepend(CPPPATH=Dir('include'))
 
@@ -435,8 +446,11 @@ for variant_path in variant_paths:
                             '-Wno-unused-but-set-variable',
                             ])
 
-        # We always compile using C++17
-        env.Append(CXXFLAGS=['-std=c++17'])
+        # We always compile using C++20 (bumped from C++17 for the CCHI
+        # integration, which needs C++20 concepts/consteval from CHIron).
+        # Strict ISO mode (not gnu++20): the gnu dialect predefines 'linux'
+        # as a macro, which collides with gem5::linux namespaces.
+        env.Append(CXXFLAGS=['-std=c++20'])
 
         if sys.platform.startswith('freebsd'):
             env.Append(CCFLAGS=['-I/usr/local/include'])

--- a/build_opts/RISCV_CCHI
+++ b/build_opts/RISCV_CCHI
@@ -1,0 +1,5 @@
+TARGET_ISA = 'riscv'
+PROTOCOL = 'MI_example'
+
+# CCHI (CHIron Cohestra) integration enabled in this variant.
+WITH_CCHI = True

--- a/build_opts/RISCV_CCHI_RTL
+++ b/build_opts/RISCV_CCHI_RTL
@@ -1,0 +1,8 @@
+TARGET_ISA = 'riscv'
+PROTOCOL = 'MI_example'
+
+# CCHI (CHIron Cohestra) integration enabled in this variant.
+WITH_CCHI = True
+
+# Verilator-based downstream RTL endpoints (Phase 3).
+WITH_CCHI_RTL = True

--- a/build_opts/RISCV_CCHI_XSCACHE
+++ b/build_opts/RISCV_CCHI_XSCACHE
@@ -1,0 +1,14 @@
+TARGET_ISA = 'riscv'
+PROTOCOL = 'MI_example'
+
+# CCHI (CHIron Cohestra) integration enabled in this variant.
+WITH_CCHI = True
+
+# Verilator-based downstream RTL endpoints (Phase 3).
+WITH_CCHI_RTL = True
+
+# Downstream endpoint: XSCache TestTop_L2OpenLLC (Oceanus L2 + OpenLLC +
+# OpenNCB -> AXI4). The XSCache checkout path is deliberately NOT recorded
+# here: pass CCHI_XSCACHE_DIR=<path-to-XSCache> on the scons command line
+# (sticky per build dir) or export XSCACHE_DIR.
+CCHI_RTL_TOP = 'TestTop_L2OpenLLC'

--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -237,6 +237,41 @@ def config_cache(options, system):
     # Set the cache line size of the system
     system.cache_line_size = options.cacheline_size
 
+    cchi = getattr(options, 'cchi', False)
+    if cchi:
+        # CCHI mode (per the approved plan): no tol2bus/L2/L3. Each core's
+        # L1I/L1D + MMU walker caches attach to one CCHIL1Agent (Taurus
+        # node); one CCHIFabric per system hosts the downstream home and
+        # talks to membus/DRAM. Requires a WITH_CCHI=True build.
+        system.cchi_fabric = CCHIFabric(
+            clk_domain=system.cpu_clk_domain,
+            upstream_node_count=options.num_cpus,
+            downstream=getattr(options, 'cchi_downstream', 'earth'),
+            flit_trace=getattr(options, 'cchi_flit_trace', False))
+        system.cchi_fabric.mem_side = system.membus.cpu_side_ports
+        system.cchi_agents = [
+            CCHIL1Agent(
+                clk_domain=system.cpu_clk_domain,
+                fabric=system.cchi_fabric,
+                node_id=i,
+                # snoop_merge must be ON here: with it off, a home victim
+                # snoop (e.g. Venus's SnpToInvalid back-invalidation) to an
+                # L1-dirty line is answered from the Taurus line alone, the
+                # L1's dirty snoop-response data is sunk, and the home
+                # drops the victim without a writeback - silent data loss
+                # (Venus linux boot wedged on exactly this). The memtest
+                # flow already enables it via --snoop-merge.
+                snoop_merge=True,
+                l2_prefetcher=(create_prefetcher(system.cpu[i], 'l2_wrapper',
+                                                 options)
+                               if not options.no_pf
+                               and not getattr(options, 'no_cchi_l2_pf',
+                                               False)
+                               else NULL))
+            for i in range(options.num_cpus)]
+        for agent in system.cchi_agents:
+            agent.mem_side = system.membus.cpu_side_ports
+
     # If elastic trace generation is enabled, make sure the memory system is
     # minimal so that compute delays do not include memory access latencies.
     # Configure the compulsory L1 caches for the O3CPU, do not configure
@@ -245,7 +280,7 @@ def config_cache(options, system):
         assert (not hasattr(options, 'elastic_trace_en') or
                 not options.elastic_trace_en)
 
-    if options.l2cache:
+    if options.l2cache and not cchi:
         if options.classic_l2:
             config_classic_l2(options, system, l2_cache_class)
         else:
@@ -312,13 +347,19 @@ def config_cache(options, system):
 
             dcache.do_fast_writeline = not options.kmh_align
             dcache.pipe_latency = 3 if options.kmh_align else 0
-            l2_prefetcher = system.l2_caches[i].prefetcher if options.classic_l2 else system.l2_wrappers[i].prefetcher
-            if (not options.no_pf) and options.l1_to_l2_pf_hint:
+            if cchi:
+                # The L2 prefetch engine lives on the CCHI agent (hosted on
+                # the bridge); the L1->L2 hint wire targets it.
+                l2_prefetcher = system.cchi_agents[i].l2_prefetcher
+            else:
+                l2_prefetcher = system.l2_caches[i].prefetcher if options.classic_l2 else system.l2_wrappers[i].prefetcher
+            if (not options.no_pf) and options.l1_to_l2_pf_hint and \
+                    not (cchi and getattr(options, 'no_cchi_l2_pf', False)):
                 assert dcache.prefetcher != NULL and \
                     l2_prefetcher != NULL
                 dcache.prefetcher.add_pf_downstream(l2_prefetcher)
 
-            if (not options.no_pf) and options.l3cache and options.l2_to_l3_pf_hint:
+            if (not options.no_pf) and options.l3cache and not cchi and options.l2_to_l3_pf_hint:
                 assert l2_prefetcher != NULL and \
                     system.l3.prefetcher != NULL
                 l2_prefetcher.add_pf_downstream(system.l3.prefetcher)
@@ -377,7 +418,18 @@ def config_cache(options, system):
 
         system.cpu[i].createInterruptController()
         set_lsq_bank_conflict_cache_params(system.cpu[i], system)
-        if options.l2cache:
+        if cchi:
+            # L1 mem-side + walker caches fan into the core's CCHI agent;
+            # uncached/interrupt traffic goes to membus directly.
+            agent = system.cchi_agents[i]
+            system.cpu[i].icache.mem_side = agent.cpu_side
+            system.cpu[i].dcache.mem_side = agent.cpu_side
+            if walk_cache_class:
+                system.cpu[i].itb_walker_cache.mem_side = agent.cpu_side
+                system.cpu[i].dtb_walker_cache.mem_side = agent.cpu_side
+            system.cpu[i].connectUncachedPorts(
+                system.membus.cpu_side_ports, system.membus.mem_side_ports)
+        elif options.l2cache:
             system.cpu[i].connectAllPorts(
                 system.tol2bus_list[i].cpu_side_ports,
                 system.membus.cpu_side_ports, system.membus.mem_side_ports)

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -163,6 +163,26 @@ def addNoISAOptions(parser, configure_xiangshan=False):
     parser.add_argument("--l2_slices", type=int, default=4)
     parser.add_argument("--classic-l2", action="store_true", default=False,
                         help="use classic L2 cache, instead of RTL aligned L2 cache")
+    parser.add_argument("--cchi", action="store_true", default=False,
+                        help="use the CCHI (CHIron Cohestra) fabric instead of "
+                        "the classic tol2bus/L2/L3 hierarchy: each core's L1 "
+                        "attaches to a CCHIL1Agent (Taurus node) connected to "
+                        "a CCHIFabric with a pluggable downstream home. "
+                        "Requires a WITH_CCHI=True build (e.g. RISCV_CCHI).")
+    parser.add_argument("--cchi-downstream", type=str, default="earth",
+                        choices=["earth", "rtl"],
+                        help="CCHI downstream endpoint: 'earth' (vendored "
+                        "behavioral home) or 'rtl' (Verilator backend, "
+                        "requires a WITH_CCHI_RTL=True build)")
+    parser.add_argument("--no-cchi-l2-pf", action="store_true", default=False,
+                        help="Disable the CCHI-hosted L2 prefetch engine "
+                        "(no stash emissions via DoPrefetchLoad/Store); use "
+                        "for downstreams that do not properly support "
+                        "stash/prefetch traffic (e.g. the XSCache RTL)")
+    parser.add_argument("--cchi-flit-trace", action="store_true", default=False,
+                        help="Attach CHIron's CCHIFlitLogger to the CCHI "
+                        "fabric ([cchi] verbose=1): flit-level transaction "
+                        "log from the Taurus nodes (very verbose; debug runs)")
 
     parser.add_argument("--l3_size", type=str, default="16MB")
     parser.add_argument("--l3_assoc", type=int, default=16)

--- a/configs/example/cchi_memtest.py
+++ b/configs/example/cchi_memtest.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026
+#
+# Functional validation config for the CCHI integration (Phase 1).
+#
+# Topology under test:
+#   MemTest (data-checking traffic tester)
+#     -> L1 DCache (classic, untouched)
+#       -> CCHIL1Agent (Taurus UpstreamNode)
+#         -> CCHIFabric (Cohestra::Instance + Earth home + CacheLineDataMonitor)
+#           -> membus -> MemCtrl (DRAM)
+#
+# The MemTester's own data model plus the fabric's CacheLineDataMonitor give
+# end-to-end data-integrity checking without needing a RISC-V binary or a
+# difftest reference.
+#
+# Run (from the repo root):
+#   ./build/RISCV_CCHI/gem5.opt configs/example/cchi_memtest.py \
+#       [--max-loads 100000] [--uncacheable 10] [--functional 10]
+
+import argparse
+
+import m5
+from m5.objects import *
+from m5.util import addToPath
+
+addToPath('../')
+addToPath('../../')
+
+from common.Caches import L1_DCache
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--max-loads", type=int, default=100000,
+                    help="loads to execute before exiting (0 = run forever)")
+parser.add_argument("--uncacheable", type=int, default=10,
+                    help="percentage of uncacheable accesses")
+parser.add_argument("--functional", type=int, default=0,
+                    help="percentage of functional accesses. NOTE: functional "
+                    "side-channel writes update gem5 memory outside CCHI "
+                    "visibility (acknowledged approximation): the "
+                    "CacheLineDataMonitor's scoreboard cannot track them and "
+                    "will flag them as mismatches. Keep 0 for monitor-clean "
+                    "validation runs.")
+parser.add_argument("--snoop-merge", action="store_true",
+                    help="enable the agent's snoop_merge path")
+parser.add_argument("--flit-trace", action="store_true",
+                    help="attach CHIron's CCHIFlitLogger ([cchi] verbose=1; "
+                    "flit-level transaction log, very verbose)")
+parser.add_argument("--num-cpus", type=int, default=1,
+                    help="number of testers (each gets its own L1 + agent; "
+                    ">1 exercises the home snoop paths)")
+parser.add_argument("--downstream", type=str, default="earth",
+                    choices=["earth", "rtl"],
+                    help="CCHI downstream endpoint (rtl requires a "
+                    "WITH_CCHI_RTL build)")
+parser.add_argument("--interval", type=int, default=10,
+                    help="MemTest request interval (cycles); raise to "
+                    "de-rate the offered load")
+args = parser.parse_args()
+
+system = System()
+system.clk_domain = SrcClockDomain(clock="2GHz",
+                                   voltage_domain=VoltageDomain())
+system.mem_mode = "timing"
+system.mem_ranges = [AddrRange("2GB")]
+
+# CCHI: one fabric (Earth or Verilator downstream) shared by all agents
+system.cchi_fabric = CCHIFabric(clk_domain=system.clk_domain,
+                                upstream_node_count=args.num_cpus,
+                                downstream=args.downstream,
+                                flit_trace=args.flit_trace,
+                                memory_start=0x0,
+                                memory_end=0x80000000)
+
+system.membus = SystemXBar()
+system.cchi_fabric.mem_side = system.membus.cpu_side_ports
+system.system_port = system.membus.cpu_side_ports
+
+# Per-core tester + L1 + agent. All testers share the same default address
+# regions, so with num_cpus > 1 the home must snoop lines between agents.
+# With shared regions the per-tester reference models race on writes to
+# the same line (each tracks only its own writes), so their data check is
+# only meaningful single-core; multi-core coherence is checked by the
+# fabric's CacheLineDataMonitor instead.
+for i in range(args.num_cpus):
+    tester = MemTest(interval=args.interval,
+                     percent_uncacheable=args.uncacheable,
+                     percent_functional=args.functional,
+                     max_loads=args.max_loads,
+                     progress_interval=10000,
+                     progress_check=1000000,
+                     check_data=(args.num_cpus == 1))
+    setattr(system, "tester%d" % i, tester)
+
+    l1 = L1_DCache(size="64kB", assoc=8, clk_domain=system.clk_domain)
+    setattr(system, "l1_%d" % i, l1)
+    tester.port = l1.cpu_side
+
+    agent = CCHIL1Agent(clk_domain=system.clk_domain,
+                        fabric=system.cchi_fabric,
+                        node_id=i,
+                        snoop_merge=args.snoop_merge)
+    setattr(system, "agent%d" % i, agent)
+    l1.mem_side = agent.cpu_side
+    agent.mem_side = system.membus.cpu_side_ports
+
+system.mem_ctrl = MemCtrl()
+system.mem_ctrl.dram = DDR4_2400_16x4(range=system.mem_ranges[0])
+system.mem_ctrl.port = system.membus.mem_side_ports
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+print("CCHI memtest: starting simulation (max_loads=%d)" % args.max_loads)
+exit_event = m5.simulate()
+print("Exiting @ tick %i because %s" % (m5.curTick(),
+                                        exit_event.getCause()))

--- a/configs/example/kmhv3.py
+++ b/configs/example/kmhv3.py
@@ -148,8 +148,8 @@ def setKmhV3Params(args, system):
             cpu.dcache.prefetch_can_offload = False
             set_lsq_bank_conflict_cache_params(cpu, system)
 
-    # l2 caches
-    if args.l2cache:
+    # l2 caches (absent in CCHI mode: the fabric/home replaces tol2bus/L2/L3)
+    if args.l2cache and not args.cchi:
         for i in range(args.num_cpus):
             if args.classic_l2:
                 system.l2_caches[i].slice_num = 4
@@ -184,8 +184,8 @@ def setKmhV3Params(args, system):
                 LayerBandwidthConfig(direction="resp", port_index=1, max_per_cycle=2),
             ]
 
-    # l3 cache
-    if args.l3cache:
+    # l3 cache (absent in CCHI mode)
+    if args.l3cache and not args.cchi:
         system.l3.mshrs = 64
         system.l3.do_fast_writeline = True
         system.l3.prefetch_can_offload = False

--- a/src/cpu/minor/dyn_inst.hh
+++ b/src/cpu/minor/dyn_inst.hh
@@ -124,7 +124,7 @@ class InstId
   public:
     /* Equal if the thread and last set sequence number matches */
     bool
-    operator== (const InstId &rhs)
+    operator== (const InstId &rhs) const
     {
         /* If any of fetch and exec sequence number are not set
          *  they need to be 0, so a straight comparison is still

--- a/src/cpu/testers/memtest/MemTest.py
+++ b/src/cpu/testers/memtest/MemTest.py
@@ -76,3 +76,11 @@ class MemTest(ClockedObject):
     # accesses as Ruby needs this
     suppress_func_errors = Param.Bool(False, "Suppress panic when "\
                                             "functional accesses fail.")
+
+    # Data-check reads against the tester's private reference model.
+    # Disable when several testers share one address space: racing
+    # writes to the same line make each private model diverge from the
+    # coherent memory state, producing false mismatches (coherence
+    # itself is checked by other means, e.g. a data monitor).
+    check_data = Param.Bool(True, "Check read data against the local "
+                                  "reference model")

--- a/src/cpu/testers/memtest/memtest.cc
+++ b/src/cpu/testers/memtest/memtest.cc
@@ -106,7 +106,8 @@ MemTest::MemTest(const Params &p)
       nextProgressMessage(p.progress_interval),
       maxLoads(p.max_loads),
       atomic(p.system->isAtomicMode()),
-      suppressFuncErrors(p.suppress_func_errors), stats(this)
+      suppressFuncErrors(p.suppress_func_errors),
+      checkData(p.check_data), stats(this)
 {
     id = TESTER_ALLOCATOR++;
     fatal_if(id >= blockSize, "Too many testers, only %d allowed\n",
@@ -155,7 +156,7 @@ MemTest::completeRequest(PacketPtr pkt, bool functional)
     } else {
         if (pkt->isRead()) {
             uint8_t ref_data = referenceData[req->getPaddr()];
-            if (pkt_data[0] != ref_data) {
+            if (checkData && pkt_data[0] != ref_data) {
                 panic("%s: read of %x (blk %x) @ cycle %d "
                       "returns %x, expected %x\n", name(),
                       req->getPaddr(), blockAlign(req->getPaddr()), curTick(),

--- a/src/cpu/testers/memtest/memtest.hh
+++ b/src/cpu/testers/memtest/memtest.hh
@@ -174,6 +174,11 @@ class MemTest : public ClockedObject
     const bool atomic;
 
     const bool suppressFuncErrors;
+
+    // Check read data against the private reference model (disabled
+    // when several testers share an address space: racing writes make
+    // each private model diverge from the coherent memory state)
+    const bool checkData;
   protected:
     struct MemTestStats : public statistics::Group
     {

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -653,7 +653,14 @@ BaseCache::calReqInterval(PacketPtr pkt)
 {
     RequestorID reqId = pkt->requestorId();
     size_t sliceId = (getActualSliceNum() == 1) ? 0 : getSliceIdx(pkt->getAddr());
-    auto& prev = prevReqCycles[sliceId][reqId];
+    auto& sliceReqs = prevReqCycles[sliceId];
+    // RequestorIDs are assigned during port binding (init), after this
+    // vector was sized at construction with system->maxRequestors();
+    // requestors registered later (e.g. testers) would otherwise index
+    // out of bounds.
+    if (reqId >= sliceReqs.size())
+        sliceReqs.resize(reqId + 1, Cycles{0});
+    auto& prev = sliceReqs[reqId];
     if (prev == 0) {
         // first request
         prev = curCycle();

--- a/src/mem/cchi/CCHIFabric.py
+++ b/src/mem/cchi/CCHIFabric.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.params import *
+from m5.objects.ClockedObject import ClockedObject
+
+# One CCHIFabric per system. It embeds CHIron's Cohestra::Instance, which
+# owns the per-core Taurus upstream nodes (driven by the CCHIL1Agents) and
+# one downstream CCHIInterface endpoint (the vendored Earth behavioral home
+# for now; a Verilator binding plugs into the same abstraction later).
+# The fabric's per-cycle event is simply Instance::Tick (CHIron's own flit
+# pump), followed by the per-agent tick hooks.
+class CCHIFabric(ClockedObject):
+    type = 'CCHIFabric'
+    cxx_header = 'mem/cchi/cchi_fabric.hh'
+    cxx_class = 'gem5::CCHIFabric'
+
+    # Port towards the gem5 memory system (membus -> MemCtrl). Serves the
+    # downstream endpoint's memory traffic: the Earth model's MemoryBackend
+    # reads/writes whole lines through it (Phase 1: atomic accesses).
+    mem_side = RequestPort("Memory-side port towards membus/DRAM; serves "
+                           "the downstream endpoint's memory traffic")
+
+    upstream_node_count = Param.Unsigned(1,
+        "Number of Taurus upstream nodes (one per core/CCHIL1Agent)")
+    downstream = Param.String("earth",
+        "Downstream endpoint: 'earth' (vendored behavioral home) or 'rtl' "
+        "(Verilator backend; requires a WITH_CCHI_RTL build)")
+    memory_start = Param.Addr(0x80000000,
+        "Start of the CCHI-managed (cacheable) memory window")
+    memory_end = Param.Addr(0xA0000000,
+        "End (exclusive) of the CCHI-managed memory window")
+
+    earth_latency_rsp = Param.Cycles(4,
+        "Earth endpoint RSP-channel latency, in fabric cycles")
+    earth_latency_dat = Param.Cycles(4,
+        "Earth endpoint DAT-channel latency, in fabric cycles")
+
+    monitor_enable = Param.Bool(True,
+        "Attach the Cohestra CacheLineDataMonitor (per-line data-integrity "
+        "scoreboard) to the embedded instance")
+    monitor_fail_on_mismatch = Param.Bool(True,
+        "Monitor data mismatches mark the Cohestra instance FAILED "
+        "(raised as a gem5 fatal at the next fabric tick)")
+    monitor_trace = Param.Bool(False,
+        "Enable the monitor's per-access trace logging (very verbose)")
+    flit_trace = Param.Bool(False,
+        "Attach CHIron's CCHIFlitLogger ([cchi] verbose=1): flit-level "
+        "transaction log from the Taurus nodes' channel events "
+        "(very verbose; debug runs)")

--- a/src/mem/cchi/CCHIL1Agent.py
+++ b/src/mem/cchi/CCHIL1Agent.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.params import *
+from m5.proxy import *
+from m5.objects.ClockedObject import ClockedObject
+from m5.objects.CCHIFabric import CCHIFabric
+from m5.objects.Prefetcher import BasePrefetcher
+
+# Per-core bridge between a gem5 classic L1 cache hierarchy (L1I + L1D +
+# MMU walker ports, all untouched) and one CCHI Taurus UpstreamNode owned
+# by the CCHIFabric. The bridge translates MemCmds to Taurus Do* calls and
+# reflects home-originated snoops into the L1s.
+#
+# Port choice: cpu_side is a VectorResponsePort so that L1I, L1D and the
+# MMU walker ports of one core can all fan into the same agent without an
+# intermediate crossbar (each master connects to the next vector index).
+# A single ResponsePort would only accept one peer and could not host the
+# walker fan-in.
+class CCHIL1Agent(ClockedObject):
+    type = 'CCHIL1Agent'
+    cxx_header = 'mem/cchi/cchi_l1_agent.hh'
+    cxx_class = 'gem5::CCHIL1Agent'
+
+    cpu_side = VectorResponsePort(
+        "CPU-side port(s): requests from the core's L1I/L1D caches and "
+        "MMU walker ports arrive here; responses and snoops return here")
+    mem_side = RequestPort(
+        "Bypass port to the gem5 memory system for uncached/MMIO/atomic "
+        "traffic (never touches CCHI)")
+
+    fabric = Param.CCHIFabric("CCHI fabric owning this agent's Taurus node")
+    system = Param.System(Parent.any, "System we belong to")
+    node_id = Param.Unsigned("CCHI upstream node ID of this agent's "
+                             "Taurus node (unique per core)")
+
+    hit_latency = Param.Cycles(4,
+        "Response latency for requests granted immediately (Taurus hits)")
+
+    snoop_merge = Param.Bool(False,
+        "Hold each home snoop at the fabric gate, reflect it into the L1 "
+        "first, merge any dirty L1 data into the Taurus line, and only "
+        "then let Taurus answer the home (exact multicore data; when "
+        "False, Taurus answers immediately and L1 snoop data is dropped)")
+
+    xaction_limit_req = Param.Unsigned(16,
+        "Taurus in-flight REQ limit (raise towards the L1D MSHR count)")
+    xaction_limit_evt = Param.Unsigned(16,
+        "Taurus in-flight EVT (eviction) limit")
+    xaction_limit_snp = Param.Unsigned(16,
+        "Taurus in-flight SNP limit")
+
+    # WIRE-UP ONLY: the L2 prefetch engine is hosted on the bridge
+    # (L2CacheWrapper-style); probe/rxHint wiring is done at the config
+    # level elsewhere. Emissions drained here become CCHI stash
+    # transactions (DoPrefetchLoad/DoPrefetchStore) targeting the
+    # endpoint-side L2.
+    l2_prefetcher = Param.BasePrefetcher(NULL,
+        "L2 prefetch engine hosted on the bridge (emissions become CCHI "
+        "stash transactions)")

--- a/src/mem/cchi/README.md
+++ b/src/mem/cchi/README.md
@@ -1,0 +1,283 @@
+# CCHI (CHIron Cohestra) Integration — Build & Run Guide
+
+This directory integrates CHIron's Cohestra CCHI fabric into XS-GEM5: each
+core's classic L1 caches (untouched, with their prefetchers and the L1
+performance model intact) attach to a `CCHIL1Agent` (a CHIron Taurus upstream
+node), and all agents share one `CCHIFabric` with a pluggable downstream home:
+
+- **Earth** — vendored C++ behavioral home (`src/mem/cchi/earth/`), no RTL
+  toolchain needed.
+- **RTL** — any Verilator-model home plugged in through CHIron's V3 pin
+  bindings. Validated with **Venus** (`venus_v3_top_extmem`) from the CHIron
+  checkout; user-specified RTL tops are supported via `CCHI_RTL_TOP` /
+  `CCHI_RTL_SRCS`.
+
+Everything is compile-time gated (`WITH_CCHI`, `WITH_CCHI_RTL`) and runtime
+gated (`--cchi`): the stock `build/RISCV` binary and the default kmhv3
+configuration are bit-identical with or without this code present.
+
+## Prerequisites
+
+- **CHIron checkout** (read-only; never modified by the build). Located by,
+  in priority order: the `CHIRON_DIR` scons variable or the `$CHIRON_DIR`
+  environment variable. There is no default location: an unset `CHIRON_DIR`
+  fails the build with an explicit error.
+- **Verilator** on `PATH` (RTL builds only).
+- **scons** via the repo venv: `.venv/bin/scons`.
+- **Workloads**: binaries from the OpenXiangShan `ready-to-run` repo (not
+  part of this repository; supply its location per run via `READY_TO_RUN`,
+  `--generic-rv-cpt` and `GCBV_REF_SO`):
+  - `coremark-2-iteration.bin`, `linux.bin`, `microbench.bin` — raw binaries
+  - `riscv64-nemu-interpreter-so` — difftest reference (`GCBV_REF_SO`)
+
+## Build
+
+All CCHI options are *sticky* per build directory: pass them once on the
+first configure; later rebuilds of the same variant need no flags.
+
+```bash
+# Baseline (no CCHI code at all)
+.venv/bin/scons build/RISCV/gem5.opt --gold-linker -j$(nproc)
+
+# Earth (C++ home): WITH_CCHI=True
+.venv/bin/scons build/RISCV_CCHI/gem5.opt --gold-linker -j$(nproc) \
+    WITH_CCHI=True CHIRON_DIR=/path/to/CHIron
+
+# RTL home (Verilator): WITH_CCHI_RTL=True + a top
+.venv/bin/scons build/RISCV_CCHI_RTL/gem5.opt --gold-linker -j$(nproc) \
+    WITH_CCHI=True WITH_CCHI_RTL=True CCHI_RTL_TOP=venus_v3_top_extmem
+
+# XSCache home (Oceanus L2 + OpenLLC + OpenNCB): dedicated variant;
+# the XSCache checkout path is a per-build knob, never a repo default
+.venv/bin/scons build/RISCV_CCHI_XSCACHE/gem5.opt --gold-linker -j$(nproc) \
+    CCHI_XSCACHE_DIR=/path/to/XSCache    # or: export XSCACHE_DIR=...
+```
+
+Notes:
+
+- Known-top shortcuts: `top_dummy` (loopback smoke top) and `venus_v3_top` /
+  `venus_v3_top_extmem` (sources auto-resolved from the CHIron checkout),
+  and `TestTop_L2OpenLLC` (sources globbed from the XSCache checkout given
+  by `CCHI_XSCACHE_DIR`/`$XSCACHE_DIR` — see "XSCache downstream" below).
+  Anything else needs an explicit `CCHI_RTL_SRCS` (see "User-specified
+  RTL" below).
+- Verilation runs at **configure time** into the machine-local temp dir
+  `/tmp/cchi_rtl_<top>_<hash>/obj_dir` — deliberately *not* the build tree
+  (some network filesystems drop freshly written build-tree files). A stamp
+  of the inputs (top, Verilator version, source paths + mtimes/sizes) skips
+  re-verilation on plain rebuilds; regenerating a developing RTL checkout
+  (e.g. XSCache's `make test-top-l2openllc`) re-verilates automatically.
+  Changing `CCHI_RTL_TOP` on an existing variant wipes that variant's
+  objects and rebuilds.
+- If a build appears to succeed but the binary is stale, re-run with the
+  exit code visible: `... ; echo "SCONS_EXIT=${PIPESTATUS[0]}"` and grep the
+  log — piping scons through `tail` can swallow compiler errors.
+
+## Run
+
+### Functional memtest (no RISC-V binary needed)
+
+`configs/example/cchi_memtest.py`: MemTest traffic generator -> classic L1D
+-> `CCHIL1Agent` -> `CCHIFabric` (with CHIron's `CacheLineDataMonitor`
+data-integrity scoreboard) -> membus -> DRAM.
+
+```bash
+# Earth, 1 core
+./build/RISCV_CCHI/gem5.opt configs/example/cchi_memtest.py \
+    --max-loads 200000
+
+# Earth, 4 cores (exercises home snoop paths)
+./build/RISCV_CCHI/gem5.opt configs/example/cchi_memtest.py \
+    --max-loads 200000 --num-cpus 4 --snoop-merge
+
+# Venus RTL, 2 cores
+./build/RISCV_CCHI_RTL/gem5.opt configs/example/cchi_memtest.py \
+    --max-loads 200000 --num-cpus 2 --downstream rtl --snoop-merge
+```
+
+Options: `--max-loads N` (0 = forever), `--num-cpus N`, `--downstream
+earth|rtl`, `--snoop-merge` (exact multicore data; **required for Venus** —
+without it Venus's victim back-invalidation drops dirty data), `--uncacheable
+PCT`, `--functional PCT` (keep 0: functional side-channel writes bypass the
+monitor), `--interval N`.
+
+A clean run exits 0 with `monitorMismatches=0` in stats.
+
+### Full workloads (kmhv3)
+
+```bash
+RTR=/mnt/c/OneDrive/ProjectFiles/XiangshanProjects/ready-to-run
+export GCBV_REF_SO=$RTR/riscv64-nemu-interpreter-so
+
+# Baseline
+./build/RISCV/gem5.opt --outdir=m5out_coremark_base \
+    configs/example/kmhv3.py --raw-cpt --generic-rv-cpt=$RTR/coremark-2-iteration.bin
+
+# Earth
+./build/RISCV_CCHI/gem5.opt --outdir=m5out_coremark_earth \
+    configs/example/kmhv3.py --cchi \
+    --raw-cpt --generic-rv-cpt=$RTR/coremark-2-iteration.bin
+
+# Venus RTL
+./build/RISCV_CCHI_RTL/gem5.opt --outdir=m5out_coremark_rtl \
+    configs/example/kmhv3.py --cchi --cchi-downstream=rtl \
+    --raw-cpt --generic-rv-cpt=$RTR/coremark-2-iteration.bin
+
+# Linux boot (difftest OFF — see caveat below)
+./build/RISCV_CCHI_RTL/gem5.opt --outdir=m5out_linux_rtl \
+    configs/example/kmhv3.py --cchi --cchi-downstream=rtl --disable-difftest \
+    --raw-cpt --generic-rv-cpt=$RTR/linux.bin
+```
+
+- `--cchi` replaces the tol2bus/L2/L3 hierarchy with the fabric (the classic
+  L1s, their prefetchers, and the L1 performance model are unchanged; the L2
+  prefetch engine is hosted on the agent and its emissions are stashed for
+  future `DoPrefetchLoad/DoPrefetchStore` work — currently unimplemented by
+  design). In the kmhv3 path `snoop_merge` is forced on (required by Venus).
+- `--raw-cpt` is for raw `.bin` images; checkpoint slices (`.zstd` GCPT) go
+  without it.
+- Difftest caveat: with difftest ON, `linux.bin` diverges on **all** configs
+  (baseline included) at the same pre-existing NEMU/gem5 interrupt-timing
+  point — not a CCHI issue. Use `--disable-difftest` for linux; coremark runs
+  clean with difftest ON.
+
+### Reference results (validated)
+
+| Workload | Baseline RISCV | Earth | Venus RTL |
+|---|---|---|---|
+| coremark (difftest on) | IPC 0.7857 | IPC 0.8128 | IPC 0.8105 |
+| linux boot (difftest off) | 14,159,157 cyc | exit @ 5.104 G tick | exit @ 5.273 G tick |
+| memtest 200k loads | — | 1/2/4c clean | 1/2c clean |
+
+All coremark runs commit the identical 663,614 instructions; linux runs reach
+`m5_exit` with 20,000,001–20,000,002 instructions (±1 is exit-boundary
+interrupt timing, not corruption).
+
+## Debug knobs
+
+- `--debug-flags=CCHI` / `--debug-flags=Earth` — agent/fabric and Earth-home
+  traces.
+- `CCHI_RTL_TRACE=/path/dump.vcd` — waveform dump of the verilated top (VCD
+  via `VerilatedVcdC`).
+- `CCHI_RTL_TRACE_START=<gem5 tick>` — deferred trace open: the dump starts
+  on the first fabric tick at/after this tick, keeping long runs from
+  producing multi-GB waves before the region of interest.
+- Fabric params (`CCHIFabric.py`): `monitor_enable`, `monitor_fail_on_mismatch`
+  (data mismatch -> gem5 fatal), `monitor_trace` (very verbose),
+  `earth_latency_rsp/dat`.
+- Agent params (`CCHIL1Agent.py`): `snoop_merge`, `hit_latency`,
+  `xaction_limit_{req,evt,snp}`.
+
+## XSCache downstream (Oceanus L2 + OpenLLC + OpenNCB)
+
+The `TestTop_L2OpenLLC` known top verilates the XSCache Oceanus L2 with
+OpenLLC + OpenNCB (CHI-only cache subsystem: CoupledL2 tl2chi + OpenLLC,
+AXI4 to memory) as the CCHI downstream. Prerequisite in the XSCache
+checkout (generates `build/l2openllc/`, ~170 firtool files):
+
+```bash
+make init && make compile && make test-top-l2openllc
+```
+
+Build/run as shown above (dedicated `RISCV_CCHI_XSCACHE` variant); the run
+commands are those of the Venus RTL endpoint (`--cchi
+--cchi-downstream=rtl` for kmhv3, `--downstream rtl` for memtest) **plus
+`--no-cchi-l2-pf`**: the XSCache RTL does not properly support the CCHI
+stash transactions emitted by the hosted L2 prefetch engine, so all L2
+prefetch must be disabled at run time with this downstream (L1 prefetch is
+unaffected).
+
+The fastest way to a linux boot is the wrapper script (checks
+prerequisites, builds the variant on first run, then boots):
+
+```bash
+# required paths: CLI flags or the same-named environment variables
+# (XSCACHE_DIR / CHIRON_DIR / READY_TO_RUN); there are no defaults
+util/cchi/run_xscache_linux.sh \
+    --xscache-dir=/path/to/XSCache \
+    --chiron-dir=/path/to/CHIron \
+    --ready-to-run=/path/to/ready-to-run            # build if needed + boot
+util/cchi/run_xscache_linux.sh ... --flit-trace     # + CCHI flit-level log
+util/cchi/run_xscache_linux.sh ... --vcd=/tmp/xscache.vcd --vcd-start=2680000000
+```
+
+Paths come from the `--xscache-dir` / `--chiron-dir` / `--ready-to-run`
+flags (or the `XSCACHE_DIR` / `CHIRON_DIR` / `READY_TO_RUN` environment
+variables); `GCBV_REF_SO` and `LINUX_BIN` default to files under
+`READY_TO_RUN`, and `OUTDIR` defaults to `<repo>/m5out_linux_xscache`.
+Missing required paths abort with an explicit error; see the script header
+for the full option list. kmhv3 runs can also attach the CHIron flit
+logger with `--cchi-flit-trace` (memtest: `--flit-trace`).
+
+Constraints of the current generated top:
+
+- One Type-1 port (`cchi_t1p0`, upstream NID hardcoded 0): single upstream
+  node only. The two `cchi_t4p{0,1}` ports (req+dat only, no CHIron
+  binding) and the `log_dump`/`log_clean` inputs are left tied off —
+  matching XSCache's own cohestra smoke harness.
+- The AXI master (`axi_m0`) has a 32-bit address: the fabric memory window
+  must stay below 4GB. The default CCHI window `[0x8000_0000,
+  0xA000_0000)` complies (and matches XSCache's own smoke configuration).
+- First configure takes minutes (firtool file count) and a few GB in the
+  temp dir. Regenerating the RTL in XSCache is picked up automatically
+  (source mtimes/sizes are folded into the verilation stamp).
+
+## User-specified RTL
+
+Any Verilator-compatible home RTL can serve as the downstream endpoint:
+
+```bash
+.venv/bin/scons build/RISCV_CCHI_RTL/gem5.opt --gold-linker -j$(nproc) \
+    WITH_CCHI=True WITH_CCHI_RTL=True \
+    CCHI_RTL_TOP=my_home_top \
+    CCHI_RTL_SRCS="/path/a.sv /path/b.sv /path/my_home_top.sv"   # dependency order
+```
+
+then run with `--cchi --cchi-downstream=rtl` (kmhv3) or `--downstream rtl`
+(memtest). The generated model is bound through CHIron's
+`V3CCHIInterface` / `V3AXISlaveInterface`, which detect ports **by name** at
+compile time (C++ concepts — missing ports simply don't get bound), so the
+top must follow the cohestra_v3 pin contract:
+
+- **Clock/reset**: `clock`, `reset` (high-active, held for 100 cycles, then
+  released with all pins quiesced by the interface).
+- **CCHI Type-1 port sets**, one per upstream node, `N` = 0..7:
+  `cchi_t1p<N>_{rxevt,rxreq}_{ready,valid,bits_*}` (upstream -> home),
+  `cchi_t1p<N>_{txsnp,txrsp,txdat,rxrsp,rxdat}_{ready,valid,bits_*}`
+  (home -> upstream). Flit fields follow CHIron's Type-1 layout
+  (`bits_TxnID/SrcID/TgtID/Opcode/Addr/NS/...`, 64-bit `Addr`, 256-bit DAT
+  `Data[0..]`). Optional upstream-width extensions
+  `..._bits_WayValid` / `..._bits_Way` are picked up when present.
+  `upstream_node_count` must not exceed the number of detected Type-1 ports.
+- **AXI4 master ports** for memory traffic: `axi_m<M>_{aw,w,b,ar,r}*`,
+  served by `CCHIAxiMemBridge` into the gem5 membus. B/R response FIFOs are
+  sized 2 per port by the fabric.
+
+Reference implementations in the CHIron checkout:
+`cchi/cohestra/cohestra_v3/top_dummy.sv` (minimal loopback, good smoke test),
+`cchi/cohestra/cohestra_v3/venus/` + `tb/venus_v3_top_extmem.sv` (full Venus
+home; the `extmem` variant exposes the AXI masters on the boundary — this is
+the one gem5 uses).
+
+Caveats for new tops:
+
+- AXI read data is expected critical-word-first (32B beats,
+  `rd_start = addr[5]`); the bridge currently serves line-base-sequential
+  data. This passes all data checking but is an assumption to revisit.
+- Venus's victim flow requires `snoop_merge` (see above); assume other homes
+  with back-invalidation do too.
+- The fabric runs one RTL cycle per fabric clock tick; in kmhv3 runs the
+  fabric sits on the CPU clock domain.
+
+## Layout
+
+- `cchi_l1_agent.{hh,cc}` — per-core bridge: gem5 L1 <-> Taurus Do* calls,
+  home-snoop reflection into L1, grant-time fill snapshots.
+- `cchi_fabric.{hh,cc}` — `CCHIFabric`: embedded `Cohestra::Instance`, Earth
+  endpoint, RTL endpoint (`RtlStack`), snoop gate (snoop_merge), monitor,
+  waveform tracing.
+- `cchi_axi_mem_bridge.{hh,cc}` — AXI4-slave -> gem5 membus bridge (RTL
+  builds only).
+- `earth/` — vendored Earth behavioral home sources.
+- `SConsopts` / `SConscript` — the `WITH_CCHI` / `WITH_CCHI_RTL` build
+  plumbing described above.

--- a/src/mem/cchi/SConscript
+++ b/src/mem/cchi/SConscript
@@ -1,0 +1,304 @@
+# -*- mode:python -*-
+# Copyright (c) 2026
+#
+# Build rules for the CCHI (CHIron Cohestra) L1-fabric integration.
+#
+# Everything in this directory is gated behind the WITH_CCHI build option
+# (declared in this directory's SConsopts as a sticky per-build variable):
+# when off, nothing here is compiled and the CCHI SimObjects do not exist.
+# WITH_CCHI_RTL gates the Verilator endpoint backend (Phase 3) and adds
+# nothing yet.
+
+import glob
+import os
+
+Import('*')
+
+if not env['WITH_CCHI']:
+    Return()
+
+# --- CHIron location ---------------------------------------------------------
+# Sticky variable first, then the environment. There is no default checkout
+# location: an unset CHIRON_DIR is a hard error, not a silent guess.
+chiron_dir = env.get('CHIRON_DIR') or os.environ.get('CHIRON_DIR')
+
+if not chiron_dir:
+    print("error: WITH_CCHI=True requires CHIRON_DIR (scons variable or "
+          "environment variable) pointing at a CHIron checkout")
+    Exit(1)
+
+chiron_dir = os.path.abspath(chiron_dir)
+
+if not os.path.isdir(chiron_dir):
+    print("error: WITH_CCHI=True requires a CHIron checkout; got "
+          "CHIRON_DIR='%s' (set the sticky variable or the environment "
+          "variable)" % chiron_dir)
+    Exit(1)
+
+env['HAVE_CHIRON'] = True
+
+# Include paths: the gem5-side code (incl. the vendored Earth endpoint)
+# uses -I<CHIRON_DIR>/cchi style includes; CHIron's own cohestra sources
+# additionally need their vendored spdlog/SimpleIni directories.
+# -isystem (not -I): gem5 builds with -Wextra/-Werror and CHIron's headers
+# are not warning-clean under it (e.g. -Wempty-body in nonstdint.hpp) —
+# the same treatment system/boost headers get.
+for inc in [
+        chiron_dir,
+        os.path.join(chiron_dir, 'cchi'),
+        os.path.join(chiron_dir, 'cchi', 'cohestra'),
+        os.path.join(chiron_dir, 'cchi', 'cohestra', 'cohestra_stimulators'),
+        os.path.join(chiron_dir, 'cchi', 'cohestra', 'spdlog', 'include'),
+        os.path.join(chiron_dir, 'cchi', 'cohestra', 'simpleini'),
+]:
+    env.Append(CCFLAGS=['-isystem', inc])
+
+# CHIron's cohestra harness headers pull in the vendored spdlog, which
+# enables its header-only mode itself when SPDLOG_COMPILED_LIB is unset
+# (see cchi/cohestra/spdlog/include/spdlog/common.h), so no define or
+# extra library is needed here.
+
+# --- gem5-side CCHI sources --------------------------------------------------
+# CCHI_HAVE_GEM5_DEBUG routes this directory's DPRINTF through the CCHI
+# debug flag; EARTH_HAVE_GEM5_DEBUG does the same for the vendored Earth
+# sources (their fprintf fallback is for standalone syntax checks only).
+gem5_cchi_defines = ['CCHI_HAVE_GEM5_DEBUG', 'EARTH_HAVE_GEM5_DEBUG']
+
+Source('cchi_l1_agent.cc', append={'CPPDEFINES': gem5_cchi_defines})
+Source('cchi_fabric.cc', append={'CPPDEFINES': gem5_cchi_defines})
+
+# Vendored Earth endpoint (parallel workstream; picked up once present)
+earth_src_dir = os.path.join(Dir('.').srcnode().abspath, 'earth')
+earth_srcs = sorted(glob.glob(os.path.join(earth_src_dir, '*.cc')) +
+                    glob.glob(os.path.join(earth_src_dir, '*.cpp')))
+for earth_src in earth_srcs:
+    # Source() paths are relative to this SConscript's (variant) directory
+    Source(os.path.join('earth', os.path.basename(earth_src)),
+           append={'CPPDEFINES': gem5_cchi_defines})
+
+SimObject('CCHIL1Agent.py', sim_objects=['CCHIL1Agent'])
+SimObject('CCHIFabric.py', sim_objects=['CCHIFabric'])
+
+DebugFlag('CCHI')
+DebugFlag('Earth')
+
+# --- Read-only CHIron cohestra sources ---------------------------------------
+# Compiled straight from the CHIron checkout (never modified, never
+# vendored). SCons places object files next to their sources for absolute
+# out-of-tree paths, which would write into the read-only checkout, so the
+# sources are copied into the variant directory at configure time and the
+# copies are compiled (mirroring how generated sources are handled).
+chiron_cohestra_srcs = [
+    'cohestra_axi.cpp',
+    'cohestra_cchi_flit_logger.cpp',
+    'cohestra_config.cpp',
+    'cohestra_instance.cpp',
+    'cohestra_instance_config.cpp',
+    'cohestra_monitor.cpp',
+    'cohestra_stimulator.cpp',
+]
+chiron_cohestra_srcs += sorted(
+    os.path.join('cohestra_stimulators', os.path.basename(p))
+    for p in glob.glob(os.path.join(chiron_dir, 'cchi', 'cohestra',
+                                    'cohestra_stimulators', '*.cpp')))
+
+chiron_build_dir = 'chiron'
+
+for rel in chiron_cohestra_srcs:
+    src = os.path.join(chiron_dir, 'cchi', 'cohestra', rel)
+    if not os.path.isfile(src):
+        print("error: expected CHIron source not found: %s" % src)
+        Exit(1)
+    # Copy via a real build action so the variant-dir copy is a proper
+    # generated source node (a plain configure-time copy leaves SCons
+    # looking for the file in the source tree, which is read-only).
+    dst = os.path.join(chiron_build_dir, os.path.basename(rel))
+    copied = env.Command(dst, src, Copy('$TARGET', '$SOURCE'))
+    # Third-party read-only sources: don't hold them to gem5's -Werror
+    # (e.g. -Wmaybe-uninitialized fires inside nonstdint.hpp when inlined).
+    Source(copied[0], append={'CCFLAGS': ['-w']})
+
+# WITH_CCHI_RTL: Verilator-based downstream RTL endpoints (Phase 3)
+# ---------------------------------------------------------------------------
+# Verilates CCHI_RTL_TOP over CCHI_RTL_SRCS (auto-resolved for the known
+# CHIron tops) into <variant>/cchi_rtl/obj_dir and compiles the generated
+# model plus the Verilator runtime into this binary. The generated top's
+# class/header are exported to the gem5 sources as CCHI_RTL_TOP_CLASS /
+# CCHI_RTL_TOP_HEADER (see cchi_rtl_top.hh).
+if env['WITH_CCHI_RTL']:
+    import hashlib
+    import shutil
+    import subprocess
+
+    rtl_top = env.get('CCHI_RTL_TOP', '')
+    rtl_srcs = env.get('CCHI_RTL_SRCS', '')
+
+    # Known top shortcuts (sources in dependency order, mirroring
+    # cohestra_v3/CMakeLists.txt)
+    v3_dir = os.path.join(chiron_dir, 'cchi', 'cohestra', 'cohestra_v3')
+    if rtl_top == 'top_dummy':
+        rtl_srcs = os.path.join(v3_dir, 'top_dummy.sv')
+    elif rtl_top == 'venus_v3_top' or rtl_top == 'venus_v3_top_extmem':
+        venus_dir = os.path.join(v3_dir, 'venus')
+        rtl_srcs = ' '.join(
+            os.path.join(venus_dir, f) for f in [
+                'venus_pkg.sv', 'venus_fifo.sv', 'venus_id_alloc.sv',
+                'venus_sram_if.sv', 'venus_sram_box.sv', 'venus_directory.sv',
+                'venus_snoop_filter.sv', 'venus_axi_map.sv',
+                'venus_axi_master.sv', 'venus_port.sv', 'venus_mshr.sv',
+                'venus.sv',
+            ]) + ' ' + os.path.join(venus_dir, 'tb',
+                                    'venus_v3_top_extmem.sv'
+                                    if rtl_top == 'venus_v3_top_extmem'
+                                    else 'venus_v3_top.sv')
+    elif rtl_top == 'TestTop_L2OpenLLC':
+        # XSCache (Oceanus L2 + OpenLLC + OpenNCB) generated top. The
+        # checkout path is a per-build knob, never a repo default. The
+        # source set mirrors XSCache's own scripts/cohestra/
+        # boot_cohestra.sh (sorted glob of the firtool output dir;
+        # Verilator resolves elaboration order itself, so filelist.f is
+        # not parsed). The waiver .vlt carries the lint waivers the
+        # firtool RTL needs.
+        xscache_dir = env.get('CCHI_XSCACHE_DIR') or \
+            os.environ.get('XSCACHE_DIR', '')
+        if not xscache_dir or not os.path.isdir(xscache_dir):
+            print("error: CCHI_RTL_TOP=TestTop_L2OpenLLC requires "
+                  "CCHI_XSCACHE_DIR (or $XSCACHE_DIR) pointing at an "
+                  "XSCache checkout; got '%s'" % xscache_dir)
+            Exit(1)
+        rtl_dir = os.path.join(xscache_dir, 'build', 'l2openllc')
+        if not os.path.isfile(os.path.join(rtl_dir,
+                                           'TestTop_L2OpenLLC.sv')):
+            print("error: %s has no generated RTL; run "
+                  "'make test-top-l2openllc' in the XSCache checkout "
+                  "first" % rtl_dir)
+            Exit(1)
+        rtl_srcs = ' '.join(
+            sorted(glob.glob(os.path.join(rtl_dir, '*.sv')) +
+                   glob.glob(os.path.join(rtl_dir, '*.v'))))
+        waivers = os.path.join(xscache_dir, 'scripts', 'cohestra',
+                               'xscache_waivers.vlt')
+        if os.path.isfile(waivers):
+            rtl_srcs += ' ' + waivers
+
+    if not rtl_top or not rtl_srcs:
+        print("error: WITH_CCHI_RTL=True requires CCHI_RTL_TOP (and "
+              "CCHI_RTL_SRCS for custom tops); known tops: top_dummy, "
+              "venus_v3_top, venus_v3_top_extmem, TestTop_L2OpenLLC")
+        Exit(1)
+
+    verilator = shutil.which('verilator')
+    if not verilator:
+        print("error: WITH_CCHI_RTL=True requires verilator on PATH")
+        Exit(1)
+    verilator_root = subprocess.check_output(
+        [verilator, '--getenv', 'VERILATOR_ROOT'], text=True).strip()
+
+    rtl_src_list = sorted(set(rtl_srcs.split()),
+                          key=rtl_srcs.split().index)  # dedupe, keep order
+    for src in rtl_src_list:
+        if not os.path.isfile(src):
+            print("error: CCHI_RTL source not found: %s" % src)
+            Exit(1)
+
+    # Verilate at configure time into the system temp dir (NOT the build
+    # tree: some network filesystems drop freshly written build-tree files
+    # between configure and compile, breaking both the archive link and
+    # the include scanner; /tmp is machine-local and stable). Guarded by a
+    # stamp of the inputs so plain rebuilds don't re-run verilator.
+    import multiprocessing
+    import tempfile
+
+    rtl_prefix = 'V' + rtl_top.replace('_v3_top', '') if '_v3_top' in rtl_top \
+        else 'V' + rtl_top
+    rtl_build_dir = os.path.join(
+        tempfile.gettempdir(),
+        'cchi_rtl_%s_%s' % (rtl_top,
+                            hashlib.md5(env['BUILDDIR'].encode()).hexdigest()[:8]))
+    rtl_obj_dir = os.path.join(rtl_build_dir, 'obj_dir')
+    rtl_archive = os.path.join(rtl_obj_dir, '%s__ALL.a' % rtl_prefix)
+    rtl_stamp = os.path.join(rtl_build_dir, '.verilator_stamp')
+    # Source freshness matters for developing checkouts (XSCache
+    # regenerates its firtool output in place): fold each source file's
+    # mtime+size into the stamp so RTL regeneration re-verilates. Cheap
+    # stat(), no content hashing.
+    src_stamps = ['%s:%d:%d' % (src, os.stat(src).st_mtime_ns,
+                                os.stat(src).st_size)
+                  for src in rtl_src_list]
+    stamp_content = '|'.join([rtl_top, rtl_prefix, verilator_root,
+                              subprocess.check_output(
+                                  [verilator, '--version'],
+                                  text=True).strip()] + src_stamps)
+
+    os.makedirs(rtl_build_dir, exist_ok=True)
+    prev_stamp = ''
+    if os.path.isfile(rtl_stamp):
+        with open(rtl_stamp) as f:
+            prev_stamp = f.read()
+
+    if prev_stamp != stamp_content or not os.path.isfile(rtl_archive):
+        shutil.rmtree(rtl_obj_dir, ignore_errors=True)
+        cmd = [verilator, '--cc', '--build', '-j',
+               str(multiprocessing.cpu_count()),
+               '--top-module', rtl_top,
+               '--prefix', rtl_prefix,
+               '-Mdir', rtl_obj_dir,
+               '-O3', '--assert', '--trace',
+               '-Wno-UNUSEDSIGNAL', '-Wno-UNUSEDPARAM', '-Wno-PINCONNECTEMPTY',
+               '-Wno-IMPORTSTAR', '-Wno-VARHIDDEN', '-Wno-BLKSEQ',
+               '-Wno-WIDTHTRUNC'] + rtl_src_list
+        print("cchi: verilating %s -> %s" % (rtl_top, rtl_obj_dir))
+        subprocess.check_call(cmd)
+        with open(rtl_stamp, 'w') as f:
+            f.write(stamp_content)
+
+    env.Append(LIBS=[File(rtl_archive),
+                     File(os.path.join(rtl_obj_dir, 'libverilated.a'))])
+
+    # The FST writer in the trace-enabled runtime needs LZ4
+    env.Append(LIBS=['lz4'])
+
+    # obj_dir (model headers) is a scanner-visible include; the verilator
+    # includes stay -isystem for warning suppression of third-party headers
+    env.Append(CPPPATH=[rtl_obj_dir])
+    for inc in [os.path.join(verilator_root, 'include'),
+                os.path.join(verilator_root, 'include', 'vltstd')]:
+        env.Append(CCFLAGS=['-isystem', inc])
+
+    # Top alias as a generated header (see cchi_rtl_top.hh): string-literal
+    # -D defines don't survive SCons' shell quoting, so the class/header
+    # binding is written out instead of macro-injected. Lives beside the
+    # obj_dir in the machine-local temp dir.
+    alias_header = os.path.join(rtl_build_dir, 'cchi_rtl_top_generated.hh')
+    alias_content = """\
+#pragma once
+// Generated by src/mem/cchi/SConscript (WITH_CCHI_RTL): the verilated top
+// alias for the configured CCHI_RTL_TOP.
+#include "verilated.h"
+#include "%s.h"
+namespace gem5
+{
+using CchiRtlModule = %s;
+constexpr const char *CCHI_RTL_TOP_NAME = "%s";
+} // namespace gem5
+""" % (rtl_prefix, rtl_prefix, rtl_top)
+
+    prev_alias = ''
+    if os.path.isfile(alias_header):
+        with open(alias_header) as f:
+            prev_alias = f.read()
+    if prev_alias != alias_content:
+        if prev_alias:
+            print("cchi: CCHI_RTL_TOP changed; wiping variant objects")
+            for d in ['mem', 'params', 'python', 'sim', 'base', 'dev',
+                      'cpu', 'arch', 'ext']:
+                shutil.rmtree(os.path.join(env['BUILDDIR'], d),
+                              ignore_errors=True)
+        with open(alias_header, 'w') as f:
+            f.write(alias_content)
+
+    env.Append(CPPPATH=[rtl_build_dir])
+
+    env.Append(CPPDEFINES=[('CCHI_RTL_ENABLED', '1')])
+
+    Source('cchi_axi_mem_bridge.cc', append={'CPPDEFINES': gem5_cchi_defines})

--- a/src/mem/cchi/SConsopts
+++ b/src/mem/cchi/SConsopts
@@ -1,0 +1,24 @@
+# Copyright (c) 2026
+#
+# Build options for the CCHI (CHIron Cohestra) integration.
+# Declared here so that they become sticky per-build-directory variables,
+# settable on the scons command line (e.g. WITH_CCHI=True CHIRON_DIR=...).
+
+Import('*')
+
+sticky_vars.AddVariables(
+    BoolVariable('WITH_CCHI',
+        'Enable the CCHI (CHIron Cohestra) L1-fabric integration', False),
+    ('CHIRON_DIR',
+        'Path to the CHIron checkout; required when WITH_CCHI=True '
+        '(sticky variable or $CHIRON_DIR, no default)', ''),
+    BoolVariable('WITH_CCHI_RTL',
+        'Enable Verilator-based CCHI downstream RTL endpoints', False),
+    ('CCHI_RTL_TOP',
+        'Verilated top module name for the CCHI RTL endpoint', ''),
+    ('CCHI_RTL_SRCS',
+        'Space-separated RTL source files/dirs for the CCHI endpoint', ''),
+    ('CCHI_XSCACHE_DIR',
+        'Path to the XSCache checkout for the TestTop_L2OpenLLC RTL '
+        'endpoint (default: $XSCACHE_DIR; required only for that top)', ''),
+)

--- a/src/mem/cchi/cchi_axi_mem_bridge.cc
+++ b/src/mem/cchi/cchi_axi_mem_bridge.cc
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026
+ *
+ * CCHIAxiMemBridge: see the header for the design contract.
+ */
+
+#include "mem/cchi/cchi_axi_mem_bridge.hh"
+
+#include "base/logging.hh"
+#include "base/trace.hh"
+#include "debug/CCHI.hh"
+#include "mem/cchi/cchi_fabric.hh"
+#include "mem/packet.hh"
+#include "mem/request.hh"
+
+namespace gem5
+{
+
+bool
+CCHIAxiMemBridge::inWindow(uint64_t addr, uint32_t bytes) const
+{
+    const AddrRangeList &ranges = fabric.getAddrRanges();
+    for (const auto &r : ranges) {
+        if (addr >= r.start() && addr + bytes <= r.end())
+            return true;
+    }
+    return false;
+}
+
+uint64_t
+CCHIAxiMemBridge::nextBeatAddr(uint64_t addr, uint8_t size,
+                               Cohestra::AXI::Burst burst) const
+{
+    switch (burst) {
+      case Cohestra::AXI::Burst::FIXED:
+        return addr;
+      case Cohestra::AXI::Burst::INCR:
+        return addr + beatBytes(size);
+      default:
+        warn_once("cchi_axi: WRAP burst treated as INCR (addr %#llx)\n", addr);
+        return addr + beatBytes(size);
+    }
+}
+
+void
+CCHIAxiMemBridge::preTick(uint64_t time)
+{
+    // Drive previously queued B/R onto the pins (idempotent per timestamp)
+    busIf->TickPreHandshake(time);
+}
+
+void
+CCHIAxiMemBridge::postTick(uint64_t time)
+{
+    // Sample the settled AW/W/AR channels and retire the driven B/R beats
+    busIf->TickPostHandshake(time);
+
+    if (ports.empty())
+        ports.resize(busIf->GetPortMaxIndex() + 1);
+
+    for (size_t index : busIf->GetPortIndices()) {
+        if (busIf->GetPortDataBits(index) == 0)
+            continue;
+        serviceWrite(index, ports[index]);
+        serviceRead(index, ports[index]);
+    }
+}
+
+void
+CCHIAxiMemBridge::serviceWrite(size_t index, PortState &ps)
+{
+    const size_t portBytes = busIf->GetPortDataBits(index) / 8;
+
+    // Admit a new burst (one outstanding per port; backpressure via Pop)
+    if (!ps.write && busIf->HasAW(index)) {
+        auto aw = busIf->PopAW(index);
+        WriteTxn txn;
+        txn.aw = *aw;
+        txn.nextAddr = aw->Addr;
+        txn.beatsLeft = aw->Len + 1;
+        txn.error = aw->Burst == Cohestra::AXI::Burst::WRAP ||
+                    beatBytes(aw->Size) > portBytes ||
+                    !inWindow(aw->Addr, beatBytes(aw->Size));
+        if (txn.error)
+            warn("cchi_axi: AW denied: addr %#llx size %u burst %u\n",
+                 aw->Addr, aw->Size, static_cast<unsigned>(aw->Burst));
+        DPRINTF(CCHI, "cchi_axi: AW port %zu addr %#llx len %u size %u%s\n",
+                index, aw->Addr, aw->Len, aw->Size,
+                txn.error ? " (DECERR)" : "");
+        ps.write = txn;
+    }
+
+    // Consume W beats. NOTE the V3 AXISlaveInterface contract: the
+    // channel mirror refreshes only on TickPostHandshake and Pop does not
+    // clear the mirrored valid, so at most ONE W beat may be popped per
+    // port per tick (a second Pop would re-read the same mirrored beat)
+    if (ps.write && busIf->HasW(index)) {
+        WriteTxn &w = *ps.write;
+        auto beat = busIf->PopW(index);
+        DPRINTF(CCHI, "cchi_axi: W port %zu addr %#llx left %u Last %d\n",
+                index, w.nextAddr, w.beatsLeft, int(beat->Last));
+        const uint32_t bytes = beatBytes(w.aw.Size);
+        const uint64_t lineBase = w.nextAddr & ~uint64_t(63);
+        const unsigned offset = w.nextAddr & 63;
+        panic_if(offset + bytes > 64,
+                 "cchi_axi: write beat straddles a line (%#llx + %u)\n",
+                 w.nextAddr, bytes);
+
+        // Line read-modify-write with the strobe mask (zero-time
+        // atomic into gem5 memory, same contract as the Earth backend)
+        RequestPtr req = std::make_shared<Request>(
+            lineBase, 64, Request::PHYSICAL, Request::funcRequestorId);
+        Packet pkt(req, MemCmd::ReadReq);
+        pkt.allocate();
+        fabric.sendAtomicOnMemSide(&pkt);
+
+        uint8_t *line = pkt.getPtr<uint8_t>();
+        for (uint32_t j = 0; j < bytes; ++j) {
+            if ((beat->Strb[j >> 6] >> (j & 63)) & 1)
+                line[offset + j] =
+                    (beat->Data[j >> 3] >> ((j & 7) * 8)) & 0xff;
+        }
+        pkt.cmd = MemCmd::WriteReq;
+        fabric.sendAtomicOnMemSide(&pkt);
+
+        w.nextAddr = nextBeatAddr(w.nextAddr, w.aw.Size, w.aw.Burst);
+        panic_if(w.beatsLeft == 1 && !beat->Last,
+                 "cchi_axi: write burst %#llx missing WLAST\n", w.aw.Addr);
+        if (--w.beatsLeft == 0) {
+            Cohestra::AXI::BundleChannelB b;
+            b.Id = w.aw.Id;
+            b.Resp = w.error ? Cohestra::AXI::Resp::DECERR
+                             : Cohestra::AXI::Resp::OKAY;
+            ps.bQueue.push_back(b);
+            ps.write.reset();
+        }
+    }
+
+    // Drive B responses
+    while (!ps.bQueue.empty()) {
+        const auto &b = ps.bQueue.front();
+        if (!busIf->PushB(index, b)) {
+            DPRINTF(CCHI, "cchi_axi: B port %zu id %u BACKPRESSURED\n",
+                    index, b.Id);
+            break;
+        }
+        DPRINTF(CCHI, "cchi_axi: B port %zu id %u resp %d\n",
+                index, b.Id, static_cast<int>(b.Resp));
+        ps.bQueue.pop_front();
+    }
+}
+
+void
+CCHIAxiMemBridge::serviceRead(size_t index, PortState &ps)
+{
+    const size_t portBytes = busIf->GetPortDataBits(index) / 8;
+
+    // Admit a new burst
+    if (!ps.read && busIf->HasAR(index)) {
+        auto ar = busIf->PopAR(index);
+        ReadTxn txn;
+        txn.ar = *ar;
+        txn.nextAddr = ar->Addr;
+        txn.beatsLeft = ar->Len + 1;
+        txn.error = ar->Burst == Cohestra::AXI::Burst::WRAP ||
+                    beatBytes(ar->Size) > portBytes ||
+                    !inWindow(ar->Addr, beatBytes(ar->Size));
+        if (txn.error)
+            warn("cchi_axi: AR denied: addr %#llx size %u burst %u\n",
+                 ar->Addr, ar->Size, static_cast<unsigned>(ar->Burst));
+        DPRINTF(CCHI, "cchi_axi: AR port %zu addr %#llx len %u size %u%s\n",
+                index, ar->Addr, ar->Len, ar->Size,
+                txn.error ? " (DECERR)" : "");
+        ps.read = txn;
+    }
+
+    // Produce R beats (bounded production; PushR backpressure drains)
+    if (ps.read) {
+        ReadTxn &r = *ps.read;
+        while (r.beatsLeft && ps.rQueue.size() < 2) {
+            const uint32_t bytes = beatBytes(r.ar.Size);
+            const uint64_t lineBase = r.nextAddr & ~uint64_t(63);
+            const unsigned offset = r.nextAddr & 63;
+            panic_if(offset + bytes > 64,
+                     "cchi_axi: read beat straddles a line (%#llx + %u)\n",
+                     r.nextAddr, bytes);
+
+            Cohestra::AXI::BundleChannelR resp;
+            resp.Id = r.ar.Id;
+            resp.Resp = r.error ? Cohestra::AXI::Resp::DECERR
+                                : Cohestra::AXI::Resp::OKAY;
+            resp.Data.assign(portBytes / 8, 0);
+            resp.Last = (r.beatsLeft == 1);
+
+            if (!r.error) {
+                RequestPtr req = std::make_shared<Request>(
+                    lineBase, 64, Request::PHYSICAL, Request::funcRequestorId);
+                Packet pkt(req, MemCmd::ReadReq);
+                pkt.allocate();
+                fabric.sendAtomicOnMemSide(&pkt);
+                const uint8_t *line = pkt.getConstPtr<uint8_t>();
+                for (uint32_t j = 0; j < bytes; ++j)
+                    resp.Data[j >> 3] |=
+                        uint64_t(line[offset + j]) << ((j & 7) * 8);
+            }
+
+            ps.rQueue.push_back(resp);
+            r.nextAddr = nextBeatAddr(r.nextAddr, r.ar.Size, r.ar.Burst);
+            if (--r.beatsLeft == 0)
+                ps.read.reset();
+        }
+    }
+
+    // Drive R beats
+    while (!ps.rQueue.empty()) {
+        const auto &r = ps.rQueue.front();
+        if (!busIf->PushR(index, r)) {
+            DPRINTF(CCHI, "cchi_axi: R port %zu id %u BACKPRESSURED\n",
+                    index, r.Id);
+            break;
+        }
+        DPRINTF(CCHI, "cchi_axi: R port %zu id %u last %d\n",
+                index, r.Id, int(r.Last));
+        ps.rQueue.pop_front();
+    }
+}
+
+} // namespace gem5

--- a/src/mem/cchi/cchi_axi_mem_bridge.hh
+++ b/src/mem/cchi/cchi_axi_mem_bridge.hh
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026
+ *
+ * CCHIAxiMemBridge: serves the AXI4 memory (slave) ports of a verilated
+ * CCHI downstream endpoint (e.g. Venus) from the gem5 memory system.
+ * Written against CHIron's Cohestra::AXISlaveInterface: the endpoint's AW/W/
+ * AR channels are drained (Pop) and B/R responses driven (Push); data
+ * movement itself goes through the fabric's zero-time atomic path into
+ * gem5's membus/DRAM (same modelling contract as the Earth endpoint's
+ * MemoryBackend - endpoint/burst latencies are carried by the RTL itself).
+ */
+
+#ifndef __MEM_CCHI_CCHI_AXI_MEM_BRIDGE_HH__
+#define __MEM_CCHI_CCHI_AXI_MEM_BRIDGE_HH__
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "base/types.hh"
+#include "cohestra_axi.hpp"
+
+namespace gem5
+{
+
+class CCHIFabric;
+
+class CCHIAxiMemBridge
+{
+  public:
+    CCHIAxiMemBridge(CCHIFabric &_fabric,
+                     std::shared_ptr<Cohestra::AXISlaveInterface> _busIf)
+        : fabric(_fabric), busIf(std::move(_busIf)) { }
+
+    /** Two-phase per-cycle service (CHIron's split tick contract):
+        preTick drives the queued B/R beats onto the pins (before the
+        clock=0 eval); postTick samples/retires the settled channels, then
+        drains AW/W/AR and queues the next B/R (after the clock=0 eval,
+        before the posedge eval). */
+    void preTick(uint64_t time);
+    void postTick(uint64_t time);
+
+  protected:
+    /** One outstanding write burst per AXI port (backpressured by Pop). */
+    struct WriteTxn {
+        Cohestra::AXI::BundleChannelAW aw;
+        uint64_t nextAddr = 0;
+        uint32_t beatsLeft = 0;
+        bool error = false;
+    };
+
+    /** One outstanding read burst per AXI port. */
+    struct ReadTxn {
+        Cohestra::AXI::BundleChannelAR ar;
+        uint64_t nextAddr = 0;
+        uint32_t beatsLeft = 0;
+        bool error = false;
+    };
+
+    struct PortState {
+        std::optional<WriteTxn> write;
+        std::optional<ReadTxn> read;
+        std::deque<Cohestra::AXI::BundleChannelB> bQueue;
+        std::deque<Cohestra::AXI::BundleChannelR> rQueue;
+    };
+
+    void serviceWrite(size_t index, PortState &ps);
+    void serviceRead(size_t index, PortState &ps);
+
+    /** Burst beat semantics: bytes per beat, next address (INCR/FIXED;
+        WRAP degrades to INCR with a one-time warning). */
+    static uint32_t beatBytes(uint8_t size) { return 1u << size; }
+    uint64_t nextBeatAddr(uint64_t addr, uint8_t size,
+                          Cohestra::AXI::Burst burst) const;
+
+    bool inWindow(uint64_t addr, uint32_t bytes) const;
+
+    CCHIFabric &fabric;
+    std::shared_ptr<Cohestra::AXISlaveInterface> busIf;
+    std::vector<PortState> ports;
+};
+
+} // namespace gem5
+
+#endif // __MEM_CCHI_CCHI_AXI_MEM_BRIDGE_HH__

--- a/src/mem/cchi/cchi_fabric.cc
+++ b/src/mem/cchi/cchi_fabric.cc
@@ -1,0 +1,751 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// spdlog-tainted CHIron harness headers: included FIRST in this TU,
+// before any gem5 header defines the warn/panic logging macros (see the
+// note in cchi_fabric.hh)
+#include "cohestra/cohestra_instance.hpp"
+#include "cohestra/cohestra_monitor.hpp"
+#include "cohestra/cohestra_cchi_flit_logger.hpp"
+
+#ifdef CCHI_RTL_ENABLED
+// Verilator backend headers (likewise spdlog-tainted via cohestra_axi.hpp)
+#include "cohestra/cohestra_v3/interface.hpp"
+#include "cohestra/cohestra_v3/interface_axi.hpp"
+#include "mem/cchi/cchi_axi_mem_bridge.hh"
+#include "mem/cchi/cchi_rtl_top.hh"
+#include "verilated_vcd_c.h"
+#endif
+
+#include "mem/cchi/cchi_fabric.hh"
+
+#include <array>
+#include <cstring>
+
+#include "base/logging.hh"
+#include "mem/cchi/cchi_l1_agent.hh"
+#include "mem/packet.hh"
+#include "mem/request.hh"
+#include "sim/system.hh"
+
+// Debug-logging plumbing: the gem5 build defines CCHI_HAVE_GEM5_DEBUG (see
+// src/mem/cchi/SConscript) and the messages go through the CCHI debug flag.
+// Without it (e.g. standalone syntax checks, where the generated
+// debug/CCHI.hh does not exist) DPRINTF* are forced to no-ops; the #undef
+// is needed because base/trace.hh (which defines the real macro and would
+// require the generated gem5::debug::CCHI flag) may already have been
+// pulled in transitively.
+#ifdef CCHI_HAVE_GEM5_DEBUG
+#include "base/trace.hh"
+#include "debug/CCHI.hh"
+#else
+#undef DPRINTF
+#define DPRINTF(...) do { } while (0)
+#undef DPRINTFR
+#define DPRINTFR(...) do { } while (0)
+#endif
+
+namespace gem5
+{
+
+#ifdef CCHI_RTL_ENABLED
+// Verilator backend stack (pimpl; see the declaration in cchi_fabric.hh)
+struct CCHIFabric::RtlStack {
+    std::unique_ptr<CchiRtlModule> top;
+    std::shared_ptr<Cohestra::V3CCHIInterface<CchiRtlModule>> interface;
+    std::shared_ptr<Cohestra::V3AXISlaveInterface<CchiRtlModule>> axiIf;
+    std::unique_ptr<CCHIAxiMemBridge> axiBridge;
+
+    // Null-snoop-responder delay lines (see the tick hook): a response
+    // must mature a few cycles so the home's slot has registered the
+    // snoop as issued before any answer can arrive (a same-cycle answer
+    // trips its unknown-snoop assertion)
+    struct DelayedSnoopResp {
+        uint64_t readyCycle;
+        CCHI::Flits::UpRSP<Cohestra::CommonFlitConfigurationType1> rsp;
+    };
+    std::map<size_t, std::deque<DelayedSnoopResp>> nullSnoopQueue;
+
+    // Optional FST waveform dump (CCHI_RTL_TRACE env var: path to write)
+    std::unique_ptr<VerilatedVcdC> tfp;
+    uint64_t traceTime = 0;
+    // Deferred trace start (CCHI_RTL_TRACE_START env var, in gem5 ticks):
+    // keeps long runs from producing multi-GB dumps before the region of
+    // interest; the dump opens on the first fabric tick at/after this tick
+    Tick traceStartTick = 0;
+    std::string tracePendingPath;
+
+    void traceDump()
+    {
+        if (tfp) {
+            tfp->dump(traceTime++);
+            // Abort paths never close the file; flush periodically
+            if ((traceTime & 0x3FF) == 0)
+                tfp->flush();
+        }
+    }
+    void traceClose()
+    {
+        if (tfp) {
+            tfp->close();
+            tfp.reset();
+        }
+    }
+};
+#endif
+
+CCHIFabric::CCHIFabric(const CCHIFabricParams &p)
+    : ClockedObject(p),
+      memSidePort(p.name + ".mem_side", *this),
+      reqQueue(*this, memSidePort),
+      snoopRespQueue(*this, memSidePort),
+      upstreamNodeCount(p.upstream_node_count),
+      downstream(p.downstream),
+      memoryStart(p.memory_start),
+      memoryEnd(p.memory_end),
+      earthLatencyRSP(p.earth_latency_rsp),
+      earthLatencyDAT(p.earth_latency_dat),
+      monitorEnable(p.monitor_enable),
+      monitorFailOnMismatch(p.monitor_fail_on_mismatch),
+      monitorTrace(p.monitor_trace),
+      flitTrace(p.flit_trace),
+      tickEvent([this] { tick(); }, p.name + ".tick"),
+      stats(this)
+{
+    fatal_if(memoryEnd <= memoryStart,
+             "%s: memory_end (%#llx) must be greater than memory_start "
+             "(%#llx)\n", name(), memoryEnd, memoryStart);
+    fatal_if(upstreamNodeCount == 0,
+             "%s: upstream_node_count must be at least 1\n", name());
+#ifndef CCHI_RTL_ENABLED
+    fatal_if(downstream == "rtl",
+             "%s: downstream='rtl' requires a WITH_CCHI_RTL build "
+             "(this binary has none)\n", name());
+#endif
+    fatal_if(downstream != "earth" && downstream != "rtl",
+             "%s: unknown downstream endpoint '%s' (expected earth|rtl)\n",
+             name(), downstream);
+    addrRanges.emplace_back(memoryStart, memoryEnd - 1);
+}
+
+void
+CCHIFabric::init()
+{
+    if (!memSidePort.isConnected())
+        fatal("%s: mem_side port is not connected\n", name());
+}
+
+void
+CCHIFabric::startup()
+{
+    ClockedObject::startup();
+
+    // All CCHIL1Agent::init() registrations are complete by now.
+    ensureInstance();
+
+    schedule(tickEvent, curTick() + clockPeriod());
+}
+
+Port &
+CCHIFabric::getPort(const std::string &if_name, PortID idx)
+{
+    if (if_name == "mem_side") {
+        return memSidePort;
+    }
+    return ClockedObject::getPort(if_name, idx);
+}
+
+void
+CCHIFabric::addUpstreamNode(uint32_t nodeId, CCHIL1Agent *agent)
+{
+    fatal_if(instanceBuilt,
+             "%s: agent %s registered after the Cohestra instance was "
+             "built\n", name(), agent->name());
+    fatal_if(!agents.emplace(nodeId, agent).second,
+             "%s: duplicate CCHI node ID %u (agents %s and %s)\n",
+             name(), nodeId, agents[nodeId]->name(), agent->name());
+}
+
+CCHIFabric::~CCHIFabric() = default;
+
+CCHIFabric::TaurusNode *
+CCHIFabric::getUpstreamNode(uint32_t nodeId)
+{
+    ensureInstance();
+
+    // The index assignment is the node-ID sort order built in
+    // ensureInstance(); locate this node ID's index.
+    size_t index = 0;
+    for (const auto &[id, agent] : agents) {
+        if (id == nodeId)
+            return instance->GetType1Upstream(index);
+        ++index;
+    }
+    return nullptr;
+}
+
+void
+CCHIFabric::ensureInstance()
+{
+    if (instanceBuilt)
+        return;
+
+    fatal_if(agents.size() != upstreamNodeCount,
+             "%s: %llu agent(s) registered but upstream_node_count=%llu\n",
+             name(), (unsigned long long)agents.size(),
+             (unsigned long long)upstreamNodeCount);
+
+    // Deterministic assignment: upstream index i is the agent with the
+    // i-th smallest CCHI node ID (std::map iteration order). Documented
+    // simplification: node IDs are expected to be dense from 0.
+    std::vector<uint32_t> nodeIds;
+    for (const auto &[id, agent] : agents) {
+        agentsByIndex.push_back(agent);
+        nodeIds.push_back(id);
+    }
+
+    // Instance upstream config. The stock Cohestra::Instance applies one
+    // uniform set of xaction limits to every node it constructs, so the
+    // values are taken from the first agent; a mismatch across agents is
+    // worth a warning since it cannot be represented.
+    const CCHIL1Agent *first = agentsByIndex.front();
+    for (const auto *agent : agentsByIndex)
+        warn_if(agent->getXactionLimitREQ() != first->getXactionLimitREQ() ||
+                agent->getXactionLimitEVT() != first->getXactionLimitEVT() ||
+                agent->getXactionLimitSNP() != first->getXactionLimitSNP(),
+                "%s: agents disagree on xaction limits; the Cohestra "
+                "instance applies the first agent's values uniformly\n",
+                name());
+
+    std::string nodeIdList;
+    for (size_t i = 0; i < nodeIds.size(); ++i) {
+        if (i)
+            nodeIdList += ",";
+        nodeIdList += std::to_string(nodeIds[i]);
+    }
+    configLoader.set("root", "upstream.type1.nodeid", nodeIdList);
+    configLoader.set("root", "upstream.type1.inflight.evt",
+                     std::to_string(first->getXactionLimitEVT()));
+    configLoader.set("root", "upstream.type1.inflight.snp",
+                     std::to_string(first->getXactionLimitSNP()));
+    configLoader.set("root", "upstream.type1.inflight.req",
+                     std::to_string(first->getXactionLimitREQ()));
+    // 'upstream.type1.inflight' (total TxnID space) keeps its CHIron
+    // default (32); the default already covers the per-class limits above.
+
+    // Monitor knobs
+    configLoader.set("monitor", "enable", monitorEnable ? "1" : "0");
+    configLoader.set("monitor", "fail.on.mismatch",
+                     monitorFailOnMismatch ? "1" : "0");
+    configLoader.set("monitor", "trace", monitorTrace ? "1" : "0");
+    // Flit-level transaction logger knob (debug)
+    configLoader.set("cchi", "verbose", flitTrace ? "1" : "0");
+
+    // Downstream endpoint: either the vendored Earth behavioral home
+    // (backed by gem5 memory through the MemoryBackend hook) or the
+    // Verilator backend (V3CCHIInterface over the verilated top, its AXI
+    // memory ports served by CCHIAxiMemBridge into gem5 memory)
+
+    if (downstream == "earth") {
+        earthInterface =
+            std::make_shared<Cohestra::EarthCCHIInterface>(upstreamNodeCount);
+        auto &model = earthInterface->GetModel();
+        memoryBackend = std::make_shared<Gem5MemoryBackend>(*this);
+        model.SetMemoryBackend(memoryBackend);
+        model.SetMemoryWindow(memoryStart, memoryEnd);
+        model.SetLatencyRSP(earthLatencyRSP);
+        model.SetLatencyDAT(earthLatencyDAT);
+        model.SetUpstreamNodeIDs(nodeIds);
+        // Earth's verbose switches keep their (on) defaults: with
+        // EARTH_HAVE_GEM5_DEBUG the verbose logs route to the Earth debug
+        // flag and stay silent unless --debug-flags=Earth is given.
+        downstreamInterface = earthInterface;
+    } else {
+#ifdef CCHI_RTL_ENABLED
+        // Verilator backend: verilated top + CHIron's pin bindings + the
+        // AXI memory bridge, then the reset sequence
+        rtl = std::make_unique<RtlStack>();
+        rtl->top = std::make_unique<CchiRtlModule>();
+        rtl->interface =
+            std::make_shared<Cohestra::V3CCHIInterface<CchiRtlModule>>(
+                rtl->top.get());
+        rtl->axiIf =
+            std::make_shared<Cohestra::V3AXISlaveInterface<CchiRtlModule>>(
+                rtl->top.get());
+        // The AXI response FIFOs default to size 0 (Push never accepted);
+        // size them like the cohestra_v3 harness does
+        for (size_t i : rtl->axiIf->GetPortIndices()) {
+            rtl->axiIf->SetPortBFIFOSize(i, 2);
+            rtl->axiIf->SetPortRFIFOSize(i, 2);
+        }
+        rtl->axiBridge =
+            std::make_unique<CCHIAxiMemBridge>(*this, rtl->axiIf);
+        // The Type-1 upstream->downstream buffers default to size 0: a
+        // combinational-bypass mode that DROPS flits whenever the RTL is
+        // not ready at the next posedge (its rx FIFOs backpressure).
+        // Size them so backpressure propagates to the pump instead
+        for (size_t i : rtl->interface->GetType1Indices()) {
+            rtl->interface->SetType1EVTBufferSize(i, 4);
+            rtl->interface->SetType1REQBufferSize(i, 4);
+            rtl->interface->SetType1UpRSPBufferSize(i, 4);
+            rtl->interface->SetType1UpDATBufferSize(i, 4);
+        }
+        rtlReset();
+
+        fatal_if(rtl->interface->GetType1Count() < upstreamNodeCount,
+                 "%s: verilated top has %llu CCHI Type-1 port(s), fewer "
+                 "than upstream_node_count %llu\n", name(),
+                 (unsigned long long)rtl->interface->GetType1Count(),
+                 (unsigned long long)upstreamNodeCount);
+        inform("%s: Verilator downstream endpoint up (%s)\n", name(),
+               CCHI_RTL_TOP_NAME);
+        downstreamInterface = rtl->interface;
+#else
+        fatal("%s: downstream='rtl' without a WITH_CCHI_RTL build\n",
+              name());
+#endif
+    }
+
+    // SNP gate decorator between the instance and the endpoint
+    gatedDownstream =
+        std::make_shared<SnoopGateCCHIInterface>(downstreamInterface, *this);
+    snoopGates.assign(upstreamNodeCount, SnoopGate{});
+    for (size_t i = 0; i < agentsByIndex.size(); ++i)
+        snoopGates[i].mergeOn = agentsByIndex[i]->getSnoopMerge();
+
+    // The embedded CHIron instance: constructs the Taurus upstream nodes
+    // from the loader-supplied config (node IDs + xaction limits)
+    instance = std::make_unique<Cohestra::Instance>();
+    fatal_if(!instance->LoadPreInitConfiguration(configLoader),
+             "%s: failed to load Cohestra pre-init configuration\n", name());
+    instance->Initialize(gatedDownstream, nullptr /* no stimulators */);
+    fatal_if(!instance->IsAlive(),
+             "%s: Cohestra instance failed to initialize\n", name());
+
+    // Data-integrity monitor, per the cohestra_v3 executable attach
+    // pattern: construct with the instance, load knobs, attach if enabled
+    monitor = std::make_unique<Cohestra::CacheLineDataMonitor>(*instance);
+    fatal_if(!monitor->LoadConfiguration(configLoader),
+             "%s: failed to load monitor configuration\n", name());
+    if (monitor->IsEnabled())
+        monitor->Attach();
+
+    // Flit-level transaction logger (debug runs): same attach pattern as
+    // the monitor; enabled via [cchi] verbose (the flit_trace param). Its
+    // records emit at spdlog debug level, so lower the instance logger's
+    // floor while it is on.
+    if (flitTrace && instance->GetLogger())
+        instance->GetLogger()->set_level(spdlog::level::debug);
+    flitLogger = std::make_unique<Cohestra::CCHIFlitLogger>(*instance);
+    fatal_if(!flitLogger->LoadConfiguration(configLoader),
+             "%s: failed to load flit logger configuration\n", name());
+    if (flitLogger->IsEnabled())
+        flitLogger->Attach();
+
+    // Home-snoop reflection hook: whenever the home's snoop is accepted
+    // by a Taurus node, reflect it into that agent's L1s. snoop_merge=on
+    // agents reflect earlier (at gate interception, pre-acceptance) and
+    // are skipped here. Registration follows CHIron's EventBus listener
+    // API; the listener must not call back into the same node (CHIron
+    // ERRATA N3) - reflectSnoopToL1 only talks to gem5 ports.
+    for (size_t i = 0; i < agentsByIndex.size(); ++i) {
+        auto *node = instance->GetType1Upstream(i);
+        fatal_if(!node, "%s: no Taurus node at upstream index %llu\n",
+                 name(), (unsigned long long)i);
+        CCHIL1Agent *agent = agentsByIndex[i];
+        agent->setUpstreamIndex(i);
+        node->events->OnAcceptedSNP.Register(Gravity::MakeListener(
+            "gem5.CCHIFabric.reflectSnoop", 0,
+            std::function<void(AcceptedSNPEvent &)>(
+                [this, agent](AcceptedSNPEvent &ev) {
+                    onAcceptedSnoop(agent, ev);
+                })));
+    }
+
+    instanceBuilt = true;
+
+    inform_once(
+        "%s: Cohestra instance up with %llu Taurus node(s), %s endpoint, "
+        "memory window [%#llx, %#llx), monitor %s\n", name(),
+        (unsigned long long)upstreamNodeCount, downstream.c_str(),
+        (unsigned long long)memoryStart, (unsigned long long)memoryEnd,
+        monitor->IsAttached() ? "attached" : "off");
+}
+
+#ifdef CCHI_RTL_ENABLED
+void
+CCHIFabric::rtlReset()
+{
+    // High-active reset (mirrors the cohestra_v3 harness): 100 full clock
+    // cycles held, then released with all pins quiesced by the interface
+    static constexpr unsigned RESET_CYCLES = 100;
+
+    if (const char *tracePath = getenv("CCHI_RTL_TRACE")) {
+        if (const char *startEnv = getenv("CCHI_RTL_TRACE_START")) {
+            rtl->traceStartTick = std::strtoull(startEnv, nullptr, 0);
+        }
+        if (rtl->traceStartTick > 0) {
+            // Defer the open to the first fabric tick at/after the start
+            rtl->tracePendingPath = tracePath;
+        } else {
+            Verilated::traceEverOn(true);
+            rtl->tfp = std::make_unique<VerilatedVcdC>();
+            rtl->top->trace(rtl->tfp.get(), 99);
+            rtl->tfp->open(tracePath);
+            inform("%s: FST waveform dump to %s\n", name(), tracePath);
+        }
+    }
+
+    rtl->top->reset = 1;
+    for (unsigned i = 0; i < RESET_CYCLES; ++i) {
+        rtl->top->clock = 0;
+        rtl->top->eval();
+        rtl->traceDump();
+        rtl->top->clock = 1;
+        rtl->top->eval();
+        rtl->traceDump();
+    }
+    rtl->top->reset = 0;
+}
+
+void
+CCHIFabric::rtlClockEvalLow()
+{
+    rtl->top->clock = 0;
+    rtl->top->eval();
+    rtl->traceDump();
+}
+
+void
+CCHIFabric::rtlClockEvalHigh()
+{
+    rtl->top->clock = 1;
+    rtl->top->eval();
+    rtl->traceDump();
+}
+#endif
+
+void
+CCHIFabric::tick()
+{
+    ++stats.ticks;
+
+    // CHIron's own pump: upstream Ticks, downstream Tick, then
+    // fixed-priority flit pumping in both directions. SNP interception
+    // for snoop_merge=on agents happens lazily inside the gate
+    // interface's Peek/PopType1SNP during this call. Taurus futures fire
+    // here as well; their bound agent lambdas only post to the agents'
+    // completion queues, which the tick hooks below drain.
+    const bool alive = instance->Tick(cycleCount);
+
+#ifdef CCHI_RTL_ENABLED
+    // Null snoop responder for RTL Type-1 ports beyond the configured
+    // upstreams: Venus broadcasts snoops on an SF-maybe to EVERY port
+    // (by design, assuming all NUM_T1 ports are live), but the Instance
+    // only pumps the ports that have agents (see the gate's capping).
+    // Snoops to unused ports would otherwise wait forever and wedge the
+    // home's tracker slots in PH_SNOOP - answer them locally with a
+    // plain SnpResp(I), which is exactly what a port without the line
+    // returns. Responses mature a few cycles in a delay line first: the
+    // home's slot must have registered the snoop as issued before any
+    // answer arrives, or its unknown-snoop assertion trips. NOTE: this
+    // runs BEFORE the clock eval below, because a Pop asserts 'ready'
+    // only until the next interface TickPreHandshake - the posedge must
+    // land in between or the snoop never leaves the RTL's FIFO.
+    if (rtl) {
+        static constexpr uint64_t NULL_SNOOP_DELAY = 4;
+
+        for (size_t i = upstreamNodeCount;
+             i < rtl->interface->GetType1Count(); ++i) {
+            auto snp = rtl->interface->PeekType1SNP(i);
+            if (snp) {
+                CCHI::Flits::UpRSP<Cohestra::CommonFlitConfigurationType1>
+                    rsp;
+                rsp.TxnID   = snp->TxnID;
+                rsp.SrcID   = snp->TgtID;   // answered by the snoop target
+                rsp.TgtID   = snp->SrcID;
+                rsp.Opcode  = CCHI::Opcodes::UpRSP::Type1::SnpResp;
+                rsp.RespErr = 0;
+                rsp.Resp    = CCHI::Resps::I;
+                rsp.TraceTag = snp->TraceTag;
+
+                rtl->nullSnoopQueue[i].push_back(
+                    {cycleCount + NULL_SNOOP_DELAY, rsp});
+                DPRINTF(CCHI, "[%s] null snoop pop: port %d addr %#llx "
+                        "id %u\n", name(), int(i),
+                        uint64_t(snp->Addr) << 3, unsigned(snp->TxnID));
+                rtl->interface->PopType1SNP(i);
+            }
+
+            auto &queue = rtl->nullSnoopQueue[i];
+            while (!queue.empty() &&
+                   queue.front().readyCycle <= cycleCount) {
+                if (!rtl->interface->PushType1UpRSP(i, queue.front().rsp))
+                    break;
+                ++stats.nullSnoopResponses;
+                DPRINTF(CCHI, "[%s] null snoop responder: port %d id %u "
+                        "(SnpResp I)\n", name(), int(i),
+                        unsigned(queue.front().rsp.TxnID));
+                queue.pop_front();
+            }
+        }
+    }
+
+    // Verilator backend: serve the endpoint's AXI memory ports, then one
+    // full RTL clock cycle in CHIron's two-phase cadence, mirroring the
+    // cohestra_v3 harness: TickPreHandshake (drive) -> Eval(clock=0) ->
+    // TickPostHandshake (sample + pop) -> Eval(clock=1). The Instance's own
+    // pre-handshake drive already ran inside instance->Tick above.
+    if (rtl && rtl->axiBridge) {
+        // Deferred waveform start (CCHI_RTL_TRACE_START)
+        if (!rtl->tracePendingPath.empty() &&
+            curTick() >= rtl->traceStartTick) {
+            Verilated::traceEverOn(true);
+            rtl->tfp = std::make_unique<VerilatedVcdC>();
+            rtl->top->trace(rtl->tfp.get(), 99);
+            rtl->tfp->open(rtl->tracePendingPath.c_str());
+            inform("%s: FST waveform dump to %s (deferred to tick %llu)\n",
+                   name(), rtl->tracePendingPath.c_str(),
+                   (unsigned long long)curTick());
+            rtl->tracePendingPath.clear();
+        }
+        rtl->axiBridge->preTick(cycleCount);
+        rtlClockEvalLow();
+        instance->TickPostHandshake(cycleCount);
+        rtl->axiBridge->postTick(cycleCount);
+        rtlClockEvalHigh();
+    }
+#endif
+    ++cycleCount;
+
+    for (auto *agent : agentsByIndex)
+        agent->tickHook();
+
+    // Monitor mismatch accounting + failure check
+    if (monitor && monitor->IsAttached()) {
+        const uint64_t mismatches = monitor->GetMismatchCount();
+        if (mismatches > lastMonitorMismatchCount) {
+            stats.monitorMismatches += mismatches - lastMonitorMismatchCount;
+            lastMonitorMismatchCount = mismatches;
+        }
+    }
+
+    if (!alive) {
+        fatal_if(instance->IsFailed(),
+                 "%s: Cohestra instance FAILED at cycle %llu (%llu monitor "
+                 "mismatch(es))\n", name(),
+                 (unsigned long long)cycleCount,
+                 (unsigned long long)lastMonitorMismatchCount);
+        // FINISHED: quiesce (nothing left to pump)
+        return;
+    }
+
+    schedule(tickEvent, curTick() + clockPeriod());
+}
+
+std::optional<CCHIFabric::FlitSNP>
+CCHIFabric::gatePeekSNP(size_t index)
+{
+    SnoopGate &gate = snoopGates[index];
+
+    if (!gate.mergeOn)
+        return downstreamInterface->PeekType1SNP(index);
+
+    if (gate.intercepted)
+        return gate.ready ? std::optional<FlitSNP>(gate.heldFlit)
+                          : std::nullopt;
+
+    // First sight of this home snoop: intercept it so the agent can
+    // reflect it into the L1 and merge dirty data before Taurus answers.
+    // Called from inside Instance::Tick (the pump peeks before pushing).
+    auto flit = downstreamInterface->PeekType1SNP(index);
+    if (!flit)
+        return std::nullopt;
+
+    gate.heldFlit = *downstreamInterface->PopType1SNP(index);
+    gate.intercepted = true;
+    gate.ready = false;
+    ++stats.snoopGateInterceptions;
+
+    agentsByIndex[index]->handleSnoopFromHome(gate.heldFlit);
+
+    // The agent releases synchronously when no L1 snoop response is
+    // expected, making the flit visible to the pump in the same cycle.
+    return gate.ready ? std::optional<FlitSNP>(gate.heldFlit)
+                      : std::nullopt;
+}
+
+std::optional<CCHIFabric::FlitSNP>
+CCHIFabric::gatePopSNP(size_t index)
+{
+    SnoopGate &gate = snoopGates[index];
+
+    if (!gate.mergeOn)
+        return downstreamInterface->PopType1SNP(index);
+
+    panic_if(!gate.intercepted || !gate.ready,
+             "%s: SNP gate pop for upstream %llu without a released flit\n",
+             name(), (unsigned long long)index);
+
+    gate.intercepted = false;
+    gate.ready = false;
+    return gate.heldFlit;
+}
+
+void
+CCHIFabric::releaseSnoop(size_t index)
+{
+    panic_if(index >= snoopGates.size() ||
+             !snoopGates[index].mergeOn ||
+             !snoopGates[index].intercepted,
+             "%s: spurious snoop release for upstream %llu\n",
+             name(), (unsigned long long)index);
+
+    snoopGates[index].ready = true;
+    ++stats.snoopGateReleases;
+}
+
+void
+CCHIFabric::onAcceptedSnoop(CCHIL1Agent *agent, AcceptedSNPEvent &ev)
+{
+    // snoop_merge=on agents reflected the snoop when the gate intercepted
+    // it (before PushRXSNP); reflecting again would double-snoop the L1
+    if (agent->getSnoopMerge())
+        return;
+
+    const auto &flit = ev.GetSNPFlit();
+    ++stats.snoopReflections;
+    // SNP Addr carries PA >> 3 (bits [2:0] are implicit zeros); the
+    // reflected snoop covers the whole 64B line
+    agent->reflectSnoopToL1(uint64_t(flit.Addr) << 3,
+                            static_cast<uint64_t>(flit.Opcode));
+}
+
+bool
+CCHIFabric::SnoopGateCCHIInterface::HasType1SNP(size_t index)
+    const noexcept
+{
+    // Informational only (the Instance pump uses Peek/Pop): mirror what
+    // PeekType1SNP would return
+    const SnoopGate &gate = fabric.snoopGates[index];
+    if (gate.mergeOn && gate.intercepted)
+        return gate.ready;
+    return real->HasType1SNP(index);
+}
+
+std::optional<CCHIFabric::FlitSNP>
+CCHIFabric::SnoopGateCCHIInterface::PeekType1SNP(size_t index)
+    const noexcept
+{
+    // const interface, mutating gate: the gate state lives in the fabric,
+    // so this stays const here while the fabric method does the work
+    return fabric.gatePeekSNP(index);
+}
+
+std::optional<CCHIFabric::FlitSNP>
+CCHIFabric::SnoopGateCCHIInterface::PopType1SNP(size_t index) noexcept
+{
+    return fabric.gatePopSNP(index);
+}
+
+void
+CCHIFabric::Gem5MemoryBackend::readLine(uint64_t lineAddr,
+                                        std::array<uint64_t, 8> &data)
+{
+    const Addr pa = lineAddr << 6;
+    // Phase 1: zero-time atomic read; the endpoint's latencyRSP/latencyDAT
+    // carry the modeled latency. See the TODO on the class declaration.
+    RequestPtr req = std::make_shared<Request>(pa, 64, Request::PHYSICAL,
+                                               Request::funcRequestorId);
+    Packet pkt(req, MemCmd::ReadReq);
+    pkt.allocate();
+    fabric.sendAtomicOnMemSide(&pkt);
+    std::memcpy(data.data(), pkt.getConstPtr<uint8_t>(), 64);
+    ++fabric.stats.backendReads;
+}
+
+void
+CCHIFabric::Gem5MemoryBackend::writeLine(uint64_t lineAddr,
+                                         const std::array<uint64_t, 8> &data)
+{
+    const Addr pa = lineAddr << 6;
+    RequestPtr req = std::make_shared<Request>(pa, 64, Request::PHYSICAL,
+                                               Request::funcRequestorId);
+    Packet pkt(req, MemCmd::WriteReq);
+    pkt.allocate();
+    std::memcpy(pkt.getPtr<uint8_t>(), data.data(), 64);
+    fabric.sendAtomicOnMemSide(&pkt);
+    ++fabric.stats.backendWrites;
+}
+
+CCHIFabric::MemSideRequestPort::MemSideRequestPort(
+    const std::string &_name, CCHIFabric &_parent)
+    : QueuedRequestPort(_name, &_parent, _parent.reqQueue,
+                        _parent.snoopRespQueue),
+      parent(_parent)
+{
+}
+
+bool
+CCHIFabric::MemSideRequestPort::recvTimingResp(PacketPtr pkt)
+{
+    // Phase 1 issues no timing requests on mem_side (the endpoint's
+    // memory backend uses atomic accesses), so a timing response here
+    // means the wiring is wrong
+    panic("%s: unexpected timing response %s\n", name(), pkt->print());
+}
+
+CCHIFabric::CCHIFabricStats::CCHIFabricStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(ticks, statistics::units::Count::get(),
+               "Fabric cycles pumped through the Cohestra instance"),
+      ADD_STAT(backendReads, statistics::units::Count::get(),
+               "Endpoint memory-backend line reads served from gem5 memory"),
+      ADD_STAT(backendWrites, statistics::units::Count::get(),
+               "Endpoint memory-backend line writes into gem5 memory"),
+      ADD_STAT(snoopGateInterceptions, statistics::units::Count::get(),
+               "Home snoops intercepted for the snoop_merge flow"),
+      ADD_STAT(snoopGateReleases, statistics::units::Count::get(),
+               "Held home snoops released to Taurus after merging"),
+      ADD_STAT(snoopReflections, statistics::units::Count::get(),
+               "Home snoops reflected into L1s (merge-off path)"),
+      ADD_STAT(nullSnoopResponses, statistics::units::Count::get(),
+               "SnpResp(I) synthesized for unused RTL ports"),
+      ADD_STAT(monitorMismatches, statistics::units::Count::get(),
+               "CacheLineDataMonitor data mismatches observed")
+{
+}
+
+} // namespace gem5

--- a/src/mem/cchi/cchi_fabric.hh
+++ b/src/mem/cchi/cchi_fabric.hh
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * CCHIFabric: one-per-system SimObject that embeds CHIron's
+ * Cohestra::Instance. The instance owns the per-core Taurus upstream
+ * nodes (one per CCHIL1Agent) and a single downstream CCHIInterface
+ * endpoint. The fabric's per-cycle event is Instance::Tick (CHIron's own
+ * flit pump) followed by each agent's tick hook.
+ *
+ * The downstream endpoint sits behind CHIron's CCHIInterface abstraction:
+ * Phase 1 uses the vendored Earth behavioral home (src/mem/cchi/earth),
+ * whose MemoryBackend is implemented here on top of the fabric's
+ * mem_side port, so gem5's memory system remains the only data store.
+ *
+ * A Cohestra::CacheLineDataMonitor is attached to the instance as the
+ * built-in end-to-end data checker (per-line scoreboard); a mismatch
+ * marks the instance FAILED and is raised as a gem5 fatal at the next
+ * fabric tick when monitor_fail_on_mismatch is set.
+ */
+
+#ifndef __MEM_CCHI_CCHI_FABRIC_HH__
+#define __MEM_CCHI_CCHI_FABRIC_HH__
+
+#include <array>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/addr_range.hh"
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "mem/packet_queue.hh"
+#include "mem/qport.hh"
+#include "params/CCHIFabric.hh"
+#include "sim/clocked_object.hh"
+
+// CHIron Cohestra harness (read-only; resolved via -I$(CHIRON_DIR)/cchi).
+// NOTE: only spdlog-free CHIron headers may be included from this header:
+// the generated SimObject pybind TU includes gem5 headers (with the
+// warn/panic logging macros) before this one, and those macros collide
+// with spdlog's member functions. Cohestra::Instance and
+// Cohestra::CacheLineDataMonitor (whose headers pull in spdlog) are
+// therefore forward-declared and only used from the .cc file.
+#include "cohestra/cohestra_config.hpp"
+#include "cohestra/cohestra_interface.hpp"
+#include "icn/taurus/cchi_taurus_component.hpp"
+
+// Vendored Earth endpoint (MemoryBackend hook, plain setters, no spdlog)
+#include "mem/cchi/earth/earth_interface.hpp"
+
+namespace Cohestra
+{
+    class Instance;
+    class CacheLineDataMonitor;
+    class CCHIFlitLogger;
+}
+
+namespace gem5
+{
+
+class CCHIL1Agent;
+
+class CCHIFabric : public ClockedObject
+{
+  public:
+    using TaurusNode =
+        CCHI::Taurus::UpstreamNode<Cohestra::CommonFlitConfigurationType1>;
+    using FlitSNP = CCHI::Flits::SNP<Cohestra::CommonFlitConfigurationType1>;
+    using AcceptedSNPEvent =
+        CCHI::Taurus::UpstreamNodeXactAcceptedSNPEvent<
+            Cohestra::CommonFlitConfigurationType1>;
+
+    CCHIFabric(const CCHIFabricParams &params);
+    ~CCHIFabric(); // out-of-line: unique_ptrs to forward-declared CHIron types
+
+    void init() override;
+    void startup() override;
+
+    Port &getPort(const std::string &if_name,
+                  PortID idx = InvalidPortID) override;
+
+    /** Agent registration, called from CCHIL1Agent::init(). */
+    void addUpstreamNode(uint32_t nodeId, CCHIL1Agent *agent);
+
+    /**
+     * Taurus node lookup for agents. Builds the embedded instance lazily
+     * on first use (guaranteed to run after all init() registrations).
+     */
+    TaurusNode *getUpstreamNode(uint32_t nodeId);
+
+    /** True for addresses served through CCHI (the endpoint window). */
+    bool isCacheable(Addr addr) const
+    { return addr >= memoryStart && addr < memoryEnd; }
+
+    /** Address window of the CCHI-managed memory. */
+    AddrRangeList getAddrRanges() const { return addrRanges; }
+
+    /**
+     * Release a home snoop held by the SNP gate of upstream 'index'
+     * (snoop_merge flow): the next Instance::Tick is allowed to push the
+     * held flit into the Taurus node, whose answer then carries the data
+     * merged from the L1.
+     */
+    void releaseSnoop(size_t index);
+
+    /** Atomic access to gem5 memory on behalf of the endpoint backend. */
+    Tick sendAtomicOnMemSide(PacketPtr pkt) { return memSidePort.sendAtomic(pkt); }
+
+  protected: // Port interface
+    class MemSideRequestPort : public QueuedRequestPort
+    {
+      public:
+        MemSideRequestPort(const std::string &_name, CCHIFabric &_parent);
+
+      protected:
+        bool recvTimingResp(PacketPtr pkt) override;
+
+      private:
+        CCHIFabric &parent;
+    };
+
+    MemSideRequestPort memSidePort;
+    ReqPacketQueue reqQueue;
+    SnoopRespPacketQueue snoopRespQueue;
+
+  protected:
+    /**
+     * gem5-memory-backed implementation of the vendored Earth's
+     * MemoryBackend: whole-line reads/writes through mem_side. Phase 1
+     * uses zero-time atomic accesses; the endpoint's own
+     * latencyRSP/latencyDAT knobs carry the modeled latency.
+     * TODO(cchi): serve endpoint memory traffic with timing-mode
+     * transactions so DRAM latency is modeled end-to-end.
+     */
+    class Gem5MemoryBackend : public Cohestra::MemoryBackend
+    {
+      public:
+        explicit Gem5MemoryBackend(CCHIFabric &_fabric) : fabric(_fabric) { }
+
+        void readLine(uint64_t lineAddr,
+                      std::array<uint64_t, 8> &data) override;
+        void writeLine(uint64_t lineAddr,
+                       const std::array<uint64_t, 8> &data) override;
+
+      private:
+        CCHIFabric &fabric;
+    };
+
+    /**
+     * gem5-Params-backed StringLoaderBase: answers CHIron's
+     * (section, key) configuration queries from values filled in by the
+     * fabric (instance upstream config + monitor knobs). Unset keys fall
+     * back to the CHIron defaults.
+     */
+    class Gem5ConfigLoader : public Cohestra::StringLoaderBase
+    {
+      public:
+        void set(const std::string &section, const std::string &key,
+                 const std::string &value)
+        { values[std::make_pair(section, key)] = value; }
+
+        std::optional<std::string> GetRawString(
+            Cohestra::ConfigurationEntryBase entry,
+            const std::string &defaultSection = "global")
+            const noexcept override
+        {
+            const std::string section =
+                entry->section ? entry->section : defaultSection;
+            auto it = values.find(std::make_pair(section, entry->key));
+            if (it == values.end())
+                return std::nullopt;
+            return it->second;
+        }
+
+      private:
+        std::map<std::pair<std::string, std::string>, std::string> values;
+    };
+
+    /**
+     * Per-upstream snoop gate state (snoop_merge=on agents). While a
+     * merge is in flight the port's SNP channel is withheld from the
+     * Instance pump (head-of-line, bounded); once the agent merged the
+     * L1 data the held flit is offered again.
+     */
+    struct SnoopGate {
+        bool mergeOn = false;     // agent runs with snoop_merge=on
+        bool intercepted = false; // a flit was taken out of the endpoint
+        bool ready = false;       // merge done, offer the held flit
+        FlitSNP heldFlit = {};
+    };
+
+    /**
+     * CCHIInterface decorator between the embedded Instance and the real
+     * endpoint: forwards every channel verbatim except Type-1 SNP, which
+     * is routed through the fabric's per-port gates so that
+     * snoop_merge=on agents can merge L1 data before Taurus answers.
+     */
+    class SnoopGateCCHIInterface : public Cohestra::CCHIInterface
+    {
+      public:
+        SnoopGateCCHIInterface(
+            std::shared_ptr<Cohestra::CCHIInterface> _real,
+            CCHIFabric &_fabric) noexcept
+            : real(std::move(_real)), fabric(_fabric) { }
+
+        void TickPreHandshake(uint64_t time) noexcept override
+        { real->TickPreHandshake(time); }
+        void TickPostHandshake(uint64_t time) noexcept override
+        { real->TickPostHandshake(time); }
+
+        // Cap the reported port set at the configured upstream count:
+        // RTL endpoints may expose more Type-1 ports than this system has
+        // agents (e.g. a 4-port Venus with a single-core config), and
+        // Instance::Initialize rejects a downstream that is larger than
+        // the configured upstream set. Earth reports exactly the
+        // configured count already, so this is a no-op for it.
+        size_t GetType1Count() const noexcept override
+        { return fabric.upstreamNodeCount; }
+        std::set<size_t> GetType1Indices() const noexcept override
+        {
+            std::set<size_t> capped;
+            for (size_t i : real->GetType1Indices())
+                if (i < fabric.upstreamNodeCount)
+                    capped.insert(i);
+            return capped;
+        }
+        size_t GetType1MaxIndex() const noexcept override
+        { return fabric.upstreamNodeCount - 1; }
+
+        bool HasType1SNP(size_t index) const noexcept override;
+        std::optional<FlitSNP> PeekType1SNP(size_t index)
+            const noexcept override;
+        std::optional<FlitSNP> PopType1SNP(size_t index) noexcept override;
+
+        bool HasType1DnRSP(size_t index) const noexcept override
+        { return real->HasType1DnRSP(index); }
+        std::optional<CCHI::Flits::DnRSP<Cohestra::CommonFlitConfigurationType1>>
+        PeekType1DnRSP(size_t index) const noexcept override
+        { return real->PeekType1DnRSP(index); }
+        std::optional<CCHI::Flits::DnRSP<Cohestra::CommonFlitConfigurationType1>>
+        PopType1DnRSP(size_t index) noexcept override
+        { return real->PopType1DnRSP(index); }
+
+        bool HasType1DnDAT(size_t index) const noexcept override
+        { return real->HasType1DnDAT(index); }
+        std::optional<CCHI::Flits::DnDAT<Cohestra::CommonFlitConfigurationType1>>
+        PeekType1DnDAT(size_t index) const noexcept override
+        { return real->PeekType1DnDAT(index); }
+        std::optional<CCHI::Flits::DnDAT<Cohestra::CommonFlitConfigurationType1>>
+        PopType1DnDAT(size_t index) noexcept override
+        { return real->PopType1DnDAT(index); }
+
+        bool PushType1EVT(size_t index,
+            const CCHI::Flits::EVT<Cohestra::CommonFlitConfigurationType1> &flit)
+            noexcept override
+        { return real->PushType1EVT(index, flit); }
+        bool PushType1REQ(size_t index,
+            const CCHI::Flits::REQ<Cohestra::CommonFlitConfigurationType1> &flit)
+            noexcept override
+        { return real->PushType1REQ(index, flit); }
+        bool PushType1UpRSP(size_t index,
+            const CCHI::Flits::UpRSP<Cohestra::CommonFlitConfigurationType1> &flit)
+            noexcept override
+        { return real->PushType1UpRSP(index, flit); }
+        bool PushType1UpDAT(size_t index,
+            const CCHI::Flits::UpDAT<Cohestra::CommonFlitConfigurationType1> &flit)
+            noexcept override
+        { return real->PushType1UpDAT(index, flit); }
+
+      private:
+        std::shared_ptr<Cohestra::CCHIInterface> real;
+        CCHIFabric &fabric;
+    };
+
+    /** Build the endpoint, instance, monitor and event listeners. */
+    void ensureInstance();
+
+    /** Per-cycle event: pump the CHIron stack, then the agent hooks. */
+    void tick();
+
+    /** SNP-gate front side, called from the gate interface. */
+    std::optional<FlitSNP> gatePeekSNP(size_t index);
+    std::optional<FlitSNP> gatePopSNP(size_t index);
+
+    /** OnAcceptedSNP listener: default (merge-off) L1 reflection hook. */
+    void onAcceptedSnoop(CCHIL1Agent *agent, AcceptedSNPEvent &ev);
+
+  protected:
+    // Params
+    const size_t upstreamNodeCount;
+    const std::string downstream;
+    const Addr memoryStart;
+    const Addr memoryEnd;
+    const uint32_t earthLatencyRSP;
+    const uint32_t earthLatencyDAT;
+    const bool monitorEnable;
+    const bool monitorFailOnMismatch;
+    const bool monitorTrace;
+    const bool flitTrace;
+
+    AddrRangeList addrRanges;
+
+    // Agent registrations by CCHI node ID (filled during init()), and the
+    // deterministic node-ID-sorted index assignment used by the instance
+    std::map<uint32_t, CCHIL1Agent *> agents;
+    std::vector<CCHIL1Agent *> agentsByIndex;
+
+    // CHIron stack (built lazily by ensureInstance())
+    bool instanceBuilt = false;
+    std::unique_ptr<Cohestra::Instance> instance;
+    std::shared_ptr<Cohestra::EarthCCHIInterface> earthInterface;
+    // The real downstream endpoint behind the gate decorator (Earth or RTL)
+    std::shared_ptr<Cohestra::CCHIInterface> downstreamInterface;
+    std::shared_ptr<SnoopGateCCHIInterface> gatedDownstream;
+    std::shared_ptr<Gem5MemoryBackend> memoryBackend;
+    std::unique_ptr<Cohestra::CacheLineDataMonitor> monitor;
+    std::unique_ptr<Cohestra::CCHIFlitLogger> flitLogger;
+    Gem5ConfigLoader configLoader;
+    std::vector<SnoopGate> snoopGates;
+
+#ifdef CCHI_RTL_ENABLED
+    // Verilator backend (downstream="rtl", WITH_CCHI_RTL build only).
+    // Pimpl: the verilated top and CHIron's pin bindings for it pull in
+    // spdlog-tainted CHIron headers, which this header must not include
+    // (see the note above); the full definition lives in cchi_fabric.cc
+    struct RtlStack;
+    std::unique_ptr<RtlStack> rtl;
+
+    /** High-active reset sequence, then the per-tick clock drivers:
+        low/high evals bracket the two-phase handshake ticks (see tick()). */
+    void rtlReset();
+    void rtlClockEvalLow();
+    void rtlClockEvalHigh();
+#endif
+
+    EventFunctionWrapper tickEvent;
+    uint64_t cycleCount = 0;
+    uint64_t lastMonitorMismatchCount = 0;
+
+  public:
+    struct CCHIFabricStats : public statistics::Group
+    {
+        CCHIFabricStats(statistics::Group *parent);
+
+        statistics::Scalar ticks;
+        statistics::Scalar backendReads;
+        statistics::Scalar backendWrites;
+        statistics::Scalar snoopGateInterceptions;
+        statistics::Scalar snoopGateReleases;
+        statistics::Scalar snoopReflections;
+        statistics::Scalar nullSnoopResponses;
+        statistics::Scalar monitorMismatches;
+    } stats;
+};
+
+} // namespace gem5
+
+#endif // __MEM_CCHI_CCHI_FABRIC_HH__

--- a/src/mem/cchi/cchi_l1_agent.cc
+++ b/src/mem/cchi/cchi_l1_agent.cc
@@ -1,0 +1,1752 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/cchi/cchi_l1_agent.hh"
+
+#include <cstring>
+
+#include "base/logging.hh"
+#include "mem/cache/prefetch/base.hh"
+#include "sim/system.hh"
+
+// Debug-logging plumbing: the gem5 build defines CCHI_HAVE_GEM5_DEBUG (see
+// src/mem/cchi/SConscript) and the messages go through the CCHI debug flag.
+// Without it (e.g. standalone syntax checks, where the generated
+// debug/CCHI.hh does not exist) DPRINTF* are forced to no-ops; the #undef
+// is needed because base/trace.hh (which defines the real macro and would
+// require the generated gem5::debug::CCHI flag) may already have been
+// pulled in transitively.
+#ifdef CCHI_HAVE_GEM5_DEBUG
+#include "base/trace.hh"
+#include "debug/CCHI.hh"
+#else
+#undef DPRINTF
+#define DPRINTF(...) do { } while (0)
+#undef DPRINTFR
+#define DPRINTFR(...) do { } while (0)
+#endif
+
+namespace gem5
+{
+
+namespace TaurusDenial = CCHI::Taurus::Denial;
+namespace TaurusState = CCHI::Taurus::CacheState;
+
+CCHIL1Agent::CCHIL1Agent(const CCHIL1AgentParams &p)
+    : ClockedObject(p),
+      memSidePort(p.name + ".mem_side", *this),
+      reqQueue(*this, memSidePort),
+      snoopRespQueue(*this, memSidePort),
+      cacheAccessor(this),
+      prefetcher(p.l2_prefetcher),
+      fabric(p.fabric),
+      nodeId(p.node_id),
+      hitLatency(p.hit_latency),
+      snoopMerge(p.snoop_merge),
+      xactionLimitREQ(p.xaction_limit_req),
+      xactionLimitEVT(p.xaction_limit_evt),
+      xactionLimitSNP(p.xaction_limit_snp),
+      stats(this)
+{
+    // L2CacheWrapper-style prefetch hosting: the accessor is backed by the
+    // Taurus node (resolved lazily), the block size is 64 (CCHI line)
+    if (prefetcher) {
+        prefetcher->setParentInfo(p.system, getProbeManager(),
+                                  &cacheAccessor, 64);
+        // The hosted prefetcher subscribes to the classic cache probe
+        // points (see prefetch::Base::setParentInfo); with no gem5 L2 in
+        // the path the agent fires them itself (see firePfProbe)
+        ppMiss = new ProbePointArg<PacketPtr>(getProbeManager(), "Miss");
+        ppHit = new ProbePointArg<PacketPtr>(getProbeManager(), "Hit");
+        ppFill = new ProbePointArg<PacketPtr>(getProbeManager(), "Fill");
+        ppStorePFTrain =
+            new ProbePointArg<PacketPtr>(getProbeManager(), "StorePFtrain");
+    }
+}
+
+// Probe feed for the hosted L2 prefetcher, approximating an L2 lookup:
+// a Taurus-resident line counts as an L2 hit, anything else as a miss.
+// Evictions, fences and bypassed traffic do not train prefetchers (they
+// do not in the gem5 L2 either).
+void
+CCHIL1Agent::firePfProbe(PacketPtr pkt)
+{
+    if (!prefetcher)
+        return;
+
+    if (taurus()->IsValid(pkt->getAddr() & ~Addr(63)))
+        ppHit->notify(pkt);
+    else
+        ppMiss->notify(pkt);
+}
+
+void
+CCHIL1Agent::init()
+{
+    fatal_if(cpuSidePorts.empty(),
+             "%s: no cpu_side port connected\n", name());
+    for (auto &port : cpuSidePorts)
+        fatal_if(!port->isConnected(),
+                 "%s: unconnected cpu_side port %s\n",
+                 name(), port->name());
+    fatal_if(!memSidePort.isConnected(),
+             "%s: mem_side port is not connected\n", name());
+
+    fabric->addUpstreamNode(nodeId, this);
+}
+
+Port &
+CCHIL1Agent::getPort(const std::string &if_name, PortID idx)
+{
+    if (if_name == "cpu_side") {
+        panic_if(idx == InvalidPortID,
+                 "%s: cpu_side is a vector port and needs an index\n",
+                 name());
+        while (cpuSidePorts.size() <= static_cast<size_t>(idx)) {
+            const PortID id = cpuSidePorts.size();
+            cpuSidePorts.emplace_back(std::make_unique<AgentResponsePort>(
+                name() + ".cpu_side[" + std::to_string(id) + "]",
+                *this, id));
+        }
+        return *cpuSidePorts[idx];
+    } else if (if_name == "mem_side") {
+        return memSidePort;
+    }
+    return ClockedObject::getPort(if_name, idx);
+}
+
+CCHIL1Agent::TaurusNode *
+CCHIL1Agent::taurus()
+{
+    if (!node) {
+        node = fabric->getUpstreamNode(nodeId);
+        panic_if(!node, "%s: no Taurus node for node_id %u\n",
+                 name(), nodeId);
+    }
+    return node;
+}
+
+// ---------------------------------------------------------------------------
+// Request path (cpu_side -> Taurus / bypass)
+// ---------------------------------------------------------------------------
+
+bool
+CCHIL1Agent::recvTimingReq(PacketPtr pkt, PortID portId)
+{
+    const Addr addr = pkt->getAddr();
+    const Addr linePA = addr & ~Addr(63);
+
+    // Store-prefetch training hints from the core/LSU: forward to the
+    // hosted prefetcher's StorePFtrain probe point and drop (gem5's L2
+    // semantics: no response, no memory traffic)
+    if (pkt->cmd == MemCmd::StorePFTrain) {
+        ++stats.pfStoreTrains;
+        if (ppStorePFTrain)
+            ppStorePFTrain->notify(pkt);
+        delete pkt;
+        return true;
+    }
+
+    // Uncached/MMIO and everything outside the fabric window bypasses CCHI
+    // entirely (the Taurus DoNonCacheable* entry points are nullptr stubs
+    // in CHIron; if they land, uncached ops can optionally go through
+    // Taurus instead - config knob, see the plan)
+    if (pkt->req->isUncacheable() || !fabric->isCacheable(addr)) {
+        ++stats.bypassReqs;
+        DPRINTF(CCHI, "[%s] bypass %s\n", name(), pkt->print());
+        pkt->pushSenderState(new BypassSenderState(portId));
+        const Tick receiveDelay = pkt->headerDelay + pkt->payloadDelay;
+        pkt->headerDelay = pkt->payloadDelay = 0;
+        memSidePort.schedTimingReq(pkt, curTick() + receiveDelay);
+        return true;
+    }
+
+    // A held home snoop blocks new L1 requests to the same line for the
+    // duration of the merge (snoop_merge flow; the bridge hazard rule)
+    if (merge && merge->linePA == linePA) {
+        ++stats.mergeBlockedReqs;
+        blockedPorts.insert(portId);
+        return false;
+    }
+
+    return handleCchiRequest(pkt, portId);
+}
+
+bool
+CCHIL1Agent::handleCchiRequest(PacketPtr pkt, PortID portId)
+{
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+
+    // Same-line serialization: never issue a second bridge transaction
+    // for a line with an undrained pending entry. Taurus's own
+    // PA_REQ_BUSY rejection covers the in-flight window, but NOT the
+    // post-completion/pre-drain window (the Taurus tracker is already
+    // freed, so a duplicate Do* would succeed and collide in the pending
+    // table). Backpressure instead: the L1 retries after the pending
+    // entry drains and the tick hook releases the port.
+    if (pending.count(linePA) || localSnoops.count(linePA)) {
+        ++stats.blockedSameLine;
+        DPRINTF(CCHI, "[%s] NACK %s (line %#llx pending%s)\n", name(),
+                pkt->print(), linePA,
+                pending.count(linePA) ? " xact" : " local-snoop");
+        blockedPorts.insert(portId);
+        return false;
+    }
+
+    // Admission of a new bridge transaction re-establishes tracking of
+    // this line, so any eviction queued from the PREVIOUS ownership
+    // epoch (a denied DoEvict parked in the retry queue) is now stale:
+    // letting it fire later would drop the line out from under the L1's
+    // fresh copy (observed: deferred writeback's queued evict reaping
+    // the line right after the L1 re-acquired it with a ReadEx).
+    if (!evictRetryQueue.empty()) {
+        const auto erased = std::erase(evictRetryQueue, linePA);
+        if (erased) {
+            stats.evictCancelled += erased;
+            DPRINTF(CCHI, "[%s] cancelled %llu stale queued evict(s) for "
+                    "%#llx\n", name(), (unsigned long long)erased, linePA);
+        }
+    }
+
+    switch (pkt->cmd.toInt()) {
+      case MemCmd::WritebackDirty:
+        return handleWriteback(pkt, portId, true);
+
+      case MemCmd::WritebackClean:
+      case MemCmd::CleanEvict:
+        return handleWriteback(pkt, portId, false);
+
+      case MemCmd::MemFenceReq:
+      case MemCmd::MemSyncReq:
+        return handleFence(pkt, portId);
+
+      default:
+        break;
+    }
+
+    // Local snoop: a node-resident line may have fresher data in a
+    // sibling L1 (the node only learns of L1 writes at writeback/merge
+    // time), and a write-class request must also invalidate sibling
+    // copies before the writer proceeds (xbar-equivalent semantics).
+    // Node-absent lines skip this: sibling-resident implies
+    // node-resident by construction (every fill goes through the node).
+    if (taurus()->IsValid(linePA)) {
+        const int expected = reflectLocalSnoop(pkt, portId);
+        if (expected > 0) {
+            ++stats.localSnoopIssued;
+            DPRINTF(CCHI, "[%s] local snoop for %#llx (expects %d)\n",
+                    name(), linePA, expected);
+            localSnoops.emplace(linePA,
+                                LocalSnoop{pkt, portId, expected,
+                                           curCycle()});
+            return true;
+        }
+        // No sibling holds the line: nothing to merge, issue inline
+    }
+
+    return dispatchCchiRequest(pkt, portId);
+}
+
+bool
+CCHIL1Agent::dispatchCchiRequest(PacketPtr pkt, PortID portId)
+{
+    switch (pkt->cmd.toInt()) {
+      case MemCmd::WritebackDirty:
+        return handleWriteback(pkt, portId, true);
+
+      case MemCmd::WritebackClean:
+      case MemCmd::CleanEvict:
+        return handleWriteback(pkt, portId, false);
+
+      case MemCmd::MemFenceReq:
+      case MemCmd::MemSyncReq:
+        return handleFence(pkt, portId);
+
+      default:
+        // Demand/store/prefetch traffic: feed the hosted L2 prefetcher's
+        // training stream (approximate L2-lookup semantics)
+        firePfProbe(pkt);
+        break;
+    }
+
+    switch (pkt->cmd.toInt()) {
+      case MemCmd::ReadReq:
+      case MemCmd::ReadSharedReq:
+      case MemCmd::ReadCleanReq:
+      case MemCmd::LoadLockedReq:
+        // Read variants a gem5 cache may emit on its mem side (the XS L1D
+        // uses ReadSharedReq for plain data loads): all map to DoLoad
+        // (ReadShared grant). LoadLockedReq degrades to a plain load here:
+        // the LL/SC reservation machinery lives in the L1/ISA (its
+        // reservation clearing is fed by our snoop reflection path)
+        ++stats.reads;
+        return issueLoad(pkt, portId, ACT_READ);
+
+      case MemCmd::ReadExReq:
+        // store miss: fill + ownership (ReadUnique with ExpCompData=1)
+        ++stats.readExes;
+        return issueStore(pkt, portId, ACT_READ_EX, false);
+
+      case MemCmd::UpgradeReq:
+      case MemCmd::SCUpgradeReq:
+        // S->U upgrade (ReadUnique with ExpCompData=0, no data - designed
+        // CHIron behavior). The SC success/fail decision lives in the
+        // L1/ISA; failing SCs arrive as SCUpgradeFailReq/StoreCondFailReq
+        // and are handled like ReadEx below
+        ++stats.upgrades;
+        return issueStore(pkt, portId, ACT_UPGRADE, false);
+
+      case MemCmd::StoreCondReq:
+        // A data-carrying SC that reached the memory side: acquire
+        // ownership and commit the data like a store; the L1/ISA owns
+        // the reservation check, so downstream success means SC success
+        ++stats.upgrades;
+        return issueStore(pkt, portId, ACT_WRITE, false);
+
+      case MemCmd::WriteReq:
+        ++stats.writes;
+        return issueStore(pkt, portId, ACT_WRITE, false);
+
+      case MemCmd::WriteLineReq:
+        ++stats.writes;
+        return issueStore(pkt, portId, ACT_WRITE, true);
+
+      case MemCmd::InvalidateReq:
+        // XS fast-writeline conversion of a whole-line write miss
+        // (cache.cc createMissPacket): "give me ownership, I will
+        // overwrite the whole line" - the miss packet carries no data,
+        // so this is ownership-only like an upgrade, but always a
+        // full-line acquisition (DoStoreLine, dataless by design)
+        ++stats.writes;
+        return issueStore(pkt, portId, ACT_INV_WRITE, true);
+
+      case MemCmd::SCUpgradeFailReq:
+      case MemCmd::StoreCondFailReq:
+        // A failing SC still fetches ownership + data (to supply
+        // snoopers); the SC failure itself is decided in the L1/ISA
+        ++stats.readExes;
+        return issueStore(pkt, portId, ACT_READ_EX, false);
+
+      case MemCmd::HardPFReq:
+      case MemCmd::SoftPFReq:
+      case MemCmd::SoftPFExReq:
+        // L1-originated prefetch: gem5's HardPFReq is NeedsWritable|
+        // IsInvalidate, so ownership (DoStore/ReadUnique) is required -
+        // a Shared DoLoad fill would let the L1 store-hit later without
+        // an UpgradeReq, and the writeback would then deadlock on a
+        // non-Unique Taurus line. Always respond, the L1's prefetch
+        // MSHRs wedge otherwise.
+        ++stats.hardPrefetches;
+        return issueStore(pkt, portId, ACT_HARD_PF, false);
+
+      case MemCmd::LockedRMWReadReq:
+        // AMO read phase: acquire Unique + data, pin the line (never
+        // evicted by the bridge while pinned)
+        ++stats.rmwReads;
+        return issueStore(pkt, portId, ACT_RMW_READ, false);
+
+      case MemCmd::LockedRMWWriteReq:
+        return handleRMWWrite(pkt, portId);
+
+      case MemCmd::SwapReq:
+        // AMO forwarded by the L1 on a miss: RMW under Unique ownership
+        // on the node line; the old value goes back as the response data
+        ++stats.rmwReads;
+        return issueStore(pkt, portId, ACT_SWAP, false);
+
+      case MemCmd::WritebackDirty:
+        return handleWriteback(pkt, portId, true);
+
+      case MemCmd::WritebackClean:
+      case MemCmd::CleanEvict:
+        return handleWriteback(pkt, portId, false);
+
+      case MemCmd::WriteClean:
+        return handleWriteClean(pkt, portId);
+
+      case MemCmd::MemFenceReq:
+      case MemCmd::MemSyncReq:
+        return handleFence(pkt, portId);
+
+      case MemCmd::CleanSharedReq:
+        return issueCMO(pkt, portId, false);
+
+      case MemCmd::CleanInvalidReq:
+        return issueCMO(pkt, portId, true);
+
+      default:
+        fatal("%s: unexpected command from L1: %s\n",
+              name(), pkt->cmd.toString());
+    }
+}
+
+bool
+CCHIL1Agent::issueLoad(PacketPtr pkt, PortID portId, XactAction action)
+{
+    auto future = taurus()->DoLoad(pkt->getAddr());
+
+    if (future->IsRejected())
+        return handleDenial(future->GetDenial(), portId);
+
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+    const bool hit = future->IsNow();
+    if (hit)
+        ++stats.reqHits;
+    else
+        ++stats.reqMisses;
+
+    DPRINTF(CCHI, "[%s] DoLoad %#llx -> %s\n", name(), linePA,
+            hit ? "hit" : "miss");
+
+    PendingXaction entry{linePA, pkt, portId, action, hit, 0, nullptr};
+    panic_if(!pending.emplace(linePA, entry).second,
+             "%s: duplicate pending entry for line %#llx\n", name(), linePA);
+
+    // The lambda only posts to the completion queue; for a now-future it
+    // runs synchronously here, for a pending future it runs inside the
+    // fabric's Instance::Tick. Responses are produced by the tick hook,
+    // never directly from the callback.
+    future->Bind([this, linePA](const TaurusNode::GrantedEvent &ev) {
+        onGrantFired(linePA, ev);
+    });
+    return true;
+}
+
+bool
+CCHIL1Agent::issueStore(PacketPtr pkt, PortID portId, XactAction action,
+                        bool wholeLine)
+{
+    // Dataless-upgrade hazard (documented Taurus behavior): a DoStore on a
+    // resident Shared line latches ExpCompData=0 and never refetches, so
+    // if a racing home snoop invalidates the line in flight, the grant
+    // completes Unique with the PRE-SNOOP (stale) data - and any later
+    // eviction would even write the stale copy back over fresher home
+    // data. DoStoreLine is exempt by construction (the L1 overwrites the
+    // whole line, so stale content never survives). For partial stores,
+    // evict the Shared line first (dataless EVT, the home keeps its
+    // copy): the ReadUnique below then always goes the with-data path.
+    if (!wholeLine) {
+        auto line = taurus()->GetCacheLine(pkt->getAddr());
+        if (line && line->GetState() == CCHI::Taurus::CacheState::Shared) {
+            auto evFuture = taurus()->DoEvict(pkt->getAddr());
+            if (evFuture->IsRejected()) {
+                const DenialEnum denial = evFuture->GetDenial();
+                if (denial != TaurusDenial::REJECTED_TAURUS_EVICT_MISS) {
+                    // Busy/limits: back off and retry the whole store on a
+                    // later tick (the L1 re-issues after sendRetryReq)
+                    ++stats.evictForRefetchDenied;
+                    DPRINTF(CCHI, "[%s] evict-for-refetch %#llx DENIED "
+                            "(%s)\n", name(),
+                            pkt->getAddr() & ~Addr(63), denial->name);
+                    blockedPorts.insert(portId);
+                    return false;
+                }
+                // EVICT_MISS: already gone - DoStore below fetches data
+            } else {
+                ++stats.evictForRefetch;
+                DPRINTF(CCHI, "[%s] evict-for-refetch %#llx\n", name(),
+                        pkt->getAddr() & ~Addr(63));
+            }
+        }
+    }
+
+    // A resident line with a snoop or eviction in flight is about to be
+    // demoted/reaped: granting a store hit on it would write the new data
+    // into a dying line - the home only ever learns the pre-store content
+    // (via the in-flight answer or CopyBack), and the post-store content
+    // would sit in a detached line object until it vanishes (observed in
+    // the XSCache linux boot: a back-invalidation answered in the same
+    // window as a store hit, reaping the line before the next merge). Back
+    // off and let the L1 retry: by then the line is either gone (a proper
+    // miss re-acquires through the home) or the flight has resolved.
+    if (auto line = taurus()->GetCacheLine(pkt->getAddr());
+        line && (line->IsSNPInFlight(taurus()->glbl) ||
+                 line->IsEVTInFlight(taurus()->glbl))) {
+        ++stats.storeFlightBackoff;
+        DPRINTF(CCHI, "[%s] DoStore %#llx backed off (snoop/evict in "
+                "flight)\n", name(), pkt->getAddr() & ~Addr(63));
+        blockedPorts.insert(portId);
+        return false;
+    }
+
+    auto future = wholeLine ? taurus()->DoStoreLine(pkt->getAddr())
+                            : taurus()->DoStore(pkt->getAddr());
+
+    if (future->IsRejected()) {
+        DPRINTF(CCHI, "[%s] DoStore %#llx (a%d) DENIED\n", name(),
+                pkt->getAddr() & ~Addr(63), static_cast<int>(action));
+        return handleDenial(future->GetDenial(), portId);
+    }
+
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+    const bool hit = future->IsNow();
+    if (hit)
+        ++stats.reqHits;
+    else
+        ++stats.reqMisses;
+
+    DPRINTF(CCHI, "[%s] DoStore %#llx (a%d) -> %s\n", name(), linePA,
+            static_cast<int>(action), hit ? "hit" : "miss");
+
+    PendingXaction entry{linePA, pkt, portId, action, hit, 0, nullptr};
+    panic_if(!pending.emplace(linePA, entry).second,
+             "%s: duplicate pending entry for line %#llx\n", name(), linePA);
+
+    future->Bind([this, linePA](const TaurusNode::GrantedEvent &ev) {
+        onGrantFired(linePA, ev);
+    });
+    return true;
+}
+
+bool
+CCHIL1Agent::issueCMO(PacketPtr pkt, PortID portId, bool invalidate)
+{
+    ++stats.cmos;
+
+    auto future = invalidate ? taurus()->DoCBOInval(pkt->getAddr())
+                             : taurus()->DoCBOClean(pkt->getAddr());
+
+    if (future->IsRejected())
+        return handleDenial(future->GetDenial(), portId);
+
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+
+    PendingXaction entry{linePA, pkt, portId, ACT_CMO,
+                         future->IsNow(), 0, nullptr};
+    panic_if(!pending.emplace(linePA, entry).second,
+             "%s: duplicate pending entry for line %#llx\n", name(), linePA);
+
+    // TODO(cchi): endpoint-side CMO servicing is still pending in CHIron
+    // (Earth does not answer CMOs with CompCMO today), so with the Earth
+    // endpoint a CMO request currently never completes. The completion
+    // path is live for endpoints that service CMOs.
+    future->Bind([this, linePA](const TaurusNode::CMOCompleteEvent &ev) {
+        onCMOFired(linePA, ev);
+    });
+    return true;
+}
+
+bool
+CCHIL1Agent::handleRMWWrite(PacketPtr pkt, PortID portId)
+{
+    ++stats.rmwWrites;
+
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+    auto line = taurus()->GetCacheLine(linePA);
+
+    if (!line || !pinnedLines.count(linePA)) {
+        // With snoop_merge=off a home snoop can drop the pinned line from
+        // Taurus between the RMW read and write (the off mode's
+        // bounded-staleness stance): re-acquire ownership and commit the
+        // modified bytes at the grant instead of failing. The write
+        // packet carries the final (post-AMO) bytes, the grant fills the
+        // rest of the line with the current content.
+        warn_once("%s: RMW write re-acquiring line %#llx (pin lost)\n",
+                  name(), linePA);
+        return issueStore(pkt, portId, ACT_RMW_WRITE, false);
+    }
+
+    // The line is already Unique and held: go through the completion
+    // machinery with a pre-granted entry (store + unpin + respond)
+    PendingXaction entry{linePA, pkt, portId, ACT_RMW_WRITE,
+                         true, curTick(), std::move(line)};
+    panic_if(!pending.emplace(linePA, entry).second,
+             "%s: duplicate pending entry for line %#llx\n", name(), linePA);
+    completionQueue.push_back(linePA);
+    return true;
+}
+
+bool
+CCHIL1Agent::handleWriteback(PacketPtr pkt, PortID portId, bool dirty)
+{
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+
+    panic_if(pinnedLines.count(linePA),
+             "%s: eviction of RMW-pinned line %#llx\n", name(), linePA);
+
+    // Evictions need no response (InvalidCmd in gem5's commandInfo): the
+    // bridge is the final destination and consumes the packet
+    if (dirty) {
+        ++stats.writebacks;
+
+        auto line = taurus()->GetCacheLine(linePA);
+        if (!line) {
+            // The node no longer tracks this line. By the bridge
+            // invariant an M-dirty L1 line always implies a resident
+            // Unique node line, so this is only reachable for an
+            // O-state (shared-dirty) eviction whose data was already
+            // merged into the home when the line was downgraded - the
+            // writeback is redundant and can be dropped. The stale
+            // queued-evict race that could re-dirty the L1 copy after
+            // the node reaped it is closed by the cancel-on-admit rule
+            // in handleCchiRequest.
+            ++stats.writebacksDropped;
+            warn_once("%s: dropping WritebackDirty for non-resident line "
+                      "%#llx (data already at the home)\n", name(), linePA);
+            delete pkt;
+            return true;
+        }
+
+        if (storeToLine(pkt, *line)) {
+            // Fresh data committed to the Taurus line; the eviction then
+            // propagates asynchronously (EVT WriteBackFull carries the
+            // data to the home)
+            DPRINTF(CCHI, "[%s] WritebackDirty %#llx stored + evict\n",
+                    name(), linePA);
+            delete pkt;
+            issueEvict(linePA);
+        } else {
+            // Defensive: the checked store should not fail on a Unique,
+            // resident line; defer through the completion machinery
+            DPRINTF(CCHI, "[%s] WritebackDirty %#llx DEFERRED (state %s)\n",
+                    name(), linePA, line->GetState()->name);
+            warn_once("%s: deferred store for WritebackDirty %#llx\n",
+                      name(), linePA);
+            PendingXaction entry{linePA, pkt, portId, ACT_WRITEBACK,
+                                 true, curTick(), std::move(line)};
+            panic_if(!pending.emplace(linePA, entry).second,
+                     "%s: duplicate pending entry for line %#llx\n",
+                     name(), linePA);
+            completionQueue.push_back(linePA);
+        }
+    } else {
+        ++stats.cleanEvicts;
+        // Clean data: the Taurus copy is at least as fresh; drop the line
+        // from the node (EVT Evict)
+        delete pkt;
+        issueEvict(linePA);
+    }
+    return true;
+}
+
+bool
+CCHIL1Agent::handleWriteClean(PacketPtr pkt, PortID portId)
+{
+    ++stats.writeCleans;
+
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+    auto line = taurus()->GetCacheLine(linePA);
+    if (!line) {
+        // Same non-resident situation as handleWriteback: the WriteClean
+        // data is either clean or already merged into the home, so the
+        // packet can be dropped (see the epoch argument there)
+        ++stats.writebacksDropped;
+        warn_once("%s: dropping WriteClean for non-resident line %#llx\n",
+                  name(), linePA);
+        delete pkt;
+        return true;
+    }
+
+    if (storeToLine(pkt, *line)) {
+        // No response needed: consume the packet, the line stays resident
+        delete pkt;
+    } else {
+        warn_once("%s: deferred store for WriteClean %#llx\n",
+                  name(), linePA);
+        PendingXaction entry{linePA, pkt, portId, ACT_WRITE_CLEAN,
+                             true, curTick(), std::move(line)};
+        panic_if(!pending.emplace(linePA, entry).second,
+                 "%s: duplicate pending entry for line %#llx\n",
+                 name(), linePA);
+        completionQueue.push_back(linePA);
+    }
+    return true;
+}
+
+bool
+CCHIL1Agent::handleFence(PacketPtr pkt, PortID portId)
+{
+    ++stats.fences;
+
+    // Drain agent futures, then respond. In-flight asynchronous evictions
+    // play the role of a write buffer here and are not awaited: their
+    // data was committed to Taurus before the writeback was answered.
+    if (pending.empty() && completionQueue.empty()) {
+        respondTo(pkt, portId, curTick() + clockPeriod());
+    } else {
+        fenceQueue.emplace_back(pkt, portId);
+    }
+    return true;
+}
+
+bool
+CCHIL1Agent::handleDenial(DenialEnum denial, PortID portId)
+{
+    if (denial == TaurusDenial::REJECTED_TAURUS_REQ_LIMIT_EXCEEDED) {
+        ++stats.deniedReqLimit;
+    } else if (denial == TaurusDenial::REJECTED_TAURUS_TOTAL_LIMIT_EXCEEDED) {
+        ++stats.deniedTotalLimit;
+    } else if (denial == TaurusDenial::REJECTED_TAURUS_PA_REQ_BUSY) {
+        // Legitimate with L1I+L1D fan-in (two independent MSHR pools may
+        // target the same line); retried on a later fabric tick
+        ++stats.deniedPABusy;
+    } else if (denial == TaurusDenial::REJECTED_TAURUS_CMO_LIMIT_EXCEEDED) {
+        ++stats.deniedCMOLimit;
+    } else {
+        fatal("%s: unexpected Taurus denial %s\n", name(), denial->name);
+    }
+
+    blockedPorts.insert(portId);
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Completion path
+// ---------------------------------------------------------------------------
+
+void
+CCHIL1Agent::onGrantFired(Addr linePA,
+                          [[maybe_unused]] const TaurusNode::GrantedEvent &ev)
+{
+    auto it = pending.find(linePA);
+    if (it == pending.end()) {
+        // Late/duplicate grant: FutureNow supports multiple fires and an
+        // escalation grant can race with the entry completing through
+        // another path. The entry is gone, the grant is stale - benign.
+        ++stats.lateGrants;
+        DPRINTF(CCHI, "[%s] late grant for %#llx (no pending entry)\n",
+                name(), linePA);
+        return;
+    }
+
+    // The const event only hands out shared_ptr<const CacheLine>;
+    // re-fetch the writable handle from the node (the line was just
+    // granted, so it is necessarily resident)
+    it->second.line = taurus()->GetCacheLine(linePA);
+    panic_if(!it->second.line,
+             "%s: granted line %#llx not resident\n", name(), linePA);
+
+    // Snapshot the fill data for read actions (see PendingXaction::fillData):
+    // taken while the grant has just completed, so a later home snoop
+    // invalidating the line cannot starve the fill
+    switch (it->second.action) {
+      case ACT_READ:
+      case ACT_READ_EX:
+      case ACT_HARD_PF:
+      case ACT_RMW_READ: {
+        const auto span = it->second.line->Load();
+        if (span) {
+            std::array<uint64_t, 8> buf;
+            std::memcpy(buf.data(), span->data(), 64);
+            it->second.fillData = buf;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    it->second.grantedTick = curTick();
+    DPRINTF(CCHI, "[%s] grant fired for %#llx\n", name(), linePA);
+    completionQueue.push_back(linePA);
+}
+
+void
+CCHIL1Agent::onCMOFired(Addr linePA,
+                        [[maybe_unused]] const TaurusNode::CMOCompleteEvent &ev)
+{
+    auto it = pending.find(linePA);
+    if (it == pending.end()) {
+        // Same late/duplicate-fire rationale as onGrantFired
+        ++stats.lateGrants;
+        return;
+    }
+
+    it->second.grantedTick = curTick();
+    completionQueue.push_back(linePA);
+}
+
+bool
+CCHIL1Agent::processCompletion(PendingXaction &entry)
+{
+    const Tick delay = entry.grantedHit ? cyclesToTicks(hitLatency)
+                                        : clockPeriod();
+
+    switch (entry.action) {
+      case ACT_READ:
+      case ACT_READ_EX:
+      case ACT_HARD_PF:
+        // Fill data readback: grant-time snapshot when present (immune to
+        // a racing home snoop invalidating the granted line), else the
+        // line's checked accessors; an empty optional means the line is
+        // not consistent yet -> retry next fabric tick
+        if (!fillFromEntry(entry))
+            return false;
+        // Feed the hosted prefetcher's Fill stream (L2-refill semantics)
+        if (ppFill)
+            ppFill->notify(entry.pkt);
+        // Mirror the Taurus grant state into the response: a DoLoad grant
+        // is Shared - if the L1 filled it as writable (gem5 marks
+        // no-sharers fills Exclusive), it would store-hit without an
+        // UpgradeReq and a later writeback would deadlock on the Shared
+        // Taurus line. DoStore/DoStoreLine grants are Unique (writable),
+        // so no sharers flag there.
+        if (entry.action == ACT_READ)
+            entry.pkt->setHasSharers();
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_RMW_READ:
+        if (!fillFromEntry(entry))
+            return false;
+        // Pin the line: the bridge never evicts pinned lines; with
+        // snoop_merge=on, SNPs to this line are held by the merge flow
+        pinnedLines.insert(entry.linePA);
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_UPGRADE:
+        // No data: S->U upgrade (ExpCompData=0) by design
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_INV_WRITE:
+        // Ownership only (full-line overwrite follows inside the L1):
+        // the miss packet carried no data, so nothing to store - the
+        // L1's own write makes the line fresh, and the next merge or
+        // writeback syncs it into the node
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_WRITE:
+        if (!storeWithEscalation(entry))
+            return false;
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_RMW_WRITE:
+        if (!storeWithEscalation(entry))
+            return false;
+        pinnedLines.erase(entry.linePA);
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_SWAP:
+        if (!storeWithEscalation(entry,
+                                 [this](PacketPtr p, TaurusCacheLine &l) {
+                                     return performAtomicOp(p, l);
+                                 }))
+            return false;
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      case ACT_WRITEBACK:
+        if (!storeWithEscalation(entry))
+            return false;
+        // Evictions need no response; consume the packet
+        delete entry.pkt;
+        issueEvict(entry.linePA);
+        return true;
+
+      case ACT_WRITE_CLEAN:
+        if (!storeWithEscalation(entry))
+            return false;
+        delete entry.pkt;
+        return true;
+
+      case ACT_CMO:
+        respondTo(entry.pkt, entry.portId, entry.grantedTick + delay);
+        return true;
+
+      default:
+        fatal("%s: bad pending action %u\n", name(), entry.action);
+    }
+}
+
+bool
+CCHIL1Agent::fillFromEntry(PendingXaction &entry)
+{
+    if (entry.fillData) {
+        const Addr offset = entry.pkt->getAddr() & Addr(63);
+        const unsigned size = entry.pkt->getSize();
+        uint8_t *data = entry.pkt->getPtr<uint8_t>();
+        std::memcpy(data,
+                    reinterpret_cast<const uint8_t *>(entry.fillData->data()) +
+                        offset,
+                    size);
+        return true;
+    }
+    return fillFromLine(entry.pkt, *entry.line);
+}
+
+bool
+CCHIL1Agent::fillFromLine(PacketPtr pkt, TaurusCacheLine &line)
+{
+    const Addr offset = pkt->getAddr() & Addr(63);
+    const unsigned size = pkt->getSize();
+    uint8_t *data = pkt->getPtr<uint8_t>();
+
+    if (offset == 0 && size == 64) {
+        const auto span = line.Load();
+        if (!span)
+            return false;
+        std::memcpy(data, span->data(), 64);
+        return true;
+    }
+
+    for (unsigned i = 0; i < size; ++i) {
+        const auto byte = line.Load8(offset + i);
+        if (!byte)
+            return false;
+        data[i] = *byte;
+    }
+    return true;
+}
+
+bool
+CCHIL1Agent::storeToLine(PacketPtr pkt, TaurusCacheLine &line)
+{
+    const Addr offset = pkt->getAddr() & Addr(63);
+    const unsigned size = pkt->getSize();
+    const uint8_t *data = pkt->getConstPtr<uint8_t>();
+
+    if (offset == 0 && size == 64) {
+        std::array<uint64_t, 8> buf;
+        std::memcpy(buf.data(), data, 64);
+        return line.Store(std::span<const uint64_t, 8>(buf));
+    }
+
+    for (unsigned i = 0; i < size; ++i)
+        if (!line.Store8(offset + i, data[i]))
+            return false;
+    return true;
+}
+
+bool
+CCHIL1Agent::performAtomicOp(PacketPtr pkt, TaurusCacheLine &line)
+{
+    const Addr offset = pkt->getAddr() & Addr(63);
+
+    // Read-modify-write on the granted line: copy the old value into the
+    // packet (the AMO's return value), apply the functor in place, and
+    // commit. Runs inside one processCompletion call, so no gem5-side
+    // event (snoop merge, ...) can interleave between Load and Store;
+    // a failed store retries the whole op on the freshest line content.
+    const auto span = line.Load();
+    if (!span)
+        return false;
+
+    std::array<uint64_t, 8> buf;
+    std::memcpy(buf.data(), span->data(), 64);
+    uint8_t *lane = reinterpret_cast<uint8_t *>(buf.data()) + offset;
+    pkt->setData(lane);
+    (*pkt->getAtomicOp())(lane);
+    return line.Store(std::span<const uint64_t, 8>(buf));
+}
+
+bool
+CCHIL1Agent::storeWithEscalation(PendingXaction &entry,
+                                 const StoreOp &op)
+{
+    if (op(entry.pkt, *entry.line))
+        return true;
+
+    // Bounded retry: a persistently failing store means the line is not
+    // (or no longer) Unique - e.g. it was downgraded after the grant.
+    // Escalate by re-acquiring ownership (DoStore upgrades S->U with
+    // ExpCompData=0, or re-fills an absent line which the store then
+    // overwrites), never spinning forever.
+    if (++entry.retries >= STORE_RETRY_ESCALATE) {
+        entry.retries = 0;
+        ++stats.storeEscalations;
+        DPRINTF(CCHI, "[%s] escalating store for %#llx (DoStore)\n",
+                name(), entry.linePA);
+        auto future = taurus()->DoStore(entry.linePA);
+        if (future->IsRejected()) {
+            DPRINTF(CCHI, "[%s] escalation for %#llx REJECTED (%s)\n",
+                    name(), entry.linePA, future->GetDenial()->name);
+        } else {
+            future->Bind([this, linePA = entry.linePA]
+                         (const TaurusNode::GrantedEvent &ev) {
+                onGrantFired(linePA, ev);
+            });
+        }
+    }
+    return false;
+}
+
+void
+CCHIL1Agent::respondTo(PacketPtr pkt, PortID portId, Tick when)
+{
+    panic_if(portId == InvalidPortID ||
+             static_cast<size_t>(portId) >= cpuSidePorts.size(),
+             "%s: response for unknown cpu_side port %d\n", name(), portId);
+    pkt->makeTimingResponse();
+    cpuSidePorts[portId]->schedTimingResp(pkt, when);
+}
+
+void
+CCHIL1Agent::issueEvict(Addr linePA)
+{
+    auto future = taurus()->DoEvict(linePA);
+
+    if (future->IsRejected()) {
+        const DenialEnum denial = future->GetDenial();
+        if (denial == TaurusDenial::REJECTED_TAURUS_EVICT_MISS) {
+            // The line is already gone (e.g. a home snoop dropped it);
+            // nothing left to do
+            ++stats.evictMisses;
+            DPRINTF(CCHI, "[%s] evict %#llx -> miss (already gone)\n",
+                    name(), linePA);
+            return;
+        }
+        // PA_EVT_BUSY / EVT_LIMIT_EXCEEDED / TOTAL_LIMIT_EXCEEDED: park
+        // and retry from the tick hook; the L1 was already answered, so
+        // this is purely internal bookkeeping
+        ++stats.evictRetries;
+        DPRINTF(CCHI, "[%s] evict %#llx DENIED (%s), queued\n",
+                name(), linePA, denial->name);
+        evictRetryQueue.push_back(linePA);
+        return;
+    }
+
+    ++stats.evictions;
+    DPRINTF(CCHI, "[%s] evict %#llx issued\n", name(), linePA);
+    // Completion is not awaited: the node reaps the line record itself
+}
+
+// ---------------------------------------------------------------------------
+// Per-cycle hook (called by the fabric after Instance::Tick)
+// ---------------------------------------------------------------------------
+
+void
+CCHIL1Agent::tickHook()
+{
+    // Debug heartbeat: periodic state dump while anything is in flight,
+    // so a silent wedge shows what was held (cheap, CCHI flag gated)
+    if (DTRACE(CCHI) && (++heartbeat & 0xFFFF) == 0 &&
+        (!pending.empty() || merge || !blockedPorts.empty() ||
+         !completionQueue.empty() || !evictRetryQueue.empty() ||
+         !localSnoops.empty())) {
+        std::string pend;
+        for (const auto &[line, e] : pending)
+            pend += csprintf(" %#llx(a%d,r%u,%s)", line,
+                             static_cast<int>(e.action), e.retries,
+                             e.line ? "g" : "-");
+        DPRINTF(CCHI, "[%s] heartbeat pend={%s }%s blocked=%d evictQ=%d "
+                "compQ=%d\n", name(), pend,
+                merge ? csprintf(" merge=%#llx(await=%d)", merge->linePA,
+                                 merge->awaitingResponses).c_str() : "",
+                blockedPorts.size(), evictRetryQueue.size(),
+                completionQueue.size());
+    }
+
+    // 1. Completions posted by the FutureNow callbacks (bounded pass:
+    //    entries whose data is not consistent yet are re-posted once)
+    size_t remaining = completionQueue.size();
+    while (remaining--) {
+        const Addr linePA = completionQueue.front();
+        completionQueue.pop_front();
+
+        auto it = pending.find(linePA);
+        if (it == pending.end()) {
+            // Stale queue entry: Taurus futures can fire a second time
+            // (at dealloc), so a line can be posted twice - once while
+            // the entry is still queued for completion (duplicate push
+            // in onGrantFired) and once after it drained (late grant).
+            // Completions are idempotent hints; skip the duplicate.
+            ++stats.lateGrants;
+            continue;
+        }
+
+        if (processCompletion(it->second)) {
+            DPRINTF(CCHI, "[%s] completed %#llx (a%d, r%u)\n", name(), linePA,
+                    static_cast<int>(it->second.action), it->second.retries);
+            pending.erase(it);
+        } else {
+            ++stats.completionRetries;
+            ++it->second.retries;
+            completionQueue.push_back(linePA);
+            // Rate-limited visibility for persistently stuck entries
+            if (it->second.retries == 100 || it->second.retries == 1000) {
+                auto line = taurus()->GetCacheLine(linePA);
+                const bool loadable = line && line->Load().has_value();
+                warn("%s: completion for %#llx (action %d) stuck after %llu "
+                     "retries; line %s, state %s, Load()=%d\n", name(), linePA,
+                     static_cast<int>(it->second.action),
+                     (unsigned long long)it->second.retries,
+                     line ? "resident" : "ABSENT",
+                     line ? line->GetState()->name : "n/a", int(loadable));
+            }
+        }
+    }
+
+    // 2. Fences: answer once the agent has fully drained
+    if (!fenceQueue.empty() && pending.empty() && completionQueue.empty()) {
+        for (auto &[pkt, portId] : fenceQueue)
+            respondTo(pkt, portId, curTick() + clockPeriod());
+        fenceQueue.clear();
+    }
+
+    // 3. Denied evictions (bounded pass, may re-enqueue)
+    size_t evictions = evictRetryQueue.size();
+    while (evictions--) {
+        const Addr linePA = evictRetryQueue.front();
+        evictRetryQueue.pop_front();
+        issueEvict(linePA);
+    }
+
+    // 4. snoop_merge timeout safety valve (bounded staleness, see the
+    //    plan's multicore risk note)
+    if (merge && (uint64_t)(curCycle() - merge->startCycle)
+                 > MERGE_TIMEOUT_CYCLES) {
+        warn("%s: snoop merge for %#llx timed out after %llu cycles; "
+             "releasing the held snoop (bounded staleness)\n",
+             name(), merge->linePA,
+             (unsigned long long)MERGE_TIMEOUT_CYCLES);
+        ++stats.snoopMergeTimeouts;
+        fabric->releaseSnoop(upstreamIndex);
+        merge.reset();
+    }
+
+    // 5. Hosted L2 prefetch engine drain -> CCHI stash
+    drainPrefetcher();
+
+    // 5b. Local-snoop dispatches denied earlier (Taurus busy): bounded
+    //     pass; entries that still deny stay parked for the next tick
+    for (auto it = localSnoops.begin(); it != localSnoops.end();) {
+        if (it->second.awaitingResponses != 0) {
+            ++it;
+            continue;
+        }
+        PacketPtr parked = it->second.pkt;
+        const PortID parkedPort = it->second.portId;
+        it = localSnoops.erase(it);
+        if (!dispatchCchiRequest(parked, parkedPort)) {
+            localSnoops.emplace(parked->getAddr() & ~Addr(63),
+                                LocalSnoop{parked, parkedPort, 0,
+                                           curCycle()});
+            break;  // still busy: leave the rest for the next tick
+        }
+    }
+
+    // 6. Backpressure release: TxnIDs freed during Instance::Tick (or a
+    //    merge completed above) make progress possible again; spurious
+    //    retries are harmless, the L1 simply re-attempts. Swap the set
+    //    out BEFORE sending: sendRetryReq is synchronous, so the L1's
+    //    immediate re-attempt can NACK and re-arm blockedPorts
+    //    re-entrantly right here - clearing AFTER the sends would wipe
+    //    that fresh state and deadlock the port.
+    if (!blockedPorts.empty()) {
+        std::set<PortID> toRetry;
+        toRetry.swap(blockedPorts);
+        for (const PortID portId : toRetry) {
+            DPRINTF(CCHI, "[%s] sendRetryReq port %d\n", name(), portId);
+            cpuSidePorts[portId]->sendRetryReq();
+        }
+    }
+}
+
+void
+CCHIL1Agent::drainPrefetcher()
+{
+    if (!prefetcher)
+        return;
+
+    while (prefetcher->hasPendingPacket()) {
+        PacketPtr pf = prefetcher->getPacket();
+        if (!pf)
+            break;
+
+        // CCHI stash: prefetch the line into the endpoint-side L2
+        // (StashShared/StashUnique); no allocation in Taurus and no gem5
+        // response is expected, so the drained packet is dropped after
+        // emission. Caveat (per plan): endpoint-side stash processing is
+        // still pending in CHIron - Earth only decodes these opcodes.
+        auto future = pf->needsWritable()
+            ? taurus()->DoPrefetchStore(pf->getAddr())
+            : taurus()->DoPrefetchLoad(pf->getAddr());
+
+        if (future->IsRejected())
+            ++stats.pfStashDropped;
+        else
+            ++stats.pfStashIssued;
+
+        delete pf;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snoop paths (home-originated only)
+// ---------------------------------------------------------------------------
+
+int
+CCHIL1Agent::reflectSnoopToL1(Addr linePA, uint64_t snpOpcode)
+{
+    const bool invalidating =
+        snpOpcode == static_cast<uint64_t>(CCHI::Opcodes::SNP::SnpToInvalid) ||
+        snpOpcode == static_cast<uint64_t>(CCHI::Opcodes::SNP::SnpMakeInvalid);
+    // Matches pkt->isInvalidate()/needsWritable() semantics in the L1's
+    // handleSnoop (also feeds the ISA's LL/SC reservation clearing)
+    const MemCmd cmd = invalidating ? MemCmd::ReadExReq
+                                    : MemCmd::ReadSharedReq;
+
+    int willRespond = 0;
+
+    for (auto &port : cpuSidePorts) {
+        // Only snoop coherent masters (L1I/L1D); MMU walker ports are not
+        // snooping, mirroring the coherent-xbar behavior
+        if (!port->isSnooping())
+            continue;
+
+        // The one place the bridge creates a Request: a home-originated
+        // snoop has no gem5 request of its own (64B, physical)
+        RequestPtr req = std::make_shared<Request>(linePA, 64,
+                                                   Request::PHYSICAL,
+                                                   Request::funcRequestorId);
+        PacketPtr pkt = new Packet(req, cmd);
+        pkt->allocate();
+
+        // Unrefusable by protocol; cacheResponding() is set synchronously
+        // if this L1 will supply dirty data (including the MSHR-deferred
+        // will-respond case)
+        port->sendTimingSnoopReq(pkt);
+        if (pkt->cacheResponding())
+            ++willRespond;
+
+        DPRINTF(CCHI, "[%s] reflected snoop %s %#llx -> %s (responds: %d)\n",
+                name(), invalidating ? "inval" : "shared", linePA,
+                port->name(), pkt->cacheResponding());
+
+        // The L1 only borrows the snoop packet synchronously (a deferred
+        // MSHR snoop is replayed from an internal copy, see mshr.cc), and
+        // any snoop response is a fresh packet owned and deleted by us
+        delete pkt;
+
+        ++stats.snoopReflected;
+    }
+
+    return willRespond;
+}
+
+int
+CCHIL1Agent::reflectLocalSnoop(PacketPtr pkt, PortID portId)
+{
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+    // Write-class (ownership) requests invalidate sibling copies, reads
+    // just ask for the freshest data - mirroring the home's
+    // SnpToInvalid/SnpToShared and the L1's handleSnoop semantics
+    const MemCmd cmd = pkt->needsWritable() ? MemCmd::ReadExReq
+                                            : MemCmd::ReadSharedReq;
+
+    int willRespond = 0;
+
+    for (size_t i = 0; i < cpuSidePorts.size(); ++i) {
+        auto &port = cpuSidePorts[i];
+        if (static_cast<PortID>(i) == portId || !port->isSnooping())
+            continue;
+
+        RequestPtr req = std::make_shared<Request>(linePA, 64,
+                                                   Request::PHYSICAL,
+                                                   Request::funcRequestorId);
+        PacketPtr snp = new Packet(req, cmd);
+        snp->allocate();
+
+        port->sendTimingSnoopReq(snp);
+        if (snp->cacheResponding())
+            ++willRespond;
+
+        DPRINTF(CCHI, "[%s] local snoop %s %#llx -> %s (responds: %d)\n",
+                name(), pkt->needsWritable() ? "inval" : "shared", linePA,
+                port->name(), snp->cacheResponding());
+
+        // Borrowed synchronously by the L1; any response is a fresh
+        // packet owned and deleted by us (same contract as the home flow)
+        delete snp;
+    }
+
+    return willRespond;
+}
+
+void
+CCHIL1Agent::mergeSnoopData(PacketPtr pkt, Addr linePA)
+{
+    auto line = taurus()->GetCacheLine(linePA);
+    if (!line) {
+        DPRINTF(CCHI, "[%s] snoop data for %#llx dropped (line gone)\n",
+                name(), linePA);
+        return;
+    }
+
+    std::array<uint64_t, 8> buf;
+    std::memcpy(buf.data(), pkt->getConstPtr<uint8_t>(), 64);
+    if (line->Store(std::span<const uint64_t, 8>(buf))) {
+        ++stats.snoopMerged;
+    } else {
+        // The line should be Unique here (an L1-dirty line implies node
+        // ownership); a rejected store means the content already matches
+        // (e.g. an O-state repeat snoop) - bounded staleness, counted
+        ++stats.snoopMergeStoreFailed;
+        warn("%s: snoop merge store rejected for %#llx\n", name(), linePA);
+    }
+}
+
+void
+CCHIL1Agent::processHomeSnoop(const FlitSNP &flit)
+{
+    // SNP Addr carries PA >> 3 (bits [2:0] are implicit zeros)
+    const Addr linePA = uint64_t(flit.Addr) << 3;
+
+    panic_if(merge.has_value(),
+             "%s: overlapping snoop merges (%#llx in flight, %#llx new)\n",
+             name(), merge->linePA, linePA);
+
+    const int willRespond =
+        reflectSnoopToL1(linePA, static_cast<uint64_t>(flit.Opcode));
+
+    if (willRespond == 0) {
+        // Nothing to merge: release the held flit right away (the fabric
+        // gate can then push it into Taurus in the same pump cycle)
+        fabric->releaseSnoop(upstreamIndex);
+    } else if (pending.count(linePA) && !pending.at(linePA).grantedHit) {
+        // Cross-transaction case: our own bridge transaction for this
+        // line is in flight at the home BEHIND this snoop's transaction
+        // (per-line serialization at the home), and the L1 deferred the
+        // snoop into the matching MSHR - its response therefore waits on
+        // OUR transaction, which waits on THIS snoop. Holding the gate
+        // would deadlock (the timeout valve would then trade the deadlock
+        // for silent staleness). The Taurus copy is as fresh as the
+        // L1's here: dirty L1 data only ever exists after a completed
+        // bridge transaction, and anything earlier was merged into (or
+        // written back through) the node already. So let the home be
+        // answered from the Taurus line right away and merge the L1's
+        // response when it eventually arrives (best effort; identical
+        // content in the cases above).
+        ++stats.snoopLateMerges;
+        lateMergeLines.insert(linePA);
+        fabric->releaseSnoop(upstreamIndex);
+    } else {
+        // No pending entry, or the pending entry is a LOCAL hit
+        // (grantedHit: IsNow at issue, so nothing is in flight at the
+        // home). The freshness premise above is false for a local hit:
+        // its dirty data lives only in the L1 until the completion merges
+        // it into the node line, so an immediate answer would go out
+        // clean and silently lose it (observed with the XSCache L2, which
+        // back-invalidates in the same cycle as a store grant: the answer
+        // went out SnpResp_I and the store's data was lost). A hit
+        // completes locally in hit_latency without home involvement, so
+        // holding the gate here cannot deadlock.
+        merge = MergeState{linePA, willRespond, curCycle()};
+    }
+}
+
+void
+CCHIL1Agent::handleSnoopFromHome(const FlitSNP &flit)
+{
+    // SNP Addr carries PA >> 3 (bits [2:0] are implicit zeros)
+    const Addr linePA = uint64_t(flit.Addr) << 3;
+
+    if (localSnoops.count(linePA)) {
+        // A local snoop for this line is in flight: the L1s owe their
+        // responses to it first (FIFO response accounting at
+        // recvTimingSnoopResp). Hold the gate and run the home snoop
+        // once the local one completes (the local snoop finishes within
+        // a few L1 snoop latencies, never blocking the home for long).
+        panic_if(deferredHomeSnoop.has_value(),
+                 "%s: overlapping deferred home snoops (%#llx)\n",
+                 name(), linePA);
+        ++stats.homeSnoopDeferred;
+        DPRINTF(CCHI, "[%s] deferring home snoop for %#llx (local snoop "
+                "in flight)\n", name(), linePA);
+        deferredHomeSnoop = flit;
+        return;
+    }
+
+    processHomeSnoop(flit);
+}
+
+void
+CCHIL1Agent::recvTimingSnoopResp(PacketPtr pkt,
+                                 [[maybe_unused]] PortID portId)
+{
+    const Addr linePA = pkt->getAddr() & ~Addr(63);
+
+    auto lsIt = localSnoops.find(linePA);
+    if (lsIt != localSnoops.end()) {
+        // Response to a local (intra-node) snoop: merge any dirty sibling
+        // data into the node line before the parked request issues
+        if (pkt->isRead() && pkt->hasData()) {
+            ++stats.localSnoopMerged;
+            mergeSnoopData(pkt, linePA);
+        }
+
+        panic_if(lsIt->second.awaitingResponses <= 0,
+                 "%s: unexpected local snoop response for %#llx\n",
+                 name(), linePA);
+        if (--lsIt->second.awaitingResponses == 0) {
+            // All siblings answered: the node line is now the freshest
+            // local copy; issue the parked request. A denial (Taurus
+            // busy) re-parks it for the tick hook's dispatch pass.
+            PacketPtr parked = lsIt->second.pkt;
+            const PortID parkedPort = lsIt->second.portId;
+            localSnoops.erase(lsIt);
+            DPRINTF(CCHI, "[%s] local snoop for %#llx complete, "
+                    "dispatching\n", name(), linePA);
+            if (!dispatchCchiRequest(parked, parkedPort)) {
+                localSnoops.emplace(
+                    linePA, LocalSnoop{parked, parkedPort, 0, curCycle()});
+            }
+
+            // A home snoop deferred behind this local one can now run
+            if (deferredHomeSnoop) {
+                const FlitSNP flit = *deferredHomeSnoop;
+                deferredHomeSnoop.reset();
+                processHomeSnoop(flit);
+            }
+        }
+    } else if (snoopMerge && lateMergeLines.count(linePA)) {
+        // Late response to a cross-transaction snoop (released early in
+        // handleSnoopFromHome): merge the L1's data into the Taurus line
+        // best-effort; by the invariant above the content matches, so a
+        // rejected/absent store is benign (counted, never fatal)
+        lateMergeLines.erase(linePA);
+        if (pkt->isRead() && pkt->hasData()) {
+            auto line = taurus()->GetCacheLine(linePA);
+            if (line) {
+                std::array<uint64_t, 8> buf;
+                std::memcpy(buf.data(), pkt->getConstPtr<uint8_t>(), 64);
+                if (line->Store(std::span<const uint64_t, 8>(buf)))
+                    ++stats.snoopLateMerged;
+                else
+                    ++stats.snoopLateMergeDropped;
+            } else {
+                ++stats.snoopLateMergeDropped;
+            }
+        }
+    } else if (snoopMerge && merge && merge->linePA == linePA) {
+        // Merge any dirty L1 data into the Taurus line BEFORE the home's
+        // snoop is answered (the fabric gate releases it when the last
+        // expected response arrives). The line can legitimately be gone
+        // here: an L1 writeback issued BEFORE the merge started already
+        // stored this data into the node line (handleWriteback stores,
+        // then DoEvicts), and the eviction's completion reaped the line
+        // while the L1's snoop response was still in flight - the EVT
+        // carried the same data home. The merge hazard rule blocks new
+        // L1 requests for the line for the merge's duration, so the
+        // response cannot be fresher: drop it, counted.
+        if (pkt->isRead() && pkt->hasData()) {
+            if (taurus()->GetCacheLine(linePA)) {
+                mergeSnoopData(pkt, linePA);
+            } else {
+                ++stats.snoopMergeLineGone;
+                DPRINTF(CCHI, "[%s] merge response for reaped line %#llx "
+                        "dropped (data already at the home)\n",
+                        name(), linePA);
+            }
+        }
+
+        panic_if(merge->awaitingResponses <= 0,
+                 "%s: unexpected snoop response for %#llx\n", name(), linePA);
+        if (--merge->awaitingResponses == 0) {
+            fabric->releaseSnoop(upstreamIndex);
+            merge.reset();
+        }
+    } else {
+        // snoop_merge=off (or stale response): the L1's data-supplying
+        // snoop response is sunk here - never merged, never awaited
+        ++stats.snoopRespDropped;
+    }
+
+    // The snoop response packet was created by the L1 for us; we own it
+    delete pkt;
+}
+
+// ---------------------------------------------------------------------------
+// Atomic / functional paths (boot, fast-forward, debugger)
+// ---------------------------------------------------------------------------
+
+Tick
+CCHIL1Agent::recvAtomic(PacketPtr pkt, [[maybe_unused]] PortID portId)
+{
+    const Addr addr = pkt->getAddr();
+
+    // Phase 1 assumption: atomic traffic (boot, fast-forward) does not
+    // overlap in-flight CCHI transactions on the same lines, so serving
+    // the resident Taurus line here cannot race the endpoint
+    if (!pkt->req->isUncacheable() && fabric->isCacheable(addr)) {
+        auto line = taurus()->GetCacheLine(addr);
+        if (line) {
+            if (pkt->isRead()) {
+                if (fillFromLine(pkt, *line)) {
+                    pkt->makeAtomicResponse();
+                    return 0;
+                }
+                // Line not readable: fall through to the bypass read
+            } else if (pkt->isWrite()) {
+                // Keep the resident line in sync with the writeback to
+                // memory below (best effort through the checked accessor)
+                storeToLine(pkt, *line);
+            }
+        }
+    }
+
+    ++stats.atomicBypasses;
+    return memSidePort.sendAtomic(pkt);
+}
+
+void
+CCHIL1Agent::recvFunctional(PacketPtr pkt, [[maybe_unused]] PortID portId)
+{
+    // Same assumptions as recvAtomic; functional writes also update a
+    // resident Taurus line so later checked loads stay consistent
+    if (!pkt->req->isUncacheable() && fabric->isCacheable(pkt->getAddr()) &&
+        pkt->isWrite()) {
+        auto line = taurus()->GetCacheLine(pkt->getAddr());
+        if (line)
+            storeToLine(pkt, *line);
+    }
+
+    ++stats.functionalBypasses;
+    memSidePort.sendFunctional(pkt);
+}
+
+void
+CCHIL1Agent::recvBypassResp(PacketPtr pkt)
+{
+    auto *state = dynamic_cast<BypassSenderState *>(pkt->popSenderState());
+    panic_if(!state, "%s: bypass response without sender state\n", name());
+
+    const PortID portId = state->portId;
+    delete state;
+
+    const Tick receiveDelay = pkt->headerDelay + pkt->payloadDelay;
+    pkt->headerDelay = pkt->payloadDelay = 0;
+    cpuSidePorts[portId]->schedTimingResp(pkt, curTick() + receiveDelay);
+}
+
+AddrRangeList
+CCHIL1Agent::getAddrRanges() const
+{
+    return fabric->getAddrRanges();
+}
+
+// ---------------------------------------------------------------------------
+// Port plumbing
+// ---------------------------------------------------------------------------
+
+bool
+CCHIL1Agent::AgentResponsePort::recvTimingReq(PacketPtr pkt)
+{
+    return parent.recvTimingReq(pkt, id);
+}
+
+bool
+CCHIL1Agent::AgentResponsePort::recvTimingSnoopResp(PacketPtr pkt)
+{
+    parent.recvTimingSnoopResp(pkt, id);
+    return true;
+}
+
+Tick
+CCHIL1Agent::AgentResponsePort::recvAtomic(PacketPtr pkt)
+{
+    return parent.recvAtomic(pkt, id);
+}
+
+void
+CCHIL1Agent::AgentResponsePort::recvFunctional(PacketPtr pkt)
+{
+    parent.recvFunctional(pkt, id);
+}
+
+AddrRangeList
+CCHIL1Agent::AgentResponsePort::getAddrRanges() const
+{
+    return parent.getAddrRanges();
+}
+
+CCHIL1Agent::BypassRequestPort::BypassRequestPort(const std::string &_name,
+                                                  CCHIL1Agent &_parent)
+    : QueuedRequestPort(_name, &_parent, _parent.reqQueue,
+                        _parent.snoopRespQueue),
+      parent(_parent)
+{
+}
+
+bool
+CCHIL1Agent::BypassRequestPort::recvTimingResp(PacketPtr pkt)
+{
+    parent.recvBypassResp(pkt);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Taurus-backed CacheAccessor for the hosted L2 prefetch engine
+// ---------------------------------------------------------------------------
+
+bool
+CCHIL1Agent::TaurusCacheAccessor::inCache(Addr addr, bool) const
+{
+    auto *node = agent->taurus();
+    return node->IsValid(addr) &&
+           node->GetState(addr) != TaurusState::Invalid;
+}
+
+bool
+CCHIL1Agent::TaurusCacheAccessor::inMissQueue(Addr addr, bool) const
+{
+    return agent->pending.count(addr & ~Addr(63)) != 0;
+}
+
+const uint8_t *
+CCHIL1Agent::TaurusCacheAccessor::findBlock(Addr addr, bool) const
+{
+    auto *node = agent->taurus();
+    if (!node->IsValid(addr) || node->GetState(addr) == TaurusState::Invalid)
+        return nullptr;
+
+    auto line = node->GetCacheLine(addr);
+    if (!line)
+        return nullptr;
+
+    // Raw unchecked view (no Invalid/fill guards): consumers use it
+    // transiently, synchronously, and the line cannot be reaped mid-call
+    // (the simulation is single-threaded)
+    const auto data = line->GetData();
+    return reinterpret_cast<const uint8_t *>(data.data());
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+CCHIL1Agent::CCHIL1AgentStats::CCHIL1AgentStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(reqHits, statistics::units::Count::get(),
+               "Requests granted immediately (Taurus hits)"),
+      ADD_STAT(reqMisses, statistics::units::Count::get(),
+               "Requests going to the CCHI fabric"),
+      ADD_STAT(reads, statistics::units::Count::get(),
+               "ReadReq/LoadLockedReq mapped to DoLoad"),
+      ADD_STAT(readExes, statistics::units::Count::get(),
+               "ReadExReq mapped to DoStore (fill + ownership)"),
+      ADD_STAT(upgrades, statistics::units::Count::get(),
+               "Upgrade/SCUpgrade/StoreCond mapped to DoStore (S->U)"),
+      ADD_STAT(writes, statistics::units::Count::get(),
+               "WriteReq/WriteLineReq mapped to DoStore/DoStoreLine"),
+      ADD_STAT(hardPrefetches, statistics::units::Count::get(),
+               "L1 prefetch requests filled via DoLoad"),
+      ADD_STAT(rmwReads, statistics::units::Count::get(),
+               "LockedRMWReadReq mapped to DoStore + pin"),
+      ADD_STAT(rmwWrites, statistics::units::Count::get(),
+               "LockedRMWWriteReq (store + unpin)"),
+      ADD_STAT(writebacks, statistics::units::Count::get(),
+               "Dirty writebacks committed to Taurus + async DoEvict"),
+      ADD_STAT(cleanEvicts, statistics::units::Count::get(),
+               "Clean evictions answered + async DoEvict"),
+      ADD_STAT(writeCleans, statistics::units::Count::get(),
+               "WriteClean stores committed to Taurus (no eviction)"),
+      ADD_STAT(fences, statistics::units::Count::get(),
+               "Fence/sync requests drained and answered"),
+      ADD_STAT(cmos, statistics::units::Count::get(),
+               "Cache-maintenance requests mapped to DoCBO*"),
+      ADD_STAT(deniedReqLimit, statistics::units::Count::get(),
+               "Taurus REQ_LIMIT_EXCEEDED backpressure events"),
+      ADD_STAT(deniedTotalLimit, statistics::units::Count::get(),
+               "Taurus TOTAL_LIMIT_EXCEEDED (TxnID space) backpressure"),
+      ADD_STAT(deniedPABusy, statistics::units::Count::get(),
+               "Taurus PA_REQ_BUSY denials (same-line REQ in flight)"),
+      ADD_STAT(deniedCMOLimit, statistics::units::Count::get(),
+               "Taurus CMO_LIMIT_EXCEEDED backpressure events"),
+      ADD_STAT(blockedSameLine, statistics::units::Count::get(),
+               "Requests backpressured by same-line pending bridge "
+               "transactions (retried by the L1 after drain)"),
+      ADD_STAT(storeEscalations, statistics::units::Count::get(),
+               "Ownership re-acquisitions after bounded store retries"),
+      ADD_STAT(lateGrants, statistics::units::Count::get(),
+               "Grant/CMO completions arriving for already-drained lines"),
+      ADD_STAT(completionRetries, statistics::units::Count::get(),
+               "Completions retried because the line was not readable yet"),
+      ADD_STAT(evictions, statistics::units::Count::get(),
+               "DoEvict issued towards the fabric"),
+      ADD_STAT(evictRetries, statistics::units::Count::get(),
+               "Denied DoEvict calls parked for retry"),
+      ADD_STAT(evictMisses, statistics::units::Count::get(),
+               "DoEvict on already-gone lines (benign)"),
+      ADD_STAT(evictForRefetch, statistics::units::Count::get(),
+               "Shared lines evicted so the store refetches with data"),
+      ADD_STAT(evictForRefetchDenied, statistics::units::Count::get(),
+               "Evict-for-refetch denials (store retried later)"),
+      ADD_STAT(evictCancelled, statistics::units::Count::get(),
+               "Stale queued evictions cancelled on re-acquisition"),
+      ADD_STAT(writebacksDropped, statistics::units::Count::get(),
+               "Writebacks dropped for non-resident lines (data already "
+               "at the home)"),
+      ADD_STAT(bypassReqs, statistics::units::Count::get(),
+               "Requests bypassed to the gem5 memory system (no CCHI)"),
+      ADD_STAT(atomicBypasses, statistics::units::Count::get(),
+               "Atomic accesses forwarded to the bypass port"),
+      ADD_STAT(functionalBypasses, statistics::units::Count::get(),
+               "Functional accesses forwarded to the bypass port"),
+      ADD_STAT(snoopReflected, statistics::units::Count::get(),
+               "Home snoops reflected into the L1s"),
+      ADD_STAT(snoopRespDropped, statistics::units::Count::get(),
+               "L1 snoop responses sunk (snoop_merge=off)"),
+      ADD_STAT(snoopMerged, statistics::units::Count::get(),
+               "L1 dirty snoop data merged into the Taurus line"),
+      ADD_STAT(snoopMergeLineGone, statistics::units::Count::get(),
+               "Merge responses for a line reaped by an in-flight "
+               "eviction (data already at the home)"),
+      ADD_STAT(storeFlightBackoff, statistics::units::Count::get(),
+               "Store issue backed off (snoop/eviction in flight on the "
+               "line)"),
+      ADD_STAT(snoopMergeStoreFailed, statistics::units::Count::get(),
+               "Snoop merge stores rejected by the checked accessor"),
+      ADD_STAT(snoopMergeTimeouts, statistics::units::Count::get(),
+               "Snoop merges force-released by the timeout safety valve"),
+      ADD_STAT(snoopLateMerges, statistics::units::Count::get(),
+               "Cross-transaction snoops released early (late-merge path)"),
+      ADD_STAT(snoopLateMerged, statistics::units::Count::get(),
+               "Late snoop responses merged into the Taurus line"),
+      ADD_STAT(snoopLateMergeDropped, statistics::units::Count::get(),
+               "Late snoop response data dropped (benign, line moved on)"),
+      ADD_STAT(localSnoopIssued, statistics::units::Count::get(),
+               "Intra-node snoops issued to sibling L1s"),
+      ADD_STAT(localSnoopMerged, statistics::units::Count::get(),
+               "Data-carrying responses to intra-node snoops"),
+      ADD_STAT(homeSnoopDeferred, statistics::units::Count::get(),
+               "Home snoops deferred behind an in-flight local snoop"),
+      ADD_STAT(mergeBlockedReqs, statistics::units::Count::get(),
+               "L1 requests blocked by an in-flight snoop merge"),
+      ADD_STAT(pfStashIssued, statistics::units::Count::get(),
+               "Hosted-prefetcher emissions stashed via DoPrefetch*"),
+      ADD_STAT(pfStashDropped, statistics::units::Count::get(),
+               "Prefetch stash emissions dropped (queue limits)"),
+      ADD_STAT(pfStoreTrains, statistics::units::Count::get(),
+               "StorePFTrain hints forwarded to the hosted prefetcher")
+{
+}
+
+} // namespace gem5

--- a/src/mem/cchi/cchi_l1_agent.hh
+++ b/src/mem/cchi/cchi_l1_agent.hh
@@ -1,0 +1,506 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * CCHIL1Agent: per-core bridge between a gem5 classic L1 cache hierarchy
+ * (L1I + L1D + MMU walkers, untouched) and one CCHI Taurus UpstreamNode
+ * owned by the CCHIFabric. See the approved plan's "Bridge semantics"
+ * section; the mapping is:
+ *
+ *   ReadReq            -> DoLoad, fill via CacheLine::Load* on grant
+ *   ReadExReq          -> DoStore (fill + ownership), same readback
+ *   UpgradeReq/SCUpgradeReq (and StoreCondReq) -> DoStore (S->U upgrade)
+ *   WriteReq/WriteLineReq -> DoStore/DoStoreLine + CacheLine::Store*
+ *   HardPFReq          -> DoLoad fill, always respond
+ *   LockedRMWReadReq   -> DoStore + pin the line
+ *   LockedRMWWriteReq  -> CacheLine::Store(span) + unpin
+ *   WritebackDirty     -> CacheLine::Store(span) + respond + async DoEvict
+ *   WritebackClean/CleanEvict -> respond + async DoEvict
+ *   WriteClean         -> CacheLine::Store(span) + respond (no eviction)
+ *   MemFenceReq/MemSyncReq -> drain agent futures, then respond
+ *   CleanSharedReq     -> DoCBOClean, CleanInvalidReq -> DoCBOInval
+ *   uncacheable/MMIO/out-of-window -> mem_side bypass port (no CCHI)
+ *
+ * All data movement goes through the Taurus CacheLine checked accessors
+ * (the Load and Store families) - never through the raw members.
+ *
+ * Futures: Do* calls return FutureNow handles; the bridge always Bind()s a
+ * lambda that only posts the line address to the agent's completion queue
+ * (now-futures run the lambda synchronously, pending futures run it inside
+ * the fabric's Instance::Tick). The fabric's per-cycle tick hook then
+ * turns completions into gem5 responses via the queued cpu_side ports.
+ *
+ * Snoops are home-originated only: with snoop_merge=off (default) the
+ * fabric's OnAcceptedSNP hook calls reflectSnoopToL1() and Taurus answers
+ * the home itself; the L1's data-supplying snoop response is sunk (drop +
+ * delete + stat). With snoop_merge=on the fabric's SNP gate intercepts the
+ * flit first, calls handleSnoopFromHome(), and only after the merge
+ * completes releases it for PushRXSNP.
+ */
+
+#ifndef __MEM_CCHI_CCHI_L1_AGENT_HH__
+#define __MEM_CCHI_CCHI_L1_AGENT_HH__
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "base/addr_range.hh"
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "mem/cache/cache_probe_arg.hh"
+#include "mem/packet.hh"
+#include "sim/probe/probe.hh"
+#include "mem/packet_queue.hh"
+#include "mem/qport.hh"
+#include "mem/request.hh"
+#include "params/CCHIL1Agent.hh"
+#include "sim/clocked_object.hh"
+
+// CHIron (read-only; resolved via -I$(CHIRON_DIR)/cchi)
+#include "cohestra/cohestra_interface.hpp"
+#include "icn/taurus/cchi_taurus_component.hpp"
+
+#include "mem/cchi/cchi_fabric.hh"
+
+namespace gem5
+{
+
+namespace prefetch { class Base; }
+
+class CCHIL1Agent : public ClockedObject
+{
+  public:
+    using TaurusNode = CCHIFabric::TaurusNode;
+    using TaurusCacheLine = TaurusNode::CacheLine;
+    using FlitSNP = CCHIFabric::FlitSNP;
+    using DenialEnum = CCHI::Taurus::DenialEnum;
+
+    CCHIL1Agent(const CCHIL1AgentParams &params);
+
+    void init() override;
+
+    Port &getPort(const std::string &if_name,
+                  PortID idx = InvalidPortID) override;
+
+    // --- fabric-facing interface -------------------------------------
+
+    /** Per-cycle hook, called by the fabric after Instance::Tick. */
+    void tickHook();
+
+    /**
+     * Home-snoop entry point for the snoop_merge=on gate flow: reflect
+     * the flit into the L1s and start (or synchronously finish) the
+     * merge. The fabric releases the held flit once no L1 snoop response
+     * is outstanding.
+     */
+    void handleSnoopFromHome(const FlitSNP &flit);
+
+    /**
+     * Reflect a home-originated snoop into every snooping cpu_side port
+     * (1:1 transliteration; the bridge never originates snoops itself).
+     * SnpToInvalid/SnpMakeInvalid map to ReadExReq (invalidate),
+     * SnpToShared/SnpToClean to ReadSharedReq.
+     * Returns the number of ports that committed to a data response.
+     */
+    int reflectSnoopToL1(Addr linePA, uint64_t snpOpcode);
+
+    bool getSnoopMerge() const { return snoopMerge; }
+    uint32_t getNodeId() const { return nodeId; }
+    uint32_t getXactionLimitREQ() const { return xactionLimitREQ; }
+    uint32_t getXactionLimitEVT() const { return xactionLimitEVT; }
+    uint32_t getXactionLimitSNP() const { return xactionLimitSNP; }
+
+    void setUpstreamIndex(size_t index) { upstreamIndex = index; }
+
+  protected: // Port interface
+    class AgentResponsePort : public QueuedResponsePort
+    {
+      public:
+        AgentResponsePort(const std::string &_name, CCHIL1Agent &_parent,
+                          PortID _id)
+            : QueuedResponsePort(_name, &_parent, queue, _id),
+              queue(_parent, *this, false, _name + ".queue"),
+              parent(_parent)
+        { }
+
+      protected:
+        bool recvTimingReq(PacketPtr pkt) override;
+        bool recvTimingSnoopResp(PacketPtr pkt) override;
+        Tick recvAtomic(PacketPtr pkt) override;
+        void recvFunctional(PacketPtr pkt) override;
+
+        AddrRangeList getAddrRanges() const override;
+        bool tryTiming(PacketPtr) override { return true; }
+
+      private:
+        // Own response queue, constructed right after the base stores its
+        // reference (the gem5 CacheResponsePort idiom)
+        RespPacketQueue queue;
+        CCHIL1Agent &parent;
+    };
+
+    class BypassRequestPort : public QueuedRequestPort
+    {
+      public:
+        BypassRequestPort(const std::string &_name, CCHIL1Agent &_parent);
+
+      protected:
+        bool recvTimingResp(PacketPtr pkt) override;
+
+      private:
+        CCHIL1Agent &parent;
+    };
+
+    // cpu_side vector (grown on demand by getPort); each port owns one
+    // response queue so that responses return on the port the request
+    // arrived on
+    std::vector<std::unique_ptr<AgentResponsePort>> cpuSidePorts;
+
+    BypassRequestPort memSidePort;
+    ReqPacketQueue reqQueue;
+    SnoopRespPacketQueue snoopRespQueue;
+
+  protected: // Packet handlers (called from the ports)
+    bool recvTimingReq(PacketPtr pkt, PortID portId);
+    void recvTimingSnoopResp(PacketPtr pkt, PortID portId);
+    Tick recvAtomic(PacketPtr pkt, PortID portId);
+    void recvFunctional(PacketPtr pkt, PortID portId);
+    void recvBypassResp(PacketPtr pkt);
+    AddrRangeList getAddrRanges() const;
+
+  protected: // Pending-transaction types (declared before use below)
+    enum XactAction : uint8_t {
+        ACT_READ = 0,   // ReadReq / LoadLockedReq: DoLoad + fill
+        ACT_READ_EX,    // ReadExReq: DoStore + fill (ownership)
+        ACT_UPGRADE,    // UpgradeReq/SCUpgradeReq/StoreCondReq: DoStore
+        ACT_WRITE,      // WriteReq/WriteLineReq: DoStore(/Line) + Store*
+        ACT_HARD_PF,    // HardPFReq: DoLoad + fill, always respond
+        ACT_RMW_READ,   // LockedRMWReadReq: DoStore + pin
+        ACT_RMW_WRITE,  // LockedRMWWriteReq: Store* + unpin
+        ACT_WRITEBACK,  // WritebackDirty (deferred store path)
+        ACT_WRITE_CLEAN,// WriteClean (deferred store path)
+        ACT_CMO,        // CleanShared/CleanInvalid: DoCBO*
+        ACT_INV_WRITE,  // InvalidateReq (XS fast-writeline): ownership only
+        ACT_SWAP        // SwapReq (AMO): RMW on the granted line
+    };
+
+    struct PendingXaction {
+        Addr linePA;
+        PacketPtr pkt;
+        PortID portId;
+        XactAction action;
+        bool grantedHit;                // FutureNow was IsNow() at issue
+        Tick grantedTick;               // set when the future fires
+        std::shared_ptr<TaurusCacheLine> line;  // set when the future fires
+        // Grant-time fill snapshot for read actions: the granted line can
+        // be invalidated (and reaped) by a racing home snoop before the
+        // completion drains, making a later Load() fail forever. The data
+        // as-of the grant is exactly what the home sent and what the L1
+        // must fill with, so capture it while the line is guaranteed
+        // consistent (the grant just completed).
+        std::optional<std::array<uint64_t, 8>> fillData = std::nullopt;
+        unsigned retries = 0;           // completion retry counter
+    };
+
+    // After this many failed store attempts on a granted line, ownership
+    // is re-acquired (DoStore) instead of retrying forever. Kept small:
+    // a failed checked store means the line is not (or no longer)
+    // Unique, which only an ownership upgrade can fix - spinning longer
+    // just stalls the completion for no benefit (the tick hook and the
+    // escalation rejection path keep this bounded and livelock-free).
+    static constexpr unsigned STORE_RETRY_ESCALATE = 4;
+
+  protected: // Bridge semantics
+    /** MemCmd -> Taurus Do* mapping for cacheable, in-window requests. */
+    bool handleCchiRequest(PacketPtr pkt, PortID portId);
+
+    bool issueLoad(PacketPtr pkt, PortID portId, XactAction action);
+    bool issueStore(PacketPtr pkt, PortID portId, XactAction action,
+                    bool wholeLine);
+    bool issueCMO(PacketPtr pkt, PortID portId, bool invalidate);
+    bool handleRMWWrite(PacketPtr pkt, PortID portId);
+    bool handleWriteback(PacketPtr pkt, PortID portId, bool dirty);
+    bool handleWriteClean(PacketPtr pkt, PortID portId);
+    bool handleFence(PacketPtr pkt, PortID portId);
+
+    /** Backpressure for a denied Do* call: block + retry next fabric tick. */
+    bool handleDenial(DenialEnum denial, PortID portId);
+
+    /**
+     * Intra-node (local) snoop: with several L1s fanning into one Taurus
+     * node (L1I/L1D/walker caches), a sibling's dirty data is invisible
+     * to home-level coherence, so a reader from another port could fill
+     * the node's stale copy (observed: PTW walker reading a PTE page that
+     * was dirty in the L1D -> spurious fetch fault). Before a data or
+     * ownership request on a node-resident line, snoop the other fan-in
+     * L1s (share for reads, invalidate for write-class), merge any dirty
+     * data into the node line, then issue the original request.
+     */
+    int reflectLocalSnoop(PacketPtr pkt, PortID portId);
+    /** Merge a data-carrying snoop response into the node line. */
+    void mergeSnoopData(PacketPtr pkt, Addr linePA);
+    /** Command dispatch after admission/local-snoop completion. */
+    bool dispatchCchiRequest(PacketPtr pkt, PortID portId);
+    /** The home-snoop flow, split so it can be deferred by a local snoop. */
+    void processHomeSnoop(const FlitSNP &flit);
+
+    /** FutureNow completion: only posts to the completion queue. */
+    void onGrantFired(Addr linePA,
+                      const TaurusNode::GrantedEvent &ev);
+    void onCMOFired(Addr linePA,
+                    const TaurusNode::CMOCompleteEvent &ev);
+
+    /** Turn a posted completion into a response; false = data not ready. */
+    bool processCompletion(PendingXaction &entry);
+
+    /** Checked data movement through the Taurus CacheLine accessors. */
+    bool fillFromLine(PacketPtr pkt, TaurusCacheLine &line);
+    /** Fill the packet from the grant-time snapshot when present (racing
+     *  home snoops can invalidate the granted line before the completion
+     *  drains); falls back to the live line otherwise. */
+    bool fillFromEntry(PendingXaction &entry);
+    bool storeToLine(PacketPtr pkt, TaurusCacheLine &line);
+    /** AMO read-modify-write on the granted line (returns old value). */
+    bool performAtomicOp(PacketPtr pkt, TaurusCacheLine &line);
+
+    /** A line store/RMW attempt under the checked accessors. */
+    using StoreOp = std::function<bool(PacketPtr, TaurusCacheLine &)>;
+    /** Bounded retry + ownership re-acquisition for a StoreOp. */
+    bool storeWithEscalation(PendingXaction &entry, const StoreOp &op);
+    bool storeWithEscalation(PendingXaction &entry)
+    {
+        return storeWithEscalation(
+            entry, [this](PacketPtr pkt, TaurusCacheLine &line) {
+                return storeToLine(pkt, line);
+            });
+    }
+
+    void respondTo(PacketPtr pkt, PortID portId, Tick when);
+    void issueEvict(Addr linePA);
+    void drainPrefetcher();
+
+    /** Lazy Taurus node lookup (built by the fabric after init()). */
+    TaurusNode *taurus();
+
+  protected: // Pending-transaction bookkeeping
+    std::unordered_map<Addr, PendingXaction> pending;
+    std::deque<Addr> completionQueue;
+
+    // Parked fence/sync requests, answered once the agent has drained
+    std::deque<std::pair<PacketPtr, PortID>> fenceQueue;
+
+    // cpu_side ports that saw a false from recvTimingReq and need a retry
+    std::set<PortID> blockedPorts;
+
+    // Evictions whose DoEvict was denied; retried from the tick hook
+    std::deque<Addr> evictRetryQueue;
+
+    // Tick counter for the debug heartbeat dump in tickHook
+    uint64_t heartbeat = 0;
+
+    // Lines pinned by an in-flight LockedRMW pair (never evicted by the
+    // bridge; SNP hold for pinned lines is subsumed by the merge flow -
+    // see the merge state below)
+    std::unordered_set<Addr> pinnedLines;
+
+    // snoop_merge state: at most one merge in flight per agent (the
+    // fabric's SNP gate withholds the port's SNP channel head-of-line)
+    struct MergeState {
+        Addr linePA;
+        int awaitingResponses;
+        Cycles startCycle;
+    };
+    std::optional<MergeState> merge;
+
+    // Local (intra-node) snoop state: one parked request per line, waiting
+    // for the sibling L1s' snoop responses before its Do* may issue.
+    struct LocalSnoop {
+        PacketPtr pkt;
+        PortID portId;
+        int awaitingResponses;
+        Cycles startCycle;
+    };
+    std::unordered_map<Addr, LocalSnoop> localSnoops;
+
+    // A home snoop that arrived while a local snoop for the same line was
+    // in flight: the gate stays held (not released) until the local snoop
+    // completes, then this deferred flit goes through processHomeSnoop.
+    std::optional<FlitSNP> deferredHomeSnoop;
+
+    // Cross-transaction snoops released early (our own bridge transaction
+    // for the same line was in flight at the home): the L1's deferred
+    // snoop response merges into the Taurus line when it eventually
+    // arrives (see handleSnoopFromHome / recvTimingSnoopResp)
+    std::unordered_set<Addr> lateMergeLines;
+
+    // Safety valve for the merge flow: if the L1 snoop response never
+    // arrives (e.g. a cross-transaction wait at the endpoint), release
+    // the held snoop anyway after this many cycles and accept bounded
+    // staleness (counted; see the plan's multicore risk note)
+    // TODO(cchi): revisit with the Phase 2 shared-line stress results
+    static constexpr uint64_t MERGE_TIMEOUT_CYCLES = 4096;
+
+  protected: // L2 prefetch engine hosting (wire-up only)
+    /**
+     * CacheAccessor backed by the Taurus node, letting the hosted L2
+     * prefetcher query "the L2" (which in CCHI mode is the Taurus node +
+     * endpoint, not a gem5 cache).
+     */
+    class TaurusCacheAccessor : public CacheAccessor
+    {
+      public:
+        explicit TaurusCacheAccessor(CCHIL1Agent *_agent) : agent(_agent) { }
+
+        bool inCache(Addr addr, bool is_secure) const override;
+        unsigned level() const override { return 2; }
+        bool hasBeenPrefetched(Addr, bool) const override
+        { return false; } // TODO(cchi): no prefetch-use tracking in Taurus
+        bool hasBeenPrefetched(Addr, bool, RequestorID) const override
+        { return false; } // TODO(cchi): as above
+        bool hasEverBeenPrefetched(Addr, bool) const override
+        { return false; } // TODO(cchi): as above
+        Request::XsMetadata getHitBlkXsMetadata(PacketPtr) override
+        { return Request::XsMetadata(); } // TODO(cchi): no per-block XS metadata
+        bool inMissQueue(Addr addr, bool is_secure) const override;
+        bool coalesce() const override { return false; }
+        const uint8_t *findBlock(Addr addr, bool is_secure) const override;
+
+      private:
+        CCHIL1Agent *agent;
+    };
+
+    TaurusCacheAccessor cacheAccessor;
+    prefetch::Base *prefetcher;
+
+    // Probe points feeding the hosted L2 prefetcher (created when a
+    // prefetcher is configured; fired by firePfProbe / fill completions)
+    ProbePointArg<PacketPtr> *ppMiss = nullptr;
+    ProbePointArg<PacketPtr> *ppHit = nullptr;
+    ProbePointArg<PacketPtr> *ppFill = nullptr;
+    ProbePointArg<PacketPtr> *ppStorePFTrain = nullptr;
+
+    /** Approximate-L2-lookup probe feed for the hosted prefetcher. */
+    void firePfProbe(PacketPtr pkt);
+
+  protected: // Params and node binding
+    CCHIFabric *fabric;
+    const uint32_t nodeId;
+    const Cycles hitLatency;
+    const bool snoopMerge;
+    const uint32_t xactionLimitREQ;
+    const uint32_t xactionLimitEVT;
+    const uint32_t xactionLimitSNP;
+
+    TaurusNode *node = nullptr;
+    size_t upstreamIndex = 0;
+
+  protected: // Bypass routing state
+    /** Remembers which cpu_side port a bypassed request arrived on. */
+    class BypassSenderState : public Packet::SenderState
+    {
+      public:
+        const PortID portId;
+        explicit BypassSenderState(PortID _portId) : portId(_portId) { }
+    };
+
+  public:
+    struct CCHIL1AgentStats : public statistics::Group
+    {
+        CCHIL1AgentStats(statistics::Group *parent);
+
+        statistics::Scalar reqHits;
+        statistics::Scalar reqMisses;
+        statistics::Scalar reads;
+        statistics::Scalar readExes;
+        statistics::Scalar upgrades;
+        statistics::Scalar writes;
+        statistics::Scalar hardPrefetches;
+        statistics::Scalar rmwReads;
+        statistics::Scalar rmwWrites;
+        statistics::Scalar writebacks;
+        statistics::Scalar cleanEvicts;
+        statistics::Scalar writeCleans;
+        statistics::Scalar fences;
+        statistics::Scalar cmos;
+        statistics::Scalar deniedReqLimit;
+        statistics::Scalar deniedTotalLimit;
+        statistics::Scalar deniedPABusy;
+        statistics::Scalar deniedCMOLimit;
+        statistics::Scalar blockedSameLine;
+        statistics::Scalar storeEscalations;
+        statistics::Scalar lateGrants;
+        statistics::Scalar completionRetries;
+        statistics::Scalar evictions;
+        statistics::Scalar evictRetries;
+        statistics::Scalar evictMisses;
+        statistics::Scalar evictForRefetch;
+        statistics::Scalar evictForRefetchDenied;
+        statistics::Scalar evictCancelled;
+        statistics::Scalar writebacksDropped;
+        statistics::Scalar bypassReqs;
+        statistics::Scalar atomicBypasses;
+        statistics::Scalar functionalBypasses;
+        statistics::Scalar snoopReflected;
+        statistics::Scalar snoopRespDropped;
+        statistics::Scalar snoopMerged;
+        statistics::Scalar snoopMergeLineGone;
+        statistics::Scalar storeFlightBackoff;
+        statistics::Scalar snoopMergeStoreFailed;
+        statistics::Scalar snoopMergeTimeouts;
+        statistics::Scalar snoopLateMerges;
+        statistics::Scalar snoopLateMerged;
+        statistics::Scalar snoopLateMergeDropped;
+        statistics::Scalar localSnoopIssued;
+        statistics::Scalar localSnoopMerged;
+        statistics::Scalar homeSnoopDeferred;
+        statistics::Scalar mergeBlockedReqs;
+        statistics::Scalar pfStashIssued;
+        statistics::Scalar pfStashDropped;
+        statistics::Scalar pfStoreTrains;
+    } stats;
+};
+
+} // namespace gem5
+
+#endif // __MEM_CCHI_CCHI_L1_AGENT_HH__

--- a/src/mem/cchi/cchi_rtl_top.hh
+++ b/src/mem/cchi/cchi_rtl_top.hh
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026
+ *
+ * Alias for the verilated CCHI downstream top module. Only available when
+ * the build enables WITH_CCHI_RTL (see SConscript): CCHI_RTL_TOP_HEADER and
+ * CCHI_RTL_TOP_CLASS come from the build as -D defines and resolve to the
+ * generated model for the configured CCHI_RTL_TOP.
+ */
+
+#ifndef __MEM_CCHI_CCHI_RTL_TOP_HH__
+#define __MEM_CCHI_CCHI_RTL_TOP_HH__
+
+#ifdef CCHI_RTL_ENABLED
+
+// Generated per build variant by the SConscript: includes verilated.h and
+// the verilated top's header, and aliases it as gem5::CchiRtlModule
+#include "cchi_rtl_top_generated.hh"
+
+#endif // CCHI_RTL_ENABLED
+
+#endif // __MEM_CCHI_CCHI_RTL_TOP_HH__

--- a/src/mem/cchi/earth/earth_interface.cpp
+++ b/src/mem/cchi/earth/earth_interface.cpp
@@ -1,0 +1,121 @@
+// Vendored from CHIron: cchi/cohestra/cohestra_earth/earth_interface.cpp
+// gem5 adaptation: tracks upstream's two-phase tick rename (Tick ->
+// TickPreHandshake); otherwise unchanged apart from the vendored header
+// locations
+
+#include "earth_interface.hpp"
+
+
+// Implementation of: class EarthCCHIInterface
+namespace Cohestra {
+
+    EarthCCHIInterface::EarthCCHIInterface(size_t type1PortCount) noexcept
+        : model (type1PortCount)
+    { }
+
+    void EarthCCHIInterface::TickPreHandshake(uint64_t time) noexcept
+    {
+        model.Tick(time);
+    }
+
+    size_t EarthCCHIInterface::GetType1Count() const noexcept
+    {
+        return model.GetPortCount();
+    }
+
+    std::set<size_t> EarthCCHIInterface::GetType1Indices() const noexcept
+    {
+        std::set<size_t> indices;
+
+        for (size_t i = 0; i < model.GetPortCount(); ++i)
+            indices.insert(i);
+
+        return indices;
+    }
+
+    size_t EarthCCHIInterface::GetType1MaxIndex() const noexcept
+    {
+        return model.GetPortCount() ? model.GetPortCount() - 1 : 0;
+    }
+
+    bool EarthCCHIInterface::HasType1SNP(size_t index) const noexcept
+    {
+        return model.HasSNP(index);
+    }
+
+    std::optional<CCHI::Flits::SNP<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PeekType1SNP(size_t index) const noexcept
+    {
+        return model.PeekSNP(index);
+    }
+
+    std::optional<CCHI::Flits::SNP<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PopType1SNP(size_t index) noexcept
+    {
+        return model.PopSNP(index);
+    }
+
+    bool EarthCCHIInterface::HasType1DnRSP(size_t index) const noexcept
+    {
+        return model.HasDnRSP(index);
+    }
+
+    std::optional<CCHI::Flits::DnRSP<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PeekType1DnRSP(size_t index) const noexcept
+    {
+        return model.PeekDnRSP(index);
+    }
+
+    std::optional<CCHI::Flits::DnRSP<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PopType1DnRSP(size_t index) noexcept
+    {
+        return model.PopDnRSP(index);
+    }
+
+    bool EarthCCHIInterface::HasType1DnDAT(size_t index) const noexcept
+    {
+        return model.HasDnDAT(index);
+    }
+
+    std::optional<CCHI::Flits::DnDAT<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PeekType1DnDAT(size_t index) const noexcept
+    {
+        return model.PeekDnDAT(index);
+    }
+
+    std::optional<CCHI::Flits::DnDAT<CommonFlitConfigurationType1>>
+    EarthCCHIInterface::PopType1DnDAT(size_t index) noexcept
+    {
+        return model.PopDnDAT(index);
+    }
+
+    bool EarthCCHIInterface::PushType1EVT(size_t index, const CCHI::Flits::EVT<CommonFlitConfigurationType1>& flit) noexcept
+    {
+        return model.PushEVT(index, flit);
+    }
+
+    bool EarthCCHIInterface::PushType1REQ(size_t index, const CCHI::Flits::REQ<CommonFlitConfigurationType1>& flit) noexcept
+    {
+        return model.PushREQ(index, flit);
+    }
+
+    bool EarthCCHIInterface::PushType1UpRSP(size_t index, const CCHI::Flits::UpRSP<CommonFlitConfigurationType1>& flit) noexcept
+    {
+        return model.PushUpRSP(index, flit);
+    }
+
+    bool EarthCCHIInterface::PushType1UpDAT(size_t index, const CCHI::Flits::UpDAT<CommonFlitConfigurationType1>& flit) noexcept
+    {
+        return model.PushUpDAT(index, flit);
+    }
+
+    EarthModel& EarthCCHIInterface::GetModel() noexcept
+    {
+        return model;
+    }
+
+    const EarthModel& EarthCCHIInterface::GetModel() const noexcept
+    {
+        return model;
+    }
+}

--- a/src/mem/cchi/earth/earth_interface.hpp
+++ b/src/mem/cchi/earth/earth_interface.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+// Vendored from CHIron: cchi/cohestra/cohestra_earth/earth_interface.hpp
+// gem5 adaptation: CHIron includes retargeted (relative "../..." includes in
+// the original), expecting -I<CHIRON_DIR>/cchi to be provided at build time;
+// otherwise unchanged
+
+#include <cstddef>
+#include <optional>
+#include <set>
+
+#include "cohestra/cohestra_interface.hpp"
+
+#include "earth_model.hpp"
+
+
+namespace Cohestra {
+
+    // EarthCCHIInterface: a Cohestra::CCHIInterface implementation that
+    // connects the framework directly to a pure-C++ EarthModel as the
+    // downstream device, without any Verilated layer in between.
+    class EarthCCHIInterface : public CCHIInterface {
+    protected:
+        EarthModel          model;
+
+    public:
+        EarthCCHIInterface(size_t type1PortCount) noexcept;
+
+        virtual ~EarthCCHIInterface() noexcept = default;
+
+    public:
+        virtual void    TickPreHandshake(uint64_t time) noexcept override;
+
+    public:
+        virtual size_t  GetType1Count() const noexcept override;
+
+        virtual std::set<size_t>
+                        GetType1Indices() const noexcept override;
+
+        virtual size_t  GetType1MaxIndex() const noexcept override;
+
+        virtual bool    HasType1SNP(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::SNP<CommonFlitConfigurationType1>>
+                        PeekType1SNP(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::SNP<CommonFlitConfigurationType1>>
+                        PopType1SNP(size_t index) noexcept override;
+
+        virtual bool    HasType1DnRSP(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::DnRSP<CommonFlitConfigurationType1>>
+                        PeekType1DnRSP(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::DnRSP<CommonFlitConfigurationType1>>
+                        PopType1DnRSP(size_t index) noexcept override;
+
+        virtual bool    HasType1DnDAT(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::DnDAT<CommonFlitConfigurationType1>>
+                        PeekType1DnDAT(size_t index) const noexcept override;
+        virtual std::optional<CCHI::Flits::DnDAT<CommonFlitConfigurationType1>>
+                        PopType1DnDAT(size_t index) noexcept override;
+
+        virtual bool    PushType1EVT(size_t index, const CCHI::Flits::EVT<CommonFlitConfigurationType1>& flit) noexcept override;
+
+        virtual bool    PushType1REQ(size_t index, const CCHI::Flits::REQ<CommonFlitConfigurationType1>& flit) noexcept override;
+
+        virtual bool    PushType1UpRSP(size_t index, const CCHI::Flits::UpRSP<CommonFlitConfigurationType1>& flit) noexcept override;
+
+        virtual bool    PushType1UpDAT(size_t index, const CCHI::Flits::UpDAT<CommonFlitConfigurationType1>& flit) noexcept override;
+
+    public:
+        EarthModel&         GetModel() noexcept;
+        const EarthModel&   GetModel() const noexcept;
+    };
+}

--- a/src/mem/cchi/earth/earth_model.cpp
+++ b/src/mem/cchi/earth/earth_model.cpp
@@ -1,0 +1,1829 @@
+// Vendored from CHIron: cchi/cohestra/cohestra_earth/earth_model.cpp
+//
+// gem5 adaptations (each also marked "gem5 adaptation:" at the site):
+//  - line data accesses go through the MemoryBackend hook (see earth_model.hpp)
+//    instead of the old internal sparse 'memory' map
+//  - the SimpleIni/ConfigurationEntry machinery (CONFIG_EARTH_* entries and
+//    LoadConfiguration) is replaced by plain setters with identical defaults
+//  - spdlog is replaced by the EARTH_* logging shim below; all format strings
+//    are printf-style now
+
+#include "earth_model.hpp"
+
+#include <string>   // gem5 adaptation: std::to_string (was pulled in via spdlog)
+
+
+// ---------------------------------------------------------------------------
+// gem5 adaptation: logging shim (replaces spdlog).
+//
+// In the gem5 build the SConscript defines EARTH_HAVE_GEM5_DEBUG and the
+// messages are routed to gem5's logging:
+//   EARTH_ERROR / EARTH_WARN -> warn()      (gem5 has no non-fatal error level)
+//   EARTH_INFO               -> inform()
+//   EARTH_DEBUG              -> DPRINTFR(Earth, ...), the raw DPRINTF variant
+//                               (EarthModel is not a SimObject and has no
+//                               name(), which the plain DPRINTF requires)
+// Without that define (e.g. standalone syntax checks, no gem5-generated
+// headers available) a tiny fprintf fallback is used instead.
+// ---------------------------------------------------------------------------
+#ifdef EARTH_HAVE_GEM5_DEBUG
+
+#include "base/logging.hh"
+#include "base/trace.hh"
+#include "debug/Earth.hh"
+
+#define EARTH_ERROR(...)    warn(__VA_ARGS__)
+#define EARTH_WARN(...)     warn(__VA_ARGS__)
+#define EARTH_INFO(...)     inform(__VA_ARGS__)
+#define EARTH_DEBUG(...)    DPRINTFR(Earth, __VA_ARGS__)
+
+#else
+
+#include <cstdio>
+
+#define EARTH_ERROR(...) \
+    do { std::fprintf(stderr, __VA_ARGS__); std::fprintf(stderr, "\n"); } while (0)
+#define EARTH_WARN(...) \
+    do { std::fprintf(stderr, __VA_ARGS__); std::fprintf(stderr, "\n"); } while (0)
+#define EARTH_INFO(...) \
+    do { std::fprintf(stdout, __VA_ARGS__); std::fprintf(stdout, "\n"); } while (0)
+#define EARTH_DEBUG(...) \
+    do { std::fprintf(stdout, __VA_ARGS__); std::fprintf(stdout, "\n"); } while (0)
+
+#endif
+
+
+// gem5 adaptation: the CONFIG_EARTH_* ConfigurationEntryBack definitions of
+// the original are removed; the same default values now appear directly in
+// the constructor initializer list below and every parameter has a setter.
+
+// Implementation of: EarthModel text decoders
+namespace {
+
+    const char* TextOfREQOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::REQ::StashShared:       return "StashShared";
+        case CCHI::Opcodes::REQ::StashUnique:       return "StashUnique";
+        case CCHI::Opcodes::REQ::ReadNoSnp:         return "ReadNoSnp";
+        case CCHI::Opcodes::REQ::ReadOnce:          return "ReadOnce";
+        case CCHI::Opcodes::REQ::ReadShared:        return "ReadShared";
+        case CCHI::Opcodes::REQ::WriteNoSnpPtl:     return "WriteNoSnpPtl";
+        case CCHI::Opcodes::REQ::WriteNoSnpFull:    return "WriteNoSnpFull";
+        case CCHI::Opcodes::REQ::WriteUniquePtl:    return "WriteUniquePtl";
+        case CCHI::Opcodes::REQ::WriteUniqueFull:   return "WriteUniqueFull";
+        case CCHI::Opcodes::REQ::CleanShared:       return "CleanShared";
+        case CCHI::Opcodes::REQ::CleanInvalid:      return "CleanInvalid";
+        case CCHI::Opcodes::REQ::MakeInvalid:       return "MakeInvalid";
+        case CCHI::Opcodes::REQ::ReadUnique:        return "ReadUnique";
+        case CCHI::Opcodes::REQ::MakeUnique:        return "MakeUnique";
+        case CCHI::Opcodes::REQ::EvictBack:         return "EvictBack";
+        case CCHI::Opcodes::REQ::EvictClean:        return "EvictClean";
+        case CCHI::Opcodes::REQ::AtomicSwap:        return "AtomicSwap";
+        case CCHI::Opcodes::REQ::AtomicCompare:     return "AtomicCompare";
+        default:
+            if (CCHI::Opcodes::REQ::AtomicStore::Is(opcode))
+                return "AtomicStore";
+
+            if (CCHI::Opcodes::REQ::AtomicLoad::Is(opcode))
+                return "AtomicLoad";
+
+            return "Reserved";
+        }
+    }
+
+    const char* TextOfEVTOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::EVT::Evict:             return "Evict";
+        case CCHI::Opcodes::EVT::WriteBackFull:     return "WriteBackFull";
+        default:                                    return "Reserved";
+        }
+    }
+
+    const char* TextOfSNPOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::SNP::SnpMakeInvalid:    return "SnpMakeInvalid";
+        case CCHI::Opcodes::SNP::SnpToInvalid:      return "SnpToInvalid";
+        case CCHI::Opcodes::SNP::SnpToShared:       return "SnpToShared";
+        case CCHI::Opcodes::SNP::SnpToClean:        return "SnpToClean";
+        default:                                    return "Reserved";
+        }
+    }
+
+    const char* TextOfUpRSPOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::UpRSP::CompAck:         return "CompAck";
+        case CCHI::Opcodes::UpRSP::SnpResp:         return "SnpResp";
+        default:                                    return "Reserved";
+        }
+    }
+
+    const char* TextOfUpDATOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::UpDAT::NonCopyBackWrData:   return "NonCopyBackWrData";
+        case CCHI::Opcodes::UpDAT::CopyBackWrData:      return "CopyBackWrData";
+        case CCHI::Opcodes::UpDAT::SnpRespData:         return "SnpRespData";
+        default:                                        return "Reserved";
+        }
+    }
+
+    const char* TextOfDnRSPOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::DnRSP::CompStash:       return "CompStash";
+        case CCHI::Opcodes::DnRSP::Comp:            return "Comp";
+        case CCHI::Opcodes::DnRSP::DBIDResp:        return "DBIDResp";
+        case CCHI::Opcodes::DnRSP::CompDBIDResp:    return "CompDBIDResp";
+        case CCHI::Opcodes::DnRSP::CompCMO:         return "CompCMO";
+        default:                                    return "Reserved";
+        }
+    }
+
+    const char* TextOfDnDATOpcode(uint32_t opcode) noexcept
+    {
+        switch (opcode)
+        {
+        case CCHI::Opcodes::DnDAT::CompData:        return "CompData";
+        default:                                    return "Reserved";
+        }
+    }
+
+    const char* TextOfResp(uint32_t resp) noexcept
+    {
+        return CCHI::Resps::ToEnum(static_cast<CCHI::Resp>(resp))->name;
+    }
+
+    const char* TextOfLineState(size_t state) noexcept
+    {
+        switch (state)
+        {
+        case 0:     return "I";
+        case 1:     return "S";
+        case 2:     return "U";
+        default:    return "?";
+        }
+    }
+
+    const char* TextOfXactKind(size_t kind) noexcept
+    {
+        switch (kind)
+        {
+        case 0:     return "ReadShared";
+        case 1:     return "ReadUnique";
+        case 2:     return "MakeUnique";
+        case 3:     return "Evict";
+        case 4:     return "WriteBackFull";
+        default:    return "?";
+        }
+    }
+
+    const char* TextOfXactPhase(size_t phase) noexcept
+    {
+        switch (phase)
+        {
+        case 0:     return "Snoop";
+        case 1:     return "Respond";
+        case 2:     return "WaitCompAck";
+        case 3:     return "WaitWrData";
+        case 4:     return "WaitPop";
+        default:    return "?";
+        }
+    }
+}
+
+// Implementation of: class EarthModel
+namespace Cohestra {
+
+    // gem5 adaptation: the defaults below are exactly the defaultValues of the
+    // removed CONFIG_EARTH_* entries
+    EarthModel::EarthModel(size_t portCount) noexcept
+        : portCount           (portCount)
+        , nodeID              (0x10)
+        , parallelism         (8)
+        , inflightSNP         (4)
+        , queueDepthEVT       (2)
+        , queueDepthREQ       (2)
+        , queueDepthRSP       (8)
+        , queueDepthDAT       (16)
+        , latencyRSP          (4)
+        , latencyDAT          (4)
+        , memoryStart         (0x80000000)
+        , memoryEnd           (0xA0000000)
+        , verbose             (true)
+        , verboseFlit         (true)
+        , verboseXact         (true)
+        , verboseState        (true)
+        , verboseInternal     (true)
+        , verboseBackpressure (false)
+        , upstreamNodeIDs     ()
+        , ports               (portCount)
+        , tracker             (8)   // = parallelism
+    {
+        EARTH_INFO(
+            "EarthModel: configured with node ID %u, parallelism %u, snoop inflight %u, "
+            "queue depths EVT %u/REQ %u/RSP %u/DAT %u, latencies RSP %u/DAT %u, memory [%#llx, %#llx).",
+            nodeID, parallelism, inflightSNP,
+            queueDepthEVT, queueDepthREQ, queueDepthRSP, queueDepthDAT,
+            latencyRSP, latencyDAT,
+            static_cast<unsigned long long>(memoryStart),
+            static_cast<unsigned long long>(memoryEnd));
+    }
+
+    // gem5 adaptation: plain setters replace LoadConfiguration(); the
+    // validation rules are the same as before, invalid values are rejected
+    // with an error log instead of failing the whole load
+    void EarthModel::SetNodeID(uint32_t nodeID) noexcept
+    {
+        if (nodeID >= (1u << CommonFlitConfigurationType1::downstreamNodeIdWidth))
+        {
+            EARTH_ERROR("EarthModel: nodeid (%u) does not fit the downstream node ID width, ignored.",
+                nodeID);
+            return;
+        }
+
+        this->nodeID = nodeID;
+    }
+
+    void EarthModel::SetParallelism(uint32_t parallelism) noexcept
+    {
+        if (!parallelism)
+        {
+            EARTH_ERROR("EarthModel: parallelism must not be zero, ignored.");
+            return;
+        }
+
+        this->parallelism = parallelism;
+
+        tracker.clear();
+        tracker.resize(parallelism);
+    }
+
+    void EarthModel::SetInflightSNP(uint32_t inflightSNP) noexcept
+    {
+        if (!inflightSNP)
+        {
+            EARTH_ERROR("EarthModel: inflight.snp must not be zero, ignored.");
+            return;
+        }
+
+        this->inflightSNP = inflightSNP;
+    }
+
+    void EarthModel::SetQueueDepthEVT(uint32_t depth) noexcept
+    {
+        if (!depth)
+        {
+            EARTH_ERROR("EarthModel: queue depths must not be zero, ignored.");
+            return;
+        }
+
+        queueDepthEVT = depth;
+    }
+
+    void EarthModel::SetQueueDepthREQ(uint32_t depth) noexcept
+    {
+        if (!depth)
+        {
+            EARTH_ERROR("EarthModel: queue depths must not be zero, ignored.");
+            return;
+        }
+
+        queueDepthREQ = depth;
+    }
+
+    void EarthModel::SetQueueDepthRSP(uint32_t depth) noexcept
+    {
+        if (!depth)
+        {
+            EARTH_ERROR("EarthModel: queue depths must not be zero, ignored.");
+            return;
+        }
+
+        queueDepthRSP = depth;
+    }
+
+    void EarthModel::SetQueueDepthDAT(uint32_t depth) noexcept
+    {
+        if (!depth)
+        {
+            EARTH_ERROR("EarthModel: queue depths must not be zero, ignored.");
+            return;
+        }
+
+        queueDepthDAT = depth;
+    }
+
+    void EarthModel::SetLatencyRSP(uint32_t latency) noexcept
+    {
+        latencyRSP = latency;
+    }
+
+    void EarthModel::SetLatencyDAT(uint32_t latency) noexcept
+    {
+        latencyDAT = latency;
+    }
+
+    void EarthModel::SetMemoryWindow(uint64_t start, uint64_t end) noexcept
+    {
+        if (end <= start)
+        {
+            EARTH_ERROR("EarthModel: memory.end (%#llx) must be greater than memory.start (%#llx), ignored.",
+                static_cast<unsigned long long>(end),
+                static_cast<unsigned long long>(start));
+            return;
+        }
+
+        memoryStart = start;
+        memoryEnd   = end;
+    }
+
+    void EarthModel::SetVerbose(bool verbose) noexcept
+    {
+        this->verbose = verbose;
+
+        // the total switch mutes every verbose category
+        if (!verbose)
+        {
+            verboseFlit         = false;
+            verboseXact         = false;
+            verboseState        = false;
+            verboseInternal     = false;
+            verboseBackpressure = false;
+        }
+    }
+
+    void EarthModel::SetVerboseFlit(bool verbose) noexcept
+    {
+        verboseFlit = verbose;
+    }
+
+    void EarthModel::SetVerboseXact(bool verbose) noexcept
+    {
+        verboseXact = verbose;
+    }
+
+    void EarthModel::SetVerboseState(bool verbose) noexcept
+    {
+        verboseState = verbose;
+    }
+
+    void EarthModel::SetVerboseInternal(bool verbose) noexcept
+    {
+        verboseInternal = verbose;
+    }
+
+    void EarthModel::SetVerboseBackpressure(bool verbose) noexcept
+    {
+        verboseBackpressure = verbose;
+    }
+
+    void EarthModel::SetMemoryBackend(std::shared_ptr<MemoryBackend> backend) noexcept
+    {
+        memoryBackend = std::move(backend);
+    }
+
+    void EarthModel::SetUpstreamNodeIDs(const std::vector<uint32_t>& nodeIDs) noexcept
+    {
+        upstreamNodeIDs = nodeIDs;
+    }
+
+    void EarthModel::Tick(uint64_t time) noexcept
+    {
+        this->time = time;
+
+        // CCHI channel priority: EVT > SNP > REQ
+        TickEVT();
+        TickSNP();
+        TickREQ();
+
+        // response emission onto the DnRSP/DnDAT channels
+        TickEmit();
+    }
+
+    void EarthModel::TickEVT() noexcept
+    {
+        // highest priority: admit and process pending EVT flits
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            Port& p = ports[port];
+
+            if (p.evtFIFO.empty())
+                continue;
+
+            const FlitEVT& flit = p.evtFIFO.front().flit;
+            uint64_t     line = flit.Addr >> 6;
+
+            if (flit.Opcode != CCHI::Opcodes::EVT::Evict
+             && flit.Opcode != CCHI::Opcodes::EVT::WriteBackFull)
+            {
+                ReportViolation("EVT with unsupported opcode, dropped", port);
+                p.evtFIFO.pop_front();
+                continue;
+            }
+
+            // one active eviction per line; an eviction may cut ahead of an
+            // active REQ transaction on the same line (see class notes)
+            if (lineEVT.find(line) != lineEVT.end())
+                continue;
+
+            std::optional<size_t> slot = AllocateSlot();
+
+            if (!slot)
+                continue;
+
+            CheckAddressWindow(flit.Addr, "EVT", port);
+
+            int dbid = -1;
+
+            if (flit.Opcode == CCHI::Opcodes::EVT::WriteBackFull)
+            {
+                std::optional<int> id = AllocateID(port);
+
+                if (!id)
+                    continue;
+
+                dbid = *id;
+            }
+
+            p.evtFIFO.pop_front();
+
+            Xaction& x  = tracker[*slot];
+            x           = Xaction{};
+            x.active    = true;
+            x.kind      = flit.Opcode == CCHI::Opcodes::EVT::Evict ? XactKind::Evict
+                                                                   : XactKind::WriteBackFull;
+            x.port      = port;
+            x.line      = line;
+            x.addr      = flit.Addr;
+            x.txnID     = static_cast<uint8_t>(flit.TxnID);
+            x.srcNodeID = static_cast<uint32_t>(flit.SrcID);
+            x.traceTag  = static_cast<uint8_t>(flit.TraceTag);
+            x.phase     = XactPhase::Respond;
+            x.readyTime = time + latencyRSP;
+            x.dbid      = dbid;
+
+            lineEVT[line] = *slot;
+
+            if (verboseXact)
+                EARTH_DEBUG("EarthModel: EVT admitted on slot %zu (opcode %s, line %#llx, port %zu, txnID %u) at time %llu.",
+                    *slot, TextOfEVTOpcode(static_cast<uint32_t>(flit.Opcode)),
+                    static_cast<unsigned long long>(line << 6), port,
+                    static_cast<uint32_t>(flit.TxnID), static_cast<unsigned long long>(time));
+
+            if (x.kind == XactKind::Evict)
+            {
+                // clean eviction: the directory entry is dropped immediately
+                DirRemove(port, line);
+            }
+            else
+            {
+                // write-back: the directory entry is dropped on data completion
+                p.dbids[static_cast<uint8_t>(dbid)] = { *slot, DBIDKind::WriteBackData };
+            }
+
+            countEVT++;
+        }
+    }
+
+    void EarthModel::TickSNP() noexcept
+    {
+        // middle priority: snoop channel progress, which covers consuming
+        // snoop responses, write-back data and CompAcks, and issuing snoops
+
+        // consume UpRSP flits, one per port per cycle
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            Port& p = ports[port];
+
+            if (p.uprspFIFO.empty())
+                continue;
+
+            FlitUpRSP flit = p.uprspFIFO.front();
+            p.uprspFIFO.pop_front();
+
+            if (flit.Opcode == CCHI::Opcodes::UpRSP::SnpResp)
+            {
+                auto it = p.snoops.find(static_cast<uint8_t>(flit.TxnID));
+
+                if (it == p.snoops.end())
+                {
+                    ReportViolation("SnpResp with unknown TxnID, dropped", port);
+                    continue;
+                }
+
+                SnoopEntry& se = it->second;
+
+                if (se.gotData)
+                {
+                    ReportViolation("SnpResp received after SnpRespData on the same TxnID", port);
+                    p.snoops.erase(it);
+                    FreeID(port, static_cast<uint8_t>(flit.TxnID));
+                    continue;
+                }
+
+                se.gotResp = true;
+
+                size_t slot = se.slot;
+
+                Snoop& snoop    = tracker[slot].snoops[se.snoop];
+                snoop.done      = true;
+                snoop.respNotI  = flit.Resp != CCHI::Resps::I;
+
+                if (verboseXact)
+                    EARTH_DEBUG("EarthModel: SnpResp completed (resp %s, port %zu, txnID %u, for slot %zu) at time %llu.",
+                        TextOfResp(static_cast<uint32_t>(flit.Resp)), port, static_cast<uint32_t>(flit.TxnID),
+                        slot, static_cast<unsigned long long>(time));
+
+                p.snoops.erase(it);
+                FreeID(port, static_cast<uint8_t>(flit.TxnID));
+
+                CheckSnoopsDone(slot);
+            }
+            else if (flit.Opcode == CCHI::Opcodes::UpRSP::CompAck)
+            {
+                auto it = p.dbids.find(static_cast<uint8_t>(flit.TxnID));
+
+                if (it == p.dbids.end())
+                {
+                    ReportViolation("CompAck with unknown DBID, dropped", port);
+                    continue;
+                }
+
+                DBIDEntry& de = it->second;
+
+                if (de.kind != DBIDKind::CompAckWait)
+                {
+                    ReportViolation("CompAck colliding with a write-back DBID", port);
+                    continue;
+                }
+
+                Xaction& x = tracker[de.slot];
+
+                if (x.ackReceived)
+                    ReportViolation("duplicated CompAck on the same DBID", port);
+
+                x.ackReceived = true;
+
+                if (verboseXact)
+                    EARTH_DEBUG("EarthModel: CompAck received (port %zu, DBID %u, for slot %zu in phase %s) at time %llu.",
+                        port, static_cast<uint32_t>(flit.TxnID), de.slot,
+                        TextOfXactPhase(static_cast<size_t>(x.phase)), static_cast<unsigned long long>(time));
+
+                if (x.phase == XactPhase::WaitCompAck)
+                    Retire(de.slot);
+            }
+            else
+                ReportViolation("UpRSP with unsupported opcode, dropped", port);
+        }
+
+        // consume UpDAT flits, one per port per cycle
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            Port& p = ports[port];
+
+            if (p.updatFIFO.empty())
+                continue;
+
+            FlitUpDAT flit = p.updatFIFO.front();
+            p.updatFIFO.pop_front();
+
+            size_t dataID = static_cast<size_t>(flit.DataID);
+
+            if (flit.Opcode == CCHI::Opcodes::UpDAT::SnpRespData)
+            {
+                auto it = p.snoops.find(static_cast<uint8_t>(flit.TxnID));
+
+                if (it == p.snoops.end())
+                {
+                    ReportViolation("SnpRespData with unknown TxnID, dropped", port);
+                    continue;
+                }
+
+                SnoopEntry& se = it->second;
+
+                if (se.gotResp)
+                {
+                    ReportViolation("SnpRespData received after SnpResp on the same TxnID", port);
+                    continue;
+                }
+
+                if (se.beatMask & (1u << dataID))
+                {
+                    ReportViolation("SnpRespData with duplicated DataID, dropped", port);
+                    continue;
+                }
+
+                if (se.beatMask && se.resp != static_cast<uint8_t>(flit.Resp))
+                    ReportViolation("SnpRespData with mismatched Resp across beats", port);
+
+                se.gotData   = true;
+                se.resp      = static_cast<uint8_t>(flit.Resp);
+                se.beatMask |= (1u << dataID);
+
+                if (CCHI::Resps::ToEnum(static_cast<CCHI::Resp>(flit.Resp))->IsPD())
+                    MergeBeat(se.line, dataID, flit.Data, static_cast<uint32_t>(flit.BE));
+
+                if (se.beatMask == ((1u << BEATS_PER_LINE) - 1))
+                {
+                    size_t slot = se.slot;
+
+                    Snoop& snoop    = tracker[slot].snoops[se.snoop];
+                    snoop.done      = true;
+                    snoop.respNotI  = se.resp != CCHI::Resps::I;
+
+                    if (verboseXact)
+                        EARTH_DEBUG("EarthModel: SnpRespData completed (resp %s, port %zu, txnID %u, for slot %zu) at time %llu.",
+                            TextOfResp(se.resp), port, static_cast<uint32_t>(flit.TxnID),
+                            slot, static_cast<unsigned long long>(time));
+
+                    p.snoops.erase(it);
+                    FreeID(port, static_cast<uint8_t>(flit.TxnID));
+
+                    CheckSnoopsDone(slot);
+                }
+            }
+            else if (flit.Opcode == CCHI::Opcodes::UpDAT::CopyBackWrData)
+            {
+                auto it = p.dbids.find(static_cast<uint8_t>(flit.TxnID));
+
+                if (it == p.dbids.end())
+                {
+                    ReportViolation("CopyBackWrData with unknown DBID, dropped", port);
+                    continue;
+                }
+
+                DBIDEntry& de = it->second;
+
+                if (de.kind != DBIDKind::WriteBackData)
+                {
+                    ReportViolation("CopyBackWrData colliding with a CompAck DBID", port);
+                    continue;
+                }
+
+                Xaction& x = tracker[de.slot];
+
+                if (x.wrBeatMask & (1u << dataID))
+                {
+                    ReportViolation("CopyBackWrData with duplicated DataID, dropped", port);
+                    continue;
+                }
+
+                x.wrBeatMask |= (1u << dataID);
+
+                MergeBeat(x.line, dataID, flit.Data, static_cast<uint32_t>(flit.BE));
+
+                if (verboseState)
+                    EARTH_DEBUG("EarthModel: CopyBackWrData beat merged (dataID %zu, BE %#x, port %zu, DBID %u, for slot %zu) at time %llu.",
+                        dataID, static_cast<uint32_t>(flit.BE), port, static_cast<uint32_t>(flit.TxnID),
+                        de.slot, static_cast<unsigned long long>(time));
+
+                if (x.wrBeatMask == ((1u << BEATS_PER_LINE) - 1))
+                {
+                    // write-back data completed: memory is up to date and the
+                    // directory ownership of the line is dropped
+                    DirRemove(x.port, x.line);
+
+                    Retire(de.slot);
+                }
+            }
+            else
+                ReportViolation("UpDAT with unsupported opcode, dropped", port);
+        }
+
+        // issue pending snoops, at most one per target port per cycle
+        std::vector<bool> snpIssued(portCount, false);
+
+        for (size_t slotIdx = 0; slotIdx < tracker.size(); ++slotIdx)
+        {
+            Xaction& x = tracker[slotIdx];
+
+            if (!x.active || x.phase != XactPhase::Snoop)
+                continue;
+
+            if (!x.snoopPlanBuilt)
+                BuildSnoopPlan(slotIdx);
+
+            if (x.phase != XactPhase::Snoop)
+                continue;
+
+            for (size_t si = 0; si < x.snoops.size(); ++si)
+            {
+                Snoop& snoop = x.snoops[si];
+
+                if (snoop.issued)
+                    continue;
+
+                Port& tp = ports[snoop.port];
+
+                if (tp.snoops.size() >= inflightSNP)
+                    continue;
+
+                if (snpIssued[snoop.port])
+                    continue;
+
+                std::optional<int> id = AllocateID(snoop.port);
+
+                if (!id)
+                    continue;
+
+                snoop.txnID  = *id;
+                snoop.issued = true;
+
+                uint32_t tgtNodeID = snoop.port < upstreamNodeIDs.size()
+                                   ? upstreamNodeIDs[snoop.port] : static_cast<uint32_t>(snoop.port);
+
+                FlitSNP flit;
+                flit.TxnID    = static_cast<FlitSNP::txnid_t>(*id);
+                flit.SrcID    = static_cast<FlitSNP::srcid_t>(nodeID);
+                flit.TgtID    = static_cast<FlitSNP::tgtid_t>(tgtNodeID);
+                flit.Opcode   = static_cast<FlitSNP::opcode_t>(snoop.opcode);
+                flit.Addr     = static_cast<FlitSNP::addr_t>(x.line << 3);
+                flit.NS       = 0;
+                flit.TraceTag = 0;
+
+                tp.snoops[static_cast<uint8_t>(*id)] = { slotIdx, si, x.line, 0, false, false, 0 };
+                tp.snpQueue.push_back(flit);
+
+                snpIssued[snoop.port] = true;
+
+                if (verboseFlit)
+                    EARTH_DEBUG("EarthModel: SNP issued (opcode %s, line %#llx, port %zu, txnID %d, for slot %zu) at time %llu.",
+                        TextOfSNPOpcode(static_cast<uint32_t>(snoop.opcode)),
+                        static_cast<unsigned long long>(x.line << 6), snoop.port, *id,
+                        slotIdx, static_cast<unsigned long long>(time));
+
+                countSNP++;
+            }
+        }
+    }
+
+    void EarthModel::TickREQ() noexcept
+    {
+        // lowest priority: admit pending REQ flits
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            Port& p = ports[port];
+
+            if (p.reqFIFO.empty())
+                continue;
+
+            StampedFlit<FlitREQ>&   head = p.reqFIFO.front();
+            const FlitREQ&          flit = head.flit;
+            uint64_t                line = flit.Addr >> 6;
+
+            if (flit.Opcode != CCHI::Opcodes::REQ::ReadShared
+             && flit.Opcode != CCHI::Opcodes::REQ::ReadUnique
+             && flit.Opcode != CCHI::Opcodes::REQ::MakeUnique)
+            {
+                ReportViolation("REQ with unsupported opcode, dropped", port);
+                p.reqFIFO.pop_front();
+                continue;
+            }
+
+            // same-line requests are serialized in arrival order
+            bool lineBusy = lineREQ.find(line) != lineREQ.end()
+                         || lineEVT.find(line) != lineEVT.end();
+
+            auto wit = lineWaiters.find(line);
+
+            bool waitersPending = wit != lineWaiters.end() && !wit->second.empty();
+            bool headWaiter     = waitersPending
+                               && wit->second.front().first == head.stamp
+                               && wit->second.front().second == port;
+
+            if (lineBusy || (waitersPending && !headWaiter))
+            {
+                if (!head.registered)
+                {
+                    lineWaiters[line].push_back({ head.stamp, port });
+                    head.registered = true;
+
+                    if (verboseInternal)
+                        EARTH_DEBUG("EarthModel: REQ waiting registered (opcode %s, line %#llx, port %zu, stamp %llu) at time %llu.",
+                            TextOfREQOpcode(static_cast<uint32_t>(flit.Opcode)),
+                            static_cast<unsigned long long>(line << 6), port,
+                            static_cast<unsigned long long>(head.stamp), static_cast<unsigned long long>(time));
+                }
+
+                continue;
+            }
+
+            std::optional<size_t> slot = AllocateSlot();
+
+            if (!slot)
+                continue;
+
+            CheckAddressWindow(flit.Addr, "REQ", port);
+
+            p.reqFIFO.pop_front();
+
+            if (headWaiter)
+            {
+                wit->second.pop_front();
+
+                if (wit->second.empty())
+                    lineWaiters.erase(wit);
+            }
+
+            Xaction& x    = tracker[*slot];
+            x             = Xaction{};
+            x.active      = true;
+            x.kind        = flit.Opcode == CCHI::Opcodes::REQ::ReadShared ? XactKind::ReadShared
+                          : flit.Opcode == CCHI::Opcodes::REQ::ReadUnique ? XactKind::ReadUnique
+                                                                          : XactKind::MakeUnique;
+            x.port        = port;
+            x.line        = line;
+            x.addr        = flit.Addr;
+            x.txnID       = static_cast<uint8_t>(flit.TxnID);
+            x.srcNodeID   = static_cast<uint32_t>(flit.SrcID);
+            x.expCompData = static_cast<uint8_t>(flit.ExpCompData) != 0;
+            x.traceTag    = static_cast<uint8_t>(flit.TraceTag);
+            x.phase       = XactPhase::Snoop;
+
+            lineREQ[line] = *slot;
+
+            if (verboseXact)
+                EARTH_DEBUG("EarthModel: REQ admitted on slot %zu (opcode %s, line %#llx, port %zu, txnID %u, ExpCompData %u) at time %llu.",
+                    *slot, TextOfREQOpcode(static_cast<uint32_t>(flit.Opcode)),
+                    static_cast<unsigned long long>(line << 6), port,
+                    static_cast<uint32_t>(flit.TxnID), static_cast<uint32_t>(flit.ExpCompData),
+                    static_cast<unsigned long long>(time));
+
+            countREQ++;
+        }
+    }
+
+    void EarthModel::TickEmit() noexcept
+    {
+        // emit scheduled responses, at most one DnRSP and one DnDAT per port
+        // per cycle (channel width)
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            Port& p = ports[port];
+
+            bool emittedRSP = false;
+            bool emittedDAT = false;
+
+            for (size_t slotIdx = 0; slotIdx < tracker.size() && !(emittedRSP && emittedDAT); ++slotIdx)
+            {
+                Xaction& x = tracker[slotIdx];
+
+                if (!x.active || x.port != port
+                 || x.phase != XactPhase::Respond
+                 || x.readyTime > time)
+                    continue;
+
+                switch (x.kind)
+                {
+                case XactKind::ReadShared:
+                case XactKind::ReadUnique:
+
+                    if (x.kind == XactKind::ReadShared || x.expCompData)
+                    {
+                        // CompData beats, both carrying the same allocated DBID
+                        if (emittedDAT)
+                            continue;
+
+                        if (x.dbid < 0)
+                        {
+                            std::optional<int> id = AllocateID(port);
+
+                            if (!id)
+                                continue;
+
+                            x.dbid = *id;
+                            p.dbids[static_cast<uint8_t>(*id)] = { slotIdx, DBIDKind::CompAckWait };
+                        }
+
+                        // gem5 adaptation: line data is read from the attached
+                        // MemoryBackend instead of the old internal sparse map
+                        // ('memory[x.line]' in the original)
+                        std::array<uint64_t, LINE_WORDS> lineData;
+                        ReadLine(x.line, lineData);
+
+                        FlitDnDAT flit;
+                        flit.TxnID      = static_cast<FlitDnDAT::txnid_t>(x.txnID);
+                        flit.SrcID      = static_cast<FlitDnDAT::srcid_t>(nodeID);
+                        flit.TgtID      = static_cast<FlitDnDAT::tgtid_t>(x.srcNodeID);
+                        flit.DBID       = static_cast<FlitDnDAT::dbid_t>(x.dbid);
+                        flit.Opcode     = CCHI::Opcodes::DnDAT::CompData;
+                        flit.RespErr    = 0;
+                        flit.Resp       = x.kind == XactKind::ReadShared ? CCHI::Resps::SC
+                                                                         : CCHI::Resps::UC;
+                        flit.DataSource = 0;
+                        flit.CBusy      = 0;
+                        flit.WayValid   = 0;
+                        flit.Way        = 0;
+                        flit.DataID     = static_cast<FlitDnDAT::dataid_t>(x.compDataBeats);
+
+                        for (size_t w = 0; w < WORDS_PER_BEAT; ++w)
+                            flit.Data[w] = lineData[x.compDataBeats * WORDS_PER_BEAT + w];
+
+                        flit.TraceTag   = static_cast<FlitDnDAT::tracetag_t>(x.traceTag);
+
+                        p.dndatQueue.push_back(flit);
+
+                        if (verboseFlit)
+                            EARTH_DEBUG("EarthModel: %s emitted (dataID %zu, resp %s, port %zu, txnID %u, DBID %d, for slot %zu) at time %llu.",
+                                TextOfDnDATOpcode(static_cast<uint32_t>(flit.Opcode)),
+                                x.compDataBeats, TextOfResp(static_cast<uint32_t>(flit.Resp)), port,
+                                static_cast<unsigned>(x.txnID), x.dbid, slotIdx,
+                                static_cast<unsigned long long>(time));
+
+                        x.compDataBeats++;
+                        emittedDAT = true;
+
+                        // every following CompData beat is scheduled on its own,
+                        // so the upstream CompAck may legitimately arrive before
+                        // or after any of them
+                        if (x.compDataBeats == BEATS_PER_LINE)
+                        {
+                            DirGrant(slotIdx);
+
+                            if (x.ackReceived)
+                                Retire(slotIdx);
+                            else
+                                x.phase = XactPhase::WaitCompAck;
+                        }
+                        else
+                            x.readyTime = time + latencyDAT;
+                    }
+                    else
+                    {
+                        // ReadUnique with data already held upstream: Comp only
+                        if (emittedRSP)
+                            continue;
+
+                        if (x.dbid < 0)
+                        {
+                            std::optional<int> id = AllocateID(port);
+
+                            if (!id)
+                                continue;
+
+                            x.dbid = *id;
+                            p.dbids[static_cast<uint8_t>(*id)] = { slotIdx, DBIDKind::CompAckWait };
+                        }
+
+                        FlitDnRSP flit;
+                        flit.TxnID    = static_cast<FlitDnRSP::txnid_t>(x.txnID);
+                        flit.SrcID    = static_cast<FlitDnRSP::srcid_t>(nodeID);
+                        flit.TgtID    = static_cast<FlitDnRSP::tgtid_t>(x.srcNodeID);
+                        flit.DBID     = static_cast<FlitDnRSP::dbid_t>(x.dbid);
+                        flit.Opcode   = CCHI::Opcodes::DnRSP::Comp;
+                        flit.RespErr  = 0;
+                        flit.Resp     = CCHI::Resps::UC;
+                        flit.CBusy    = 0;
+                        flit.WayValid = 0;
+                        flit.Way      = 0;
+                        flit.TraceTag = static_cast<FlitDnRSP::tracetag_t>(x.traceTag);
+
+                        p.dnrspQueue.push_back(flit);
+
+                        if (verboseFlit)
+                            EARTH_DEBUG("EarthModel: %s emitted (%s, port %zu, txnID %u, DBID %d, for slot %zu) at time %llu.",
+                                TextOfDnRSPOpcode(static_cast<uint32_t>(flit.Opcode)),
+                                TextOfXactKind(static_cast<size_t>(x.kind)), port,
+                                static_cast<unsigned>(x.txnID), x.dbid, slotIdx,
+                                static_cast<unsigned long long>(time));
+
+                        DirGrant(slotIdx);
+
+                        emittedRSP = true;
+
+                        if (x.ackReceived)
+                            Retire(slotIdx);
+                        else
+                            x.phase = XactPhase::WaitCompAck;
+                    }
+
+                    break;
+
+                case XactKind::MakeUnique:
+
+                    if (emittedRSP)
+                        continue;
+
+                    if (x.dbid < 0)
+                    {
+                        std::optional<int> id = AllocateID(port);
+
+                        if (!id)
+                            continue;
+
+                        x.dbid = *id;
+                        p.dbids[static_cast<uint8_t>(*id)] = { slotIdx, DBIDKind::CompAckWait };
+                    }
+
+                    {
+                        FlitDnRSP flit;
+                        flit.TxnID    = static_cast<FlitDnRSP::txnid_t>(x.txnID);
+                        flit.SrcID    = static_cast<FlitDnRSP::srcid_t>(nodeID);
+                        flit.TgtID    = static_cast<FlitDnRSP::tgtid_t>(x.srcNodeID);
+                        flit.DBID     = static_cast<FlitDnRSP::dbid_t>(x.dbid);
+                        flit.Opcode   = CCHI::Opcodes::DnRSP::Comp;
+                        flit.RespErr  = 0;
+                        flit.Resp     = CCHI::Resps::UC;
+                        flit.CBusy    = 0;
+                        flit.WayValid = 0;
+                        flit.Way      = 0;
+                        flit.TraceTag = static_cast<FlitDnRSP::tracetag_t>(x.traceTag);
+
+                        p.dnrspQueue.push_back(flit);
+                    }
+
+                    if (verboseFlit)
+                        EARTH_DEBUG("EarthModel: %s emitted (%s, port %zu, txnID %u, DBID %d, for slot %zu) at time %llu.",
+                            TextOfDnRSPOpcode(CCHI::Opcodes::DnRSP::Comp),
+                            TextOfXactKind(static_cast<size_t>(x.kind)), port,
+                            static_cast<unsigned>(x.txnID), x.dbid, slotIdx,
+                            static_cast<unsigned long long>(time));
+
+                    DirGrant(slotIdx);
+
+                    emittedRSP = true;
+
+                    if (x.ackReceived)
+                        Retire(slotIdx);
+                    else
+                        x.phase = XactPhase::WaitCompAck;
+
+                    break;
+
+                case XactKind::Evict:
+
+                    if (emittedRSP)
+                        continue;
+
+                    {
+                        FlitDnRSP flit;
+                        flit.TxnID    = static_cast<FlitDnRSP::txnid_t>(x.txnID);
+                        flit.SrcID    = static_cast<FlitDnRSP::srcid_t>(nodeID);
+                        flit.TgtID    = static_cast<FlitDnRSP::tgtid_t>(x.srcNodeID);
+                        flit.DBID     = 0;
+                        flit.Opcode   = CCHI::Opcodes::DnRSP::Comp;
+                        flit.RespErr  = 0;
+                        flit.Resp     = 0;
+                        flit.CBusy    = 0;
+                        flit.WayValid = 0;
+                        flit.Way      = 0;
+                        flit.TraceTag = static_cast<FlitDnRSP::tracetag_t>(x.traceTag);
+
+                        p.dnrspQueue.push_back(flit);
+                    }
+
+                    if (verboseFlit)
+                        EARTH_DEBUG("EarthModel: %s emitted (%s, port %zu, txnID %u, for slot %zu) at time %llu.",
+                            TextOfDnRSPOpcode(CCHI::Opcodes::DnRSP::Comp),
+                            TextOfXactKind(static_cast<size_t>(x.kind)), port,
+                            static_cast<unsigned>(x.txnID), slotIdx,
+                            static_cast<unsigned long long>(time));
+
+                    emittedRSP = true;
+
+                    // an Evict retires once its Comp is delivered downstream
+                    x.phase = XactPhase::WaitPop;
+
+                    break;
+
+                case XactKind::WriteBackFull:
+
+                    if (emittedRSP)
+                        continue;
+
+                    {
+                        FlitDnRSP flit;
+                        flit.TxnID    = static_cast<FlitDnRSP::txnid_t>(x.txnID);
+                        flit.SrcID    = static_cast<FlitDnRSP::srcid_t>(nodeID);
+                        flit.TgtID    = static_cast<FlitDnRSP::tgtid_t>(x.srcNodeID);
+                        flit.DBID     = static_cast<FlitDnRSP::dbid_t>(x.dbid);
+                        flit.Opcode   = CCHI::Opcodes::DnRSP::CompDBIDResp;
+                        flit.RespErr  = 0;
+                        flit.Resp     = 0;
+                        flit.CBusy    = 0;
+                        flit.WayValid = 0;
+                        flit.Way      = 0;
+                        flit.TraceTag = static_cast<FlitDnRSP::tracetag_t>(x.traceTag);
+
+                        p.dnrspQueue.push_back(flit);
+                    }
+
+                    if (verboseFlit)
+                        EARTH_DEBUG("EarthModel: %s emitted (%s, port %zu, txnID %u, DBID %d, for slot %zu) at time %llu.",
+                            TextOfDnRSPOpcode(CCHI::Opcodes::DnRSP::CompDBIDResp),
+                            TextOfXactKind(static_cast<size_t>(x.kind)), port,
+                            static_cast<unsigned>(x.txnID), x.dbid, slotIdx,
+                            static_cast<unsigned long long>(time));
+
+                    emittedRSP = true;
+
+                    x.phase = XactPhase::WaitWrData;
+
+                    break;
+                }
+            }
+        }
+    }
+
+    bool EarthModel::PushEVT(size_t port, const FlitEVT& flit) noexcept
+    {
+        if (port >= portCount)
+        {
+            ReportViolation("EVT pushed to a non-existent port, dropped", port);
+            return false;
+        }
+
+        Port& p = ports[port];
+
+        // concurrent upstream transactions per port are supported: Taurus nodes
+        // drive unique TxnIDs, and responses are told apart by the DBIDs and
+        // snoop TxnIDs this model allocates per transaction
+        if (p.evtFIFO.size() >= queueDepthEVT)
+        {
+            ReportBackpressure("EVT denied: channel queue full", port);
+            return false;
+        }
+
+        p.evtFIFO.push_back({ flit, stampCounter++, false });
+
+        if (verboseFlit)
+            EARTH_DEBUG("EarthModel: EVT accepted (opcode %s, addr %#llx, port %zu, txnID %u) at time %llu.",
+                TextOfEVTOpcode(static_cast<uint32_t>(flit.Opcode)),
+                static_cast<unsigned long long>(static_cast<uint64_t>(flit.Addr)), port,
+                static_cast<uint32_t>(flit.TxnID), static_cast<unsigned long long>(time));
+
+        return true;
+    }
+
+    bool EarthModel::PushREQ(size_t port, const FlitREQ& flit) noexcept
+    {
+        if (port >= portCount)
+        {
+            ReportViolation("REQ pushed to a non-existent port, dropped", port);
+            return false;
+        }
+
+        Port& p = ports[port];
+
+        // concurrent upstream transactions per port are supported: Taurus nodes
+        // drive unique TxnIDs, and responses are told apart by the DBIDs and
+        // snoop TxnIDs this model allocates per transaction
+        if (p.reqFIFO.size() >= queueDepthREQ)
+        {
+            ReportBackpressure("REQ denied: channel queue full", port);
+            return false;
+        }
+
+        p.reqFIFO.push_back({ flit, stampCounter++, false });
+
+        if (verboseFlit)
+            EARTH_DEBUG("EarthModel: REQ accepted (opcode %s, addr %#llx, port %zu, txnID %u, ExpCompData %u) at time %llu.",
+                TextOfREQOpcode(static_cast<uint32_t>(flit.Opcode)),
+                static_cast<unsigned long long>(static_cast<uint64_t>(flit.Addr)), port,
+                static_cast<uint32_t>(flit.TxnID), static_cast<uint32_t>(flit.ExpCompData),
+                static_cast<unsigned long long>(time));
+
+        return true;
+    }
+
+    bool EarthModel::PushUpRSP(size_t port, const FlitUpRSP& flit) noexcept
+    {
+        if (port >= portCount)
+        {
+            ReportViolation("UpRSP pushed to a non-existent port, dropped", port);
+            return false;
+        }
+
+        Port& p = ports[port];
+
+        if (p.uprspFIFO.size() >= queueDepthRSP)
+        {
+            ReportBackpressure("UpRSP denied: channel queue full", port);
+            return false;
+        }
+
+        p.uprspFIFO.push_back(flit);
+
+        if (verboseFlit)
+            EARTH_DEBUG("EarthModel: UpRSP accepted (opcode %s, resp %s, port %zu, txnID %u) at time %llu.",
+                TextOfUpRSPOpcode(static_cast<uint32_t>(flit.Opcode)), TextOfResp(static_cast<uint32_t>(flit.Resp)),
+                port, static_cast<uint32_t>(flit.TxnID), static_cast<unsigned long long>(time));
+
+        return true;
+    }
+
+    bool EarthModel::PushUpDAT(size_t port, const FlitUpDAT& flit) noexcept
+    {
+        if (port >= portCount)
+        {
+            ReportViolation("UpDAT pushed to a non-existent port, dropped", port);
+            return false;
+        }
+
+        Port& p = ports[port];
+
+        if (p.updatFIFO.size() >= queueDepthDAT)
+        {
+            ReportBackpressure("UpDAT denied: channel queue full", port);
+            return false;
+        }
+
+        p.updatFIFO.push_back(flit);
+
+        if (verboseFlit)
+            EARTH_DEBUG("EarthModel: UpDAT accepted (opcode %s, resp %s, dataID %u, port %zu, txnID %u) at time %llu.",
+                TextOfUpDATOpcode(static_cast<uint32_t>(flit.Opcode)), TextOfResp(static_cast<uint32_t>(flit.Resp)),
+                static_cast<uint32_t>(flit.DataID), port, static_cast<uint32_t>(flit.TxnID),
+                static_cast<unsigned long long>(time));
+
+        return true;
+    }
+
+    bool EarthModel::HasSNP(size_t port) const noexcept
+    {
+        return port < portCount && !ports[port].snpQueue.empty();
+    }
+
+    std::optional<EarthModel::FlitSNP> EarthModel::PeekSNP(size_t port) const noexcept
+    {
+        if (!HasSNP(port))
+            return std::nullopt;
+
+        return { ports[port].snpQueue.front() };
+    }
+
+    std::optional<EarthModel::FlitSNP> EarthModel::PopSNP(size_t port) noexcept
+    {
+        if (!HasSNP(port))
+            return std::nullopt;
+
+        FlitSNP flit = ports[port].snpQueue.front();
+        ports[port].snpQueue.pop_front();
+
+        return { flit };
+    }
+
+    bool EarthModel::HasDnRSP(size_t port) const noexcept
+    {
+        return port < portCount && !ports[port].dnrspQueue.empty();
+    }
+
+    std::optional<EarthModel::FlitDnRSP> EarthModel::PeekDnRSP(size_t port) const noexcept
+    {
+        if (!HasDnRSP(port))
+            return std::nullopt;
+
+        return { ports[port].dnrspQueue.front() };
+    }
+
+    std::optional<EarthModel::FlitDnRSP> EarthModel::PopDnRSP(size_t port) noexcept
+    {
+        if (!HasDnRSP(port))
+            return std::nullopt;
+
+        Port& p = ports[port];
+
+        FlitDnRSP flit = p.dnrspQueue.front();
+        p.dnrspQueue.pop_front();
+
+        // an Evict transaction retires once its Comp is delivered downstream
+        if (flit.Opcode == CCHI::Opcodes::DnRSP::Comp)
+        {
+            for (size_t slotIdx = 0; slotIdx < tracker.size(); ++slotIdx)
+            {
+                Xaction& x = tracker[slotIdx];
+
+                if (x.active && x.phase == XactPhase::WaitPop
+                 && x.port == port && x.txnID == static_cast<uint8_t>(flit.TxnID))
+                {
+                    Retire(slotIdx);
+                    break;
+                }
+            }
+        }
+
+        return { flit };
+    }
+
+    bool EarthModel::HasDnDAT(size_t port) const noexcept
+    {
+        return port < portCount && !ports[port].dndatQueue.empty();
+    }
+
+    std::optional<EarthModel::FlitDnDAT> EarthModel::PeekDnDAT(size_t port) const noexcept
+    {
+        if (!HasDnDAT(port))
+            return std::nullopt;
+
+        return { ports[port].dndatQueue.front() };
+    }
+
+    std::optional<EarthModel::FlitDnDAT> EarthModel::PopDnDAT(size_t port) noexcept
+    {
+        if (!HasDnDAT(port))
+            return std::nullopt;
+
+        FlitDnDAT flit = ports[port].dndatQueue.front();
+        ports[port].dndatQueue.pop_front();
+
+        return { flit };
+    }
+
+    size_t EarthModel::GetPortCount() const noexcept
+    {
+        return portCount;
+    }
+
+    uint32_t EarthModel::GetNodeID() const noexcept
+    {
+        return nodeID;
+    }
+
+    bool EarthModel::IsIdle() const noexcept
+    {
+        for (const Port& p : ports)
+        {
+            if (!p.evtFIFO.empty()   || !p.reqFIFO.empty()
+             || !p.uprspFIFO.empty() || !p.updatFIFO.empty()
+             || !p.snpQueue.empty()  || !p.dnrspQueue.empty() || !p.dndatQueue.empty()
+             || !p.snoops.empty()    || !p.dbids.empty())
+                return false;
+        }
+
+        for (const Xaction& x : tracker)
+        {
+            if (x.active)
+                return false;
+        }
+
+        return true;
+    }
+
+    uint64_t EarthModel::GetBackpressureDenialCount() const noexcept
+    {
+        return countDeniedBackpressure;
+    }
+
+    uint64_t EarthModel::GetProtocolDenialCount() const noexcept
+    {
+        return countDeniedProtocol;
+    }
+
+    uint64_t EarthModel::GetServicedREQCount() const noexcept
+    {
+        return countREQ;
+    }
+
+    uint64_t EarthModel::GetServicedEVTCount() const noexcept
+    {
+        return countEVT;
+    }
+
+    uint64_t EarthModel::GetServicedSNPCount() const noexcept
+    {
+        return countSNP;
+    }
+
+    std::optional<int> EarthModel::AllocateID(size_t port) noexcept
+    {
+        Port& p = ports[port];
+
+        for (size_t i = 0; i < TXNID_SPACE; ++i)
+        {
+            if (!p.idUsed[i])
+            {
+                p.idUsed[i] = true;
+
+                if (verboseInternal)
+                    EARTH_DEBUG("EarthModel: ID %zu allocated on port %zu at time %llu.",
+                        i, port, static_cast<unsigned long long>(time));
+
+                return { static_cast<int>(i) };
+            }
+        }
+
+        if (verboseInternal)
+            EARTH_DEBUG("EarthModel: no free ID on port %zu at time %llu.",
+                port, static_cast<unsigned long long>(time));
+
+        return std::nullopt;
+    }
+
+    void EarthModel::FreeID(size_t port, int id) noexcept
+    {
+        ports[port].idUsed[static_cast<size_t>(id)] = false;
+
+        if (verboseInternal)
+            EARTH_DEBUG("EarthModel: ID %d freed on port %zu at time %llu.",
+                id, port, static_cast<unsigned long long>(time));
+    }
+
+    std::optional<size_t> EarthModel::AllocateSlot() noexcept
+    {
+        for (size_t i = 0; i < tracker.size(); ++i)
+        {
+            if (!tracker[i].active)
+                return { i };
+        }
+
+        return std::nullopt;
+    }
+
+    void EarthModel::BuildSnoopPlan(size_t slot) noexcept
+    {
+        Xaction& x = tracker[slot];
+
+        x.snoopPlanBuilt = true;
+        x.snoops.clear();
+
+        DirectoryEntry dir = DirLookup(x.line);
+
+        switch (x.kind)
+        {
+        case XactKind::ReadShared:
+
+            // a unique owner is downgraded to shared, returning dirty data
+            if (dir.state == LineState::U && dir.owner != x.port)
+                x.snoops.push_back({ dir.owner, CCHI::Opcodes::SNP::SnpToShared, -1, false, false, false });
+
+            break;
+
+        case XactKind::ReadUnique:
+        case XactKind::MakeUnique:
+
+            // all other holders are invalidated; a unique owner may hold dirty
+            // data and is snooped with a data-returning opcode
+            if (dir.state == LineState::U && dir.owner != x.port)
+            {
+                x.snoops.push_back({ dir.owner, CCHI::Opcodes::SNP::SnpToInvalid, -1, false, false, false });
+            }
+            else if (dir.state == LineState::S)
+            {
+                for (size_t p = 0; p < portCount; ++p)
+                {
+                    if (p != x.port && (dir.sharers & (uint32_t(1) << p)))
+                        x.snoops.push_back({ p, CCHI::Opcodes::SNP::SnpMakeInvalid, -1, false, false, false });
+                }
+            }
+
+            break;
+
+        default:
+            break;
+        }
+
+        if (x.snoops.empty())
+        {
+            x.phase     = XactPhase::Respond;
+            x.readyTime = time + (x.kind == XactKind::ReadShared || x.expCompData ? latencyDAT
+                                                                                 : latencyRSP);
+        }
+
+        if (verboseInternal)
+        {
+            // gem5 adaptation: the target list string is built up front (the
+            // original built it in a lambda inside the spdlog argument list)
+            std::string targets;
+            for (const Snoop& snoop : x.snoops)
+            {
+                targets += " (port " + std::to_string(snoop.port)
+                         + ", opcode " + TextOfSNPOpcode(static_cast<uint32_t>(snoop.opcode)) + ")";
+            }
+
+            EARTH_DEBUG("EarthModel: snoop plan for slot %zu (kind %s, line %#llx, port %zu): %zu target(s)%s, directory state %s sharers %#x owner %zu.",
+                slot, TextOfXactKind(static_cast<size_t>(x.kind)),
+                static_cast<unsigned long long>(x.line << 6), x.port, x.snoops.size(),
+                targets.c_str(),
+                TextOfLineState(static_cast<size_t>(dir.state)), dir.sharers, dir.owner);
+        }
+    }
+
+    bool EarthModel::CheckSnoopsDone(size_t slot) noexcept
+    {
+        Xaction& x = tracker[slot];
+
+        if (!x.active || x.phase != XactPhase::Snoop)
+            return false;
+
+        for (const Snoop& snoop : x.snoops)
+        {
+            if (!snoop.done)
+                return false;
+        }
+
+        x.phase     = XactPhase::Respond;
+        x.readyTime = time + (x.kind == XactKind::ReadShared || x.expCompData ? latencyDAT
+                                                                             : latencyRSP);
+
+        return true;
+    }
+
+    void EarthModel::Retire(size_t slot) noexcept
+    {
+        Xaction& x = tracker[slot];
+
+        if (verboseXact)
+            EARTH_DEBUG("EarthModel: slot %zu retired (kind %s, line %#llx, port %zu) at time %llu.",
+                slot, TextOfXactKind(static_cast<size_t>(x.kind)),
+                static_cast<unsigned long long>(x.line << 6), x.port,
+                static_cast<unsigned long long>(time));
+
+        if (x.dbid >= 0)
+        {
+            ports[x.port].dbids.erase(static_cast<uint8_t>(x.dbid));
+            FreeID(x.port, x.dbid);
+            x.dbid = -1;
+        }
+
+        if (x.kind == XactKind::Evict || x.kind == XactKind::WriteBackFull)
+            lineEVT.erase(x.line);
+        else
+            lineREQ.erase(x.line);
+
+        x.active = false;
+    }
+
+    EarthModel::DirectoryEntry EarthModel::DirLookup(uint64_t line) const noexcept
+    {
+        auto it = directory.find(line);
+
+        if (it == directory.end())
+            return {};
+
+        return it->second;
+    }
+
+    void EarthModel::DirRemove(size_t port, uint64_t line) noexcept
+    {
+        auto it = directory.find(line);
+
+        if (it == directory.end())
+        {
+            if (verboseState)
+                EARTH_DEBUG("EarthModel: directory drop of line %#llx for port %zu ignored, entry absent.",
+                    static_cast<unsigned long long>(line << 6), port);
+            return;
+        }
+
+        DirectoryEntry& dir = it->second;
+
+        if (dir.state == LineState::U && dir.owner == port)
+        {
+            if (verboseState)
+                EARTH_DEBUG("EarthModel: directory line %#llx: U(owner %zu) -> I at time %llu.",
+                    static_cast<unsigned long long>(line << 6), dir.owner,
+                    static_cast<unsigned long long>(time));
+
+            directory.erase(it);
+        }
+        else if (dir.state == LineState::S)
+        {
+            dir.sharers &= ~(uint32_t(1) << port);
+
+            if (verboseState)
+                EARTH_DEBUG("EarthModel: directory line %#llx: sharer %zu dropped, sharers now %#x at time %llu.",
+                    static_cast<unsigned long long>(line << 6), port, dir.sharers,
+                    static_cast<unsigned long long>(time));
+
+            if (!dir.sharers)
+                directory.erase(it);
+        }
+        else if (verboseState)
+            EARTH_DEBUG("EarthModel: directory drop of line %#llx for port %zu ignored, state %s owner %zu sharers %#x.",
+                static_cast<unsigned long long>(line << 6), port,
+                TextOfLineState(static_cast<size_t>(dir.state)), dir.owner, dir.sharers);
+    }
+
+    void EarthModel::DirGrant(size_t slot) noexcept
+    {
+        Xaction& x = tracker[slot];
+
+        DirectoryEntry& dir = directory[x.line];
+
+        if (x.kind == XactKind::ReadShared)
+        {
+            if (dir.state == LineState::U && dir.owner == x.port)
+            {
+                // defensive: the requester already owns the line
+                if (verboseState)
+                    EARTH_DEBUG("EarthModel: directory line %#llx: grant skipped, requester %zu already owns it.",
+                        static_cast<unsigned long long>(x.line << 6), x.port);
+                return;
+            }
+
+            if (dir.state == LineState::U)
+            {
+                // the previous owner was snooped SnpToShared and stays a
+                // sharer, unless it answered I (e.g. it evicted in between)
+                bool keepOwner = true;
+
+                for (const Snoop& snoop : x.snoops)
+                {
+                    if (snoop.port == dir.owner
+                     && snoop.opcode == CCHI::Opcodes::SNP::SnpToShared)
+                    {
+                        keepOwner = snoop.respNotI;
+                    }
+                }
+
+                uint32_t sharers = uint32_t(1) << x.port;
+
+                if (keepOwner)
+                    sharers |= uint32_t(1) << dir.owner;
+
+                if (verboseState)
+                    EARTH_DEBUG("EarthModel: directory line %#llx: U(owner %zu) -> S(sharers %#x) at time %llu.",
+                        static_cast<unsigned long long>(x.line << 6), dir.owner, sharers,
+                        static_cast<unsigned long long>(time));
+
+                dir.state   = LineState::S;
+                dir.sharers = sharers;
+            }
+            else if (dir.state == LineState::S)
+            {
+                dir.sharers |= uint32_t(1) << x.port;
+
+                if (verboseState)
+                    EARTH_DEBUG("EarthModel: directory line %#llx: sharer %zu added, sharers now %#x at time %llu.",
+                        static_cast<unsigned long long>(x.line << 6), x.port, dir.sharers,
+                        static_cast<unsigned long long>(time));
+            }
+            else
+            {
+                dir.state   = LineState::S;
+                dir.sharers = uint32_t(1) << x.port;
+
+                if (verboseState)
+                    EARTH_DEBUG("EarthModel: directory line %#llx: I -> S(sharers %#x) at time %llu.",
+                        static_cast<unsigned long long>(x.line << 6), dir.sharers,
+                        static_cast<unsigned long long>(time));
+            }
+        }
+        else if (x.kind == XactKind::ReadUnique || x.kind == XactKind::MakeUnique)
+        {
+            if (verboseState)
+                EARTH_DEBUG("EarthModel: directory line %#llx: (state %s, sharers %#x, owner %zu) -> U(owner %zu) at time %llu.",
+                    static_cast<unsigned long long>(x.line << 6),
+                    TextOfLineState(static_cast<size_t>(dir.state)), dir.sharers, dir.owner,
+                    x.port, static_cast<unsigned long long>(time));
+
+            dir.state   = LineState::U;
+            dir.sharers = 0;
+            dir.owner   = x.port;
+        }
+    }
+
+    // gem5 adaptation: whole-line data access routed through the attached
+    // MemoryBackend (gem5 memory); replaces the old internal sparse map.
+    // Without a backend there is no storage: reads return zeros and writes
+    // are dropped, and the misconfiguration is reported once.
+    void EarthModel::ReadLine(uint64_t line, std::array<uint64_t, LINE_WORDS>& data) noexcept
+    {
+        if (memoryBackend)
+        {
+            memoryBackend->readLine(line, data);
+            return;
+        }
+
+        if (!backendMissingWarned)
+        {
+            backendMissingWarned = true;
+            EARTH_WARN("EarthModel: no MemoryBackend attached, reads return zeros and writes are dropped.");
+        }
+
+        data.fill(0);
+    }
+
+    void EarthModel::WriteLine(uint64_t line, const std::array<uint64_t, LINE_WORDS>& data) noexcept
+    {
+        if (memoryBackend)
+        {
+            memoryBackend->writeLine(line, data);
+            return;
+        }
+
+        if (!backendMissingWarned)
+        {
+            backendMissingWarned = true;
+            EARTH_WARN("EarthModel: no MemoryBackend attached, reads return zeros and writes are dropped.");
+        }
+    }
+
+    void EarthModel::MergeBeat(uint64_t line, size_t dataID, const uint64_t* data, uint32_t BE) noexcept
+    {
+        // gem5 adaptation: the beat is merged into the backend copy of the
+        // line (read-modify-write); the original merged in place into the
+        // internal sparse map entry ('memory[line]')
+        std::array<uint64_t, LINE_WORDS> lineData;
+        ReadLine(line, lineData);
+
+        // one BE bit per byte within the beat payload
+        for (size_t w = 0; w < WORDS_PER_BEAT; ++w)
+        {
+            for (size_t b = 0; b < sizeof(uint64_t); ++b)
+            {
+                if (BE & (uint32_t(1) << (w * sizeof(uint64_t) + b)))
+                {
+                    uint64_t  mask = uint64_t(0xFF) << (b * 8);
+                    uint64_t& dst  = lineData[dataID * WORDS_PER_BEAT + w];
+
+                    dst = (dst & ~mask) | (data[w] & mask);
+                }
+            }
+        }
+
+        WriteLine(line, lineData);
+    }
+
+    void EarthModel::ReportBackpressure(const char* what, size_t port) noexcept
+    {
+        countDeniedBackpressure++;
+
+        if (verboseBackpressure)
+            EARTH_DEBUG("EarthModel: %s at time %llu (port %zu).",
+                what, static_cast<unsigned long long>(time), port);
+    }
+
+    void EarthModel::ReportViolation(const char* what, size_t port) noexcept
+    {
+        countDeniedProtocol++;
+
+        EARTH_WARN("EarthModel: %s at time %llu (port %zu).",
+            what, static_cast<unsigned long long>(time), port);
+    }
+
+    bool EarthModel::CheckAddressWindow(uint64_t addr, const char* what, size_t port) noexcept
+    {
+        if (addr < memoryStart || addr >= memoryEnd)
+        {
+            EARTH_WARN("EarthModel: %s address %#llx outside the configured memory window [%#llx, %#llx) at time %llu (port %zu).",
+                what, static_cast<unsigned long long>(addr),
+                static_cast<unsigned long long>(memoryStart),
+                static_cast<unsigned long long>(memoryEnd),
+                static_cast<unsigned long long>(time), port);
+
+            countDeniedProtocol++;
+            return false;
+        }
+
+        return true;
+    }
+
+    void EarthModel::DumpState() const noexcept
+    {
+        EARTH_INFO("EarthModel state dump at time %llu:", static_cast<unsigned long long>(time));
+
+        for (size_t slotIdx = 0; slotIdx < tracker.size(); ++slotIdx)
+        {
+            const Xaction& x = tracker[slotIdx];
+
+            if (!x.active)
+                continue;
+
+            // gem5 adaptation: the done count is computed up front (the
+            // original computed it in a lambda inside the spdlog argument list)
+            size_t snoopsDone = 0;
+            for (const Snoop& snoop : x.snoops)
+                snoopsDone += snoop.done;
+
+            EARTH_INFO(" - slot %zu: %s %s on line %#llx (port %zu), txnID %u, dbid %d, "
+                "ack %s, CompData beats %zu, snoops %zu/%zu done, ready time %llu",
+                slotIdx,
+                TextOfXactKind(static_cast<size_t>(x.kind)),
+                TextOfXactPhase(static_cast<size_t>(x.phase)),
+                static_cast<unsigned long long>(x.line << 6), x.port,
+                static_cast<unsigned>(x.txnID), x.dbid,
+                x.ackReceived ? "true" : "false", x.compDataBeats,
+                snoopsDone, x.snoops.size(),
+                static_cast<unsigned long long>(x.readyTime));
+        }
+
+        for (size_t port = 0; port < portCount; ++port)
+        {
+            const Port& p = ports[port];
+
+            EARTH_INFO(" - port %zu: FIFOs EVT %zu / REQ %zu / UpRSP %zu / UpDAT %zu, "
+                "queues SNP %zu / DnRSP %zu / DnDAT %zu, snoops outstanding %zu, DBIDs outstanding %zu",
+                port,
+                p.evtFIFO.size(), p.reqFIFO.size(), p.uprspFIFO.size(), p.updatFIFO.size(),
+                p.snpQueue.size(), p.dnrspQueue.size(), p.dndatQueue.size(),
+                p.snoops.size(), p.dbids.size());
+        }
+
+        // gem5 adaptation: no local memory map anymore, so the dump reports
+        // backend presence instead of the old 'memory.size()' line count
+        EARTH_INFO(" - lines: %zu REQ-active, %zu EVT-active, %zu waiting, directory %zu entries, memory backend %s",
+            lineREQ.size(), lineEVT.size(), lineWaiters.size(), directory.size(),
+            memoryBackend ? "attached" : "absent");
+    }
+}

--- a/src/mem/cchi/earth/earth_model.hpp
+++ b/src/mem/cchi/earth/earth_model.hpp
@@ -1,0 +1,376 @@
+#pragma once
+
+// Vendored from CHIron: cchi/cohestra/cohestra_earth/earth_model.hpp
+//
+// gem5 adaptations (each also marked "gem5 adaptation:" at the site):
+//  - the internal sparse memory map is replaced by the MemoryBackend hook,
+//    so gem5's memory system (checkpoint restore, golden memory, ...) is the
+//    backing store for line data; the directory stays internal to the model
+//  - the SimpleIni/ConfigurationEntry machinery (CONFIG_EARTH_* entries and
+//    LoadConfiguration) is replaced by plain setters; defaults are unchanged
+//  - spdlog is removed; logging goes through the shim at the top of
+//    earth_model.cpp (gem5 warn/inform/DPRINTF, or an fprintf fallback)
+//  - CHIron includes are retargeted to -I<CHIRON_DIR>/cchi style paths
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+// gem5 adaptation: retargeted CHIron includes (relative "../..." includes in
+// the original), expecting -I<CHIRON_DIR>/cchi to be provided at build time
+#include "cohestra/cohestra_interface.hpp"
+#include "spec/cchi_protocol_encoding.hpp"
+
+
+namespace Cohestra {
+
+    // gem5 adaptation: pluggable backing store for line data.
+    //
+    // Earth no longer keeps its own sparse memory; every line-sized data
+    // access goes through this interface so that gem5's memory system always
+    // holds the real data.
+    //
+    // 'lineAddr' is the 64-byte line number, i.e. the physical byte address
+    // shifted right by 6 (Earth's internal line key); implementations recover
+    // the byte address as (lineAddr << 6).
+    class MemoryBackend {
+    public:
+        virtual ~MemoryBackend() = default;
+
+        virtual void    readLine(uint64_t lineAddr, std::array<uint64_t, 8>& data) = 0;
+        virtual void    writeLine(uint64_t lineAddr, const std::array<uint64_t, 8>& data) = 0;
+    };
+
+    // EarthModel: a simple, pure-C++ downstream (home node + memory) CCHI model.
+    //
+    // One instance serves all Type 1 ports with a shared memory and a shared
+    // directory, so cross-port (multi-agent) cache coherency is exercised.
+    //
+    // Coherency policy:
+    //  - directory states per 64B line: I / S (clean, sharer bitmask) / U (possibly
+    //    dirty, single owner); S lines are always clean, U lines are always
+    //    snooped with data-returning opcodes before ownership transfers.
+    //  - ReadShared      : SnpToShared to a unique owner, then CompData (SC).
+    //  - ReadUnique      : SnpToInvalid to a unique owner or SnpMakeInvalid to
+    //                      other sharers, then CompData (UC) or Comp, honoring
+    //                      ExpCompData.
+    //  - MakeUnique      : same invalidation flow, then Comp.
+    //  - Evict           : directory drop, then Comp.
+    //  - WriteBackFull   : CompDBIDResp, then CopyBackWrData beats are merged
+    //                      into memory.
+    //
+    // Channel priority: EVT > SNP > REQ, applied to the per-cycle processing
+    // order (TickEVT -> TickSNP -> TickREQ). EVT admissions are additionally
+    // allowed to cut ahead of an active REQ transaction on the same line,
+    // because Taurus upstream nodes hold snoop responses until their in-flight
+    // eviction is completed; completing the eviction first is always coherent
+    // and avoids the request/snoop/eviction circular wait.
+    //
+    // Transactional parallelism is configurable (home transaction tracker size,
+    // per-port snoop inflight limit, per-channel queue depths, response
+    // latencies). One upstream-initiated transaction (REQ or EVT) is accepted
+    // per port at a time: Taurus nodes always drive TxnID 0, so a second
+    // concurrent one could not be told apart on the response channels. Excess
+    // pushes are denied (backpressured) and reported.
+    //
+    // Denials are always reported: flow-control (backpressure) denials are
+    // counted and logged at debug level, protocol violations are counted and
+    // logged at warning/error level; both are readable through counters.
+    class EarthModel {
+    public:
+        using FlitEVT   = CCHI::Flits::EVT<CommonFlitConfigurationType1>;
+        using FlitREQ   = CCHI::Flits::REQ<CommonFlitConfigurationType1>;
+        using FlitSNP   = CCHI::Flits::SNP<CommonFlitConfigurationType1>;
+        using FlitUpRSP = CCHI::Flits::UpRSP<CommonFlitConfigurationType1>;
+        using FlitUpDAT = CCHI::Flits::UpDAT<CommonFlitConfigurationType1>;
+        using FlitDnRSP = CCHI::Flits::DnRSP<CommonFlitConfigurationType1>;
+        using FlitDnDAT = CCHI::Flits::DnDAT<CommonFlitConfigurationType1>;
+
+        static constexpr size_t     LINE_SIZE           = 64;
+        static constexpr size_t     LINE_WORDS          = LINE_SIZE / sizeof(uint64_t);
+        static constexpr size_t     BEATS_PER_LINE      = 512 / CommonFlitConfigurationType1::dataWidth;
+        static constexpr size_t     WORDS_PER_BEAT      = LINE_WORDS / BEATS_PER_LINE;
+        static constexpr size_t     TXNID_SPACE         = size_t(1) << CommonFlitConfigurationType1::dbIdWidth;
+
+    protected:
+        enum class LineState {
+            I = 0,
+            S,
+            U
+        };
+
+        struct DirectoryEntry {
+            LineState   state           = LineState::I;
+            uint32_t    sharers         = 0;    // port bitmask, valid when S
+            size_t      owner           = 0;    // port index, valid when U
+        };
+
+        enum class XactKind {
+            ReadShared = 0,
+            ReadUnique,
+            MakeUnique,
+            Evict,
+            WriteBackFull
+        };
+
+        enum class XactPhase {
+            Snoop = 0,      // issuing snoops and/or waiting for snoop responses
+            Respond,        // waiting for readyTime to emit Comp/CompData/CompDBIDResp
+            WaitCompAck,    // waiting for CompAck of the emitted DBID
+            WaitWrData,     // waiting for CopyBackWrData beats of the emitted DBID
+            WaitPop         // waiting for the Evict Comp to be popped downstream
+        };
+
+        struct Snoop {
+            size_t      port            = 0;
+            uint8_t     opcode          = 0;
+            int         txnID           = -1;
+            bool        issued          = false;
+            bool        done            = false;
+            bool        respNotI        = false;
+        };
+
+        struct Xaction {
+            bool                        active          = false;
+            XactKind                    kind            = XactKind::ReadShared;
+            size_t                      port            = 0;
+            uint64_t                    line            = 0;      // PA >> 6
+            uint64_t                    addr            = 0;
+            uint8_t                     txnID           = 0;
+            uint32_t                    srcNodeID       = 0;
+            bool                        expCompData     = false;
+            uint8_t                     traceTag        = 0;
+
+            XactPhase                   phase           = XactPhase::Snoop;
+            uint64_t                    readyTime       = 0;
+
+            int                         dbid            = -1;
+            bool                        ackReceived     = false;
+            size_t                      compDataBeats   = 0;
+
+            bool                        snoopPlanBuilt  = false;
+            std::vector<Snoop>          snoops;
+
+            uint32_t                    wrBeatMask      = 0;
+        };
+
+        enum class DBIDKind {
+            CompAckWait = 0,
+            WriteBackData
+        };
+
+        struct DBIDEntry {
+            size_t      slot;
+            DBIDKind    kind;
+        };
+
+        struct SnoopEntry {
+            size_t      slot;
+            size_t      snoop;
+            uint64_t    line;
+            uint32_t    beatMask        = 0;
+            bool        gotData         = false;
+            bool        gotResp         = false;
+            uint8_t     resp            = 0;
+        };
+
+        template<class TFlit>
+        struct StampedFlit {
+            TFlit       flit;
+            uint64_t    stamp;
+            bool        registered;
+        };
+
+        struct Port {
+            std::deque<StampedFlit<FlitEVT>>    evtFIFO;
+            std::deque<StampedFlit<FlitREQ>>    reqFIFO;
+            std::deque<FlitUpRSP>               uprspFIFO;
+            std::deque<FlitUpDAT>               updatFIFO;
+
+            std::deque<FlitSNP>                 snpQueue;
+            std::deque<FlitDnRSP>               dnrspQueue;
+            std::deque<FlitDnDAT>               dndatQueue;
+
+            // one allocator per port shared by snoop TxnIDs and DBIDs, so an
+            // UpRSP/UpDAT flit always resolves to exactly one transaction
+            std::array<bool, TXNID_SPACE>       idUsed          = {};
+
+            std::unordered_map<uint8_t, SnoopEntry>
+                                                snoops;
+            std::unordered_map<uint8_t, DBIDEntry>
+                                                dbids;
+        };
+
+    protected:
+        const size_t            portCount;
+
+        uint64_t                time                = 0;
+
+        uint32_t                nodeID;
+        uint32_t                parallelism;
+        uint32_t                inflightSNP;
+
+        uint32_t                queueDepthEVT;
+        uint32_t                queueDepthREQ;
+        uint32_t                queueDepthRSP;
+        uint32_t                queueDepthDAT;
+
+        uint32_t                latencyRSP;
+        uint32_t                latencyDAT;
+
+        uint64_t                memoryStart;
+        uint64_t                memoryEnd;
+
+        // verbose switches: 'verbose' is the total switch of all categories
+        bool                    verbose;
+        bool                    verboseFlit;
+        bool                    verboseXact;
+        bool                    verboseState;
+        bool                    verboseInternal;
+        bool                    verboseBackpressure;
+
+        std::vector<uint32_t>   upstreamNodeIDs;
+
+        std::vector<Port>       ports;
+
+        std::vector<Xaction>    tracker;
+
+        // gem5 adaptation: backing store for line data, attached through
+        // SetMemoryBackend(); replaces the old internal sparse map
+        // std::unordered_map<uint64_t, std::array<uint64_t, LINE_WORDS>> memory
+        std::shared_ptr<MemoryBackend>
+                                memoryBackend;
+
+        bool                    backendMissingWarned  = false;
+
+        std::unordered_map<uint64_t, DirectoryEntry>
+                                directory;
+
+        std::unordered_map<uint64_t, size_t>
+                                lineREQ;
+
+        std::unordered_map<uint64_t, size_t>
+                                lineEVT;
+
+        std::unordered_map<uint64_t, std::deque<std::pair<uint64_t, size_t>>>
+                                lineWaiters;
+
+        uint64_t                stampCounter        = 0;
+
+        uint64_t                countDeniedBackpressure = 0;
+        uint64_t                countDeniedProtocol     = 0;
+
+        uint64_t                countREQ            = 0;
+        uint64_t                countEVT            = 0;
+        uint64_t                countSNP            = 0;
+
+    public:
+        EarthModel(size_t portCount) noexcept;
+
+        virtual ~EarthModel() noexcept = default;
+
+    public:
+        // gem5 adaptation: plain parameter setters replacing the SimpleIni
+        // LoadConfiguration() flow; defaults match the old CONFIG_EARTH_*
+        // defaultValues and invalid values are rejected with an error log
+        void                                SetNodeID(uint32_t nodeID) noexcept;
+        void                                SetParallelism(uint32_t parallelism) noexcept;
+        void                                SetInflightSNP(uint32_t inflightSNP) noexcept;
+
+        void                                SetQueueDepthEVT(uint32_t depth) noexcept;
+        void                                SetQueueDepthREQ(uint32_t depth) noexcept;
+        void                                SetQueueDepthRSP(uint32_t depth) noexcept;
+        void                                SetQueueDepthDAT(uint32_t depth) noexcept;
+
+        void                                SetLatencyRSP(uint32_t latency) noexcept;
+        void                                SetLatencyDAT(uint32_t latency) noexcept;
+
+        void                                SetMemoryWindow(uint64_t start, uint64_t end) noexcept;
+
+        void                                SetVerbose(bool verbose) noexcept;
+        void                                SetVerboseFlit(bool verbose) noexcept;
+        void                                SetVerboseXact(bool verbose) noexcept;
+        void                                SetVerboseState(bool verbose) noexcept;
+        void                                SetVerboseInternal(bool verbose) noexcept;
+        void                                SetVerboseBackpressure(bool verbose) noexcept;
+
+        // gem5 adaptation: attach the backing store (gem5 memory) for line data
+        void                                SetMemoryBackend(std::shared_ptr<MemoryBackend> backend) noexcept;
+
+        void                                SetUpstreamNodeIDs(const std::vector<uint32_t>& nodeIDs) noexcept;
+
+    public:
+        void                                Tick(uint64_t time) noexcept;
+
+    protected:
+        void                                TickEVT() noexcept;
+        void                                TickSNP() noexcept;
+        void                                TickREQ() noexcept;
+        void                                TickEmit() noexcept;
+
+    public:
+        bool                                PushEVT(size_t port, const FlitEVT& flit) noexcept;
+        bool                                PushREQ(size_t port, const FlitREQ& flit) noexcept;
+        bool                                PushUpRSP(size_t port, const FlitUpRSP& flit) noexcept;
+        bool                                PushUpDAT(size_t port, const FlitUpDAT& flit) noexcept;
+
+        bool                                HasSNP(size_t port) const noexcept;
+        std::optional<FlitSNP>              PeekSNP(size_t port) const noexcept;
+        std::optional<FlitSNP>              PopSNP(size_t port) noexcept;
+
+        bool                                HasDnRSP(size_t port) const noexcept;
+        std::optional<FlitDnRSP>            PeekDnRSP(size_t port) const noexcept;
+        std::optional<FlitDnRSP>            PopDnRSP(size_t port) noexcept;
+
+        bool                                HasDnDAT(size_t port) const noexcept;
+        std::optional<FlitDnDAT>            PeekDnDAT(size_t port) const noexcept;
+        std::optional<FlitDnDAT>            PopDnDAT(size_t port) noexcept;
+
+    public:
+        size_t                              GetPortCount() const noexcept;
+        uint32_t                            GetNodeID() const noexcept;
+
+        bool                                IsIdle() const noexcept;
+
+        uint64_t                            GetBackpressureDenialCount() const noexcept;
+        uint64_t                            GetProtocolDenialCount() const noexcept;
+
+        uint64_t                            GetServicedREQCount() const noexcept;
+        uint64_t                            GetServicedEVTCount() const noexcept;
+        uint64_t                            GetServicedSNPCount() const noexcept;
+
+        void                                DumpState() const noexcept;
+
+    protected:
+        std::optional<int>                  AllocateID(size_t port) noexcept;
+        void                                FreeID(size_t port, int id) noexcept;
+
+        std::optional<size_t>               AllocateSlot() noexcept;
+
+        void                                BuildSnoopPlan(size_t slot) noexcept;
+        bool                                CheckSnoopsDone(size_t slot) noexcept;
+
+        void                                Retire(size_t slot) noexcept;
+
+        DirectoryEntry                      DirLookup(uint64_t line) const noexcept;
+        void                                DirRemove(size_t port, uint64_t line) noexcept;
+        void                                DirGrant(size_t slot) noexcept;
+
+        // gem5 adaptation: line data access routed through the MemoryBackend;
+        // without a backend, reads return zeros and writes are dropped (a
+        // warning is emitted once)
+        void                                ReadLine(uint64_t line, std::array<uint64_t, LINE_WORDS>& data) noexcept;
+        void                                WriteLine(uint64_t line, const std::array<uint64_t, LINE_WORDS>& data) noexcept;
+
+        void                                MergeBeat(uint64_t line, size_t dataID, const uint64_t* data, uint32_t BE) noexcept;
+
+        void                                ReportBackpressure(const char* what, size_t port) noexcept;
+        void                                ReportViolation(const char* what, size_t port) noexcept;
+
+        bool                                CheckAddressWindow(uint64_t addr, const char* what, size_t port) noexcept;
+    };
+}

--- a/util/cchi/run_xscache_linux.sh
+++ b/util/cchi/run_xscache_linux.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# run_xscache_linux.sh — boot linux on XS-GEM5 with the XSCache
+# (Oceanus L2 + OpenLLC + OpenNCB) RTL as the CCHI downstream endpoint.
+#
+# Usage (builds the RISCV_CCHI_XSCACHE variant on first run):
+#   util/cchi/run_xscache_linux.sh --xscache-dir=<path> --chiron-dir=<path> \
+#       --ready-to-run=<path> [options]
+#
+# Required paths (CLI flag wins over the environment variable; there are
+# no built-in defaults — the script errors out when one is missing):
+#   --xscache-dir=PATH   XSCache checkout    (env: XSCACHE_DIR)
+#   --chiron-dir=PATH    CHIron checkout     (env: CHIRON_DIR)
+#   --ready-to-run=PATH  workload directory  (env: READY_TO_RUN)
+# Derived from --ready-to-run unless given explicitly:
+#   --gcbv-ref-so=PATH   difftest reference .so (env: GCBV_REF_SO;
+#                        default: $READY_TO_RUN/riscv64-nemu-interpreter-so)
+#   --linux-bin=PATH     raw linux image        (env: LINUX_BIN;
+#                        default: $READY_TO_RUN/linux.bin)
+# Optional:
+#   --outdir=PATH        gem5 output directory  (env: OUTDIR;
+#                        default: <repo>/m5out_linux_xscache)
+#
+# Options:
+#   --build            force a rebuild of the RISCV_CCHI_XSCACHE variant
+#   -I N               cap at N committed instructions (gem5 -I)
+#   --difftest         run WITH difftest (default is --disable-difftest; the
+#                      NEMU/gem5 interrupt-timing divergence on linux boots
+#                      is pre-existing and unrelated to CCHI)
+#   --flit-trace       attach the CCHI flit logger (very verbose, to stdout)
+#   --debug-flags=F    gem5 debug flags (e.g. --debug-flags=CCHI)
+#   --vcd=PATH         dump the downstream RTL waveform (VCD) to PATH
+#   --vcd-start=TICK   open the waveform at gem5 tick TICK (default: 0)
+#   -- ...             everything after a bare -- is passed to gem5 verbatim
+#
+# Prerequisites the script checks for you:
+#   - generated XSCache RTL ($XSCACHE_DIR/build/l2openllc/TestTop_L2OpenLLC.sv);
+#     if missing, run `make test-top-l2openllc` in the XSCache checkout
+set -euo pipefail
+
+GEM5_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$GEM5_ROOT"
+
+XSCACHE_DIR="${XSCACHE_DIR:-}"
+CHIRON_DIR="${CHIRON_DIR:-}"
+READY_TO_RUN="${READY_TO_RUN:-}"
+GCBV_REF_SO="${GCBV_REF_SO:-}"
+LINUX_BIN="${LINUX_BIN:-}"
+OUTDIR="${OUTDIR:-$GEM5_ROOT/m5out_linux_xscache}"
+
+VARIANT="build/RISCV_CCHI_XSCACHE"
+GEM5_BIN="$GEM5_ROOT/$VARIANT/gem5.opt"
+SCONS="$GEM5_ROOT/.venv/bin/scons"
+[ -x "$SCONS" ] || SCONS="scons"
+
+BUILD=0
+MAXINSTS=""
+DIFFTEST_OFF=1
+FLIT_TRACE=0
+DEBUG_FLAGS=""
+VCD=""
+VCD_START=0
+EXTRA=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --xscache-dir=*)  XSCACHE_DIR="${1#*=}" ;;
+        --chiron-dir=*)   CHIRON_DIR="${1#*=}" ;;
+        --ready-to-run=*) READY_TO_RUN="${1#*=}" ;;
+        --gcbv-ref-so=*)  GCBV_REF_SO="${1#*=}" ;;
+        --linux-bin=*)    LINUX_BIN="${1#*=}" ;;
+        --outdir=*)       OUTDIR="${1#*=}" ;;
+        --build)       BUILD=1 ;;
+        -I)            MAXINSTS="$2"; shift ;;
+        --difftest)    DIFFTEST_OFF=0 ;;
+        --flit-trace)  FLIT_TRACE=1 ;;
+        --debug-flags=*) DEBUG_FLAGS="${1#*=}" ;;
+        --vcd=*)       VCD="${1#*=}" ;;
+        --vcd-start=*) VCD_START="${1#*=}" ;;
+        --)            shift; EXTRA+=("$@"); break ;;
+        *) echo "unknown option: $1 (see header)" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --- required paths ------------------------------------------------------------
+missing() {
+    echo "error: missing required path: $1" >&2
+    echo "       pass $2 or set the \$$3 environment variable" >&2
+    exit 2
+}
+[ -n "$XSCACHE_DIR" ]  || missing "XSCache checkout"  "--xscache-dir=PATH"  "XSCACHE_DIR"
+[ -n "$CHIRON_DIR" ]   || missing "CHIron checkout"   "--chiron-dir=PATH"   "CHIRON_DIR"
+[ -n "$READY_TO_RUN" ] || missing "workload directory" "--ready-to-run=PATH" "READY_TO_RUN"
+GCBV_REF_SO="${GCBV_REF_SO:-$READY_TO_RUN/riscv64-nemu-interpreter-so}"
+LINUX_BIN="${LINUX_BIN:-$READY_TO_RUN/linux.bin}"
+
+# --- prerequisite checks -------------------------------------------------------
+[ -d "$CHIRON_DIR" ]  || { echo "error: not a directory (CHIron checkout): $CHIRON_DIR" >&2; exit 1; }
+[ -d "$XSCACHE_DIR" ] || { echo "error: not a directory (XSCache checkout): $XSCACHE_DIR" >&2; exit 1; }
+if [ ! -f "$XSCACHE_DIR/build/l2openllc/TestTop_L2OpenLLC.sv" ]; then
+    echo "error: $XSCACHE_DIR/build/l2openllc has no generated RTL;" >&2
+    echo "       run 'make test-top-l2openllc' in the XSCache checkout first" >&2
+    exit 1
+fi
+for f in "$LINUX_BIN" "$GCBV_REF_SO"; do
+    [ -f "$f" ] || { echo "error: not found: $f" >&2; exit 1; }
+done
+
+# --- build ---------------------------------------------------------------------
+if [ "$BUILD" = 1 ] || [ ! -x "$GEM5_BIN" ]; then
+    "$SCONS" "$VARIANT/gem5.opt" --gold-linker -j"$(nproc)" \
+        CHIRON_DIR="$CHIRON_DIR" CCHI_XSCACHE_DIR="$XSCACHE_DIR"
+fi
+
+# --- run -----------------------------------------------------------------------
+ARGS=(--outdir="$OUTDIR" configs/example/kmhv3.py
+      --cchi --cchi-downstream=rtl --no-cchi-l2-pf
+      --raw-cpt --generic-rv-cpt="$LINUX_BIN")
+[ "$DIFFTEST_OFF" = 1 ] && ARGS+=(--disable-difftest)
+[ "$FLIT_TRACE" = 1 ]   && ARGS+=(--cchi-flit-trace)
+[ -n "$DEBUG_FLAGS" ]   && ARGS+=(--debug-flags="$DEBUG_FLAGS")
+[ -n "$MAXINSTS" ]      && ARGS+=(-I "$MAXINSTS")
+[ ${#EXTRA[@]} -gt 0 ]  && ARGS+=("${EXTRA[@]}")
+
+if [ -n "$VCD" ]; then
+    export CCHI_RTL_TRACE="$VCD"
+    export CCHI_RTL_TRACE_START="$VCD_START"
+fi
+
+echo "+ GCBV_REF_SO=$GCBV_REF_SO $GEM5_BIN ${ARGS[*]}"
+exec env GCBV_REF_SO="$GCBV_REF_SO" "$GEM5_BIN" "${ARGS[@]}"


### PR DESCRIPTION
**- "May be we need a L2 model no more."**
**- "But how?"**
**- "We just plug the real L2 in."**

***"Make everything as simple as possible, but not simpler."*** - attributed to **Albert Einstein**

Add an alternative to the classic tol2bus/L2/L3 hierarchy: each core's L1I/L1D (+ walker caches) attaches to a CCHIL1Agent (CHIron Taurus node) wired to a per-system CCHIFabric hosting the downstream home and bridging to membus/DRAM via AXI4. Fully opt-in; stock builds/configs are bit-identical (verified on coremark and linux boot).

Downstream endpoints (--cchi-downstream):
- earth: vendored behavioral home (src/mem/cchi/earth)
- rtl:   Verilator backend for user-supplied tops (e.g. Venus;
         ships wiring for the XSCache TestTop_L2OpenLLC: Oceanus L2 +
         OpenLLC + OpenNCB -> AXI4)

Build-time (sticky scons vars, compile-time toggles only):
- WITH_CCHI + CHIRON_DIR: core fabric (build_opts/RISCV_CCHI)
- WITH_CCHI_RTL: Verilator endpoints (build_opts/RISCV_CCHI_RTL)
- CCHI_RTL_TOP=TestTop_L2OpenLLC + CCHI_XSCACHE_DIR: XSCache variant (build_opts/RISCV_CCHI_XSCACHE); checkout paths are never repo defaults and missing paths fail the build with explicit errors

Runtime: --cchi, --cchi-downstream={earth,rtl}, --no-cchi-l2-pf (downstreams without stash support, e.g. XSCache RTL), --cchi-flit-trace. The L2 prefetch engine is preserved on the agent and the L1->L2 pf-hint wire targets it as before.

Agent coherence fixes found during Venus/XSCache bring-up:
- early-release snoop branch now requires !grantedHit (was silently losing L1-only dirty data)
- reaped snoop-merge line: counted drop instead of panic
- store-hit backoff while SNP/EVT in flight

Supporting changes:
- memtest: check_data param (testers sharing one address space)
- BaseCache::calReqInterval: grow prevReqCycles for requestors registered after construction (testers bind at init)
- minor: const InstId::operator==
- SConstruct: C++20 for CHIron; optional vendored boost/sqlite3 include paths for hosts without the system packages
- util/cchi/run_xscache_linux.sh: parameterized one-shot XSCache linux boot (errors on missing inputs)

Validation (see src/mem/cchi/README.md):
- memtest 100k loads clean on earth/Venus/XSCache, monitor 0
- coremark difftest-on pass (CRC 0x8e3a/0x72be); linux boots to m5_exit on all endpoints; stock RISCV/RISCV_CCHI bit-identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CCHI cache-coherence fabric support, including configurable Earth and Verilator-based downstream endpoints.
  * Added RISC-V build configurations for CCHI, RTL integration, and XSCache.
  * Added CCHI-enabled MemTest and Linux launch workflows.
  * Added command-line controls for CCHI selection, downstream type, prefetching, and flit tracing.
  * Added optional MemTest data validation and improved support for dynamically registered requestors.

* **Documentation**
  * Added comprehensive CCHI setup, configuration, and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->