### PR TITLE
Revert "misc: Reduce performance archive retention to 100 runs"

### DIFF
--- a/.github/workflows/gem5-perf-template.yml
+++ b/.github/workflows/gem5-perf-template.yml
@@ -394,11 +394,11 @@ jobs:
             cp "$GITHUB_WORKSPACE/score.txt" "$TARGET_DIR/"
           fi
           
-          # Auto cleanup: keep only last 100 runs for this benchmark type
-          if [ -d "$BENCHMARK_DIR" ] && [ $(ls -1 "$BENCHMARK_DIR" 2>/dev/null | wc -l) -gt 100 ]; then
-            echo "Cleaning up old performance data, keeping last 100 runs"
+          # Auto cleanup: keep only last 200 runs for this benchmark type
+          if [ -d "$BENCHMARK_DIR" ] && [ $(ls -1 "$BENCHMARK_DIR" 2>/dev/null | wc -l) -gt 200 ]; then
+            echo "Cleaning up old performance data, keeping last 200 runs"
             # Use absolute paths to avoid accidental deletion if cd fails
-            ls -1t "$BENCHMARK_DIR" | tail -n +101 | while read -r old_run; do
+            ls -1t "$BENCHMARK_DIR" | tail -n +201 | while read -r old_run; do
               if [ -n "$old_run" ] && [ -d "$BENCHMARK_DIR/$old_run" ]; then
                 rm -rf "$BENCHMARK_DIR/$old_run"
                 echo "Deleted: $BENCHMARK_DIR/$old_run"


### PR DESCRIPTION
Reverts OpenXiangShan/GEM5#1139
初步测试，发现现在一周合入20个PR，200个会被ideal，align 共享，差不多能保存1个月的数据，还是比较必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance archive cleanup to retain the latest 200 runs per benchmark type, increasing the previous retention limit of 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->